### PR TITLE
Implement timedata service based on Rrd4j

### DIFF
--- a/cnf/pom.xml
+++ b/cnf/pom.xml
@@ -154,6 +154,12 @@
 			<version>42.2.7</version>
 		</dependency>
 		<dependency>
+			<!-- Used by io.openems.edge.timedata.rrd4j -->
+			<groupId>org.rrd4j</groupId>
+			<artifactId>rrd4j</artifactId>
+			<version>3.5</version>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>1.8.0-beta4</version>

--- a/io.openems.common/src/io/openems/common/OpenemsConstants.java
+++ b/io.openems.common/src/io/openems/common/OpenemsConstants.java
@@ -1,5 +1,7 @@
 package io.openems.common;
 
+import java.util.Optional;
+
 import org.osgi.framework.Constants;
 
 import io.openems.common.types.SemanticVersion;
@@ -104,4 +106,17 @@ public class OpenemsConstants {
 	public final static String PROPERTY_FACTORY_PID = "service.factoryPid";
 	public final static String PROPERTY_LAST_CHANGE_BY = "_lastChangeBy";
 	public final static String PROPERTY_LAST_CHANGE_AT = "_lastChangeAt";
+
+	private static final String OPENEMS_DATA_DIR = "openems.data.dir";
+
+	/**
+	 * Gets the path of the OpenEMS Data Directory, configured by "openems.data.dir"
+	 * command line parameter.
+	 * 
+	 * @return the path of the OpenEMS Data Directory
+	 */
+	public final static String getOpenemsDataDir() {
+		return Optional.ofNullable(System.getProperty(OPENEMS_DATA_DIR)).orElse("");
+	}
+
 }

--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -6,7 +6,8 @@
 
 -runproperties: \
 	org.osgi.service.http.port=8080,\
-	felix.cm.dir=c:/openems-config
+	felix.cm.dir=c:/openems-config,\
+	openems.data.dir=c:/openems/data
 
 -runee: JavaSE-1.8
 
@@ -84,17 +85,22 @@
 	bnd.identity;id='io.openems.edge.meter.microcare.sdm630',\
 	bnd.identity;id='io.openems.edge.meter.pqplus.umd97',\
 	bnd.identity;id='io.openems.edge.meter.socomec',\
+	bnd.identity;id='io.openems.edge.meter.sunspec',\
 	bnd.identity;id='io.openems.edge.meter.virtual',\
 	bnd.identity;id='io.openems.edge.meter.weidmueller',\
 	bnd.identity;id='io.openems.edge.predictor.persistencemodel',\
 	bnd.identity;id='io.openems.edge.pvinverter.kaco.blueplanet',\
 	bnd.identity;id='io.openems.edge.pvinverter.solarlog',\
+	bnd.identity;id='io.openems.edge.pvinverter.sunspec',\
 	bnd.identity;id='io.openems.edge.scheduler.allalphabetically',\
+	bnd.identity;id='io.openems.edge.scheduler.daily',\
 	bnd.identity;id='io.openems.edge.scheduler.fixedorder',\
+	bnd.identity;id='io.openems.edge.solaredge',\
 	bnd.identity;id='io.openems.edge.simulator',\
 	bnd.identity;id='io.openems.edge.solaredge',\
+	bnd.identity;id='io.openems.edge.tesla.powerwall2',\
 	bnd.identity;id='io.openems.edge.timedata.influxdb',\
-	bnd.identity;id='io.openems.edge.tesla.powerwall2'
+	bnd.identity;id='io.openems.edge.timedata.rrd4j'
 
 -runbundles: \
 	com.google.gson;version='[2.8.5,2.8.6)',\
@@ -209,4 +215,7 @@
 	com.fasterxml.jackson.core.jackson-annotations;version='[2.10.0,2.10.1)',\
 	com.fasterxml.jackson.core.jackson-core;version='[2.10.0,2.10.1)',\
 	com.fasterxml.jackson.core.jackson-databind;version='[2.10.0,2.10.1)',\
-	com.github.scribejava.core;version='[6.9.0,6.9.1)'
+	com.github.scribejava.core;version='[6.9.0,6.9.1)',\
+	io.openems.edge.scheduler.daily;version=snapshot,\
+	io.openems.edge.timedata.rrd4j;version=snapshot,\
+	rrd4j;version='[3.5.0,3.5.1)'

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/Channel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/Channel.java
@@ -1,5 +1,6 @@
 package io.openems.edge.common.channel;
 
+import java.time.LocalDateTime;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -8,6 +9,7 @@ import io.openems.common.types.OpenemsType;
 import io.openems.edge.common.channel.internal.AbstractReadChannel;
 import io.openems.edge.common.channel.value.Value;
 import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.type.CircularTreeMap;
 import io.openems.edge.common.type.TypeUtils;
 
 /**
@@ -126,6 +128,13 @@ public interface Channel<T> {
 	 * Gets the currently active value, wrapped in a @{link Value}.
 	 */
 	Value<T> value();
+
+	/**
+	 * Gets the past values for this Channel.
+	 * 
+	 * @return a map of recording time and historic value at that time
+	 */
+	public CircularTreeMap<LocalDateTime, Value<T>> getPastValues();
 
 	/**
 	 * Add an onUpdate callback. It is called, after the active value was updated by

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/value/Value.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/value/Value.java
@@ -1,5 +1,6 @@
 package io.openems.edge.common.channel.value;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import com.google.gson.JsonElement;
@@ -15,7 +16,7 @@ import io.openems.edge.common.type.TypeUtils;
  * This wraps a 'value' information for a Channel and provides convenience
  * methods for retrieving it.
  * 
- * @param <T>
+ * @param <T> the type of the value
  */
 public class Value<T> {
 
@@ -23,10 +24,12 @@ public class Value<T> {
 
 	private final Channel<T> parent;
 	private final T value;
+	private final LocalDateTime timestamp;
 
 	public Value(Channel<T> parent, T value) {
 		this.parent = parent;
 		this.value = value;
+		this.timestamp = LocalDateTime.now();
 	}
 
 	/**
@@ -186,5 +189,14 @@ public class Value<T> {
 		} else {
 			return null;
 		}
+	}
+
+	/**
+	 * Gets the timestamp when the value was created.
+	 * 
+	 * @return the timestamp
+	 */
+	public LocalDateTime getTimestamp() {
+		return this.timestamp;
 	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/type/CircularTreeMap.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/type/CircularTreeMap.java
@@ -1,0 +1,32 @@
+package io.openems.edge.common.type;
+
+import java.util.Iterator;
+import java.util.TreeMap;
+
+public class CircularTreeMap<K, V> extends TreeMap<K, V> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final int limit;
+
+	public CircularTreeMap(int limit) {
+		this.limit = limit;
+	}
+
+	@Override
+	public V put(K key, V value) {
+		V result = super.put(key, value);
+		if (super.size() > this.limit) {
+			this.removeEldest();
+		}
+		return result;
+	}
+
+	private void removeEldest() {
+		Iterator<K> iterator = this.keySet().iterator();
+		if (iterator.hasNext()) {
+			this.remove(iterator.next());
+		}
+	}
+
+}

--- a/io.openems.edge.common/src/io/openems/edge/common/type/CircularTreeMap.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/type/CircularTreeMap.java
@@ -3,6 +3,16 @@ package io.openems.edge.common.type;
 import java.util.Iterator;
 import java.util.TreeMap;
 
+/**
+ * Implements a circular buffer with a TreeMap.
+ * 
+ * <p>
+ * Be aware that not the eldest entry is removed when the buffer is full, but
+ * the entry with the lowest key is removed!
+ * 
+ * @param <K> the type of the Key
+ * @param <V> the type of the Value
+ */
 public class CircularTreeMap<K, V> extends TreeMap<K, V> {
 
 	private static final long serialVersionUID = 1L;
@@ -17,12 +27,12 @@ public class CircularTreeMap<K, V> extends TreeMap<K, V> {
 	public V put(K key, V value) {
 		V result = super.put(key, value);
 		if (super.size() > this.limit) {
-			this.removeEldest();
+			this.removeLowest();
 		}
 		return result;
 	}
 
-	private void removeEldest() {
+	private void removeLowest() {
 		Iterator<K> iterator = this.keySet().iterator();
 		if (iterator.hasNext()) {
 			this.remove(iterator.next());

--- a/io.openems.edge.common/test/io/openems/edge/common/type/CircularTreeMapTest.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/type/CircularTreeMapTest.java
@@ -1,0 +1,27 @@
+package io.openems.edge.common.type;
+
+import static org.junit.Assert.*;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class CircularTreeMapTest {
+
+	@Test
+	public void test() {
+		CircularTreeMap<String, String> m = new CircularTreeMap<>(3);
+		m.put("1", "one");
+		m.put("2", "two");
+		m.put("3", "three");
+		m.put("4", "four");
+
+		Set<String> ks = m.keySet();
+		Iterator<String> i = ks.iterator();
+		assertEquals("2", i.next());
+		assertEquals("3", i.next());
+		assertEquals("4", i.next());
+	}
+
+}

--- a/io.openems.edge.common/test/io/openems/edge/common/type/CircularTreeMapTest.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/type/CircularTreeMapTest.java
@@ -24,4 +24,18 @@ public class CircularTreeMapTest {
 		assertEquals("4", i.next());
 	}
 
+	@Test
+	public void testAnotherOrder() {
+		CircularTreeMap<String, String> m = new CircularTreeMap<>(3);
+		m.put("4", "four");
+		m.put("3", "three");
+		m.put("2", "two");
+		m.put("1", "one");
+		
+		Set<String> ks = m.keySet();
+		Iterator<String> i = ks.iterator();
+		assertEquals("2", i.next());
+		assertEquals("3", i.next());
+		assertEquals("4", i.next());
+	}
 }

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/RestApi.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/RestApi.java
@@ -7,6 +7,9 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +23,7 @@ import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.user.UserService;
 import io.openems.edge.controller.api.Controller;
 import io.openems.edge.controller.api.core.ApiWorker;
+import io.openems.edge.timedata.api.Timedata;
 
 @Designate(ocd = Config.class, factory = true)
 @Component(//
@@ -42,6 +46,9 @@ public class RestApi extends AbstractOpenemsComponent implements Controller, Ope
 
 	@Reference
 	protected UserService userService;
+
+	@Reference(policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.OPTIONAL)
+	private volatile Timedata timedata = null;
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
 		;
@@ -124,5 +131,18 @@ public class RestApi extends AbstractOpenemsComponent implements Controller, Ope
 
 	protected boolean isDebugModeEnabled() {
 		return isDebugModeEnabled;
+	}
+
+	/**
+	 * Gets the Timedata service.
+	 * 
+	 * @return the service
+	 * @throws OpenemsException if the timeservice is not available
+	 */
+	public Timedata getTimedata() throws OpenemsException {
+		if (this.timedata != null) {
+			return this.timedata;
+		}
+		throw new OpenemsException("There is no Timedata-Service available!");
 	}
 }

--- a/io.openems.edge.timedata.rrd4j/.classpath
+++ b/io.openems.edge.timedata.rrd4j/.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="src" output="bin_test" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/io.openems.edge.timedata.rrd4j/.gitignore
+++ b/io.openems.edge.timedata.rrd4j/.gitignore
@@ -1,0 +1,2 @@
+/bin_test/
+/generated/

--- a/io.openems.edge.timedata.rrd4j/.project
+++ b/io.openems.edge.timedata.rrd4j/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openems.edge.timedata.rrd4j</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/io.openems.edge.timedata.rrd4j/bnd.bnd
+++ b/io.openems.edge.timedata.rrd4j/bnd.bnd
@@ -1,0 +1,23 @@
+Bundle-Name: OpenEMS Edge Timedata RRD4J
+Bundle-Vendor: FENECON GmbH
+Bundle-License: https://opensource.org/licenses/EPL-2.0
+Bundle-Version: 1.0.0.${tstamp}
+Export-Package: io.openems.edge.timedata.api
+Private-Package: io.openems.edge.timedata.rrd4j
+
+-includeresource: {readme.adoc}
+
+-buildpath: \
+	${buildpath},\
+	io.openems.common;version=latest,\
+	io.openems.edge.common;version=latest,\
+	io.openems.edge.timedata.api;version=latest,\
+	com.google.gson,\
+	com.google.guava,\
+	slf4j.api,\
+	rrd4j
+
+-testpath: ${testpath}
+
+javac.source: 1.8
+javac.target: 1.8

--- a/io.openems.edge.timedata.rrd4j/readme.adoc
+++ b/io.openems.edge.timedata.rrd4j/readme.adoc
@@ -1,0 +1,5 @@
+= RRD4J 
+
+Persists data of OpenEMS Edge Channels to RRD4J files.
+
+https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.timedata.rrd4j[Source Code icon:github[]]

--- a/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/Config.java
+++ b/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/Config.java
@@ -1,0 +1,24 @@
+package io.openems.edge.timedata.rrd4j;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@ObjectClassDefinition( //
+		name = "Timedata RRD4J", //
+		description = "This component persists data to RRD4J files.")
+@interface Config {
+
+	@AttributeDefinition(name = "Component-ID", description = "Unique ID of this Component")
+	String id() default "rrd4j0";
+
+	@AttributeDefinition(name = "Alias", description = "Human-readable name of this Component; defaults to Component-ID")
+	String alias() default "";
+
+	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
+	boolean enabled() default true;
+
+	@AttributeDefinition(name = "No. of Cycles", description = "How many Cycles till data is recorded.")
+	int noOfCycles() default RecordWorker.DEFAULT_NO_OF_CYCLES;
+
+	String webconsole_configurationFactory_nameHint() default "Timedata RRD4J [{id}]";
+}

--- a/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/RecordWorker.java
+++ b/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/RecordWorker.java
@@ -1,0 +1,227 @@
+package io.openems.edge.timedata.rrd4j;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.OptionalDouble;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Function;
+import java.util.function.ToDoubleFunction;
+import java.util.stream.DoubleStream;
+
+import org.rrd4j.core.RrdDb;
+import org.rrd4j.core.Sample;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.openems.common.channel.AccessMode;
+import io.openems.common.channel.Unit;
+import io.openems.common.types.ChannelAddress;
+import io.openems.common.types.OpenemsType;
+import io.openems.common.worker.AbstractImmediateWorker;
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.component.OpenemsComponent;
+
+public class RecordWorker extends AbstractImmediateWorker {
+
+	protected static final int DEFAULT_NO_OF_CYCLES = 60;
+
+	private final Logger log = LoggerFactory.getLogger(RecordWorker.class);
+	private final Rrd4jTimedata parent;
+	protected int noOfCycles = DEFAULT_NO_OF_CYCLES; // default, is going to be overwritten by config
+
+	// Counts the number of Cycles till data is recorded
+	private int cycleCount = 0;
+
+	private static class Record {
+		private final long timestamp;
+		private final ChannelAddress address;
+		private final Unit unit;
+		private final double value;
+
+		public Record(long timestamp, ChannelAddress address, Unit unit, double value) {
+			this.timestamp = timestamp;
+			this.address = address;
+			this.unit = unit;
+			this.value = value;
+		}
+	}
+
+	// Record queue
+	private LinkedBlockingQueue<Record> records = new LinkedBlockingQueue<>();
+	private LocalDateTime lastRecordedTimestamp = LocalDateTime.MIN;
+
+	public RecordWorker(Rrd4jTimedata parent) {
+		this.parent = parent;
+	}
+
+	/**
+	 * Collects the data from Channels. This is called synchronously by the main
+	 * OpenEMS cycle. On finish it triggers a next async task to write the data to
+	 * RRD4J.
+	 */
+	public void collectData() {
+		// Increase CycleCount
+		if (++this.cycleCount < this.noOfCycles) {
+			// Stop here if not reached CycleCount
+			return;
+		}
+
+		LocalDateTime recordTimestamp = LocalDateTime.now();
+		long timestamp = recordTimestamp.toEpochSecond(ZoneOffset.UTC);
+		for (OpenemsComponent component : this.parent.componentManager.getEnabledComponents()) {
+			for (Channel<?> channel : component.channels()) {
+				if (channel.channelDoc().getAccessMode() != AccessMode.READ_ONLY
+						&& channel.channelDoc().getAccessMode() != AccessMode.READ_WRITE) {
+					// Ignore WRITE_ONLY Channels
+					continue;
+				}
+
+				ToDoubleFunction<? super Object> channelMapFunction = this
+						.getChannelMapFunction(channel.channelDoc().getType());
+				Function<DoubleStream, OptionalDouble> channelAggregateFunction = getChannelAggregateFunction(
+						channel.channelDoc().getUnit());
+
+				OptionalDouble value = channelAggregateFunction.apply( //
+						channel.getPastValues() //
+								.tailMap(this.lastRecordedTimestamp, false) // new values since last recording
+								.values().stream() //
+								.map(v -> v.get()) //
+								.filter(v -> v != null) // only not-null values
+								.mapToDouble(channelMapFunction) // convert to double
+				);
+				if (!value.isPresent()) {
+					// only available channels
+					continue;
+				}
+
+				if (!this.records.offer(//
+						new Record(timestamp, channel.address(), channel.channelDoc().getUnit(),
+								value.getAsDouble()))) {
+					this.log.warn("Unable to add record [" + channel.address() + "]. Queue is full!");
+				}
+			}
+		}
+		this.lastRecordedTimestamp = recordTimestamp;
+		this.triggerNextRun();
+	}
+
+	@Override
+	protected void forever() throws InterruptedException {
+		Record record = this.records.take();
+		try {
+			RrdDb db = this.parent.getRrdDb(record.address, record.unit, record.timestamp - 1);
+
+			// Add Sample to RRD4J
+			Sample sample = db.createSample(record.timestamp);
+			sample.setValue(0, record.value);
+			sample.update();
+
+			// Close file
+			db.close();
+
+		} catch (IOException | URISyntaxException e) {
+			this.parent.logWarn(this.log, "Unable to insert Sample [" + record.address + "] "
+					+ e.getClass().getSimpleName() + ": " + e.getMessage());
+			e.printStackTrace();
+		} catch (Throwable e) {
+			this.parent.logWarn(this.log, "Unhandled error on insert Sample [" + record.address + "]. "
+					+ e.getClass().getSimpleName() + ": " + e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	private final static ToDoubleFunction<? super Object> MAP_BOOLEAN_TO_DOUBLE = (value) -> {
+		return (Boolean) value ? 1d : 0d;
+	};
+
+	private final static ToDoubleFunction<? super Object> MAP_SHORT_TO_DOUBLE = (value) -> {
+		return ((Short) value).doubleValue();
+	};
+	private final static ToDoubleFunction<? super Object> MAP_INTEGER_TO_DOUBLE = (value) -> {
+		return ((Integer) value).doubleValue();
+	};
+	private final static ToDoubleFunction<? super Object> MAP_LONG_TO_DOUBLE = (value) -> {
+		return ((Long) value).doubleValue();
+	};
+	private final static ToDoubleFunction<? super Object> MAP_FLOAT_TO_DOUBLE = (value) -> {
+		return ((Float) value).doubleValue();
+	};
+	private final static ToDoubleFunction<? super Object> MAP_DOUBLE_TO_DOUBLE = (value) -> {
+		return (Double) value;
+	};
+	private final static ToDoubleFunction<? super Object> MAP_TO_DOUBLE_NOT_SUPPORTED = (value) -> {
+		return 0d;
+	};
+
+	private ToDoubleFunction<? super Object> getChannelMapFunction(OpenemsType openemsType) {
+		switch (openemsType) {
+		case BOOLEAN:
+			return MAP_BOOLEAN_TO_DOUBLE;
+		case SHORT:
+			return MAP_SHORT_TO_DOUBLE;
+		case INTEGER:
+			return MAP_INTEGER_TO_DOUBLE;
+		case LONG:
+			return MAP_LONG_TO_DOUBLE;
+		case FLOAT:
+			return MAP_FLOAT_TO_DOUBLE;
+		case DOUBLE:
+			return MAP_DOUBLE_TO_DOUBLE;
+		case STRING:
+			// Strings are not supported by RRD4J
+			return MAP_TO_DOUBLE_NOT_SUPPORTED;
+		}
+		throw new IllegalArgumentException("Type [" + openemsType + "] is not supported.");
+	}
+
+	private Function<DoubleStream, OptionalDouble> getChannelAggregateFunction(Unit channelUnit) {
+		switch (channelUnit) {
+		case AMPERE:
+		case AMPERE_HOURS:
+		case DEGREE_CELSIUS:
+		case DEZIDEGREE_CELSIUS:
+		case HERTZ:
+		case HOUR:
+		case KILOAMPERE_HOURS:
+		case KILOOHM:
+		case KILOVOLT_AMPERE:
+		case KILOVOLT_AMPERE_REACTIVE:
+		case KILOWATT:
+		case MICROOHM:
+		case MILLIAMPERE_HOURS:
+		case MILLIAMPERE:
+		case MILLIHERTZ:
+		case MILLIOHM:
+		case MILLISECONDS:
+		case MILLIVOLT:
+		case MILLIWATT:
+		case MINUTE:
+		case NONE:
+		case WATT:
+		case VOLT:
+		case VOLT_AMPERE:
+		case VOLT_AMPERE_REACTIVE:
+		case WATT_HOURS_BY_WATT_PEAK:
+		case OHM:
+		case SECONDS:
+		case THOUSANDTH:
+		case PERCENT:
+		case ON_OFF:
+			return DoubleStream::average;
+		case WATT_HOURS:
+		case KILOWATT_HOURS:
+		case VOLT_AMPERE_HOURS:
+		case VOLT_AMPERE_REACTIVE_HOURS:
+		case KILOVOLT_AMPERE_REACTIVE_HOURS:
+			return DoubleStream::max;
+		}
+		throw new IllegalArgumentException("Channel Unit [" + channelUnit + "] is not supported.");
+	}
+
+	public void setNoOfCycles(int noOfCycles) {
+		this.noOfCycles = noOfCycles;
+	}
+
+}

--- a/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/Rrd4jTimedata.java
+++ b/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/Rrd4jTimedata.java
@@ -58,6 +58,7 @@ import io.openems.edge.timedata.api.Timedata;
 		property = EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE)
 public class Rrd4jTimedata extends AbstractOpenemsComponent implements Timedata, OpenemsComponent, EventHandler {
 
+	private static final String OPENEMS_DATA_PROPERTY = "openems.data.dir";
 	private final static String RRD4J_PATH = "rrd4j";
 	private final static String DEFAULT_DATASOURCE_NAME = "value";
 	private final static int DEFAULT_STEP_SECONDS = 60;
@@ -240,7 +241,7 @@ public class Rrd4jTimedata extends AbstractOpenemsComponent implements Timedata,
 
 	private File getDbFile(ChannelAddress channelAddress) {
 		File file = Paths.get(//
-				Optional.ofNullable(System.getProperty("openems.data.dir")).orElse(""), //
+				Optional.ofNullable(System.getProperty(OPENEMS_DATA_PROPERTY)).orElse(""), //
 				RRD4J_PATH, //
 				this.id(), //
 				channelAddress.getComponentId(), //

--- a/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/Rrd4jTimedata.java
+++ b/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/Rrd4jTimedata.java
@@ -7,7 +7,6 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -37,6 +36,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonPrimitive;
 
+import io.openems.common.OpenemsConstants;
 import io.openems.common.channel.Level;
 import io.openems.common.channel.Unit;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -58,7 +58,6 @@ import io.openems.edge.timedata.api.Timedata;
 		property = EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE)
 public class Rrd4jTimedata extends AbstractOpenemsComponent implements Timedata, OpenemsComponent, EventHandler {
 
-	private static final String OPENEMS_DATA_PROPERTY = "openems.data.dir";
 	private final static String RRD4J_PATH = "rrd4j";
 	private final static String DEFAULT_DATASOURCE_NAME = "value";
 	private final static int DEFAULT_STEP_SECONDS = 60;
@@ -160,7 +159,8 @@ public class Rrd4jTimedata extends AbstractOpenemsComponent implements Timedata,
 	@Override
 	public SortedMap<ChannelAddress, JsonElement> queryHistoricEnergy(String edgeId, ZonedDateTime fromDate,
 			ZonedDateTime toDate, Set<ChannelAddress> channels) throws OpenemsNamedException {
-		return new TreeMap<>();
+		// TODO implement Energy calculation
+		throw new OpenemsException("This method is not implemented");
 	}
 
 	/**
@@ -241,7 +241,7 @@ public class Rrd4jTimedata extends AbstractOpenemsComponent implements Timedata,
 
 	private File getDbFile(ChannelAddress channelAddress) {
 		File file = Paths.get(//
-				Optional.ofNullable(System.getProperty(OPENEMS_DATA_PROPERTY)).orElse(""), //
+				OpenemsConstants.getOpenemsDataDir(), //
 				RRD4J_PATH, //
 				this.id(), //
 				channelAddress.getComponentId(), //

--- a/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/Rrd4jTimedata.java
+++ b/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/Rrd4jTimedata.java
@@ -1,0 +1,333 @@
+package io.openems.edge.timedata.rrd4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.metatype.annotations.Designate;
+import org.rrd4j.ConsolFun;
+import org.rrd4j.DsType;
+import org.rrd4j.core.DsDef;
+import org.rrd4j.core.FetchData;
+import org.rrd4j.core.FetchRequest;
+import org.rrd4j.core.RrdDb;
+import org.rrd4j.core.RrdDef;
+import org.rrd4j.core.RrdRandomAccessFileBackendFactory;
+import org.slf4j.Logger;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+
+import io.openems.common.channel.Unit;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.types.ChannelAddress;
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.component.AbstractOpenemsComponent;
+import io.openems.edge.common.component.ComponentManager;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.event.EdgeEventConstants;
+import io.openems.edge.timedata.api.Timedata;
+
+@Designate(ocd = Config.class, factory = true)
+@Component(name = "Timedata.Rrd4j", //
+		immediate = true, //
+		configurationPolicy = ConfigurationPolicy.REQUIRE, //
+		property = EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE)
+public class Rrd4jTimedata extends AbstractOpenemsComponent implements Timedata, OpenemsComponent, EventHandler {
+
+	private final static String RRD4J_PATH = "rrd4j";
+	private final static String DEFAULT_DATASOURCE_NAME = "value";
+	private final static int DEFAULT_STEP_SECONDS = 60;
+	private final static int DEFAULT_HEARTBEAT_SECONDS = DEFAULT_STEP_SECONDS;
+
+	private final RecordWorker worker;
+	private final RrdRandomAccessFileBackendFactory factory;
+
+	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+		;
+		private final Doc doc;
+
+		private ChannelId(Doc doc) {
+			this.doc = doc;
+		}
+
+		@Override
+		public Doc doc() {
+			return this.doc;
+		}
+	}
+
+	public Rrd4jTimedata() {
+		super(//
+				OpenemsComponent.ChannelId.values(), //
+				Timedata.ChannelId.values(), //
+				ChannelId.values() //
+		);
+		this.worker = new RecordWorker(this);
+		this.factory = new RrdRandomAccessFileBackendFactory();
+	}
+
+	@Reference
+	protected ComponentManager componentManager;
+
+	@Activate
+	void activate(ComponentContext context, Config config) throws Exception {
+		super.activate(context, config.id(), config.alias(), config.enabled());
+
+		if (config.enabled()) {
+			this.worker.setNoOfCycles(config.noOfCycles());
+			this.worker.activate(config.id());
+		}
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		this.worker.deactivate();
+		super.deactivate();
+	}
+
+	@Override
+	public SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> queryHistoricData(String edgeId,
+			ZonedDateTime fromDate, ZonedDateTime toDate, Set<ChannelAddress> channels, int resolution)
+			throws OpenemsNamedException {
+		ZoneId timezone = fromDate.getZone();
+		SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> table = new TreeMap<>();
+
+		try {
+			long fromTimestamp = fromDate.toEpochSecond();
+			long toTimeStamp = toDate.toEpochSecond();
+
+			for (ChannelAddress channelAddress : channels) {
+				Channel<?> channel = this.componentManager.getChannel(channelAddress);
+				RrdDb database = this.getExistingRrdDb(channel.address());
+				if (database == null) {
+					continue; // not existing -> abort
+				}
+
+				FetchRequest request = database.createFetchRequest(ConsolFun.AVERAGE, fromTimestamp, toTimeStamp,
+						resolution);
+				FetchData data = request.fetchData();
+				for (int i = 0; i < data.getTimestamps().length; i++) {
+					Instant timestampInstant = Instant.ofEpochSecond(data.getTimestamps()[i]);
+					ZonedDateTime dateTime = ZonedDateTime.ofInstant(timestampInstant, timezone);
+					SortedMap<ChannelAddress, JsonElement> tableRow = table.get(dateTime);
+					if (tableRow == null) {
+						tableRow = new TreeMap<>();
+					}
+					double value = data.getValues(0)[i];
+					if (Double.isNaN(value)) {
+						tableRow.put(channelAddress, JsonNull.INSTANCE);
+					} else {
+						tableRow.put(channelAddress, new JsonPrimitive(value));
+					}
+					table.put(dateTime, tableRow);
+				}
+			}
+		} catch (IOException | IllegalArgumentException e) {
+			throw new OpenemsException("Unable to read historic data: " + e.getMessage());
+		}
+		return table;
+	}
+
+	@Override
+	public SortedMap<ChannelAddress, JsonElement> queryHistoricEnergy(String edgeId, ZonedDateTime fromDate,
+			ZonedDateTime toDate, Set<ChannelAddress> channels) throws OpenemsNamedException {
+		return new TreeMap<>();
+	}
+
+	/**
+	 * Gets the RRD4j database for the given Channel-Address.
+	 * 
+	 * <p>
+	 * The predefined RRD4J archives match the requirements of
+	 * {@link CommonTimedataService#calculateResolution(ZonedDateTime,
+	 * ZonedDateTime).
+	 * 
+	 * @param channelAddress the Channel-Address
+	 * @param startTime      the starttime for newly created RrdDbs
+	 * @return the RrdDb
+	 * @throws IOException        on error
+	 * @throws URISyntaxException on error
+	 */
+	protected synchronized RrdDb getRrdDb(ChannelAddress channelAddress, Unit channelUnit, long startTime)
+			throws IOException, URISyntaxException {
+		RrdDb rrdDb = this.getExistingRrdDb(channelAddress);
+		if (rrdDb != null) {
+			/*
+			 * Open existing DB
+			 */
+			return rrdDb;
+
+		} else {
+			/*
+			 * Create new DB
+			 */
+			ChannelDef channelDef = this.getDsDefForChannel(channelUnit);
+			RrdDef rrdDef = new RrdDef(//
+					this.getDbFile(channelAddress).toURI(), //
+					startTime, // Start-Time
+					DEFAULT_STEP_SECONDS // Step in [s], default: 60 = 1 minute
+			);
+			rrdDef.addDatasource(//
+					new DsDef(DEFAULT_DATASOURCE_NAME, //
+							channelDef.dsType, //
+							DEFAULT_HEARTBEAT_SECONDS, // Heartbeat in [s], default 60 = 1 minute
+							channelDef.minValue, channelDef.maxValue));
+			// detailed recordings
+			rrdDef.addArchive(channelDef.consolFun, 0.5, 1, 1_440); // 1 step (1 minute), 1440 rows (1 day)
+			rrdDef.addArchive(channelDef.consolFun, 0.5, 5, 2_880); // 5 steps (5 minutes), 2880 rows (10 days)
+			// hourly values for a very long time
+			rrdDef.addArchive(channelDef.consolFun, 0.5, 60, 87_600); // 60 steps (1 hour), 87600 rows (10 years)
+
+			return RrdDb.getBuilder() //
+					.setBackendFactory(this.factory) //
+					.usePool() //
+					.setRrdDef(rrdDef) //
+					.build();
+		}
+	}
+
+	/**
+	 * Gets an existing RrdDb.
+	 * 
+	 * @param channelAddress the ChannelAddress
+	 * @return the RrdDb or null
+	 * @throws IOException        on error
+	 * @throws URISyntaxException on error
+	 */
+	protected synchronized RrdDb getExistingRrdDb(ChannelAddress channelAddress) {
+		File file = this.getDbFile(channelAddress);
+		if (!file.exists()) {
+			return null;
+		}
+		try {
+			return RrdDb.getBuilder() //
+					.setBackendFactory(this.factory) //
+					.setPath(file.toURI()) //
+					.build();
+		} catch (IOException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	private File getDbFile(ChannelAddress channelAddress) {
+		File file = Paths.get(//
+				Optional.ofNullable(System.getProperty("openems.data.dir")).orElse(""), //
+				RRD4J_PATH, //
+				this.id(), //
+				channelAddress.getComponentId(), //
+				channelAddress.getChannelId()) //
+				.toFile();
+		if (!file.getParentFile().exists()) {
+			file.getParentFile().mkdirs();
+		}
+		return file;
+	}
+
+	private static class ChannelDef {
+		private final DsType dsType;
+		private final double minValue;
+		private final double maxValue;
+		private final ConsolFun consolFun;
+
+		public ChannelDef(DsType dsType, double minValue, double maxValue, ConsolFun consolFun) {
+			this.dsType = dsType;
+			this.minValue = minValue;
+			this.maxValue = maxValue;
+			this.consolFun = consolFun;
+		}
+	}
+
+	/**
+	 * Defines the datasource properties for a given Channel, i.e. min/max allowed
+	 * value and GAUGE vs. COUNTER type.
+	 * 
+	 * @param channel the Channel
+	 * @return the {@link DsDef}
+	 */
+	private ChannelDef getDsDefForChannel(Unit channelUnit) {
+		switch (channelUnit) {
+		case AMPERE:
+		case AMPERE_HOURS:
+		case DEGREE_CELSIUS:
+		case DEZIDEGREE_CELSIUS:
+		case HERTZ:
+		case HOUR:
+		case KILOAMPERE_HOURS:
+		case KILOOHM:
+		case KILOVOLT_AMPERE:
+		case KILOVOLT_AMPERE_REACTIVE:
+		case KILOWATT:
+		case MICROOHM:
+		case MILLIAMPERE_HOURS:
+		case MILLIAMPERE:
+		case MILLIHERTZ:
+		case MILLIOHM:
+		case MILLISECONDS:
+		case MILLIVOLT:
+		case MILLIWATT:
+		case MINUTE:
+		case NONE:
+		case WATT:
+		case VOLT:
+		case VOLT_AMPERE:
+		case VOLT_AMPERE_REACTIVE:
+		case WATT_HOURS_BY_WATT_PEAK:
+		case OHM:
+		case SECONDS:
+		case THOUSANDTH:
+			return new ChannelDef(DsType.GAUGE, Double.NaN, Double.NaN, ConsolFun.AVERAGE);
+		case PERCENT:
+			return new ChannelDef(DsType.GAUGE, Double.NaN, 100, ConsolFun.AVERAGE);
+		case ON_OFF:
+			return new ChannelDef(DsType.GAUGE, Double.NaN, 1, ConsolFun.AVERAGE);
+		case WATT_HOURS:
+		case KILOWATT_HOURS:
+		case VOLT_AMPERE_HOURS:
+		case VOLT_AMPERE_REACTIVE_HOURS:
+		case KILOVOLT_AMPERE_REACTIVE_HOURS:
+			return new ChannelDef(DsType.GAUGE, Double.NaN, 1, ConsolFun.MAX);
+		}
+		throw new IllegalArgumentException("Unhandled Channel unit [" + channelUnit + "]");
+	}
+
+	@Override
+	protected void logInfo(Logger log, String message) {
+		super.logInfo(log, message);
+	}
+
+	@Override
+	protected void logWarn(Logger log, String message) {
+		super.logWarn(log, message);
+	}
+
+	@Override
+	public void handleEvent(Event event) {
+		switch (event.getTopic()) {
+		case EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE:
+			this.worker.collectData();
+			break;
+		}
+	}
+}


### PR DESCRIPTION
- Introduce new environment variable "openems.data.dir". Rrd4j data is stored in this directory
- "Channel" now keeps the past 100 values in a local cache; TODO: use this everywhere where we are currently doing this manually, e.g. BackendApi
- Channel "Value" now keeps a timestamp of when the value was set
- Add JSON-RPC requests for QueryHistoricTimeseriesData and QueryHistoricTimeseriesEnergy to JSON/REST Api
- Add CircularTreeMap type - it is used for the past values mentioned above