### PR TITLE
Fixes of Channelthreshold/Colors in History Chart/'Null' values

### DIFF
--- a/ui/src/app/edge/history/energy/energy.component.ts
+++ b/ui/src/app/edge/history/energy/energy.component.ts
@@ -84,7 +84,6 @@ export class EnergyComponent extends AbstractHistoryChart implements OnChanges {
     this.queryHistoricTimeseriesData(this.period.from, this.period.to).then(response => {
       this.service.getCurrentEdge().then(edge => {
         this.service.getConfig().then(config => {
-
           let result = (response as QueryHistoricTimeseriesDataResponse).result;
 
           // convert labels
@@ -220,6 +219,10 @@ export class EnergyComponent extends AbstractHistoryChart implements OnChanges {
               data: dischargeData,
               hidden: false
             });
+          }
+          // keep colors the same if no producing device
+          if (!config.hasProducer()) {
+            this.colors = this.colors.slice(1, this.colors.length);
           }
 
           this.datasets = datasets;

--- a/ui/src/app/edge/history/history.component.html
+++ b/ui/src/app/edge/history/history.component.html
@@ -16,7 +16,7 @@
           <ion-grid class="ion-no-padding">
             <ng-container *ngFor="let clazz of widgets.classes" [ngSwitch]="clazz">
 
-              <ion-row *ngSwitchCase="'Storage'" [style.height]="socChartHeight">
+              <ion-row *ngSwitchCase="'Autarchy' || 'Storage' || 'Selfconsumption'" [style.height]="socChartHeight">
                 <ion-col size="12">
                   <soc [period]="service.historyPeriod"></soc>
                 </ion-col>

--- a/ui/src/app/edge/history/soc/soc.component.ts
+++ b/ui/src/app/edge/history/soc/soc.component.ts
@@ -85,11 +85,11 @@ export class SocComponent extends AbstractHistoryChart implements OnInit, OnChan
           let datasets = [];
 
           // required data for autarchy and self consumption
-          let buyFromGridData: number[];
-          let sellToGridData: number[];
-          let consumptionData: number[];
-          let dischargeData: number[];
-          let productionData: number[];
+          let buyFromGridData: number[] = [];
+          let sellToGridData: number[] = [];
+          let consumptionData: number[] = [];
+          let dischargeData: number[] = [];
+          let productionData: number[] = [];
 
           if (!edge.isVersionAtLeast('2018.8')) {
             this.convertDeprecatedData(config, result.data); // TODO deprecated
@@ -120,7 +120,6 @@ export class SocComponent extends AbstractHistoryChart implements OnInit, OnChan
             } else {
               effectivePower = result.data['_sum/EssActivePower'];
             }
-
             dischargeData = effectivePower.map(value => {
               if (value == null) {
                 return null

--- a/ui/src/app/edge/live/channelthreshold/channelthreshold.component.html
+++ b/ui/src/app/edge/live/channelthreshold/channelthreshold.component.html
@@ -9,21 +9,19 @@
     <ion-label translate>Edge.Index.Widgets.Channeltreshold.Output</ion-label>
   </ion-item>
   <ion-card-content *ngIf="(edge.currentData | async).channel as channel">
-    <ion-grid no-padding>
-      <table class="full_width">
-        <tr>
-          <td style="width: 90%" *ngIf="component.id != component.alias" translate>
-            &nbsp;{{component.alias}}
-          </td>
-          <td style="width: 90%" *ngIf="component.id == component.alias" translate>
-            {{ outputChannel.channelId }}
-          </td>
-          <td style="width: 10%" *ngIf="channel[outputChannel.toString()] == null">?</td>
-          <td style="width: 10%" *ngIf="channel[outputChannel.toString()] == 1" translate>General.On</td>
-          <td style="width: 10%" *ngIf="channel[outputChannel.toString()] == 0" translate>General.Off</td>
-        </tr>
-      </table>
-    </ion-grid>
+    <table class="full_width">
+      <tr>
+        <td style="width: 90%" *ngIf="component.id != component.alias" translate>
+          &nbsp;{{component.alias}}
+        </td>
+        <td style="width: 90%" *ngIf="component.id == component.alias" translate>
+          {{ outputChannel.channelId }}
+        </td>
+        <td style="width: 10%" *ngIf="channel[outputChannel.toString()] == null">?</td>
+        <td style="width: 10%" *ngIf="channel[outputChannel.toString()] == 1" translate>General.On</td>
+        <td style="width: 10%" *ngIf="channel[outputChannel.toString()] == 0" translate>General.Off</td>
+      </tr>
+    </table>
   </ion-card-content>
 </ion-card>
 <!-- &nbsp;<span translate>Edge.Index.Widgets.Channeltreshold.Output</span>&nbsp; -->

--- a/ui/src/app/edge/live/channelthreshold/channelthreshold.component.html
+++ b/ui/src/app/edge/live/channelthreshold/channelthreshold.component.html
@@ -1,15 +1,15 @@
 <ion-card *ngIf="edge">
   <ngx-loading [show]="!(edge.currentData | async)"></ngx-loading>
-  <ng-container *ngIf="(edge.currentData | async).channel[outputChannel.toString()] as channel">
-    <ion-item lines="full" color="light">
-      <ion-avatar slot="start">
-        <ion-icon size="large" *ngIf="channel == null" name="help"></ion-icon>
-        <ion-icon size="large" *ngIf="channel == 1" name="radio-button-on"></ion-icon>
-        <ion-icon size="large" *ngIf="channel == 0" name="radio-button-off"></ion-icon>
-      </ion-avatar>
-      <ion-label translate>Edge.Index.Widgets.Channeltreshold.Output</ion-label>
-    </ion-item>
-    <ion-card-content>
+  <ion-item lines="full" color="light">
+    <ion-avatar slot="start" *ngIf="(edge.currentData | async).channel as channel">
+      <ion-icon size="large" *ngIf="channel[outputChannel.toString()] == null" name="help"></ion-icon>
+      <ion-icon size="large" *ngIf="channel[outputChannel.toString()] == 1" name="radio-button-on"></ion-icon>
+      <ion-icon size="large" *ngIf="channel[outputChannel.toString()] == 0" name="radio-button-off"></ion-icon>
+    </ion-avatar>
+    <ion-label translate>Edge.Index.Widgets.Channeltreshold.Output</ion-label>
+  </ion-item>
+  <ion-card-content *ngIf="(edge.currentData | async).channel as channel">
+    <ion-grid no-padding>
       <table class="full_width">
         <tr>
           <td style="width: 90%" *ngIf="component.id != component.alias" translate>
@@ -18,15 +18,12 @@
           <td style="width: 90%" *ngIf="component.id == component.alias" translate>
             {{ outputChannel.channelId }}
           </td>
-          <td style="width: 10%" class="align_right" *ngIf="channel == null">?</td>
-          <td style="width: 10%" class="align_right" *ngIf="channel == 1" translate>General.On
-          </td>
-          <td style="width: 10%" class="align_right" *ngIf="channel == 0" translate>General.Off
-          </td>
+          <td style="width: 10%" *ngIf="channel[outputChannel.toString()] == null">?</td>
+          <td style="width: 10%" *ngIf="channel[outputChannel.toString()] == 1" translate>General.On</td>
+          <td style="width: 10%" *ngIf="channel[outputChannel.toString()] == 0" translate>General.Off</td>
         </tr>
       </table>
-    </ion-card-content>
-  </ng-container>
+    </ion-grid>
+  </ion-card-content>
 </ion-card>
-
 <!-- &nbsp;<span translate>Edge.Index.Widgets.Channeltreshold.Output</span>&nbsp; -->

--- a/ui/src/app/edge/live/consumption/consumption.component.html
+++ b/ui/src/app/edge/live/consumption/consumption.component.html
@@ -12,14 +12,9 @@
                     <ng-container *ngIf="evcsComponents.length == 0">
                         <tr>
                             <td style="width:65%"></td>
-                            <ng-container *ngIf="sum.activePower != 0; else empty">
-                                <td style="width:35%" class="align_right">
-                                    {{ sum.activePower | number:'1.0-0' }}&nbsp;W
-                                </td>
-                            </ng-container>
-                            <ng-template #empty>
-                                <td style="width:35%" class="align_right">-&nbsp;</td>
-                            </ng-template>
+                            <td style="width:35%" class="align_right">
+                                {{ sum.activePower | unitvalue:'W' }}
+                            </td>
                         </tr>
                     </ng-container>
                     <ng-container *ngIf="evcsComponents.length > 0">
@@ -32,7 +27,7 @@
                                         {{component.alias}}
                                     </td>
                                     <td style="width:35%" class="align_right">
-                                        {{ currentData[component.id + '/ChargePower'] == 0? '-&nbsp;' : (currentData[component.id + '/ChargePower'] | number:'1.0-0') + '&nbsp;W' }}
+                                        {{ currentData[component.id + '/ChargePower'] | unitvalue:'W' }}
                                     </td>
                                 </tr>
                             </ng-container>
@@ -42,7 +37,7 @@
                             <td style="width: 65%" translate>General.otherConsumption</td>
                             <ng-container *ngIf="sum.activePower - currentTotalChargingPower() as otherPower">
                                 <td style="width: 35%" class="align_right">
-                                    {{ otherPower == null ? '-&nbsp;' : (otherPower | number:'1.0-0') + '&nbsp;W' }}
+                                    {{ otherPower | unitvalue:'W' }}
                                 </td>
                             </ng-container>
                         </tr>

--- a/ui/src/app/edge/live/consumption/modal/modal.component.html
+++ b/ui/src/app/edge/live/consumption/modal/modal.component.html
@@ -17,14 +17,9 @@
           <table class="full_width">
             <tr>
               <td style="width:65%" translate>General.Total</td>
-              <ng-container *ngIf="sum.activePower != null; else empty">
-                <td style="width:35%" class="align_right">
-                  {{ sum.activePower | number:'1.0-0' }}&nbsp;W
-                </td>
-              </ng-container>
-              <ng-template #empty>
-                <td style="width:35%" class="align_right">-&nbsp;</td>
-              </ng-template>
+              <td style="width:35%" class="align_right">
+                {{ sum.activePower | unitvalue:'W' }}
+              </td>
             </tr>
           </table>
           <!-- for spacing between Phases and Total Consumption -->
@@ -38,7 +33,7 @@
               <td style="width:23%"><span translate>General.Phase</span>&nbsp;L1</td>
               <td style="width:40%"></td>
               <td style="width:35%" class="align_right">
-                {{ sum.activePowerL1 == 0? '-&nbsp;' : (sum.activePowerL1 | number:'1.0-0') + '&nbsp;W' }}
+                {{ sum.activePowerL1 | unitvalue:'W' }}
               </td>
             </tr>
             <tr *ngIf="sum.activePowerL2 != null">
@@ -46,7 +41,7 @@
               <td style="width:23%"><span translate>General.Phase</span>&nbsp;L2</td>
               <td style="width:40%"></td>
               <td class="align_right" style="width: 35%">
-                {{ sum.activePowerL2 == 0? '-&nbsp;' : (sum.activePowerL2 | number:'1.0-0') + '&nbsp;W' }}
+                {{ sum.activePowerL2 | unitvalue:'W' }}
               </td>
             </tr>
             <tr *ngIf="sum.activePowerL3 != null">
@@ -54,7 +49,7 @@
               <td style="width:23%"><span translate>General.Phase</span>&nbsp;L3</td>
               <td style="width:40%"></td>
               <td class="align_right" style="width: 35%">
-                {{ sum.activePowerL3 == 0? '-&nbsp;' : (sum.activePowerL3 | number:'1.0-0') + '&nbsp;W' }}
+                {{ sum.activePowerL3 | unitvalue:'W' }}
               </td>
             </tr>
           </table>
@@ -70,7 +65,7 @@
               translate>Edge.Index.Widgets.EVCS.ChargingPower</span>
           </td>
           <td class="align_right" style="width: 35%">
-            {{ currentTotalChargingPower() == 0? '-&nbsp;' : (currentTotalChargingPower() | number:'1.0-0') + '&nbsp;W' }}
+            {{ currentTotalChargingPower() | unitvalue:'W' }}
           </td>
         </tr>
       </table>
@@ -86,7 +81,7 @@
             <td style="width: 65%" *ngIf="component.id != component.alias">{{component.alias}}
             </td>
             <td class="align_right" style="width: 35%">
-              {{ currentData[component.id + '/ChargePower'] == 0? '-&nbsp;' : (currentData[component.id + '/ChargePower'] | number:'1.0-0') + '&nbsp;W' }}
+              {{ currentData[component.id + '/ChargePower'] | unitvalue:'W' }}
             </td>
           </tr>
         </table>
@@ -103,7 +98,7 @@
               <td style="width: 65%" translate>General.otherConsumption</td>
               <ng-container *ngIf="sum.activePower - currentTotalChargingPower() as otherPower">
                 <td style="width: 35%" class="align_right">
-                  {{ otherPower == null ? '-&nbsp;' : (otherPower | number:'1.0-0') + '&nbsp;W' }}
+                  {{ otherPower | unitvalue:'W'}}
                 </td>
               </ng-container>
             </tr>

--- a/ui/src/app/edge/live/evcs/evcs.component.ts
+++ b/ui/src/app/edge/live/evcs/evcs.component.ts
@@ -16,7 +16,7 @@ export class EvcsComponent {
 
   private static readonly SELECTOR = "evcs";
 
-  @Input() private componentId: string;
+  @Input() public componentId: string;
 
   public edge: Edge = null;
   public controller: EdgeConfig.Component = null;

--- a/ui/src/app/edge/live/grid/grid.component.html
+++ b/ui/src/app/edge/live/grid/grid.component.html
@@ -15,13 +15,13 @@
                     <tr>
                         <td style="width:65%" translate>General.GridBuyAdvanced</td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.buyActivePower == 0? '-&nbsp;' : (sum.buyActivePower | number:'1.0-0') + '&nbsp;W' }}
+                            {{ sum.buyActivePower | unitvalue:'W' }}
                         </td>
                     </tr>
                     <tr>
                         <td style="width:65%" translate>General.GridSellAdvanced</td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.sellActivePower == 0? '-&nbsp;' : (sum.sellActivePower | number:'1.0-0') + '&nbsp;W' }}
+                            {{ sum.sellActivePower | unitvalue:'W' }}
                         </td>
                     </tr>
                 </table>

--- a/ui/src/app/edge/live/grid/modal/modal.component.html
+++ b/ui/src/app/edge/live/grid/modal/modal.component.html
@@ -20,13 +20,13 @@
                     <tr>
                         <td style="width:65%" translate>General.GridBuyAdvanced</td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.buyActivePower == 0? '-&nbsp;' : (sum.buyActivePower | number:'1.0-0') + '&nbsp;W' }}
+                            {{ sum.buyActivePower | unitvalue:'W' }}
                         </td>
                     </tr>
                     <tr>
                         <td style="width:65%" translate>General.GridSellAdvanced</td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.sellActivePower == 0? '-&nbsp;' : (sum.sellActivePower | number:'1.0-0') + '&nbsp;W' }}
+                            {{ sum.sellActivePower | unitvalue:'W' }}
                         </td>
                     </tr>
                 </table>
@@ -41,7 +41,7 @@
                         <td style="width:63%"><span translate>Phase</span> L1 <span
                                 translate>General.GridBuyAdvanced</span></td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.activePowerL1 == 0? '-&nbsp;' : (sum.activePowerL1 | number:'1.0-0') + '&nbsp;W' }}
+                            {{ sum.activePowerL1 | unitvalue:'W' }}
                         </td>
                     </tr>
                     <tr *ngIf="sum.activePowerL1 <= 0">
@@ -49,7 +49,7 @@
                         <td style="width:63%"><span translate>Phase</span> L1 <span
                                 translate>General.GridSellAdvanced</span></td>
                         <td style="width:35%" class="align_right">
-                            {{ (sum.activePowerL1 * -1) == 0? '-&nbsp;' : ((sum.activePowerL1 * -1) | number:'1.0-0') + '&nbsp;W' }}
+                            {{ (sum.activePowerL1 * -1) | unitvalue:'W' }}
                         </td>
                     </tr>
                     <tr *ngIf="sum.activePowerL2 > 0">
@@ -57,7 +57,7 @@
                         <td style="width:63%"><span translate>Phase</span> L2 <span
                                 translate>General.GridBuyAdvanced</span></td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.activePowerL2 == 0? '-&nbsp;' : (sum.activePowerL2 | number:'1.0-0') + '&nbsp;W' }}
+                            {{ sum.activePowerL2 | unitvalue:'W' }}
                         </td>
                     </tr>
                     <tr *ngIf="sum.activePowerL2 <= 0">
@@ -65,7 +65,7 @@
                         <td style="width:63%"><span translate>Phase</span> L2 <span
                                 translate>General.GridSellAdvanced</span></td>
                         <td style="width:35%" class="align_right">
-                            {{ (sum.activePowerL2 * -1) == 0? '-&nbsp;' : ((sum.activePowerL1 * -2) | number:'1.0-0') + '&nbsp;W' }}
+                            {{ (sum.activePowerL2 * -1) | unitvalue:'W' }}
                         </td>
                     </tr>
                     <tr *ngIf="sum.activePowerL3 > 0">
@@ -73,7 +73,7 @@
                         <td style="width:63%"><span translate>Phase</span> L3 <span
                                 translate>General.GridBuyAdvanced</span></td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.activePowerL3 == 0? '-&nbsp;' : (sum.activePowerL3 | number:'1.0-0') + '&nbsp;W' }}
+                            {{ sum.activePowerL3 | unitvalue:'W' }}
                         </td>
                     </tr>
                     <tr *ngIf="sum.activePowerL3 <= 0">
@@ -81,7 +81,7 @@
                         <td style="width:63%"><span translate>Phase</span> L3 <span
                                 translate>General.GridSellAdvanced</span></td>
                         <td style="width:35%" class="align_right">
-                            {{ (sum.activePowerL3 * -1) == 0? '-&nbsp;' : ((sum.activePowerL3 * -2) | number:'1.0-0') + '&nbsp;W' }}
+                            {{ (sum.activePowerL3 * -1) | unitvalue:'W' }}
                         </td>
                     </tr>
                 </table>

--- a/ui/src/app/edge/live/production/modal/modal.component.html
+++ b/ui/src/app/edge/live/production/modal/modal.component.html
@@ -21,7 +21,7 @@
                         <tr>
                             <td style="width:65%" translate>General.Total</td>
                             <td style="width:35%" class="align_right">
-                                {{ sum.activePower == 0? '-&nbsp;' : (sum.activePower | number:'1.0-0') + '&nbsp;W' }}
+                                {{ sum.activePower | unitvalue:'W' }}
                             </td>
                         </tr>
                     </table>
@@ -38,14 +38,14 @@
                     <ng-container *ngIf="(edge.currentData | async)['channel'] as currentData">
                         <table class="full_width">
                             <ng-container
-                                *ngIf="factory.natureIds.includes('io.openems.edge.meter.api.SymmetricMeter') && currentData[component.id + '/ActivePower'] != null">
+                                *ngIf="factory.natureIds.includes('io.openems.edge.meter.api.SymmetricMeter')">
                                 <tr>
                                     <td style="width:65%" *ngIf="component.id == component.alias">{{component.id}}
                                     </td>
                                     <td style="width:65%" *ngIf="component.id != component.alias">
                                         {{component.alias}}</td>
                                     <td style="width:35%" class="align_right">
-                                        {{ currentData[component.id + '/ActivePower'] == 0? '-&nbsp;' : (currentData[component.id + '/ActivePower'] | number:'1.0-0') + '&nbsp;W' }}
+                                        {{ currentData[component.id + '/ActivePower'] | unitvalue:'W' }}
                                     </td>
                                 </tr>
                             </ng-container>
@@ -65,7 +65,7 @@
                                         <td style="width:23%"><span translate>General.Phase</span> L1</td>
                                         <td style="width:40%"></td>
                                         <td style="width:35%" class="align_right">
-                                            {{ sum.activePowerAcL1 == 0? '-&nbsp;' : (sum.activePowerAcL1 | number:'1.0-0') + '&nbsp;W' }}
+                                            {{ sum.activePowerAcL1 | unitvalue:'W' }}
                                         </td>
                                     </tr>
                                     <tr>
@@ -73,7 +73,7 @@
                                         <td style="width:23%"><span translate>General.Phase</span> L2</td>
                                         <td style="width:40%"></td>
                                         <td style="width:35%" class="align_right">
-                                            {{ sum.activePowerAcL2 == 0? '-&nbsp;' : (sum.activePowerAcL2 | number:'1.0-0') + '&nbsp;W' }}
+                                            {{ sum.activePowerAcL2 | unitvalue:'W' }}
                                         </td>
                                     </tr>
                                     <tr>
@@ -81,7 +81,7 @@
                                         <td style="width:23%"><span translate>General.Phase</span> L3</td>
                                         <td style="width:40%"></td>
                                         <td style="width:35%" class="align_right">
-                                            {{ sum.activePowerAcL3 == 0? '-&nbsp;' : (sum.activePowerAcL3 | number:'1.0-0') + '&nbsp;W' }}
+                                            {{ sum.activePowerAcL3 | unitvalue:'W' }}
                                         </td>
                                     </tr>
                                 </table>
@@ -109,7 +109,7 @@
                                 <td style="width:65%" translate>General.Total</td>
                             </ng-template>
                             <td style="width:35%" class="align_right">
-                                {{ sum.activePowerAc == 0? '-&nbsp;' : (sum.activePowerAc | number:'1.0-0') + '&nbsp;W' }}
+                                {{ sum.activePowerAc | unitvalue:'W' }}
                             </td>
                         </tr>
                     </table>
@@ -124,7 +124,7 @@
                                 <td style="width:23%"><span translate>General.Phase</span> L1</td>
                                 <td style="width:40%"></td>
                                 <td style="width:35%" class="align_right">
-                                    {{ sum.activePowerAcL1 == 0? '-&nbsp;' : (sum.activePowerAcL1 | number:'1.0-0') + '&nbsp;W' }}
+                                    {{ sum.activePowerAcL1 | unitvalue:'W' }}
                                 </td>
                             </tr>
                             <tr>
@@ -132,7 +132,7 @@
                                 <td style="width:23%"><span translate>General.Phase</span> L2</td>
                                 <td style="width:40%"></td>
                                 <td style="width:35%" class="align_right">
-                                    {{ sum.activePowerAcL2 == 0? '-&nbsp;' : (sum.activePowerAcL2 | number:'1.0-0') + '&nbsp;W' }}
+                                    {{ sum.activePowerAcL2 | unitvalue:'W' }}
                                 </td>
                             </tr>
                             <tr>
@@ -140,7 +140,7 @@
                                 <td style="width:23%"><span translate>General.Phase</span> L3</td>
                                 <td style="width:40%"></td>
                                 <td style="width:35%" class="align_right">
-                                    {{ sum.activePowerAcL3 == 0? '-&nbsp;' : (sum.activePowerAcL3 | number:'1.0-0') + '&nbsp;W' }}
+                                    {{ sum.activePowerAcL3 | unitvalue:'W' }}
                                 </td>
                             </tr>
                         </table>
@@ -157,13 +157,12 @@
                 <ion-card-content
                     [class.underline]="chargerComponents.length > 0 || !isLastElement(component, productionMeterComponents)">
                     <table class="full_width">
-                        <ng-container
-                            *ngIf="factory.natureIds.includes('io.openems.edge.meter.api.SymmetricMeter') && currentData[component.id + '/ActivePower'] != null">
+                        <ng-container *ngIf="factory.natureIds.includes('io.openems.edge.meter.api.SymmetricMeter')">
                             <tr>
                                 <td style="width:65%" *ngIf="component.id == component.alias">{{component.id}}</td>
                                 <td style="width:65%" *ngIf="component.id != component.alias">{{component.alias}}</td>
                                 <td style="width:35%" class="align_right">
-                                    {{ currentData[component.id + '/ActivePower'] == 0? '-&nbsp;' : (currentData[component.id + '/ActivePower'] | number:'1.0-0') + '&nbsp;W' }}
+                                    {{ currentData[component.id + '/ActivePower'] | unitvalue:'W' }}
                                 </td>
                             </tr>
                         </ng-container>
@@ -183,7 +182,7 @@
                         <td style="width:65%" *ngIf="component.id == component.alias">{{component.id}}</td>
                         <td style="width:65%" *ngIf="component.id != component.alias">{{component.alias}}</td>
                         <td style="width:35%" class="align_right">
-                            {{ currentData[component.id + '/ActualPower'] == 0? '-&nbsp;' : (currentData[component.id + '/ActualPower'] | number:'1.0-0') + '&nbsp;W' }}
+                            {{ currentData[component.id + '/ActualPower'] | unitvalue:'W' }}
                         </td>
                     </tr>
                 </table>
@@ -210,7 +209,7 @@
                                 </ng-template>
                                 <td style="width:15%"></td>
                                 <td style="width:50%" class="align_right">
-                                    {{ sum.activePowerDc == 0? '-&nbsp;' : (sum.activePowerDc | number:'1.0-0') + '&nbsp;W' }}
+                                    {{ sum.activePowerDc | unitvalue:'W' }}
                                 </td>
                             </tr>
                         </table>
@@ -226,7 +225,7 @@
                         <td style="width:35%" *ngIf="component.id != component.alias">{{component.alias}}</td>
                         <td style="width:15%"></td>
                         <td style="width:50%" class="align_right">
-                            {{ currentData[component.id + '/ActualPower'] == 0? '-&nbsp;' : (currentData[component.id + '/ActualPower'] | number:'1.0-0') + '&nbsp;W' }}
+                            {{ currentData[component.id + '/ActualPower'] | unitvalue:'W' }}
                         </td>
                     </tr>
                 </table>

--- a/ui/src/app/edge/live/production/production.component.html
+++ b/ui/src/app/edge/live/production/production.component.html
@@ -14,10 +14,9 @@
                             <tr>
                                 <td style="width:65%" translate>General.Production
                                 </td>
-                                <td style="width:25%" class="align_right">
-                                    {{ sum.activePower | number:'1.0-0' }}
+                                <td style="width:35%" class="align_right">
+                                    {{ sum.activePower | unitvalue:'W' }}
                                 </td>
-                                <td style="width:10%">&nbsp;W</td>
                             </tr>
                         </table>
                     </ion-grid>
@@ -31,13 +30,13 @@
                                 <tr *ngIf="sum.activePowerDc != null">
                                     <td style="width:65%">DC</td>
                                     <td style="width:35%" class="align_right">
-                                        {{ sum.activePowerDc == 0? '-&nbsp;' : (sum.activePowerDc | number:'1.0-0') + '&nbsp;W' }}
+                                        {{ sum.activePowerDc | unitvalue:'W' }}
                                     </td>
                                 </tr>
                                 <tr *ngIf="sum.activePowerAc != null">
                                     <td style="width:65%">AC</td>
                                     <td style="width:35%" class="align_right">
-                                        {{ sum.activePowerAc == 0? '-&nbsp;' : (sum.activePowerAc | number:'1.0-0') + '&nbsp;W' }}
+                                        {{ sum.activePowerAc | unitvalue:'W' }}
                                     </td>
                                 </tr>
                             </table>
@@ -53,7 +52,7 @@
                                             <td style="width:65%" *ngIf="component.id != component.alias">
                                                 {{component.alias}}</td>
                                             <td style="width:35%" class="align_right">
-                                                {{ currentData[component.id + '/ActivePower'] == 0? '-&nbsp;' : (currentData[component.id + '/ActivePower'] | number:'1.0-0') + '&nbsp;W' }}
+                                                {{ currentData[component.id + '/ActivePower'] | unitvalue:'W' }}
                                             </td>
                                         </tr>
                                     </table>
@@ -69,7 +68,7 @@
                                             <td style="width:65%" *ngIf="component.id != component.alias">
                                                 {{component.alias}}</td>
                                             <td style="width:35%" class="align_right">
-                                                {{ currentData[component.id + '/ActualPower'] == 0? '-&nbsp;' : (currentData[component.id + '/ActualPower'] | number:'1.0-0') + '&nbsp;W' }}
+                                                {{ currentData[component.id + '/ActualPower'] | unitvalue:'W' }}
                                             </td>
                                         </tr>
                                     </table>

--- a/ui/src/app/edge/live/production/production.component.ts
+++ b/ui/src/app/edge/live/production/production.component.ts
@@ -61,6 +61,7 @@ export class ProductionComponent {
     }
 
     async presentModal() {
+        console.log("PRODUCTIONMETER", this.productionMeterComponents)
         const modal = await this.modalCtrl.create({
             component: ProductionModalComponent,
             componentProps: {

--- a/ui/src/app/edge/live/production/production.component.ts
+++ b/ui/src/app/edge/live/production/production.component.ts
@@ -61,7 +61,6 @@ export class ProductionComponent {
     }
 
     async presentModal() {
-        console.log("PRODUCTIONMETER", this.productionMeterComponents)
         const modal = await this.modalCtrl.create({
             component: ProductionModalComponent,
             componentProps: {

--- a/ui/src/app/edge/live/storage/modal/modal.component.html
+++ b/ui/src/app/edge/live/storage/modal/modal.component.html
@@ -18,23 +18,18 @@
                 <table class="full_width">
                     <div style="padding-top: 5px;"></div>
                     <tr>
-                        <td style="width: 65%" translate>General.Soc</td>
+                        <td style="width:65%" translate>General.Soc</td>
                         <td style="width: 35%" class="align_right">
-                            {{ sum.soc | number:'1.0-0' }}&nbsp;%</td>
+                            {{ sum.soc| unitvalue:'%' }}
+                        </td>
                     </tr>
-                    <!-- <tr class="underline">
-                                    <td style="width:20%" translate>General.Capacity</td>
-                                    <td style="width: 30%"></td>
-                                    <ng-container *ngIf="currentData[component.id + '/Capacity'] != null; else empty">
-                                        <td style="width:50%" class="align_right">
-                                            {{ currentData[component.id + '/Capacity'] | number:'1.0-0' }}&nbsp;Wh
-                                        </td>
-                                    </ng-container>
-                                    <ng-template #empty>
-                                        <td style="width:50%" class="align_right">-&nbsp;</td>
-                                    </ng-template>
-                                </tr> -->
+                    <tr *ngIf="currentData[component.id + '/Capacity'] != null">
+                        <td style="width:65%" translate>General.Capacity</td>
+                        <td style="width:35%" class="align_right">
+                            {{ currentData[component.id + '/Capacity'] | unitvalue:'Wh' }}
+                        </td>
 
+                    </tr>
                     <!-- Charge/Discharge -->
                     <tr>
                         <td style="width:65%" translate>General.ChargePower</td>
@@ -59,7 +54,7 @@
                         <td style="width:63%"><span translate>General.Phase</span> L1 <span
                                 translate>General.DischargePower</span></td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.activePowerL1 == 0? '-&nbsp;' : (sum.activePowerL1 | number:'1.0-0') + '&nbsp;W' }}
+                            {{ sum.activePowerL1 | unitvalue:'W' }}
                         </td>
                     </tr>
                     <tr *ngIf="sum.activePowerL1 <= 0">
@@ -67,7 +62,7 @@
                         <td style="width:63%"><span translate>General.Phase</span> L1 <span
                                 translate>General.ChargePower</span></td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.activePowerL1 == 0? '-&nbsp;' : ((sum.activePowerL1 * -1) | number:'1.0-0') + '&nbsp;W' }}
+                            {{(sum.activePowerL1 * -1) | unitvalue:'W'}}
                         </td>
                     </tr>
                     <tr *ngIf="sum.activePowerL2 > 0">
@@ -76,7 +71,7 @@
                                 translate>General.DischargePower</span>
                         </td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.activePowerL2 == 0? '-&nbsp;' : (sum.activePowerL2 | number:'1.0-0') + '&nbsp;W' }}
+                            {{ sum.activePowerL2 | unitvalue:'W' }}
                         </td>
                     </tr>
                     <tr *ngIf="sum.activePowerL2 <= 0">
@@ -85,7 +80,7 @@
                                 translate>General.ChargePower</span>
                         </td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.activePowerL2 == 0? '-&nbsp;' : ((sum.activePowerL2 * -1) | number:'1.0-0') + '&nbsp;W' }}
+                            {{ (sum.activePowerL2 * -1) | unitvalue:'W' }}
                         </td>
                     </tr>
                     <tr *ngIf="sum.activePowerL3 > 0">
@@ -95,7 +90,7 @@
                                 translate>General.DischargePower</span>
                         </td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.activePowerL3 == 0? '-&nbsp;' : (sum.activePowerL3 | number:'1.0-0') + '&nbsp;W' }}
+                            {{ sum.activePowerL3 | unitvalue:'W' }}
                         </td>
                     </tr>
                     <tr *ngIf="sum.activePowerL3 <= 0">
@@ -104,7 +99,7 @@
                                 translate>General.ChargePower</span>
                         </td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.activePowerL3 == 0? '-&nbsp;' : ((sum.activePowerL3 * -1) | number:'1.0-0') + '&nbsp;W' }}
+                            {{ (sum.activePowerL3 * -1) | unitvalue:'W' }}
                         </td>
                     </tr>
                 </table>
@@ -125,27 +120,26 @@
                     <div style="padding-top: 5px;"></div>
                     <tr>
                         <td style="width: 65%" translate>General.Soc</td>
-                        <td style="width: 35%" class="align_right">
-                            {{ sum.soc | number:'1.0-0' }}&nbsp;%</td>
+                        <td style="width:35%" class="align_right">
+                            {{ sum.soc | unitvalue:'%' }}
+                        </td>
                     </tr>
-                    <!-- </table> -->
-                    <!-- <table class="full_width"> -->
-                    <tr>
+                    <tr *ngIf="sum.capacity != null">
                         <td style="width:65%" translate>General.Capacity</td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.capacity == null? '-&nbsp;' : (sum.capacity | number:'1.0-0') + '&nbsp;Wh' }}
+                            {{ sum.capacity | unitvalue:'Wh' }}
                         </td>
                     </tr>
                     <tr>
                         <td style="width:65%" translate>General.ChargePower</td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.effectiveChargePower == null? '-&nbsp;' : (sum.effectiveChargePower | number:'1.0-0') + '&nbsp;W' }}
+                            {{ sum.effectiveChargePower | unitvalue:'W' }}
                         </td>
                     </tr>
                     <tr>
                         <td style="width:65%" translate>General.DischargePower</td>
                         <td style="width:35%" class="align_right">
-                            {{ sum.effectiveDischargePower == null? '-&nbsp;' : (sum.effectiveDischargePower | number:'1.0-0') + '&nbsp;W' }}
+                            {{ sum.effectiveDischargePower | unitvalue:'W' }}
                         </td>
                     </tr>
                 </table>
@@ -161,7 +155,7 @@
                                     translate>General.DischargePower</span>
                             </td>
                             <td style="width:35%" class="align_right">
-                                {{ sum.activePowerL1 == 0? '-&nbsp;' : (sum.activePowerL1 | number:'1.0-0') + '&nbsp;W' }}
+                                {{ sum.activePowerL1 | unitvalue:'W' }}
                             </td>
                         </tr>
                         <tr *ngIf="sum.activePowerL1 <= 0">
@@ -170,7 +164,7 @@
                                     translate>General.ChargePower</span>
                             </td>
                             <td style="width:35%" class="align_right">
-                                {{ sum.activePowerL1 == 0? '-&nbsp;' : ((sum.activePowerL1 * -1) | number:'1.0-0') + '&nbsp;W' }}
+                                {{ (sum.activePowerL1 * -1) | unitvalue:'W' }}
                             </td>
                         </tr>
                         <tr *ngIf="sum.activePowerL2 > 0">
@@ -179,7 +173,7 @@
                                     translate>General.DischargePower</span>
                             </td>
                             <td style="width:35%" class="align_right">
-                                {{ sum.activePowerL2 == 0? '-&nbsp;' : (sum.activePowerL2 | number:'1.0-0') + '&nbsp;W' }}
+                                {{ sum.activePowerL2 | unitvalue:'W' }}
                             </td>
                         </tr>
                         <tr *ngIf="sum.activePowerL2 <= 0">
@@ -188,7 +182,7 @@
                                     translate>General.ChargePower</span>
                             </td>
                             <td style="width:35%" class="align_right">
-                                {{ sum.activePowerL2 == 0? '-&nbsp;' : ((sum.activePowerL2 * -1) | number:'1.0-0') + '&nbsp;W' }}
+                                {{ (sum.activePowerL2 * -1) | unitvalue:'W' }}
                             </td>
                         </tr>
                         <tr *ngIf="sum.activePowerL3 > 0">
@@ -197,7 +191,7 @@
                                     translate>General.DischargePower</span>
                             </td>
                             <td style="width:35%" class="align_right">
-                                {{ sum.activePowerL3 == 0? '-&nbsp;' : (sum.activePowerL3 | number:'1.0-0') + '&nbsp;W' }}
+                                {{ sum.activePowerL3 | unitvalue:'W' }}
                             </td>
                         </tr>
                         <tr *ngIf="sum.activePowerL3 <= 0">
@@ -206,7 +200,7 @@
                                     translate>General.ChargePower</span>
                             </td>
                             <td style="width:35%" class="align_right">
-                                {{ sum.activePowerL3 == 0? '-&nbsp;' : ((sum.activePowerL3 * -1) | number:'1.0-0') + '&nbsp;W' }}
+                                {{ (sum.activePowerL3 * -1) | unitvalue:'W' }}
                             </td>
                         </tr>
                     </table>
@@ -231,12 +225,13 @@
                             <tr>
                                 <td style="width: 65%" translate>General.Soc</td>
                                 <td style="width: 35%" class="align_right">
-                                    {{ currentData[component.id + '/Soc'] | number:'1.0-0' }}&nbsp;%</td>
+                                    {{ currentData[component.id + '/Soc'] | unitvalue:'%' }}
+                                </td>
                             </tr>
                             <tr>
                                 <td style="width:65%" translate>General.Capacity</td>
                                 <td style="width:35%" class="align_right">
-                                    {{ currentData[component.id + '/Capacity'] == null? '-&nbsp;' : (currentData[component.id + '/Capacity'] | number:'1.0-0') + '&nbsp;Wh' }}
+                                    {{ currentData[component.id + '/Capacity'] | unitvalue:'Wh' }}
                                 </td>
                             </tr>
                         </table>
@@ -269,7 +264,7 @@
                                             translate>General.DischargePower</span>
                                     </td>
                                     <td style="width:35%" class="align_right">
-                                        {{ currentData[component.id + '/ActivePowerL1'] == 0? '-&nbsp;' : (currentData[component.id + '/ActivePowerL1'] | number:'1.0-0') + '&nbsp;W' }}
+                                        {{ currentData[component.id + '/ActivePowerL1'] | unitvalue:'W' }}
                                     </td>
                                 </ng-container>
                                 <ng-container *ngIf="currentData[component.id + '/ActivePowerL1'] <= 0">
@@ -278,7 +273,7 @@
                                             translate>General.ChargePower</span>
                                     </td>
                                     <td style="width:35%" class="align_right">
-                                        {{ currentData[component.id + '/ActivePowerL1'] == 0? '-&nbsp;' : ((currentData[component.id + '/ActivePowerL1'] * -1) | number:'1.0-0') + '&nbsp;W' }}
+                                        {{ (currentData[component.id + '/ActivePowerL1'] * -1) | unitvalue:'W' }}
                                     </td>
                                 </ng-container>
                             </tr>
@@ -288,7 +283,7 @@
                                     <td style="width:63%"><span translate>General.Phase</span> L2<span
                                             translate>General.DischargePower</span></td>
                                     <td style="width:35%" class="align_right">
-                                        {{ currentData[component.id + '/ActivePowerL2'] == 0? '-&nbsp;' : (currentData[component.id + '/ActivePowerL2'] | number:'1.0-0') + '&nbsp;W' }}
+                                        {{ currentData[component.id + '/ActivePowerL2'] | unitvalue:'W' }}
                                     </td>
                                 </ng-container>
                                 <ng-container *ngIf="currentData[component.id + '/ActivePowerL2'] <= 0">
@@ -297,7 +292,7 @@
                                             translate>General.ChargePower</span>
                                     </td>
                                     <td style="width:35%" class="align_right">
-                                        {{ currentData[component.id + '/ActivePowerL2'] == 0? '-&nbsp;' : ((currentData[component.id + '/ActivePowerL2'] * -1) | number:'1.0-0') + '&nbsp;W' }}
+                                        {{ (currentData[component.id + '/ActivePowerL2'] * -1) | unitvalue:'W' }}
                                     </td>
                                 </ng-container>
                             </tr>
@@ -308,7 +303,7 @@
                                             translate>General.DischargePower</span>
                                     </td>
                                     <td style="width:35%" class="align_right">
-                                        {{ currentData[component.id + '/ActivePowerL3'] == 0? '-&nbsp;' : (currentData[component.id + '/ActivePowerL3'] | number:'1.0-0') + '&nbsp;W' }}
+                                        {{ currentData[component.id + '/ActivePowerL3'] | unitvalue:'W' }}
                                     </td>
                                 </ng-container>
                                 <ng-container *ngIf="currentData[component.id + '/ActivePowerL3'] <= 0">
@@ -317,7 +312,7 @@
                                             translate>General.ChargePower</span>
                                     </td>
                                     <td style="width:35%" class="align_right">
-                                        {{ currentData[component.id + '/ActivePowerL3'] == 0? '-&nbsp;' : ((currentData[component.id + '/ActivePowerL3'] * -1) | number:'1.0-0') + '&nbsp;W' }}
+                                        {{ (currentData[component.id + '/ActivePowerL3'] * -1) | unitvalue:'W' }}
                                     </td>
                                 </ng-container>
                             </tr>

--- a/ui/src/app/edge/live/storage/storage.component.html
+++ b/ui/src/app/edge/live/storage/storage.component.html
@@ -80,13 +80,13 @@
                                 <tr>
                                     <td style="width:65%" translate>General.ChargePower</td>
                                     <td style="width:35%" class="align_right">
-                                        {{ sum.effectiveChargePower == null? '-&nbsp;' : (sum.effectiveChargePower | number:'1.0-0') + '&nbsp;W' }}
+                                        {{ sum.effectiveChargePower | unitvalue:'W' }}
                                     </td>
                                 </tr>
                                 <tr>
                                     <td style="width:65%" translate>General.DischargePower</td>
                                     <td style="width:35%" class="align_right">
-                                        {{ sum.effectiveDischargePower == null? '-&nbsp;' : (sum.effectiveDischargePower | number:'1.0-0') + '&nbsp;W' }}
+                                        {{ sum.effectiveDischargePower | unitvalue:'W' }}
                                     </td>
                                 </tr>
                             </table>
@@ -97,8 +97,8 @@
         </ng-container>
         <ng-container *ngIf="essComponents.length > 1">
             <ng-container *ngIf="(edge.currentData | async)['channel'] as currentData">
-                <ion-card-content>
-                    <ng-container *ngFor="let component of essComponents">
+                <ng-container *ngFor="let component of essComponents">
+                    <ion-card-content class="underline">
                         <table class="full_width">
                             <tr>
                                 <td style="width:100%" *ngIf="component.id == component.alias">{{component.id}}
@@ -128,9 +128,8 @@
                                 </td>
                             </tr>
                         </table>
-                    </ng-container>
-                    <div style="padding-top: 5px;"></div>
-                </ion-card-content>
+                    </ion-card-content>
+                </ng-container>
             </ng-container>
         </ng-container>
     </ng-template>

--- a/ui/src/app/shared/edge/currentdata.ts
+++ b/ui/src/app/shared/edge/currentdata.ts
@@ -205,7 +205,7 @@ export class CurrentData {
         + (result.consumption.activePower > 0 ? result.consumption.activePower : 0)
       );
       result.system.autarchy = CurrentData.calculateAutarchy(result.grid.buyActivePower, result.consumption.activePower);
-      result.system.selfConsumption = CurrentData.calculateSelfConsumption(result.grid.sellActivePower, result.production.activePower, result.storage.dischargeActivePower);
+      result.system.selfConsumption = CurrentData.calculateSelfConsumption(result.grid.sellActivePower, result.production.activePower, result.storage.effectiveDischargePower);
     }
     return result;
   }

--- a/ui/src/app/shared/edge/edgeconfig.ts
+++ b/ui/src/app/shared/edge/edgeconfig.ts
@@ -158,9 +158,16 @@ export class EdgeConfig {
     }
 
     /**
-     * Determines if Edge has a producing device
-     * 
+     * Determines if Edge has a Storage device
      */
+    public hasStorage(): boolean {
+        if (this.getComponentIdsImplementingNature('io.openems.edge.ess.api.SymmetricEss').length > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     /**
      * Determines if Edge has a producing device
      */

--- a/ui/src/app/shared/pipe/unitvalue/unitvalue.pipe.ts
+++ b/ui/src/app/shared/pipe/unitvalue/unitvalue.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DecimalPipe } from '@angular/common';
+
+@Pipe({
+    name: 'unitvalue'
+})
+export class UnitvaluePipe implements PipeTransform {
+
+    constructor(private decimalPipe: DecimalPipe) { }
+
+    transform(value: any, unit: string): any {
+        if (value === null) {
+            return '-' + '\u00A0';
+        } else {
+            return this.decimalPipe.transform(value, '1.0-0') + '\u00A0' + unit;
+        }
+    }
+}

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { CommonModule, DecimalPipe } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -26,6 +26,7 @@ import { IsclassPipe } from './pipe/isclass/isclass.pipe';
  */
 import { KeysPipe } from './pipe/keys/keys.pipe';
 import { SignPipe } from './pipe/sign/sign.pipe';
+import { UnitvaluePipe } from './pipe/unitvalue/unitvalue.pipe';
 /*
  * Services
  */
@@ -59,6 +60,7 @@ import { PercentageBarComponent } from './percentagebar/percentagebar.component'
     SignPipe,
     IsclassPipe,
     HasclassPipe,
+    UnitvaluePipe,
     // components
     SocComponent,
     PickDateComponent,
@@ -71,6 +73,7 @@ import { PercentageBarComponent } from './percentagebar/percentagebar.component'
     ClassnamePipe,
     IsclassPipe,
     HasclassPipe,
+    UnitvaluePipe,
     // modules
     BrowserAnimationsModule,
     ChartsModule,
@@ -95,7 +98,8 @@ import { PercentageBarComponent } from './percentagebar/percentagebar.component'
     Service,
     Websocket,
     ToasterService,
-    appRoutingProviders
+    appRoutingProviders,
+    DecimalPipe
   ]
 })
 export class SharedModule {

--- a/ui/src/app/shared/translate/de.ts
+++ b/ui/src/app/shared/translate/de.ts
@@ -82,8 +82,8 @@ export const TRANSLATION = {
                     Output: "Ausgang"
                 },
                 phasesInfo: "Die Summe der einzelnen Phasen kann aus technischen Gründen geringfügig von der Gesamtsumme abweichen.",
-                autarchyInfo: "Die Autarkie gibt an zu wie viel Prozent die aktuell genutzte Leistung durch Erzeugung und Speicherentladung gedeckt werden kann.",
-                selfconsumptionInfo: "Der Eigenverbrauch gibt an zu wie viel Prozent die aktuell erzeugte Leistung durch direkten Verbrauch und durch Speicherbeladung selbst genutzt werden kann.",
+                autarchyInfo: "Die Autarkie gibt an zu wie viel Prozent die aktuell genutzte Leistung durch Erzeugung und Speicherentladung gedeckt wird.",
+                selfconsumptionInfo: "Der Eigenverbrauch gibt an zu wie viel Prozent die aktuell erzeugte Leistung durch direkten Verbrauch und durch Speicherbeladung selbst genutzt wird.",
                 CHP: {
                     LowThreshold: "Unterer Schwellenwert",
                     HighThreshold: "Oberer Schwellenwert"

--- a/ui/src/app/shared/type/widget.ts
+++ b/ui/src/app/shared/type/widget.ts
@@ -42,11 +42,11 @@ export class Widgets {
                 switch (clazz) {
                     case 'Grid':
                     case 'Consumption':
-                        return true; // Always show Grid + Consumption
-                    case 'Storage':
-                        return config.getComponentIdsImplementingNature('io.openems.edge.ess.api.SymmetricEss').length > 0;
-                    case 'Production':
                     case 'Autarchy':
+                        return true; // Always show Grid + Consumption + Autarchy
+                    case 'Storage':
+                        return config.hasStorage();
+                    case 'Production':
                     case 'Selfconsumption':
                         return config.hasProducer();
                 };


### PR DESCRIPTION
fixed that all channelthreshold controller are shown in live component (*not just the active ones)
fixed that the colors remain the same in energy chart if edge has no storage
fixed that 'null' values are shown

- added unitValue pipe