### PR TITLE
Refactor Channel options to use OptionsEnum

### DIFF
--- a/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/ChargeIndication.java
+++ b/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/ChargeIndication.java
@@ -1,0 +1,33 @@
+package io.openems.edge.battery.soltaro;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum ChargeIndication implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	STANDING(0, "Standing"), //
+	DISCHARGING(1, "Discharging"), //
+	CHARGING(2, "Charging");
+
+	private int value;
+	private String name;
+
+	private ChargeIndication(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/ClusterRunState.java
+++ b/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/ClusterRunState.java
@@ -1,0 +1,34 @@
+package io.openems.edge.battery.soltaro;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum ClusterRunState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	NORMAL(0, "Normal"), //
+	STOP_CHARGING(1, "Stop charging"), //
+	STOP_DISCHARGE(2, "Stop discharging"), //
+	STANDBY(3, "Standby");
+
+	private int value;
+	private String name;
+
+	private ClusterRunState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/ContactorControl.java
+++ b/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/ContactorControl.java
@@ -1,0 +1,33 @@
+package io.openems.edge.battery.soltaro;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum ContactorControl implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	CUT_OFF(0, "Cut off"), //
+	CONNECTION_INITIATING(1, "Connection initiating"), //
+	ON_GRID(3, "On grid");
+
+	int value;
+	String name;
+
+	private ContactorControl(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/SoltaroRack.java
+++ b/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/SoltaroRack.java
@@ -35,7 +35,6 @@ import io.openems.edge.common.channel.IntegerWriteChannel;
 import io.openems.edge.common.channel.doc.AccessMode;
 import io.openems.edge.common.channel.doc.Doc;
 import io.openems.edge.common.channel.doc.Level;
-import io.openems.edge.common.channel.doc.OptionsEnum;
 import io.openems.edge.common.channel.doc.Unit;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.event.EdgeEventConstants;
@@ -103,12 +102,7 @@ public class SoltaroRack extends AbstractOpenemsModbusComponent implements Batte
 
 	private void initializeCallbacks() {
 		this.channel(ChannelId.BMS_CONTACTOR_CONTROL).onChange(value -> {
-			Optional<Enum<?>> ccOpt = value.asEnumOptional();
-			if (!ccOpt.isPresent()) {
-				return;
-			}
-
-			ContactorControl cc = (ContactorControl) ccOpt.get();
+			ContactorControl cc = value.asEnum();
 
 			switch (cc) {
 			case CONNECTION_INITIATING:
@@ -188,11 +182,7 @@ public class SoltaroRack extends AbstractOpenemsModbusComponent implements Batte
 
 		IntegerReadChannel contactorControlChannel = this.channel(ChannelId.BMS_CONTACTOR_CONTROL);
 
-		Optional<Enum<?>> ccOpt = contactorControlChannel.value().asEnumOptional();
-		if (!ccOpt.isPresent()) {
-			return;
-		}
-		ContactorControl cc = (ContactorControl) ccOpt.get();
+		ContactorControl cc = contactorControlChannel.value().asEnum();
 
 		if (cc == ContactorControl.CONNECTION_INITIATING) {
 			if (timeForSystemInitialization == null || timeForSystemInitialization
@@ -263,76 +253,6 @@ public class SoltaroRack extends AbstractOpenemsModbusComponent implements Batte
 			isStopping = true;
 		} catch (OpenemsException e) {
 			log.error("Error while trying to stop system\n" + e.getMessage());
-		}
-	}
-
-	public enum ChargeIndication implements OptionsEnum {
-
-		STANDING(0, "Standing"), DISCHARGING(1, "Discharging"), CHARGING(2, "Charging");
-
-		private int value;
-		private String option;
-
-		private ChargeIndication(int value, String option) {
-			this.value = value;
-			this.option = option;
-		}
-
-		@Override
-		public int getValue() {
-			return value;
-		}
-
-		@Override
-		public String getOption() {
-			return option;
-		}
-	}
-
-	public enum ContactorControl implements OptionsEnum {
-
-		CUT_OFF(0, "Cut off"), CONNECTION_INITIATING(1, "Connection initiating"), ON_GRID(3, "On grid");
-
-		int value;
-		String option;
-
-		private ContactorControl(int value, String option) {
-			this.value = value;
-			this.option = option;
-		}
-
-		@Override
-		public int getValue() {
-			return value;
-		}
-
-		@Override
-		public String getOption() {
-			return option;
-		}
-	}
-
-	public enum ClusterRunState implements OptionsEnum {
-
-		NORMAL(0, "Normal"), STOP_CHARGING(1, "Stop charging"), STOP_DISCHARGE(2, "Stop discharging"),
-		STANDBY(3, "Standby");
-
-		private int value;
-		private String option;
-
-		private ClusterRunState(int value, String option) {
-			this.value = value;
-			this.option = option;
-		}
-
-		@Override
-		public int getValue() {
-			return value;
-		}
-
-		@Override
-		public String getOption() {
-			return option;
 		}
 	}
 

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/WriteChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/WriteChannel.java
@@ -19,6 +19,16 @@ public interface WriteChannel<T> extends Channel<T> {
 	}
 
 	/**
+	 * Updates the 'next' write value of Channel from an Enum value.
+	 * 
+	 * @param value
+	 * @throws OpenemsException
+	 */
+	public default void setNextWriteValue(Enum<?> value) throws OpenemsException {
+		this.setNextWriteValueFromObject(value);
+	}
+
+	/**
 	 * Updates the 'next' write value of Channel from an Object value. Use this
 	 * method if the value is not yet in the correct Type. Otherwise use
 	 * setNextWriteValue() directly.
@@ -26,6 +36,15 @@ public interface WriteChannel<T> extends Channel<T> {
 	 * @param value
 	 */
 	public default void setNextWriteValueFromObject(Object value) throws OpenemsException {
+		// Convert Strings to their Enum-Value
+		if (value instanceof String) {
+			try {
+				value = this.channelDoc().getOptionFromEnumString((String) value);
+			} catch (IllegalArgumentException e) {
+				// No enum value with this string; continue with original value
+			}
+		}
+
 		T typedValue = TypeUtils.<T>getAsType(this.getType(), value);
 		// set the write value
 		this._setNextWriteValue(typedValue);

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/doc/Doc.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/doc/Doc.java
@@ -5,29 +5,30 @@ import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
-import com.google.common.base.CaseFormat;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 
 import io.openems.common.types.OpenemsType;
 import io.openems.edge.common.channel.AbstractReadChannel;
 import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.channel.value.Value;
 
 /**
  * Provides static meta information for a {@link Channel} using Builder pattern.
  * 
  * Possible meta information:
  * <ul>
- * <li>access-mode (read-only/read-write/write-only) flag {@link #accessMode(AccessMode)}
+ * <li>access-mode (read-only/read-write/write-only) flag
+ * {@link #accessMode(AccessMode)}
  * <li>expected OpenemsType via {@link #getType()}
  * <li>descriptive text via {@link #getText()}
  * <li>a Unit via {@link #getUnit()}
  * <li>possible named option values as String or Enum via
- * {@link #getOption(String)}, {@link #getOption(int)}, {@link #getOption(Enum)} methods
+ * {@link #getOption(String)}, {@link #getOption(int)}, {@link #getOption(Enum)}
+ * methods
  * <li>importance {@link Level} via {@link #getLevel()}
  * <li>is debug mode activated via {@link #isDebug()}
- * <li>callback on initialisation of a Channel via
- * {@link #getOnInitCallback()}
+ * <li>callback on initialisation of a Channel via {@link #getOnInitCallback()}
  * </ul>
  */
 public class Doc {
@@ -119,35 +120,31 @@ public class Doc {
 	}
 
 	/*
-	 * Options. Value is either a String or an Enum.
+	 * Options.
 	 */
-	private BiMap<Integer, Object> options = HashBiMap.create();
+	private BiMap<Integer, OptionsEnum> options = HashBiMap.create();
 
-	public boolean hasOptions() {
-		return this.options.size() > 0;
-	}
-
-	public Doc option(int value, Enum<?> option) {
-		this.options.put(value, option);
-		return this;
-	}
-
-	public Doc option(Enum<?> option) {
-		this.options.put(option.ordinal(), option);
-		// this.options.put(option.ordinal(), option.name());
-		return this;
-	}
-
+	/**
+	 * Set the possible options using an OptionsEnum
+	 * 
+	 * @param options
+	 * @return
+	 */
 	public Doc options(Enum<? extends OptionsEnum>[] options) {
 		for (Enum<? extends OptionsEnum> option : options) {
-			this.option(((OptionsEnum) option).getValue(), option);
+			OptionsEnum o = (OptionsEnum) option;
+			this.options.put(o.getValue(), o);
 		}
 		return this;
 	}
 
-	public Doc option(int value, String option) {
-		this.options.put(value, option);
-		return this;
+	/**
+	 * Gets whether this Doc has registered Options
+	 * 
+	 * @return
+	 */
+	public boolean hasOptions() {
+		return !this.options.isEmpty();
 	}
 
 	/**
@@ -157,67 +154,49 @@ public class Doc {
 	 * @param name
 	 * @return
 	 */
-	public int getOption(String name) {
-		Integer value = this.options.inverse().get(name);
+	public int getOptionFromEnumString(String name) {
+		for (OptionsEnum e : this.options.values()) {
+			if (e.getName().equalsIgnoreCase(name)) {
+				return e.getValue();
+			}
+		}
+		throw new IllegalArgumentException(
+				"Channel has no option [" + name + "]! Existing options: " + this.options.values());
+	}
+
+	/**
+	 * Get the Option Enum.
+	 * 
+	 * @param value
+	 * @return
+	 */
+	public OptionsEnum getOption(Integer value) {
+		if (this.options.isEmpty()) {
+			return null;
+		}
+		OptionsEnum undefined = this.options.values().iterator().next().getUndefined();
 		if (value == null) {
-			throw new IllegalArgumentException(
-					"Channel has no option [" + name + "]! Existing options: " + this.options.values());
+			return undefined;
 		}
-		return value;
+		OptionsEnum option = this.options.get(value);
+		if (option == null) {
+			return undefined;
+		}
+		return option;
 	}
 
 	/**
-	 * Get the Option value. Throws IllegalArgumentException if there is no option
-	 * with that name
-	 * 
-	 * @param nameEnum
-	 * @return
-	 */
-	public int getOption(Enum<?> nameEnum) {
-		Integer value = this.options.inverse().get(nameEnum);
-		if (value != null) {
-			return value;
-		}
-		return this.getOption(nameEnum.name());
-	}
-
-	/**
-	 * Get the Option name. Throws IllegalArgumentException if there is no option
-	 * with that value
+	 * Get the Option name or Undefined if there is no option with that value
 	 * 
 	 * @param value
 	 * @return
 	 */
-	public String getOption(int value) {
-		Object option = this.options.get(value);
+	public String getOptionString(Integer value) {
+		OptionsEnum option = this.getOption(value);
 		if (option == null) {
-			throw new IllegalArgumentException(
-					"Channel has no option value [" + value + "]! Existing options: " + this.options.values());
+			return Value.UNDEFINED_VALUE_STRING;
 		}
-		if (option instanceof Enum<?>) {
-			return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, ((Enum<?>) option).name());
-		}
-		return option.toString();
-	}
-
-	/**
-	 * Get the Option Enum. Throws IllegalArgumentException if there is no Enum
-	 * option with that value
-	 * 
-	 * @param value
-	 * @return
-	 */
-	public Enum<?> getOptionEnum(int value) {
-		Object option = this.options.get(value);
-		if (option == null) {
-			throw new IllegalArgumentException(
-					"Channel has no option value [" + value + "]! Existing options: " + this.options.values());
-		}
-		if (!(option instanceof Enum<?>)) {
-			throw new IllegalArgumentException(
-					"Channel has no Enum option value [" + value + "]! Existing options: " + this.options.values());
-		}
-		return (Enum<?>) option;
+		return option.getName();
 	}
 
 	/*

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/doc/Level.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/doc/Level.java
@@ -3,16 +3,32 @@ package io.openems.edge.common.channel.doc;
 /**
  * Severity/visibility Level
  */
-public enum Level {
-	INFO(1), WARNING(2), FAULT(3);
-	
+public enum Level implements OptionsEnum {
+	OK(0, "Ok"), //
+	INFO(1, "Info"), //
+	WARNING(2, "Warning"), //
+	FAULT(3, "Fault");
+
 	private final int value;
-	
-	private Level(int value) {
+	private final String name;
+
+	private Level(int value, String name) {
 		this.value = value;
+		this.name = name;
 	}
-	
+
+	@Override
 	public int getValue() {
 		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return OK;
 	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/doc/OptionsEnum.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/doc/OptionsEnum.java
@@ -2,7 +2,33 @@ package io.openems.edge.common.channel.doc;
 
 public interface OptionsEnum {
 
+	/**
+	 * Gets this enums int representation.
+	 * 
+	 * @return
+	 */
 	int getValue();
-	
-	String getOption();
+
+	/**
+	 * Gets this enums String representation.
+	 * 
+	 * @return
+	 */
+	String getName();
+
+	/**
+	 * Gets the enum that is used for 'UNDEFINED' values
+	 * 
+	 * @return
+	 */
+	OptionsEnum getUndefined();
+
+	/**
+	 * Gets whether the current enum represents the 'UNDEFINED' value
+	 * 
+	 * @return
+	 */
+	public default boolean isUndefined() {
+		return this.equals(this.getUndefined());
+	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/value/Value.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/value/Value.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonElement;
 import io.openems.common.exceptions.InvalidValueException;
 import io.openems.common.types.OpenemsType;
 import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.channel.doc.OptionsEnum;
 import io.openems.edge.common.type.TypeUtils;
 
 /**
@@ -38,7 +39,11 @@ public class Value<T> {
 
 	public String toString() {
 		if (this.value == null) {
-			return UNDEFINED_VALUE_STRING;
+			if (this.parent.channelDoc().hasOptions()) {
+				return this.parent.channelDoc().getOptionString(null);
+			} else {
+				return UNDEFINED_VALUE_STRING;
+			}
 		} else {
 			return this.parent.channelDoc().getUnit().format(this.value, this.parent.getType());
 		}
@@ -104,13 +109,18 @@ public class Value<T> {
 	 * @throws IllegalArgumentException no matching option existing
 	 * @return
 	 */
-	public String asOptionString() throws IllegalArgumentException {
+	public String asOptionString() {
 		T value = this.get();
-		if (value == null) {
-			return Value.UNDEFINED_VALUE_STRING;
+		try {
+			Integer intValue = TypeUtils.<Integer>getAsType(OpenemsType.INTEGER, value);
+			return this.parent.channelDoc().getOptionString(intValue);
+		} catch (IllegalArgumentException e) {
+			if (this.parent.channelDoc().hasOptions()) {
+				return this.parent.channelDoc().getOptionString(null);
+			} else {
+				return "";
+			}
 		}
-		int intValue = TypeUtils.<Integer>getAsType(OpenemsType.INTEGER, value);
-		return this.parent.channelDoc().getOption(intValue);
 	}
 
 	/**
@@ -120,22 +130,17 @@ public class Value<T> {
 	 * @return
 	 * @throws InvalidValueException
 	 */
-	public Enum<?> asEnum() throws InvalidValueException {
+	@SuppressWarnings("unchecked")
+	public <O extends OptionsEnum> O asEnum() {
 		T value = this.get();
-		int intValue = TypeUtils.<Integer>getAsType(OpenemsType.INTEGER, value);
-		return this.parent.channelDoc().getOptionEnum(intValue);
-	}
-
-	/**
-	 * Gets the value as an Optional enum
-	 * 
-	 * @return
-	 */
-	public Optional<Enum<?>> asEnumOptional() {
+		if (value == null) {
+			return (O) this.parent.channelDoc().getOption(null);
+		}
 		try {
-			return Optional.ofNullable(asEnum());
-		} catch (Exception e) { // if there is null in asEnum a NullPointerException is thrown
-			return Optional.empty();
+			int intValue = TypeUtils.<Integer>getAsType(OpenemsType.INTEGER, value);
+			return (O) this.parent.channelDoc().getOption(intValue);
+		} catch (Exception e) {
+			return (O) this.parent.channelDoc().getOption(null);
 		}
 	}
 

--- a/io.openems.edge.common/src/io/openems/edge/common/component/OpenemsComponent.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/OpenemsComponent.java
@@ -26,7 +26,8 @@ import io.openems.edge.common.channel.doc.Level;
  * <li>an enabled/disabled state (see {@link #isEnabled()})
  * <li>an OSGi service PID (see {@link #servicePid()}
  * <li>Channels (see {@link Channel}), identified by {@link ChannelId} or
- * String-ID and provided via {@link #channel(String)}, {@link #channel(io.openems.edge.common.channel.doc.ChannelId)} and
+ * String-ID and provided via {@link #channel(String)},
+ * {@link #channel(io.openems.edge.common.channel.doc.ChannelId)} and
  * {@link #channels()}
  * <li>a kind of 'toString' method which provides the most important info about
  * the component. (see {@link #debugLog()})
@@ -120,11 +121,7 @@ public interface OpenemsComponent {
 
 	public enum ChannelId implements io.openems.edge.common.channel.doc.ChannelId {
 		// Running State of the component. Keep values in sync with 'Level' enum!
-		STATE(new Doc().unit(Unit.NONE) //
-				.option(0, "Ok") //
-				.option(1, Level.INFO) //
-				.option(2, Level.WARNING) //
-				.option(3, Level.FAULT));
+		STATE(new Doc().unit(Unit.NONE).options(Level.values()));
 
 		private final Doc doc;
 

--- a/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
@@ -16,7 +16,7 @@ import io.openems.edge.common.channel.value.Value;
 public class TypeUtils {
 
 	@SuppressWarnings("unchecked")
-	public static <T> T getAsType(OpenemsType type, Object value) {
+	public static <T> T getAsType(OpenemsType type, Object value) throws IllegalArgumentException {
 		// Extract Value containers
 		if (value instanceof Value<?>) {
 			value = ((Value<?>) value).get();

--- a/io.openems.edge.common/test/io/openems/edge/common/channel/ChannelId.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/channel/ChannelId.java
@@ -1,0 +1,18 @@
+package io.openems.edge.common.channel;
+
+import io.openems.edge.common.channel.doc.Doc;
+
+public enum ChannelId implements io.openems.edge.common.channel.doc.ChannelId {
+	TEST_CHANNEL_WITH_OPTIONS(new Doc().options(TestOptions.values()));
+
+	private final Doc doc;
+
+	private ChannelId(Doc doc) {
+		this.doc = doc;
+	}
+
+	@Override
+	public Doc doc() {
+		return this.doc;
+	}
+}

--- a/io.openems.edge.common/test/io/openems/edge/common/channel/ChannelTest.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/channel/ChannelTest.java
@@ -1,0 +1,28 @@
+package io.openems.edge.common.channel;
+
+import static org.junit.Assert.*;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.openems.common.exceptions.OpenemsException;
+
+public class ChannelTest {
+
+	@Test
+	public void testWriteEnum() throws OpenemsException {
+		WriteChannel<?> channel = new IntegerWriteChannel(null, ChannelId.TEST_CHANNEL_WITH_OPTIONS);
+
+		// Test write with String
+		channel.setNextWriteValueFromObject("Option 2");
+		Optional<?> writtenValue = channel._getNextWriteValue();
+		assertEquals(TestOptions.OPTION_2.getValue(), writtenValue.get());
+
+		// Test write with Enum
+		channel.setNextWriteValueFromObject(TestOptions.OPTION_1);
+		writtenValue = channel._getNextWriteValue();
+		assertEquals(TestOptions.OPTION_1.getValue(), writtenValue.get());
+	}
+
+}

--- a/io.openems.edge.common/test/io/openems/edge/common/channel/TestOptions.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/channel/TestOptions.java
@@ -1,0 +1,32 @@
+package io.openems.edge.common.channel;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum TestOptions implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	OPTION_1(1, "Option 1"), //
+	OPTION_2(2, "Option 2"); //
+
+	private final int value;
+	private final String name;
+
+	private TestOptions(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.controller.dischargelimitconsideringcellvoltage/src/io/openems/edge/controller/dischargelimitconsideringcellvoltage/DischargeLimitConsideringCellVoltage.java
+++ b/io.openems.edge.controller.dischargelimitconsideringcellvoltage/src/io/openems/edge/controller/dischargelimitconsideringcellvoltage/DischargeLimitConsideringCellVoltage.java
@@ -316,13 +316,12 @@ public class DischargeLimitConsideringCellVoltage extends AbstractOpenemsCompone
 	}
 	
 	public enum State implements OptionsEnum {
-		UNDEFINED(0, "Undefined"),
-		INITIALIZING(1, "Initializing"),
-		NO_VALUES_PRESENT(2, "No values present"),
-		NORMAL(3, "Normal"),
-		PENDING(4, "Pending"),
-		CHARGING(5, "Charging"), 
-		;
+		UNDEFINED(-1, "Undefined"), //
+		INITIALIZING(1, "Initializing"), //
+		NO_VALUES_PRESENT(2, "No values present"), //
+		NORMAL(3, "Normal"), //
+		PENDING(4, "Pending"), //
+		CHARGING(5, "Charging");
 
 		@Override
 		public int getValue() {
@@ -330,17 +329,22 @@ public class DischargeLimitConsideringCellVoltage extends AbstractOpenemsCompone
 		}
 
 		@Override
-		public String getOption() {
-			return this.option;
+		public String getName() {
+			return this.name;
 		}
 		
-		State(int value, String option) {
+		State(int value, String name) {
 			this.value = value;
-			this.option = option;
+			this.name = name;
 		}
 		
 		private int value;
-		private String option;		
+		private String name;		
+	
+		@Override
+		public OptionsEnum getUndefined() {
+			return UNDEFINED;
+		}
 	}
 
 }

--- a/io.openems.edge.controller.ess.limittotaldischarge/src/io/openems/edge/controller/ess/limittotaldischarge/LimitTotalDischargeController.java
+++ b/io.openems.edge.controller.ess.limittotaldischarge/src/io/openems/edge/controller/ess/limittotaldischarge/LimitTotalDischargeController.java
@@ -56,14 +56,17 @@ public class LimitTotalDischargeController extends AbstractOpenemsComponent impl
 	private ManagedSymmetricEss ess;
 
 	public enum State implements OptionsEnum {
-		NORMAL(0, "Normal"), MIN_SOC(1, "Min-SoC"), FORCE_CHARGE_SOC(2, "Force-Charge-SoC");
+		UNDEFINED(-1, "Undefined"), //
+		NORMAL(0, "Normal"), //
+		MIN_SOC(1, "Min-SoC"), //
+		FORCE_CHARGE_SOC(2, "Force-Charge-SoC");
 
 		private final int value;
-		private final String option;
+		private final String name;
 
-		private State(int value, String option) {
+		private State(int value, String name) {
 			this.value = value;
-			this.option = option;
+			this.name = name;
 		}
 
 		@Override
@@ -72,8 +75,13 @@ public class LimitTotalDischargeController extends AbstractOpenemsComponent impl
 		}
 
 		@Override
-		public String getOption() {
-			return option;
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public OptionsEnum getUndefined() {
+			return UNDEFINED;
 		}
 	}
 
@@ -138,6 +146,7 @@ public class LimitTotalDischargeController extends AbstractOpenemsComponent impl
 
 		State nextState = this.state;
 		switch (this.state) {
+		case UNDEFINED:
 		case NORMAL:
 			/*
 			 * Normal State

--- a/io.openems.edge.controller.symmetric.balancing/src/io/openems/edge/controller/symmetric/balancing/Balancing.java
+++ b/io.openems.edge.controller.symmetric.balancing/src/io/openems/edge/controller/symmetric/balancing/Balancing.java
@@ -1,7 +1,5 @@
 package io.openems.edge.controller.symmetric.balancing;
 
-import java.util.Optional;
-
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -22,6 +20,7 @@ import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.controller.api.Controller;
 import io.openems.edge.ess.api.ManagedSymmetricEss;
 import io.openems.edge.ess.api.SymmetricEss;
+import io.openems.edge.ess.api.SymmetricEss.GridMode;
 import io.openems.edge.ess.power.api.Phase;
 import io.openems.edge.ess.power.api.PowerException;
 import io.openems.edge.ess.power.api.Pwr;
@@ -76,11 +75,11 @@ public class Balancing extends AbstractOpenemsComponent implements Controller, O
 		/*
 		 * Check that we are On-Grid (and warn on undefined Grid-Mode)
 		 */
-		Optional<Enum<?>> gridMode = this.ess.getGridMode().value().asEnumOptional();
-		if (gridMode.orElse(SymmetricEss.GridMode.UNDEFINED) == SymmetricEss.GridMode.UNDEFINED) {
-			this.logWarn(this.log, "Grid-Mode is [" + gridMode + "]");
+		GridMode gridMode = this.ess.getGridMode().value().asEnum();
+		if (gridMode.isUndefined()) {
+			this.logWarn(this.log, "Grid-Mode is [UNDEFINED]");
 		}
-		if (gridMode.orElse(SymmetricEss.GridMode.UNDEFINED) != SymmetricEss.GridMode.ON_GRID) {
+		if (gridMode != SymmetricEss.GridMode.ON_GRID) {
 			return;
 		}
 		/*

--- a/io.openems.edge.controller.symmetric.peakshaving/src/io/openems/edge/controller/symmetric/peakshaving/PeakShaving.java
+++ b/io.openems.edge.controller.symmetric.peakshaving/src/io/openems/edge/controller/symmetric/peakshaving/PeakShaving.java
@@ -1,7 +1,5 @@
 package io.openems.edge.controller.symmetric.peakshaving;
 
-import java.util.Optional;
-
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -21,6 +19,7 @@ import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.controller.api.Controller;
 import io.openems.edge.ess.api.ManagedSymmetricEss;
 import io.openems.edge.ess.api.SymmetricEss;
+import io.openems.edge.ess.api.SymmetricEss.GridMode;
 import io.openems.edge.ess.power.api.Phase;
 import io.openems.edge.ess.power.api.Power;
 import io.openems.edge.ess.power.api.PowerException;
@@ -88,11 +87,11 @@ public class PeakShaving extends AbstractOpenemsComponent implements Controller,
 		/*
 		 * Check that we are On-Grid (and warn on undefined Grid-Mode)
 		 */
-		Optional<Enum<?>> gridMode = this.ess.getGridMode().value().asEnumOptional();
-		if (gridMode.orElse(SymmetricEss.GridMode.UNDEFINED) == SymmetricEss.GridMode.UNDEFINED) {
-			this.logWarn(this.log, "Grid-Mode is [" + gridMode + "]");
+		GridMode gridMode = this.ess.getGridMode().value().asEnum();
+		if (gridMode.isUndefined()) {
+			this.logWarn(this.log, "Grid-Mode is [UNDEFINED]");
 		}
-		if (gridMode.orElse(SymmetricEss.GridMode.UNDEFINED) != SymmetricEss.GridMode.ON_GRID) {
+		if (gridMode != SymmetricEss.GridMode.ON_GRID) {
 			return;
 		}
 

--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/api/Phase.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/api/Phase.java
@@ -3,7 +3,10 @@ package io.openems.edge.ess.api;
 import io.openems.edge.common.channel.doc.OptionsEnum;
 
 public enum Phase implements OptionsEnum {
-	L1("L1", 1), L2("L2", 2), L3("L3", 3);
+	UNDEFINED("Undefined", -1), //
+	L1("L1", 1), //
+	L2("L2", 2), //
+	L3("L3", 3);
 
 	private final String symbol;
 	private final int value;
@@ -23,7 +26,12 @@ public enum Phase implements OptionsEnum {
 	}
 
 	@Override
-	public String getOption() {
+	public String getName() {
 		return this.symbol;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
 	}
 }

--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/api/SymmetricEss.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/api/SymmetricEss.java
@@ -17,16 +17,16 @@ public interface SymmetricEss extends OpenemsComponent {
 	public final static String POWER_DOC_TEXT = "Negative values for Charge; positive for Discharge";
 
 	public enum GridMode implements OptionsEnum {
-		UNDEFINED(0, "Undefined"), //
+		UNDEFINED(-1, "Undefined"), //
 		ON_GRID(1, "On-Grid"), //
 		OFF_GRID(2, "Off-Grid");
 
 		private int value;
-		private String option;
+		private String name;
 
-		private GridMode(int value, String option) {
+		private GridMode(int value, String name) {
 			this.value = value;
-			this.option = option;
+			this.name = name;
 		}
 
 		@Override
@@ -35,8 +35,13 @@ public interface SymmetricEss extends OpenemsComponent {
 		}
 
 		@Override
-		public String getOption() {
-			return option;
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public OptionsEnum getUndefined() {
+			return UNDEFINED;
 		}
 	}
 

--- a/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/BatteryMaintenanceState.java
+++ b/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/BatteryMaintenanceState.java
@@ -1,0 +1,32 @@
+package io.openems.edge.ess.fenecon.commercial40;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum BatteryMaintenanceState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	OFF(0, "Off"), //
+	ON(1, "On"); //
+
+	private final int value;
+	private final String name;
+
+	private BatteryMaintenanceState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/BatteryStringSwitchState.java
+++ b/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/BatteryStringSwitchState.java
@@ -1,0 +1,35 @@
+package io.openems.edge.ess.fenecon.commercial40;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum BatteryStringSwitchState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	MAIN_CONTATCTOR(1, "Main contactor"), //
+	PRECHARGE_CONTACTOR(2, "Precharge contactor"), //
+	FAN_CONTACTOR(4, "FAN contactor"), //
+	BMU_POWER_SUPPLY_RELAY(8, "BMU power supply relay"), //
+	MIDDLE_RELAY(16, "Middle relay");
+
+	private final int value;
+	private final String name;
+
+	private BatteryStringSwitchState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/BmsDcdcWorkMode.java
+++ b/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/BmsDcdcWorkMode.java
@@ -1,0 +1,33 @@
+package io.openems.edge.ess.fenecon.commercial40;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum BmsDcdcWorkMode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	CONSTANT_CURRENT(128, "Constant Current"), //
+	CONSTANT_VOLTAGE(256, "Constant Voltage"), //
+	BOOST_MPPT(512, "Boost MPPT"); //
+
+	private final int value;
+	private final String name;
+
+	private BmsDcdcWorkMode(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/BmsDcdcWorkState.java
+++ b/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/BmsDcdcWorkState.java
@@ -1,0 +1,37 @@
+package io.openems.edge.ess.fenecon.commercial40;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum BmsDcdcWorkState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	INITIAL(2, "Initial"), //
+	STOP(4, "Stop"), //
+	READY(8, "Ready"), //
+	RUNNING(16, "Running"), //
+	FAULT(32, "Fault"), //
+	DEBUG(64, "Debug"), //
+	LOCKED(128, "Locked"); //
+
+	private final int value;
+	private final String name;
+
+	private BmsDcdcWorkState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/ControlMode.java
+++ b/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/ControlMode.java
@@ -1,0 +1,32 @@
+package io.openems.edge.ess.fenecon.commercial40;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum ControlMode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	REMOTE(1, "Remote"), //
+	LOCAL(2, "Local"); //
+
+	private final int value;
+	private final String name;
+
+	private ControlMode(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/EssFeneconCommercial40.java
+++ b/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/EssFeneconCommercial40.java
@@ -119,10 +119,6 @@ public class EssFeneconCommercial40 extends AbstractOpenemsModbusComponent
 		return modbusBridgeId;
 	}
 
-	private enum SetWorkState {
-		STOP, STANDBY, START
-	}
-
 	public enum ChannelId implements io.openems.edge.common.channel.doc.ChannelId {
 		ORIGINAL_ALLOWED_CHARGE_POWER(new Doc() //
 				.onInit(channel -> { //
@@ -168,39 +164,14 @@ public class EssFeneconCommercial40 extends AbstractOpenemsModbusComponent
 						currentValueChannel.setNextValue(value);
 					});
 				})), //
-		SYSTEM_STATE(new Doc() //
-				.option(2, "Stop") //
-				.option(4, "PV-Charge") //
-				.option(8, "Standby") //
-				.option(16, "Start") //
-				.option(32, "Fault") //
-				.option(64, "Debug")), //
-		CONTROL_MODE(new Doc() //
-				.option(1, "Remote") //
-				.option(2, "Local")), //
-		BATTERY_MAINTENANCE_STATE(new Doc() //
-				.option(0, "Off") //
-				.option(1, "On")), //
-		INVERTER_STATE(new Doc() //
-				.option(0, "Init") //
-				.option(2, "Fault") //
-				.option(4, "Stop") //
-				.option(8, "Standby") //
-				.option(16, "Grid-Monitor") // ,
-				.option(32, "Ready") //
-				.option(64, "Start") //
-				.option(128, "Debug")), //
+		SYSTEM_STATE(new Doc().options(SystemState.values())), //
+		CONTROL_MODE(new Doc().options(ControlMode.values())), //
+		BATTERY_MAINTENANCE_STATE(new Doc().options(BatteryMaintenanceState.values())), //
+		INVERTER_STATE(new Doc().options(InverterState.values())), //
 		PROTOCOL_VERSION(new Doc()), //
-		SYSTEM_MANUFACTURER(new Doc() //
-				.option(1, "BYD")), //
-		SYSTEM_TYPE(new Doc() //
-				.option(1, "CESS")), //
-		BATTERY_STRING_SWITCH_STATE(new Doc() //
-				.option(1, "Main contactor") //
-				.option(2, "Precharge contactor") //
-				.option(4, "FAN contactor") //
-				.option(8, "BMU power supply relay") //
-				.option(16, "Middle relay")), //
+		SYSTEM_MANUFACTURER(new Doc().options(SystemManufacturer.values())), //
+		SYSTEM_TYPE(new Doc().options(SystemType.values())), //
+		BATTERY_STRING_SWITCH_STATE(new Doc().options(BatteryStringSwitchState.values())), //
 		BATTERY_VOLTAGE(new Doc().unit(Unit.MILLIVOLT)), //
 		BATTERY_CURRENT(new Doc().unit(Unit.MILLIAMPERE)), //
 		BATTERY_POWER(new Doc().unit(Unit.WATT)), //
@@ -225,25 +196,12 @@ public class EssFeneconCommercial40 extends AbstractOpenemsModbusComponent
 		IPM_TEMPERATURE_L2(new Doc().unit(Unit.DEGREE_CELSIUS)), //
 		IPM_TEMPERATURE_L3(new Doc().unit(Unit.DEGREE_CELSIUS)), //
 		TRANSFORMER_TEMPERATURE_L2(new Doc().unit(Unit.DEGREE_CELSIUS)), //
-		SET_WORK_STATE(new Doc() //
-				.option(4, SetWorkState.STOP) //
-				.option(32, SetWorkState.STANDBY) //
-				.option(64, SetWorkState.START)), //
+		SET_WORK_STATE(new Doc().options(SetWorkState.values())), //
 		SET_ACTIVE_POWER(new Doc().unit(Unit.WATT)), //
 		SET_REACTIVE_POWER(new Doc().unit(Unit.VOLT_AMPERE_REACTIVE)), //
 		SET_PV_POWER_LIMIT(new Doc().unit(Unit.WATT)), //
-		BMS_DCDC_WORK_STATE(new Doc() //
-				.option(2, "Initial") //
-				.option(4, "Stop") //
-				.option(8, "Ready") //
-				.option(16, "Running") //
-				.option(32, "Fault") //
-				.option(64, "Debug") //
-				.option(128, "Locked")), //
-		BMS_DCDC_WORK_MODE(new Doc() //
-				.option(128, "Constant Current") //
-				.option(256, "Constant Voltage") //
-				.option(512, "Boost MPPT")), //
+		BMS_DCDC_WORK_STATE(new Doc().options(BmsDcdcWorkState.values())), //
+		BMS_DCDC_WORK_MODE(new Doc().options(BmsDcdcWorkMode.values())), //
 		STATE_0(new Doc().level(Level.WARNING).text("Emergency Stop")), //
 		STATE_1(new Doc().level(Level.WARNING).text("Key Manual Stop")), //
 		STATE_2(new Doc().level(Level.WARNING).text("Transformer Phase B Temperature Sensor Invalidation")), //
@@ -733,8 +691,7 @@ public class EssFeneconCommercial40 extends AbstractOpenemsModbusComponent
 			this.lastDefineWorkState = now;
 			IntegerWriteChannel setWorkStateChannel = this.channel(ChannelId.SET_WORK_STATE);
 			try {
-				int startOption = setWorkStateChannel.channelDoc().getOption(SetWorkState.START);
-				setWorkStateChannel.setNextWriteValue(startOption);
+				setWorkStateChannel.setNextWriteValue(SetWorkState.START);
 			} catch (OpenemsException e) {
 				logError(this.log, "Unable to start: " + e.getMessage());
 			}

--- a/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/InverterState.java
+++ b/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/InverterState.java
@@ -1,0 +1,38 @@
+package io.openems.edge.ess.fenecon.commercial40;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum InverterState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	INIT(0, "Init"), //
+	FAULT(2, "Fault"), //
+	STOP(4, "Stop"), //
+	STANDBY(8, "Standby"), //
+	GRID_MONITOR(16, "Grid-Monitor"), //
+	READY(32, "Ready"), //
+	START(64, "Start"), //
+	DEBUG(128, "Debug"); //
+
+	private final int value;
+	private final String name;
+
+	private InverterState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/SetWorkState.java
+++ b/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/SetWorkState.java
@@ -1,0 +1,33 @@
+package io.openems.edge.ess.fenecon.commercial40;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum SetWorkState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	START(4, "Start"), //
+	STANDBY(32, "Standby"), //
+	STOP(64, "Stop");
+
+	private final int value;
+	private final String name;
+
+	private SetWorkState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/SystemManufacturer.java
+++ b/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/SystemManufacturer.java
@@ -1,0 +1,31 @@
+package io.openems.edge.ess.fenecon.commercial40;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum SystemManufacturer implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	BYD(1, "BYD");
+
+	private final int value;
+	private final String name;
+
+	private SystemManufacturer(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/SystemState.java
+++ b/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/SystemState.java
@@ -1,0 +1,36 @@
+package io.openems.edge.ess.fenecon.commercial40;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum SystemState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	STARTING(2, "Stop"), //
+	PV_CHARGE(4, "PV-Charge"), //
+	STANDBY(8, "Standby"), //
+	START(16, "Start"), //
+	FAULT(32, "Fault"), //
+	DEBUG(64, "Debug");
+
+	private final int value;
+	private final String name;
+
+	private SystemState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/SystemType.java
+++ b/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/SystemType.java
@@ -1,0 +1,31 @@
+package io.openems.edge.ess.fenecon.commercial40;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum SystemType implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	CESS(1, "CESS"); //
+
+	private final int value;
+	private final String name;
+
+	private SystemType(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.kaco.blueplanet.gridsave50/src/io/openems/edge/ess/kaco/blueplanet/gridsave50/CurrentState.java
+++ b/io.openems.edge.ess.kaco.blueplanet.gridsave50/src/io/openems/edge/ess/kaco/blueplanet/gridsave50/CurrentState.java
@@ -3,7 +3,7 @@ package io.openems.edge.ess.kaco.blueplanet.gridsave50;
 import io.openems.edge.common.channel.doc.OptionsEnum;
 
 public enum CurrentState implements OptionsEnum {
-	OFF(1, "Off"), // directly addressable
+	UNDEFINED(-1, "Undefined"), OFF(1, "Off"), // directly addressable
 	STANDBY(8, "Standby"), // directly addressable
 	GRID_CONNECTED(11, "Grid connected"), // directly addressable
 	ERROR(7, "Error"), // can be reached from every state, not directly addressable
@@ -16,12 +16,12 @@ public enum CurrentState implements OptionsEnum {
 	NO_ERROR_PENDING(12, "No error pending"), // State when system goes from ERROR to OFF, not directly addressable
 	THROTTLED(5, "Throttled"); // State that can occur when system is GRID_CONNECTED, not directly addressable
 
-	int value;
-	String option;
+	private final int value;
+	private final String name;
 
-	private CurrentState(int value, String option) {
+	private CurrentState(int value, String name) {
 		this.value = value;
-		this.option = option;
+		this.name = name;
 	}
 
 	@Override
@@ -30,7 +30,12 @@ public enum CurrentState implements OptionsEnum {
 	}
 
 	@Override
-	public String getOption() {
-		return option;
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
 	}
 }

--- a/io.openems.edge.ess.kaco.blueplanet.gridsave50/src/io/openems/edge/ess/kaco/blueplanet/gridsave50/ErrorCode.java
+++ b/io.openems.edge.ess.kaco.blueplanet.gridsave50/src/io/openems/edge/ess/kaco/blueplanet/gridsave50/ErrorCode.java
@@ -3,6 +3,7 @@ package io.openems.edge.ess.kaco.blueplanet.gridsave50;
 import io.openems.edge.common.channel.doc.OptionsEnum;
 
 public enum ErrorCode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"),
 	WAITING_FOR_FEED_IN(1, "Self-test: Grid parameters and generator voltage are being checked"),
 	BATTERY_VOLTAGE_TOO_LOW(2, "Battery Voltage too low! Transition from or to 'Standby'"),
 	YIELD_COUNTER_FOR_DAILY(4, "Yield counter for daily and annual yields are displayed"),
@@ -113,8 +114,7 @@ public enum ErrorCode implements OptionsEnum {
 	BATTERY_DISCONNECTED(198,
 			"Battery disconnected Connection to the battery disconnected. Check connection. The battery voltage may be outside the parameterised battery limits."),
 	BATTERY_CONSTRAINTS_MISSING(199, "Battery constraints are missing // Batteriegrenzen nicht vorhanden"),
-	WAITING_FOR_FAULT_ACKNOWLEDGEMENT(215,
-			"Waiting for fault acknowledgement by EMS"),
+	WAITING_FOR_FAULT_ACKNOWLEDGEMENT(215, "Waiting for fault acknowledgement by EMS"),
 	PRECHARGE_UNIT_FAULT(218, "Precharge unit fault Precharge unit: Group fault for precharge unit"),
 	READY_FOR_PRECHARGING(219, "Ready for precharging Precharge unit: Ready for precharging"),
 	PRECHARGE_PRECHARGE_UNIT(220, "Precharge Precharge unit: Precharge process being carried out"),
@@ -122,11 +122,11 @@ public enum ErrorCode implements OptionsEnum {
 			"Wait for cooldown time Precharge unit: Precharge resistance requires time to cool down");
 
 	private final int value;
-	private final String option;
+	private final String name;
 
-	private ErrorCode(int value, String option) {
+	private ErrorCode(int value, String name) {
 		this.value = value;
-		this.option = option;
+		this.name = name;
 	}
 
 	@Override
@@ -135,7 +135,12 @@ public enum ErrorCode implements OptionsEnum {
 	}
 
 	@Override
-	public String getOption() {
-		return option;
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
 	}
 }

--- a/io.openems.edge.ess.kaco.blueplanet.gridsave50/src/io/openems/edge/ess/kaco/blueplanet/gridsave50/EssKacoBlueplanetGridsave50.java
+++ b/io.openems.edge.ess.kaco.blueplanet.gridsave50/src/io/openems/edge/ess/kaco/blueplanet/gridsave50/EssKacoBlueplanetGridsave50.java
@@ -207,11 +207,7 @@ public class EssKacoBlueplanetGridsave50 extends AbstractOpenemsModbusComponent
 		setWatchdog();
 
 		IntegerReadChannel currentStateChannel = this.channel(ChannelId.CURRENT_STATE);
-		Optional<Enum<?>> currentStateOpt = currentStateChannel.value().asEnumOptional();
-		if (!currentStateOpt.isPresent()) {
-			return;
-		}
-		CurrentState currentState = (CurrentState) currentStateOpt.get();
+		CurrentState currentState = currentStateChannel.value().asEnum();
 		switch (currentState) {
 		case OFF:
 			doOffHandling();
@@ -232,6 +228,7 @@ public class EssKacoBlueplanetGridsave50 extends AbstractOpenemsModbusComponent
 		case STARTING:
 		case THROTTLED:
 		case CURRENTLY_UNKNOWN:
+		case UNDEFINED:
 			// Do nothing because these states are only temporarily reached
 			break;
 		}

--- a/io.openems.edge.ess.kaco.blueplanet.gridsave50/src/io/openems/edge/ess/kaco/blueplanet/gridsave50/RequestedState.java
+++ b/io.openems.edge.ess.kaco.blueplanet.gridsave50/src/io/openems/edge/ess/kaco/blueplanet/gridsave50/RequestedState.java
@@ -7,11 +7,11 @@ public enum RequestedState implements OptionsEnum {
 	OFF(1, "Off"), STANDBY(8, "Standby"), GRID_CONNECTED(11, "Grid connected");
 
 	int value;
-	String option;
+	String name;
 
-	private RequestedState(int value, String option) {
+	private RequestedState(int value, String name) {
 		this.value = value;
-		this.option = option;
+		this.name = name;
 	}
 
 	@Override
@@ -20,7 +20,12 @@ public enum RequestedState implements OptionsEnum {
 	}
 
 	@Override
-	public String getOption() {
-		return option;
+	public String getName() {
+		return name;
+	}
+	
+	@Override
+	public OptionsEnum getUndefined() {
+		return CurrentState.UNDEFINED;
 	}
 }

--- a/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/Command.java
+++ b/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/Command.java
@@ -2,18 +2,22 @@ package io.openems.edge.ess.mr.gridcon.enums;
 
 import io.openems.edge.common.channel.doc.OptionsEnum;
 
-public enum Command implements OptionsEnum { // see manual(Betriebsanleitung Feldbus Konfiguration (Anybus-Modul)) page 15
-	PLAY(1, "Start active filter"),
-	PAUSE(2, "Set outgoing current of ACF to zero"),
-	ACKNOWLEDGE(4, "Achnowledge errors"),
+/*
+ * see manual (Betriebsanleitung Feldbus Konfiguration (Anybus-Modul)) page 15
+ */
+public enum Command implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	PLAY(1, "Start active filter"), //
+	PAUSE(2, "Set outgoing current of ACF to zero"), //
+	ACKNOWLEDGE(4, "Achnowledge errors"), //
 	STOP(8, "Switch off");
 
 	int value;
-	String option;
+	String name;
 
-	private Command(int value, String option) {
+	private Command(int value, String name) {
 		this.value = value;
-		this.option = option;
+		this.name = name;
 	}
 
 	@Override
@@ -22,7 +26,12 @@ public enum Command implements OptionsEnum { // see manual(Betriebsanleitung Fel
 	}
 
 	@Override
-	public String getOption() {
-		return option;
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
 	}
 }

--- a/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/CurrentState.java
+++ b/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/CurrentState.java
@@ -4,22 +4,23 @@ import io.openems.edge.common.channel.doc.OptionsEnum;
 
 // TODO numbers are not correctly
 public enum CurrentState implements OptionsEnum { // see Software manual chapter 5.1
-	OFFLINE(1, "Offline"),
-	INIT(2, "Init"),
-	IDLE(3, "Idle"),
-	PRECHARGE(4, "Precharge"),
-	STOP_PRECHARGE(5, "Stop precharge"),
-	ECO(6, "Eco"),
-	PAUSE(7, "Pause"),
-	RUN(8, "Run"),
+	UNDEFINED(-1, "Undefined"), //
+	OFFLINE(1, "Offline"), //
+	INIT(2, "Init"), //
+	IDLE(3, "Idle"), //
+	PRECHARGE(4, "Precharge"), //
+	STOP_PRECHARGE(5, "Stop precharge"), //
+	ECO(6, "Eco"), //
+	PAUSE(7, "Pause"), //
+	RUN(8, "Run"), //
 	ERROR(99, "Error");
 
-	int value;
-	String option;
+	private final int value;
+	private final String name;
 
-	private CurrentState(int value, String option) {
+	private CurrentState(int value, String name) {
 		this.value = value;
-		this.option = option;
+		this.name = name;
 	}
 
 	@Override
@@ -28,7 +29,12 @@ public enum CurrentState implements OptionsEnum { // see Software manual chapter
 	}
 
 	@Override
-	public String getOption() {
-		return option;
+	public String getName() {
+		return name;
+	}
+	
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
 	}
 }

--- a/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/ErrorCode.java
+++ b/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/ErrorCode.java
@@ -3,6 +3,7 @@ package io.openems.edge.ess.mr.gridcon.enums;
 import io.openems.edge.common.channel.doc.OptionsEnum;
 
 public enum ErrorCode implements OptionsEnum {
+	UNDEFINED("", "", "", 0,0,0,0, "Undefined", "", "", false), //
 
 	TEMP_TRIP_IGBT_3_IPU_1_0x20_2_0("Hardware", "IPU", "MCU", 0x20,0,2,1, "Temp Trip IGBT 3", "RESTART", "SHUTDOWN", false),
 	TEMP_TRIP_IGBT_2_IPU_1_0x20_2_1("Hardware", "IPU", "MCU", 0x20,1,2,1, "Temp Trip IGBT 2", "RESTART", "SHUTDOWN", false),
@@ -866,10 +867,7 @@ public enum ErrorCode implements OptionsEnum {
 	SOC_FULL("ESS", "Rack", "Modbus", 0x04,12,3,0, "Rack Charge Completed", "", "INFO", false),
 	SENSOR_COMMUNICATION_FAULT("ESS", "Rack", "Modbus", 0x04,13,3,0, "Warning: Current Sensor Communication Fault", "", "WARNING", false),
 	CHARGE_OVERCURRENT("ESS", "Rack", "Modbus", 0x04,14,3,0, "Warning: Charge Current Limit Exceeded", "", "WARNING", false),
-	FAN_FAULT("ESS", "Rack", "Modbus", 0x04,15,3,0, "Warning: Fan Fault", "", "WARNING", false),
-	
-	UNDEFINED("", "", "", 0x00,0,0,0, "", "", "", false),
-	;
+	FAN_FAULT("ESS", "Rack", "Modbus", 0x04,15,3,0, "Warning: Fan Fault", "", "WARNING", false);
 
 	private ErrorCode(String level, String Type, String source, int mainCode, int bit, int b, int iPU, String text,	String autoAcknowledge, String level2, boolean needsHardReset) {
 		this.level = level;
@@ -907,7 +905,7 @@ public enum ErrorCode implements OptionsEnum {
 	}
 
 	@Override
-	public String getOption() {
+	public String getName() {
 		return this.text;
 	}
 
@@ -920,4 +918,8 @@ public enum ErrorCode implements OptionsEnum {
 		return UNDEFINED;
 	}
 
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
 }

--- a/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/PCSControlWordBitPosition.java
+++ b/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/PCSControlWordBitPosition.java
@@ -5,35 +5,35 @@ package io.openems.edge.ess.mr.gridcon.enums;
  * gridcon. The index is based on 0.
  */
 public enum PCSControlWordBitPosition {
-	PLAY(0),
-	READY(1),
-	ACKNOWLEDGE(2),
-	STOP(3),
-	BLACKSTART_APPROVAL(4),
-	SYNC_APPROVAL(5),
-	ACTIVATE_SHORT_CIRCUIT_HANDLING(6),
+	PLAY(0), //
+	READY(1), //
+	ACKNOWLEDGE(2), //
+	STOP(3), //
+	BLACKSTART_APPROVAL(4), //
+	SYNC_APPROVAL(5), //
+	ACTIVATE_SHORT_CIRCUIT_HANDLING(6), //
 	/**
 	 * 1 = current, 0 = voltage
 	 */
-	MODE_SELECTION(7),
-	TRIGGER_SIA(8),
-	ACTIVATE_HARMONIC_COMPENSATION(9),
+	MODE_SELECTION(7), //
+	TRIGGER_SIA(8), //
+	ACTIVATE_HARMONIC_COMPENSATION(9), //
 	/**
 	 * 1 is the value for disable, 0 is the value for enable
 	 */
-	DISABLE_IPU_4(28),
+	DISABLE_IPU_4(28), //
 	/**
 	 * 1 is the value for disable, 0 is the value for enable
 	 */
-	DISABLE_IPU_3(29),
+	DISABLE_IPU_3(29), //
 	/**
 	 * 1 is the value for disable, 0 is the value for enable
 	 */
-	DISABLE_IPU_2(30),
+	DISABLE_IPU_2(30), //
 	/**
 	 * 1 is the value for disable, 0 is the value for enable
 	 */
-	DISABLE_IPU_1(31),;
+	DISABLE_IPU_1(31);
 
 	PCSControlWordBitPosition(int value) {
 		this.bitPosition = value;

--- a/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/PControlMode.java
+++ b/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/PControlMode.java
@@ -3,31 +3,35 @@ package io.openems.edge.ess.mr.gridcon.enums;
 import io.openems.edge.common.channel.doc.OptionsEnum;
 
 public enum PControlMode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
 	DISABLED(1, "Disabled"), // TODO Check values!!!
-	ACTIVE_POWER_CONTROL(1, "Active Power Control Mode"), //TODO maybe inverted word order?!
+	ACTIVE_POWER_CONTROL(1, "Active Power Control Mode"), // TODO maybe inverted word order?!
 	POWER_LIMITER(4, "Power Limiter Mode");
 
-	private float value;
-	String option;
+	private final float value;
+	private final String name;
 
-	private PControlMode(float value, String option) {
+	private PControlMode(float value, String name) {
 		this.value = value;
-		this.option = option;
+		this.name = name;
 	}
 
-	
 	public float getFloatValue() {
 		return value;
 	}
 
 	@Override
-	public String getOption() {
-		return option;
+	public String getName() {
+		return name;
 	}
-
 
 	@Override
 	public int getValue() {
 		return 0;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
 	}
 }

--- a/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/StatusIPUStateMachine.java
+++ b/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/StatusIPUStateMachine.java
@@ -3,24 +3,25 @@ package io.openems.edge.ess.mr.gridcon.enums;
 import io.openems.edge.common.channel.doc.OptionsEnum;
 
 public enum StatusIPUStateMachine implements OptionsEnum {
-	OFFLINE(0, "Offline"),
-	INIT(1, "Init"),
-	IDLE(2, "Idle"),
-	PRECHARGE(3, "Precharge"),
-	GO_IDLE(4, "Go idle"), //TODO are values right?
-	READY(6, "Ready"),
-	RUN(7, "Run"),
-	ERROR(8, "Error"),
-	SIA(14, "SIA"),
-	FRT(15, "FRT"),
+	UNDEFINED(-1, "Undefined"), //
+	OFFLINE(0, "Offline"), //
+	INIT(1, "Init"), //
+	IDLE(2, "Idle"), //
+	PRECHARGE(3, "Precharge"), //
+	GO_IDLE(4, "Go idle"), // TODO are values right?
+	READY(6, "Ready"), //
+	RUN(7, "Run"), //
+	ERROR(8, "Error"), //
+	SIA(14, "SIA"), //
+	FRT(15, "FRT"), //
 	NOT_DEFINED(16, "Not defined");
 
-	int value;
-	String option;
+	private final int value;
+	private final String name;
 
-	private StatusIPUStateMachine(int value, String option) {
+	private StatusIPUStateMachine(int value, String name) {
 		this.value = value;
-		this.option = option;
+		this.name = name;
 	}
 
 	@Override
@@ -29,7 +30,12 @@ public enum StatusIPUStateMachine implements OptionsEnum {
 	}
 
 	@Override
-	public String getOption() {
-		return option;
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
 	}
 }

--- a/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/StatusIPUStatusMCU.java
+++ b/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/StatusIPUStatusMCU.java
@@ -3,31 +3,31 @@ package io.openems.edge.ess.mr.gridcon.enums;
 import io.openems.edge.common.channel.doc.OptionsEnum;
 
 public enum StatusIPUStatusMCU implements OptionsEnum {
-	FAN_MONITOR(1, "Fan monitor"),
-	HARD_TRIP(2, "Hard trip"),
-	WAIT_FOR_ENABLE(3, "Wait for enable"),
-	IDLE(4, "Idle"),
-	WAIT_RPT(5, "Wait RPT"),
-	PRECHARGE(6, "Precharge wait for voltage"),
-	TRIP_PRECHG(7, "Trip, prechg"),
-	PRECHG_WAIT(8, "Prechg wait"),
-	PRECHG_CANCELED(9, "Prechg cancelled"),
-	HS_ON(10, "Hs on"),
-	HS_ON_POST(11, "Ha on post"),
-	READY(12, "Ready extern"),
-	READY_INTERN(13, "Ready intern"),
-	RUN(14, "Run extern"),
-	RUN_INTERN(15, "Run intern"),
-	UNKNOWN_STATE_18(18, "Unknown State"),
-	UNKNOWN_STATE_21(21, "Unknown State")
-	;
+	UNDEFINED(-1, "Undefined"), //
+	FAN_MONITOR(1, "Fan monitor"), //
+	HARD_TRIP(2, "Hard trip"), //
+	WAIT_FOR_ENABLE(3, "Wait for enable"), //
+	IDLE(4, "Idle"), //
+	WAIT_RPT(5, "Wait RPT"), //
+	PRECHARGE(6, "Precharge wait for voltage"), //
+	TRIP_PRECHG(7, "Trip, prechg"), //
+	PRECHG_WAIT(8, "Prechg wait"), //
+	PRECHG_CANCELED(9, "Prechg cancelled"), //
+	HS_ON(10, "Hs on"), //
+	HS_ON_POST(11, "Ha on post"), //
+	READY(12, "Ready extern"), //
+	READY_INTERN(13, "Ready intern"), //
+	RUN(14, "Run extern"), //
+	RUN_INTERN(15, "Run intern"), //
+	UNKNOWN_STATE_18(18, "Unknown State"), //
+	UNKNOWN_STATE_21(21, "Unknown State");
 
-	int value;
-	String option;
+	private final int value;
+	private final String name;
 
-	private StatusIPUStatusMCU(int value, String option) {
+	private StatusIPUStatusMCU(int value, String name) {
 		this.value = value;
-		this.option = option;
+		this.name = name;
 	}
 
 	@Override
@@ -36,7 +36,12 @@ public enum StatusIPUStatusMCU implements OptionsEnum {
 	}
 
 	@Override
-	public String getOption() {
-		return option;
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
 	}
 }

--- a/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/BatteryMode.java
+++ b/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/BatteryMode.java
@@ -1,0 +1,31 @@
+package io.openems.edge.ess.refu;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum BatteryMode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	NORMAL(0, "Normal Mode");
+
+	private final int value;
+	private final String option;
+
+	private BatteryMode(int value, String option) {
+		this.value = value;
+		this.option = option;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return option;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/BatteryState.java
+++ b/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/BatteryState.java
@@ -1,0 +1,36 @@
+package io.openems.edge.ess.refu;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum BatteryState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	INITIAL(0, "Initial"), //
+	STOP(1, "STOP"), //
+	STARTING(2, "Starting"), //
+	START(3, "START"), //
+	STOPPING(4, "Stopping"), //
+	FAULT(5, "Fault");
+
+	private final int value;
+	private final String option;
+
+	private BatteryState(int value, String option) {
+		this.value = value;
+		this.option = option;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return option;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/DcdcStatus.java
+++ b/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/DcdcStatus.java
@@ -1,0 +1,37 @@
+package io.openems.edge.ess.refu;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum DcdcStatus implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	READY_TO_POWER_ON(1, "Ready to Power on"), //
+	READY_FOR_OPERATING(2, "Ready for Operating"), //
+	ENABLED(4, "Enabled"), //
+	DCDC_FAULT(8, "DCDC Fault"), //
+	DCDC_WARNING(128, "DCDC Warning"), //
+	VOLTAGE_CURRENT_MODE(256, "Voltage/Current mode"), //
+	POWER_MODE(512, "Power mode");
+
+	private final int value;
+	private final String option;
+
+	private DcdcStatus(int value, String option) {
+		this.value = value;
+		this.option = option;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return option;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/ErrorHandler.java
+++ b/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/ErrorHandler.java
@@ -1,7 +1,6 @@
 package io.openems.edge.ess.refu;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,13 +45,7 @@ public class ErrorHandler implements Runnable {
 		IntegerReadChannel errorHandlerState = this.parent.channel(ChannelId.ERROR_HANDLER_STATE);
 		errorHandlerState.setNextValue(this.currentSystemStateHandling.getValue());
 
-		Optional<Enum<?>> systemStateOpt = this.parent.channel(ChannelId.SYSTEM_STATE).value().asEnumOptional();
-		SystemState systemState;
-		if (systemStateOpt.isPresent()) {
-			systemState = (SystemState) systemStateOpt.get();
-		} else {
-			systemState = SystemState.UNDEFINED;
-		}
+		SystemState systemState = this.parent.channel(ChannelId.SYSTEM_STATE).value().asEnum();
 		IntegerWriteChannel setWorkStateChannel = this.parent.channel(ChannelId.SET_WORK_STATE);
 		IntegerWriteChannel systemErrorResetChannel = this.parent.channel(ChannelId.SET_SYSTEM_ERROR_RESET);
 

--- a/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/RefuEss.java
+++ b/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/RefuEss.java
@@ -1,7 +1,5 @@
 package io.openems.edge.ess.refu;
 
-import java.util.Optional;
-
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -461,22 +459,11 @@ public class RefuEss extends AbstractOpenemsModbusComponent implements Symmetric
 
 	public enum ChannelId implements io.openems.edge.common.channel.doc.ChannelId {
 		ERROR_HANDLER_STATE(new Doc()), //
-		SYSTEM_STATE(new Doc() //
-				.options(SystemState.values())),
+		SYSTEM_STATE(new Doc().options(SystemState.values())), //
 		INVERTER_ERROR_CODE(new Doc()), //
 		DCDC_ERROR_CODE(new Doc()), //
-
-		SET_WORK_STATE(new Doc() //
-				.options(StopStart.values())),
-
-		DCDC_STATUS(new Doc() //
-				.option(1, "Ready to Power on")//
-				.option(2, "Ready for Operating")//
-				.option(4, "Enabled")//
-				.option(8, "DCDC Fault")//
-				.option(128, "DCDC Warning")//
-				.option(256, "Voltage/Current mode").option(512, "Power mode")), //
-
+		SET_WORK_STATE(new Doc().options(StopStart.values())), //
+		DCDC_STATUS(new Doc().options(DcdcStatus.values())), //
 		BATTERY_VOLTAGE(new Doc().unit(Unit.MILLIVOLT)), //
 		BATTERY_CURRENT(new Doc().unit(Unit.MILLIAMPERE)), //
 		BATTERY_POWER(new Doc().unit(Unit.WATT)), //
@@ -512,23 +499,10 @@ public class RefuEss extends AbstractOpenemsModbusComponent implements Symmetric
 		COS_PHI_L2(new Doc()), //
 		COS_PHI_L3(new Doc()), //
 
-		BATTERY_STATE(new Doc() //
-				.option(0, "Initial")//
-				.option(1, "STOP")//
-				.option(2, "Starting")//
-				.option(3, "START")//
-				.option(4, "Stopping")//
-				.option(5, "Fault")), //
-
-		BATTERY_MODE(new Doc() //
-				.option(0, "Normal Mode")), //
-
-		SET_SYSTEM_ERROR_RESET(new Doc()//
-				.options(StopStart.values())),
-
-		SET_OPERATION_MODE(new Doc()//
-				.option(0, "P/Q Set point")//
-				.option(1, "IAC/cosphi set point")), //
+		BATTERY_STATE(new Doc().options(BatteryState.values())), //
+		BATTERY_MODE(new Doc().options(BatteryMode.values())), //
+		SET_SYSTEM_ERROR_RESET(new Doc().options(StopStart.values())), //
+		SET_OPERATION_MODE(new Doc().options(SetOperationMode.values())), //
 
 		STATE_0(new Doc().level(Level.FAULT).text("BMS In Error")), //
 		STATE_1(new Doc().level(Level.FAULT).text("BMS Overvoltage")), //
@@ -785,13 +759,7 @@ public class RefuEss extends AbstractOpenemsModbusComponent implements Symmetric
 	}
 
 	public Constraint[] getStaticConstraints() {
-		Optional<Enum<?>> systemStateOpt = this.channel(ChannelId.SYSTEM_STATE).value().asEnumOptional();
-		SystemState systemState;
-		if (systemStateOpt.isPresent()) {
-			systemState = (SystemState) systemStateOpt.get();
-		} else {
-			systemState = SystemState.UNDEFINED;
-		}
+		SystemState systemState = this.channel(ChannelId.SYSTEM_STATE).value().asEnum();
 		switch (systemState) {
 		case ERROR:
 		case INIT:

--- a/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/SetOperationMode.java
+++ b/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/SetOperationMode.java
@@ -1,0 +1,32 @@
+package io.openems.edge.ess.refu;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum SetOperationMode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	PQ_SET_POINT(0, "P/Q Set point"), //
+	IAC_COSPHI_SET_POINT(1, "IAC/cosphi set point");
+
+	private final int value;
+	private final String option;
+
+	private SetOperationMode(int value, String option) {
+		this.value = value;
+		this.option = option;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return option;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/StopStart.java
+++ b/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/StopStart.java
@@ -3,6 +3,7 @@ package io.openems.edge.ess.refu;
 import io.openems.edge.common.channel.doc.OptionsEnum;
 
 enum StopStart implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
 	STOP(0, "Stop"), //
 	START(1, "Start");
 
@@ -20,7 +21,12 @@ enum StopStart implements OptionsEnum {
 	}
 
 	@Override
-	public String getOption() {
+	public String getName() {
 		return option;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
 	}
 }

--- a/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/SystemState.java
+++ b/io.openems.edge.ess.refu/src/io/openems/edge/ess/refu/SystemState.java
@@ -25,7 +25,12 @@ enum SystemState implements OptionsEnum {
 	}
 
 	@Override
-	public String getOption() {
+	public String getName() {
 		return option;
 	}
+	
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}	
 }

--- a/io.openems.edge.ess.streetscooter/src/io/openems/edge/ess/streetscooter/InverterMode.java
+++ b/io.openems.edge.ess.streetscooter/src/io/openems/edge/ess/streetscooter/InverterMode.java
@@ -15,11 +15,11 @@ public enum InverterMode implements OptionsEnum {
 	UPDATE_SLAVE(8, "Program update of slave controller");
 
 	private final int value;
-	private final String option;
+	private final String name;
 
-	private InverterMode(int value, String option) {
+	private InverterMode(int value, String name) {
 		this.value = value;
-		this.option = option;
+		this.name = name;
 	}
 
 	@Override
@@ -28,7 +28,12 @@ public enum InverterMode implements OptionsEnum {
 	}
 
 	@Override
-	public String getOption() {
-		return option;
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
 	}
 }

--- a/io.openems.edge.evcs.keba.kecontact/src/io/openems/edge/evcs/keba/kecontact/KebaKeContact.java
+++ b/io.openems.edge.evcs.keba.kecontact/src/io/openems/edge/evcs/keba/kecontact/KebaKeContact.java
@@ -50,14 +50,6 @@ public class KebaKeContact extends AbstractOpenemsComponent implements Evcs, Ope
 	@Reference(policy = ReferencePolicy.STATIC, cardinality = ReferenceCardinality.MANDATORY)
 	private KebaKeContactCore kebaKeContactCore = null;
 
-	private enum Status {
-		STARTING, NOT_READY_FOR_CHARGING, READY_FOR_CHARGING, CHARGING, ERROR, AUTHORIZATION_REJECTED
-	}
-
-	private enum Plug {
-		UNPLUGGED, PLUGGED_ON_EVCS, PLUGGED_ON_EVCS_AND_LOCKED, PLUGGED_ON_EVCS_AND_ON_EV, PLUGGED_ON_EVCS_AND_ON_EV_AND_LOCKED
-	}
-
 	public enum ChannelId implements io.openems.edge.common.channel.doc.ChannelId {
 		/*
 		 * Report 1
@@ -69,26 +61,13 @@ public class KebaKeContact extends AbstractOpenemsComponent implements Evcs, Ope
 		/*
 		 * Report 2
 		 */
-		STATUS(new Doc().type(OpenemsType.INTEGER).text("Current state of the charging station") //
-				.option(0, Status.STARTING) //
-				.option(1, Status.NOT_READY_FOR_CHARGING) // e.g. unplugged, X1 or "ena" not enabled, RFID not
-															// enabled,...
-				.option(2, Status.READY_FOR_CHARGING) // waiting for EV charging request
-				.option(3, Status.CHARGING) //
-				.option(4, Status.ERROR) //
-				.option(5, Status.AUTHORIZATION_REJECTED) //
-		), //
+		STATUS(new Doc().type(OpenemsType.INTEGER).text("Current state of the charging station")
+				.options(Status.values())),
 		ERROR_1(new Doc().type(OpenemsType.INTEGER)
 				.text("Detail code for state ERROR; exceptions see FAQ on www.kecontact.com")), //
 		ERROR_2(new Doc().type(OpenemsType.INTEGER)
 				.text("Detail code for state ERROR; exceptions see FAQ on www.kecontact.com")), //
-		PLUG(new Doc().type(OpenemsType.INTEGER) //
-				.option(0, Plug.UNPLUGGED) //
-				.option(1, Plug.PLUGGED_ON_EVCS) //
-				.option(3, Plug.PLUGGED_ON_EVCS_AND_LOCKED) //
-				.option(5, Plug.PLUGGED_ON_EVCS_AND_ON_EV) //
-				.option(7, Plug.PLUGGED_ON_EVCS_AND_ON_EV_AND_LOCKED) //
-		), //
+		PLUG(new Doc().type(OpenemsType.INTEGER).options(Plug.values())),
 		ENABLE_SYS(new Doc().type(OpenemsType.BOOLEAN)
 				.text("Enable state for charging (contains Enable input, RFID, UDP,..)")), //
 		ENABLE_USER(new Doc().type(OpenemsType.BOOLEAN).text("Enable condition via UDP")), //

--- a/io.openems.edge.evcs.keba.kecontact/src/io/openems/edge/evcs/keba/kecontact/Plug.java
+++ b/io.openems.edge.evcs.keba.kecontact/src/io/openems/edge/evcs/keba/kecontact/Plug.java
@@ -1,0 +1,35 @@
+package io.openems.edge.evcs.keba.kecontact;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum Plug implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	UNPLUGGED(0, "Unplugged"), //
+	PLUGGED_ON_EVCS(1, "Plugged on EVCS"), //
+	PLUGGED_ON_EVCS_AND_LOCKED(3, "Plugged on EVCS and locked"), //
+	PLUGGED_ON_EVCS_AND_ON_EV(5, "Plugged on EVCS and on EV"), //
+	PLUGGED_ON_EVCS_AND_ON_EV_AND_LOCKED(7, "Plugged on EVCS and on EV and locked");
+
+	private final int value;
+	private final String name;
+
+	private Plug(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.evcs.keba.kecontact/src/io/openems/edge/evcs/keba/kecontact/Status.java
+++ b/io.openems.edge.evcs.keba.kecontact/src/io/openems/edge/evcs/keba/kecontact/Status.java
@@ -1,0 +1,37 @@
+package io.openems.edge.evcs.keba.kecontact;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum Status implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	STARTING(0, "Starting"), //
+	NOT_READY_FOR_CHARGING(1, "Not ready for Charging"), // e.g. unplugged, X1 or "ena" not enabled, RFID not
+															// enabled,...
+	READY_FOR_CHARGING(2, "Ready for Charging"), // waiting for EV charging request
+	CHARGING(3, "Charging"), //
+	ERROR(4, "Error"), //
+	AUTHORIZATION_REJECTED(5, "Authorization rejected");
+
+	private final int value;
+	private final String name;
+
+	private Status(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/BatteryGroupState.java
+++ b/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/BatteryGroupState.java
@@ -1,0 +1,36 @@
+package io.openems.edge.fenecon.mini.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum BatteryGroupState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	INITIAL(0, "Initial"), //
+	STOP(1, "Stop"), //
+	STARTING(2, "Starting"), //
+	RUNNING(3, "Running"), //
+	STOPPING(4, "Stopping"), //
+	FAIL(5, "Fail");
+
+	private final int value;
+	private final String name;
+
+	private BatteryGroupState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/ControlMode.java
+++ b/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/ControlMode.java
@@ -1,0 +1,32 @@
+package io.openems.edge.fenecon.mini.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum ControlMode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	REMOTE(1, "Remote"), //
+	LOCAL(2, "Local"); //
+
+	private final int value;
+	private final String name;
+
+	private ControlMode(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/FeneconMiniEss.java
+++ b/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/FeneconMiniEss.java
@@ -70,33 +70,11 @@ public class FeneconMiniEss extends AbstractOpenemsModbusComponent
 		super.deactivate();
 	}
 
-	enum SetWorkState {
-		LOCAL_CONTROL, START, REMOTE_CONTROL_OF_GRID, STOP, EMERGENCY_STOP
-	}
-
 	public enum ChannelId implements io.openems.edge.common.channel.doc.ChannelId {
-		SYSTEM_STATE(new Doc() //
-				.option(0, "STANDBY") //
-				.option(1, "Start Off-Grid") //
-				.option(2, "START") //
-				.option(3, "FAULT") //
-				.option(4, "Off-Grd PV")), //
-		CONTROL_MODE(new Doc()//
-				.option(1, "Remote")//
-				.option(2, "Local")), //
-		BATTERY_GROUP_STATE(new Doc()//
-				.option(0, "Initial")//
-				.option(1, "Stop")//
-				.option(2, "Starting")//
-				.option(3, "Running")//
-				.option(4, "Stopping")//
-				.option(5, "Fail")), //
-		SET_WORK_STATE(new Doc() //
-				.option(0, SetWorkState.LOCAL_CONTROL)//
-				.option(1, SetWorkState.START) //
-				.option(2, SetWorkState.REMOTE_CONTROL_OF_GRID) //
-				.option(3, SetWorkState.STOP) //
-				.option(4, SetWorkState.EMERGENCY_STOP)), //
+		SYSTEM_STATE(new Doc().options(SystemState.values())), //
+		CONTROL_MODE(new Doc().options(ControlMode.values())), //
+		BATTERY_GROUP_STATE(new Doc().options(BatteryGroupState.values())), //
+		SET_WORK_STATE(new Doc().options(SetWorkState.values())),
 
 		SOC(new Doc().unit(Unit.PERCENT)), //
 		BATTERY_VOLTAGE(new Doc().unit(Unit.MILLIVOLT)), //
@@ -154,30 +132,8 @@ public class FeneconMiniEss extends AbstractOpenemsModbusComponent
 		RTC_HOUR(new Doc().text("Hour")), //
 		RTC_MINUTE(new Doc().text("Minute")), //
 		RTC_SECOND(new Doc().text("Second")), //
-		SET_SETUP_MODE(new Doc()//
-				.option(0, "OFF")//
-				.option(1, "ON")), //
-		SET_PCS_MODE(new Doc()//
-				.option(0, "Emergency")//
-				.option(1, "ConsumersPeakPattern")//
-				.option(2, "Economic")//
-				.option(3, "Eco")//
-				.option(4, "Debug")//
-				.option(5, "SmoothPv")//
-				.option(6, "Remote")), //
-		SETUP_MODE(new Doc()//
-				.option(0, "OFF")//
-				.option(1, "ON")), //
-		PCS_MODE(new Doc()//
-				.option(0, "Emergency")//
-				.option(1, "ConsumersPeakPattern")//
-				.option(2, "Economic")//
-				.option(3, "Eco")//
-				.option(4, "Debug")//
-				.option(5, "SmoothPv")//
-				.option(6, "Remote")//
-
-		), //
+		SETUP_MODE(new Doc().options(SetupMode.values())), //
+		PCS_MODE(new Doc().options(PcsMode.values())), //
 
 		STATE_1(new Doc().level(Level.WARNING).text("BECU1GeneralChargeOverCurrentAlarm")), //
 		STATE_2(new Doc().level(Level.WARNING).text("BECU1GeneralDischargeOverCurrentAlarm")), //
@@ -588,9 +544,9 @@ public class FeneconMiniEss extends AbstractOpenemsModbusComponent
 						m(FeneconMiniEss.ChannelId.RTC_MINUTE, new UnsignedWordElement(9018)), //
 						m(FeneconMiniEss.ChannelId.RTC_SECOND, new UnsignedWordElement(9019))), //
 				new FC16WriteRegistersTask(30558, //
-						m(FeneconMiniEss.ChannelId.SET_SETUP_MODE, new UnsignedWordElement(30558))), //
+						m(FeneconMiniEss.ChannelId.SETUP_MODE, new UnsignedWordElement(30558))), //
 				new FC16WriteRegistersTask(30559, //
-						m(FeneconMiniEss.ChannelId.SET_PCS_MODE, new UnsignedWordElement(30559))), //
+						m(FeneconMiniEss.ChannelId.PCS_MODE, new UnsignedWordElement(30559))), //
 				new FC16WriteRegistersTask(30157, //
 						m(FeneconMiniEss.ChannelId.SETUP_MODE, new UnsignedWordElement(30157)), //
 						m(FeneconMiniEss.ChannelId.PCS_MODE, new UnsignedWordElement(30158))));//

--- a/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/PcsMode.java
+++ b/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/PcsMode.java
@@ -1,0 +1,37 @@
+package io.openems.edge.fenecon.mini.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum PcsMode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	EMERGENCY(0, "Emergency"), //
+	CONSUMERS_PEAK_PATTERN(1, "Consumers Peak Pattern"), //
+	ECONOMIC(2, "Economic"), //
+	ECO(3, "Eco"), //
+	DEBUG(4, "Debug"), //
+	SMOOTH_PV(5, "Smooth PV"), //
+	REMOTE(6, "Remote");
+	
+	private final int value;
+	private final String name;
+
+	private PcsMode(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/SetWorkState.java
+++ b/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/SetWorkState.java
@@ -1,0 +1,35 @@
+package io.openems.edge.fenecon.mini.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum SetWorkState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	LOCAL_CONTROL(0, "Local Control"), //
+	START(1, "Start"), //
+	REMOTE_CONTROL_OFF_GRID_STARTING(2, "Remote Control off Grid Starting"), //
+	STOP(3, "Stop"), //
+	EMERGENCY_STOP(4, "Emergency Stop"); //
+
+	private final int value;
+	private final String name;
+
+	private SetWorkState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/SetupMode.java
+++ b/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/SetupMode.java
@@ -1,0 +1,32 @@
+package io.openems.edge.fenecon.mini.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum SetupMode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	OFF(0, "Off"), //
+	ON(1, "On");
+
+	private final int value;
+	private final String name;
+
+	private SetupMode(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/SystemState.java
+++ b/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/SystemState.java
@@ -1,0 +1,35 @@
+package io.openems.edge.fenecon.mini.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum SystemState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	STANDBY(0, "Standby"), //
+	START_OFF_GRID(1, "Start Off-Grid"), //
+	START(2, "START"), //
+	FAULT(3, "FAULT"), //
+	OFF_GRID_PV(4, "Off-Grid PV");
+
+	private final int value;
+	private final String name;
+
+	private SystemState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/Utils.java
+++ b/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/Utils.java
@@ -82,10 +82,8 @@ public class Utils {
 					case BECU_VOLT:
 					case BECU_WORK_STATE:
 					case SYSTEM_WORK_STATE:
-
 						return new IntegerReadChannel(c, channelId);
 
-					case PCS_MODE:
 					case RTC_DAY:
 					case RTC_HOUR:
 					case RTC_MINUTE:
@@ -93,8 +91,7 @@ public class Utils {
 					case RTC_SECOND:
 					case RTC_YEAR:
 					case SETUP_MODE:
-					case SET_PCS_MODE:
-					case SET_SETUP_MODE:
+					case PCS_MODE:
 					case SET_WORK_STATE:
 						return new IntegerWriteChannel(c, channelId);
 

--- a/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/BatteryGroupState.java
+++ b/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/BatteryGroupState.java
@@ -1,0 +1,36 @@
+package io.openems.edge.fenecon.pro.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum BatteryGroupState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	INITIAL(0, "Initial"), //
+	STOP(1, "Stop"), //
+	STARTING(2, "Starting"), //
+	RUNNING(3, "Running"), //
+	STOPPING(4, "Stopping"), //
+	FAIL(5, "Fail");
+	
+	private final int value;
+	private final String name;
+
+	private BatteryGroupState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/ControlMode.java
+++ b/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/ControlMode.java
@@ -1,0 +1,32 @@
+package io.openems.edge.fenecon.pro.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum ControlMode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	REMOTE(1, "Remote"), //
+	LOCAL(2, "Local"); //
+
+	private final int value;
+	private final String name;
+
+	private ControlMode(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/PcsMode.java
+++ b/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/PcsMode.java
@@ -1,0 +1,37 @@
+package io.openems.edge.fenecon.pro.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum PcsMode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	EMERGENCY(0, "Emergency"), //
+	CONSUMERS_PEAK_PATTERN(1, "Consumers Peak Pattern"), //
+	ECONOMIC(2, "Economic"), //
+	ECO(3, "Eco"), //
+	DEBUG(4, "Debug"), //
+	SMOOTH_PV(5, "Smooth PV"), //
+	REMOTE(6, "Remote");
+
+	private final int value;
+	private final String name;
+
+	private PcsMode(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/PcsOperationState.java
+++ b/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/PcsOperationState.java
@@ -1,0 +1,38 @@
+package io.openems.edge.fenecon.pro.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum PcsOperationState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	SELF_CHECKING(0, "Self-checking"), //
+	STANDBY(1, "Standby"), //
+	OFF_GRID_PV(2, "Off-Grid PV"), //
+	OFF_GRID(3, "Off-Grid"), //
+	ON_GRID(4, "ON_GRID"), //
+	FAIL(5, "Fail"), //
+	BYPASS_1(6, "ByPass 1"), //
+	BYPASS_2(7, "ByPass 2");
+
+	private final int value;
+	private final String name;
+
+	private PcsOperationState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/SetWorkState.java
+++ b/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/SetWorkState.java
@@ -1,0 +1,35 @@
+package io.openems.edge.fenecon.pro.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum SetWorkState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	LOCAL_CONTROL(0, "Local Control"), //
+	START(1, "Start"), //
+	REMOTE_CONTROL_OFF_GRID_STARTING(2, "Remote Control off Grid Starting"), //
+	STOP(3, "Stop"), //
+	EMERGENCY_STOP(4, "Emergency Stop"); //
+	
+	private final int value;
+	private final String name;
+
+	private SetWorkState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/SetupMode.java
+++ b/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/SetupMode.java
@@ -1,0 +1,32 @@
+package io.openems.edge.fenecon.pro.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum SetupMode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	OFF(0, "Off"), //
+	ON(1, "On");
+
+	private final int value;
+	private final String name;
+
+	private SetupMode(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/SystemState.java
+++ b/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/SystemState.java
@@ -1,0 +1,35 @@
+package io.openems.edge.fenecon.pro.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum SystemState implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	STANDBY(0, "Standby"), //
+	START_OFF_GRID(1, "Start Off-Grid"), //
+	START(2, "START"), //
+	FAULT(3, "FAULT"), //
+	OFF_GRID_PV(4, "Off-Grid PV");
+	
+	private final int value;
+	private final String name;
+
+	private SystemState(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/Utils.java
+++ b/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/Utils.java
@@ -143,8 +143,6 @@ public class Utils {
 					case RTC_SECOND:
 					case RTC_YEAR:
 					case SETUP_MODE:
-					case SET_PCS_MODE:
-					case SET_SETUP_MODE:
 					case SET_WORK_STATE:
 					case SET_ACTIVE_POWER_L1:
 					case SET_ACTIVE_POWER_L2:

--- a/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/WorkMode.java
+++ b/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/WorkMode.java
@@ -1,0 +1,33 @@
+package io.openems.edge.fenecon.pro.ess;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum WorkMode implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	ECONOMOY(2, "Economy"), //
+	REMOTE(6, "Remote"), //
+	TIMING(8, "Timing");
+
+	private final int value;
+	private final String name;
+
+	private WorkMode(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.kostal.piko/src/io/openems/edge/kostal/piko/core/api/BatteryCurrentDirection.java
+++ b/io.openems.edge.kostal.piko/src/io/openems/edge/kostal/piko/core/api/BatteryCurrentDirection.java
@@ -1,0 +1,32 @@
+package io.openems.edge.kostal.piko.core.api;
+
+import io.openems.edge.common.channel.doc.OptionsEnum;
+
+public enum BatteryCurrentDirection implements OptionsEnum {
+	UNDEFINED(-1, "Undefined"), //
+	CHARGE(0, "Charge"), //
+	DISCHARGE(1, "Discharge");
+
+	private final int value;
+	private final String name;
+
+	private BatteryCurrentDirection(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return UNDEFINED;
+	}
+}

--- a/io.openems.edge.kostal.piko/src/io/openems/edge/kostal/piko/core/api/KostalPikoCore.java
+++ b/io.openems.edge.kostal.piko/src/io/openems/edge/kostal/piko/core/api/KostalPikoCore.java
@@ -74,7 +74,7 @@ public interface KostalPikoCore {
 		/*
 		 * ESS
 		 */
-		BATTERY_CURRENT_DIRECTION(new Doc().option(0, "charge").option(1, "discharge").type(OpenemsType.FLOAT)), //
+		BATTERY_CURRENT_DIRECTION(new Doc().options(BatteryCurrentDirection.values()).type(OpenemsType.FLOAT)), //
 		BATTERY_CURRENT(new Doc().type(OpenemsType.FLOAT).unit(Unit.AMPERE)), //
 		BATTERY_VOLTAGE(new Doc().type(OpenemsType.FLOAT).unit(Unit.VOLT)), //
 		BATTERY_TEMPERATURE(new Doc().type(OpenemsType.FLOAT).unit(Unit.DEGREE_CELSIUS)), //


### PR DESCRIPTION
- Adds an "**Undefined**" enum value that always needs to exist. It is used when the Channel has no value.
- This simplifies reading and writing option values. It can be used like this:
```
IntegerWriteChannel channel = this.channel(ChannelId.PCS_MODE);`
```
Read:
```
PcsMode pcsMode = this.getPcsModeChannel().value().asEnum();
if (this.getPcsMode() != PcsMode.REMOTE) {
    ...
}
```
Write:
```
channel.setNextWriteValue(PcsMode.REMOTE);
```
or:
```
channel.setNextWriteValueFromObject("Remote");
```