### PR TITLE
fix issue with concurrent instance creation

### DIFF
--- a/edge/src/io/openems/impl/device/simulator/SimulatorGridMeter.java
+++ b/edge/src/io/openems/impl/device/simulator/SimulatorGridMeter.java
@@ -173,7 +173,7 @@ public class SimulatorGridMeter extends SimulatorMeter implements ChannelChangeL
 			essNatures = new ArrayList<>();
 			getEssNatures();
 		}
-		if (meterNatures == null) {
+		if (meterNatures == null || meterNatures.empty();) {
 			meterNatures = new ArrayList<>();
 			getMeterNatures();
 		}


### PR DESCRIPTION
Hallo,
mir ist beim herumprobieren aufgefallen, dass die UI für die selbe config verschiedene Verhalten zeigt abhängig davon ob ich debugge oder die App normal starte. Habe festgestellt, dass bein debuggen das SimulatorGridMeter erzeugt wird bevor das ProductionMeter zur ThingMap hinzugefügt wurde. Ergo arbeitet das GridMeter ohne die Daten des ProductionMeter. 
Ein Breakpoint beim Hinzufügen der "Things" zur Thingmap gibt dem anderen Thread genug Zeit damit das GridMeter erst erzeugt wird wenn das ProductionMeter über die Map gefunden werden kann.

Habe im GridMeter die Prüfung auf die leere Liste hinzugefügt. das behebt das Problem, da die anderen Meter erneut abgefragt werden.

Die Lösung ist nicht schön, da für eine config ohne Erzeugung für jedes Update das ProductionMeter gesucht wird. Möglich wäre auch sich über ein Flag zu merken dass hier noch ein Meter zu suchen ist. Mir fehlt aber die Übersicht das richtig zu bewerten.

Um das ganze zu reproduzieren habe ich die Zufallskomponente imSimulatorGridMeter in l. 185 auskommentiert:
`		activePower = activePower + SimulatorTools.getRandomLong(-1000, +1000);
`
Hier noch die config mit der mir das ganze aufgefallen ist:
`{
  "things": [
    {
      "class": "io.openems.impl.protocol.simulator.SimulatorBridge",
      "devices": [
        {
          "class": "io.openems.impl.device.simulator.Simulator",
          "gridMeter": {
            "id": "meter0",
            "producer": [
              "meter1"
            ],
            "reactivePowerGeneratorConfig": {
              "className": "io.openems.impl.device.simulator.FixValueLoadGenerator",
              "config": {
                "value": 0
              }
            },
            "minActivePower": -10929,
            "esss": [
              "ess0"
            ],
            "activePowerGeneratorConfig": {
              "className": "io.openems.impl.device.simulator.FixValueLoadGenerator",
              "config": {
                "value": 0
              }
            },
            "frequency": 50000,
            "maxActivePower": 801,
            "voltage": 230000,
            "type": "grid"
          },
          "productionMeter": {
            "id": "meter1",
            "frequency": 50000,
            "reactivePowerGeneratorConfig": {
              "className": "io.openems.impl.device.simulator.FixValueLoadGenerator",
              "config": {
                "value": 0
              }
            },
            "maxActivePower": 11000,
            "voltage": 230000,
            "activePowerGeneratorConfig": {
              "className": "io.openems.impl.device.simulator.FixValueLoadGenerator",
              "config": {
                "value": 10000
              }
            }
          },
          "symmetricEss": {
            "id": "ess0",
            "reactivePowerGeneratorConfig": {
              "className": "io.openems.impl.device.simulator.FixValueLoadGenerator",
              "config": {
                "value": 0
              }
            },
            "activePowerGeneratorConfig": {
              "className": "io.openems.impl.device.simulator.FixValueLoadGenerator",
              "config": {
                "value": 0
              }
            },
            "minSoc": 15,
            "chargeSoc": 13
          }
        }
      ]
    },
    {
      "class": "io.openems.impl.protocol.system.SystemBridge",
      "devices": [
        {
          "class": "io.openems.impl.device.system.System",
          "system": {
            "id": "system0"
          }
        }
      ]
    }
  ],
  "scheduler": {
    "class": "io.openems.impl.scheduler.SimpleScheduler",
    "controllers": [
      {
        "class": "io.openems.impl.controller.api.rest.RestApiController",
        "priority": 150
      },
      {
        "class": "io.openems.impl.controller.symmetric.balancing.BalancingController",
        "meter": "meter0",
        "priority": 100,
        "esss": [
          "ess0"
        ]
      },
      {
        "class": "io.openems.impl.controller.api.websocket.WebsocketApiController",
        "priority": 0
      },
      {
        "class": "io.openems.impl.controller.debuglog.DebugLogController",
        "esss": [
          "ess0"
        ],
        "meters": [
          "meter1",
          "meter0"
        ],
        "priority": 10
      }
    ]
  },
  "persistence": [],
  "users": {
    "admin": {
      "password": "txASlUVQkEI9Bxa/IZOJe8l3+R4lMzFTShz27vK44go\u003d",
      "salt": "YWRtaW4\u003d"
    },
    "installer": {
      "password": "2O1dMlsFdwafy58ehrT+X+0CEWaAmBRad5JFbTLx/Wo\u003d",
      "salt": "aW5zdGFsbGVy"
    },
    "owner": {
      "password": "eJgLBfHTmehv4S1whsfjeE3q3AJmJCBabV59Y65eoYI\u003d",
      "salt": "b3duZXI\u003d"
    },
    "guest": {
      "password": "IcIzJSOvNM1PvQ8v5ypFvPoTZyHw3Knob+zi7d+WspU\u003d",
      "salt": "dXNlcg\u003d\u003d"
    }
  }
}`