### PR TITLE
Improve EdgeConfig & create Channel for each configuration Property

### DIFF
--- a/io.openems.common/src/io/openems/common/types/EdgeConfig.java
+++ b/io.openems.common/src/io/openems/common/types/EdgeConfig.java
@@ -19,6 +19,7 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
+import io.openems.common.OpenemsConstants;
 import io.openems.common.channel.AccessMode;
 import io.openems.common.channel.ChannelCategory;
 import io.openems.common.channel.Level;
@@ -953,4 +954,27 @@ public class EdgeConfig {
 		return result;
 	}
 
+	/**
+	 * Internal Method to decide whether a configuration property should be ignored.
+	 * 
+	 * @param key the property key
+	 * @return true if it should get ignored
+	 */
+	public static boolean ignorePropertyKey(String key) {
+		if (key.endsWith(".target")) {
+			return true;
+		}
+		switch (key) {
+		case OpenemsConstants.PROPERTY_COMPONENT_ID:
+		case OpenemsConstants.PROPERTY_OSGI_COMPONENT_ID:
+		case OpenemsConstants.PROPERTY_OSGI_COMPONENT_NAME:
+		case OpenemsConstants.PROPERTY_FACTORY_PID:
+		case OpenemsConstants.PROPERTY_PID:
+		case "webconsole.configurationFactory.nameHint":
+		case "event.topics":
+			return true;
+		default:
+			return false;
+		}
+	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/ChannelId.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/ChannelId.java
@@ -2,10 +2,22 @@ package io.openems.edge.common.channel;
 
 import com.google.common.base.CaseFormat;
 
+/**
+ * A {@link ChannelId} defines a Channel. It provides a unique Name and and a
+ * {@link Doc}.
+ * 
+ * <p>
+ * This interface is typically implemented by an {@link Enum} type which
+ * automatically provides a {@link ChannelId#name()} method.
+ */
 public interface ChannelId {
 
 	/**
-	 * Gets the name. This is available by default for an Enum.
+	 * Gets the name in format {@link CaseFormat#UPPER_UNDERSCORE}. This is
+	 * available by default for an Enum.
+	 * 
+	 * <p>
+	 * Names starting with underscore ("_") are reserved for internal usage.
 	 * 
 	 * @return the name
 	 */
@@ -17,7 +29,12 @@ public interface ChannelId {
 	 * @return the Channel-ID in CamelCase
 	 */
 	default String id() {
-		return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, this.name());
+		if (this.name().startsWith("_")) {
+			// special handling for reserved Channel-IDs starting with "_".
+			return "_" + CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, this.name().substring(1));
+		} else {
+			return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, this.name());
+		}
 	}
 
 	/**

--- a/io.openems.edge.common/src/io/openems/edge/common/component/AbstractOpenemsComponent.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/AbstractOpenemsComponent.java
@@ -2,6 +2,8 @@ package io.openems.edge.common.component;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -10,9 +12,21 @@ import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.CaseFormat;
+
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.types.EdgeConfig;
+import io.openems.edge.common.channel.BooleanDoc;
 import io.openems.edge.common.channel.Channel;
 import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.DoubleDoc;
+import io.openems.edge.common.channel.FloatDoc;
+import io.openems.edge.common.channel.IntegerDoc;
+import io.openems.edge.common.channel.LongDoc;
+import io.openems.edge.common.channel.ShortDoc;
 import io.openems.edge.common.channel.StateChannel;
+import io.openems.edge.common.channel.StringDoc;
+import io.openems.edge.common.channel.internal.OpenemsTypeDoc;
 
 /**
  * This is the default implementation of the {@link OpenemsComponent} interface.
@@ -23,6 +37,7 @@ import io.openems.edge.common.channel.StateChannel;
  */
 public abstract class AbstractOpenemsComponent implements OpenemsComponent {
 
+	private static final String PROPERTY_CHANNEL_ID_PREFIX = "_PROPERTY_";
 	private static final AtomicInteger NEXT_GENERATED_COMPONENT_ID = new AtomicInteger(-1);
 
 	private final Logger log = LoggerFactory.getLogger(AbstractOpenemsComponent.class);
@@ -105,11 +120,14 @@ public abstract class AbstractOpenemsComponent implements OpenemsComponent {
 
 		this.enabled = enabled;
 		this.componentContext = context;
+
 		if (isEnabled()) {
 			this.logMessage("Activate");
 		} else {
 			this.logMessage("Activate DISABLED");
 		}
+
+		this.addChannelsForProperties(context.getProperties());
 	}
 
 	/**
@@ -135,6 +153,66 @@ public abstract class AbstractOpenemsComponent implements OpenemsComponent {
 					"ComponentContext is null. Please make sure to call AbstractOpenemsComponent.activate()-method early!");
 		}
 		return this.componentContext;
+	}
+
+	/**
+	 * Add a Channel for each Property and set the configured value.
+	 * 
+	 * <p>
+	 * If the Property key is "enabled" then a Channel with the ID
+	 * "_PropertyEnabled" is generated.
+	 * 
+	 * @param properties the {@link ComponentContext} properties
+	 */
+	private void addChannelsForProperties(Dictionary<String, Object> properties) {
+		if (properties == null) {
+			return;
+		}
+
+		Enumeration<String> keys = properties.keys();
+		while (keys.hasMoreElements()) {
+			try {
+				String key = keys.nextElement();
+				Object value = properties.get(key);
+				if (EdgeConfig.ignorePropertyKey(key)) {
+					// ignore
+					continue;
+				}
+				switch (key) {
+				case "alias":
+					// ignore
+					continue;
+				case "enabled":
+					// special treatment as the value always comes as a String
+					if (value != null && value instanceof String) {
+						value = ((String) value).toLowerCase().equals("true");
+					}
+				}
+				key = key.replace(".", "_");
+
+				String channelName = PROPERTY_CHANNEL_ID_PREFIX
+						+ CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, key);
+				Doc doc = AbstractOpenemsComponent.getDocFromObject(value);
+				io.openems.edge.common.channel.ChannelId channelId = new io.openems.edge.common.channel.ChannelId() {
+
+					@Override
+					public String name() {
+						return channelName;
+					}
+
+					@Override
+					public Doc doc() {
+						return doc;
+					}
+				};
+				Channel<?> channel = this.addChannel(channelId);
+				channel.setNextValue(value);
+
+			} catch (OpenemsException e) {
+				this.logWarn(this.log, "Unable to add Property Channel: " + e.getMessage());
+				e.printStackTrace();
+			}
+		}
 	}
 
 	/**
@@ -296,5 +374,34 @@ public abstract class AbstractOpenemsComponent implements OpenemsComponent {
 	 */
 	protected void logError(Logger log, String message) {
 		log.error("[" + this.id() + "] " + message);
+	}
+
+	/**
+	 * Gets an {@link OpenemsTypeDoc} from an Object.
+	 * 
+	 * @param value the Object
+	 * @return the {@link OpenemsTypeDoc}
+	 * @throws OpenemsException if the TypeDoc cannot be guessed from the Object.
+	 */
+	private static OpenemsTypeDoc<?> getDocFromObject(Object value) throws OpenemsException {
+		if (value instanceof Boolean) {
+			return new BooleanDoc();
+		} else if (value instanceof Float) {
+			return new FloatDoc();
+		} else if (value instanceof Double) {
+			return new DoubleDoc();
+		} else if (value instanceof Short) {
+			return new ShortDoc();
+		} else if (value instanceof Integer) {
+			return new IntegerDoc();
+		} else if (value instanceof Long) {
+			return new LongDoc();
+		} else if (value instanceof String) {
+			return new StringDoc();
+		} else if (value.getClass().isArray()) {
+			return new StringDoc();
+		}
+		throw new OpenemsException(
+				"Unable to find OpenemsType for Class [" + value.getClass() + "] of Object [" + value + "]");
 	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/component/OpenemsComponent.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/OpenemsComponent.java
@@ -80,11 +80,28 @@ public interface OpenemsComponent {
 	}
 
 	/**
+	 * Returns the Service Factory-PID.
+	 * 
+	 * @return the OSGi Service Factory-PID
+	 */
+	default String serviceFactoryPid() {
+		ComponentContext context = this.getComponentContext();
+		if (context != null) {
+			Dictionary<String, Object> properties = context.getProperties();
+			Object servicePid = properties.get("service.factoryPid");
+			if (servicePid != null) {
+				return servicePid.toString();
+			}
+		}
+		return "";
+	}
+
+	/**
 	 * Returns the ComponentContext.
 	 * 
 	 * @return the OSGi ComponentContext
 	 */
-	public ComponentContext getComponentContext();	
+	public ComponentContext getComponentContext();
 
 	/**
 	 * Returns an undefined Channel defined by its ChannelId string representation.

--- a/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
@@ -1,5 +1,6 @@
 package io.openems.edge.common.type;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 import com.google.gson.JsonElement;
@@ -264,6 +265,30 @@ public class TypeUtils {
 		case STRING:
 			if (value == null) {
 				return (T) ((String) value);
+
+			} else if (value instanceof Object[]) {
+				return (T) Arrays.deepToString((Object[]) value);
+
+			} else if (value.getClass().isArray()) {
+				if (value instanceof boolean[]) {
+					return (T) Arrays.toString((boolean[]) value);
+				} else if (value instanceof byte[]) {
+					return (T) Arrays.toString((byte[]) value);
+				} else if (value instanceof char[]) {
+					return (T) Arrays.toString((char[]) value);
+				} else if (value instanceof double[]) {
+					return (T) Arrays.toString((double[]) value);
+				} else if (value instanceof float[]) {
+					return (T) Arrays.toString((float[]) value);
+				} else if (value instanceof int[]) {
+					return (T) Arrays.toString((int[]) value);
+				} else if (value instanceof long[]) {
+					return (T) Arrays.toString((long[]) value);
+				} else if (value instanceof short[]) {
+					return (T) Arrays.toString((short[]) value);
+				} else {
+					return (T) value.toString();
+				}
 
 			} else {
 				return (T) value.toString();

--- a/io.openems.edge.fenecon.dess/src/io/openems/edge/fenecon/dess/gridmeter/FeneconDessGridMeter.java
+++ b/io.openems.edge.fenecon.dess/src/io/openems/edge/fenecon/dess/gridmeter/FeneconDessGridMeter.java
@@ -30,7 +30,10 @@ import io.openems.edge.meter.api.SymmetricMeter;
 @Component( //
 		name = "Fenecon.Dess.GridMeter", //
 		immediate = true, //
-		configurationPolicy = ConfigurationPolicy.REQUIRE)
+		configurationPolicy = ConfigurationPolicy.REQUIRE, //
+		property = { //
+				"type=GRID" //
+		})
 public class FeneconDessGridMeter extends AbstractOpenemsModbusComponent
 		implements AsymmetricMeter, SymmetricMeter, OpenemsComponent {
 

--- a/io.openems.edge.fenecon.dess/src/io/openems/edge/fenecon/dess/pvmeter/FeneconDessPvMeter.java
+++ b/io.openems.edge.fenecon.dess/src/io/openems/edge/fenecon/dess/pvmeter/FeneconDessPvMeter.java
@@ -30,7 +30,10 @@ import io.openems.edge.meter.api.SymmetricMeter;
 @Component( //
 		name = "Fenecon.Dess.PvMeter", //
 		immediate = true, //
-		configurationPolicy = ConfigurationPolicy.REQUIRE)
+		configurationPolicy = ConfigurationPolicy.REQUIRE, //
+		property = { //
+				"type=PRODUCTION" //
+		})
 public class FeneconDessPvMeter extends AbstractOpenemsModbusComponent
 		implements AsymmetricMeter, SymmetricMeter, OpenemsComponent {
 

--- a/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/gridmeter/FeneconMiniGridMeter.java
+++ b/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/gridmeter/FeneconMiniGridMeter.java
@@ -34,8 +34,10 @@ import io.openems.edge.meter.api.SymmetricMeter;
 		name = "Fenecon.Mini.GridMeter", //
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
-		property = EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_WRITE //
-)
+		property = { //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_WRITE, //
+				"type=GRID" //
+		})
 public class FeneconMiniGridMeter extends AbstractOpenemsModbusComponent implements SymmetricMeter, OpenemsComponent {
 
 	@Reference

--- a/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/pvmeter/FeneconMiniPvMeter.java
+++ b/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/pvmeter/FeneconMiniPvMeter.java
@@ -34,8 +34,10 @@ import io.openems.edge.meter.api.SymmetricMeter;
 		name = "Fenecon.Mini.PvMeter", //
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
-		property = EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_WRITE //
-)
+		property = { //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_WRITE, //
+				"type=PRODUCTION" //
+		})
 public class FeneconMiniPvMeter extends AbstractOpenemsModbusComponent implements SymmetricMeter, OpenemsComponent {
 
 	@Reference

--- a/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/pvmeter/FeneconProPvMeter.java
+++ b/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/pvmeter/FeneconProPvMeter.java
@@ -43,9 +43,10 @@ import io.openems.edge.meter.api.SymmetricMeter;
 		name = "Fenecon.Pro.PvMeter", //
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
-		property = EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_BEFORE_WRITE //
-)
-
+		property = { //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_BEFORE_WRITE, //
+				"type=PRODUCTION" //
+		})
 public class FeneconProPvMeter extends AbstractOpenemsModbusComponent
 		implements AsymmetricMeter, SymmetricMeter, OpenemsComponent {
 

--- a/io.openems.edge.goodwe.et/src/io/openems/edge/goodwe/et/gridmeter/GoodWeEtGridMeter.java
+++ b/io.openems.edge.goodwe.et/src/io/openems/edge/goodwe/et/gridmeter/GoodWeEtGridMeter.java
@@ -35,8 +35,10 @@ import io.openems.edge.meter.api.AsymmetricMeter;
 		name = "GoodWe.ET.Grid-Meter", //
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
-		property = EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_WRITE //
-)
+		property = { //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_WRITE, //
+				"type=GRID" //
+		})
 public class GoodWeEtGridMeter extends AbstractOpenemsModbusComponent
 		implements AsymmetricMeter, SymmetricMeter, OpenemsComponent {
 

--- a/io.openems.edge.kostal.piko/src/io/openems/edge/kostal/piko/gridmeter/KostalPikoGridMeter.java
+++ b/io.openems.edge.kostal.piko/src/io/openems/edge/kostal/piko/gridmeter/KostalPikoGridMeter.java
@@ -28,8 +28,10 @@ import io.openems.edge.meter.api.SymmetricMeter;
 		name = "Kostal.Piko.GridMeter", //
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
-		property = EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_WRITE //
-)
+		property = { //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_WRITE, //
+				"type=GRID" //
+		})
 public class KostalPikoGridMeter extends AbstractOpenemsComponent implements SymmetricMeter, OpenemsComponent {
 
 	@Reference

--- a/io.openems.edge.pvinverter.cluster/src/io/openems/edge/pvinverter/cluster/PvInverterCluster.java
+++ b/io.openems.edge.pvinverter.cluster/src/io/openems/edge/pvinverter/cluster/PvInverterCluster.java
@@ -41,7 +41,8 @@ import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
 		property = { //
 				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_BEFORE_PROCESS_IMAGE, //
-				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_CONTROLLERS //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_CONTROLLERS, //
+				"type=PRODUCTION" //
 		})
 public class PvInverterCluster extends AbstractOpenemsComponent
 		implements ManagedSymmetricPvInverter, SymmetricMeter, OpenemsComponent, EventHandler {
@@ -55,7 +56,7 @@ public class PvInverterCluster extends AbstractOpenemsComponent
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
 		EXECUTION_FAILED(Doc.of(Level.FAULT).text("Execution failed"));
-		;
+
 		private final Doc doc;
 
 		private ChannelId(Doc doc) {

--- a/io.openems.edge.pvinverter.kaco.blueplanet/src/io/openems/edge/pvinverter/kaco/blueplanet/KacoBlueplanet.java
+++ b/io.openems.edge.pvinverter.kaco.blueplanet/src/io/openems/edge/pvinverter/kaco/blueplanet/KacoBlueplanet.java
@@ -30,7 +30,8 @@ import io.openems.edge.pvinverter.sunspec.AbstractSunSpecPvInverter;
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
 		property = { //
-				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE, //
+				"type=PRODUCTION" //
 		})
 public class KacoBlueplanet extends AbstractSunSpecPvInverter
 		implements ManagedSymmetricPvInverter, SymmetricMeter, OpenemsComponent, EventHandler {

--- a/io.openems.edge.pvinverter.solarlog/src/io/openems/edge/pvinverter/solarlog/SolarLog.java
+++ b/io.openems.edge.pvinverter.solarlog/src/io/openems/edge/pvinverter/solarlog/SolarLog.java
@@ -46,7 +46,8 @@ import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
 		property = { //
-				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE, //
+				"type=PRODUCTION" //
 		})
 public class SolarLog extends AbstractOpenemsModbusComponent
 		implements ManagedSymmetricPvInverter, SymmetricMeter, OpenemsComponent, EventHandler {

--- a/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/SunSpecPvInverter.java
+++ b/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/SunSpecPvInverter.java
@@ -29,7 +29,8 @@ import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
 		property = { //
-				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE, //
+				"type=PRODUCTION" //
 		})
 public class SunSpecPvInverter extends AbstractSunSpecPvInverter
 		implements ManagedSymmetricPvInverter, SymmetricMeter, OpenemsComponent, EventHandler {

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/meter/grid/acting/GridMeter.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/meter/grid/acting/GridMeter.java
@@ -34,8 +34,12 @@ import io.openems.edge.simulator.datasource.api.SimulatorDatasource;
 
 @Designate(ocd = Config.class, factory = true)
 @Component(name = "Simulator.GridMeter.Acting", //
-		immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, //
-		property = EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_BEFORE_PROCESS_IMAGE)
+		immediate = true, //
+		configurationPolicy = ConfigurationPolicy.REQUIRE, //
+		property = { //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_BEFORE_PROCESS_IMAGE, //
+				"type=GRID" //
+		})
 public class GridMeter extends AbstractOpenemsComponent
 		implements SymmetricMeter, AsymmetricMeter, OpenemsComponent, EventHandler {
 

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/meter/grid/reacting/GridMeter.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/meter/grid/reacting/GridMeter.java
@@ -32,8 +32,12 @@ import io.openems.edge.meter.api.SymmetricMeter;
 
 @Designate(ocd = Config.class, factory = true)
 @Component(name = "Simulator.GridMeter.Reacting", //
-		immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, //
-		property = EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_BEFORE_PROCESS_IMAGE)
+		immediate = true, //
+		configurationPolicy = ConfigurationPolicy.REQUIRE, //
+		property = { //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_BEFORE_PROCESS_IMAGE, //
+				"type=GRID" //
+		})
 public class GridMeter extends AbstractOpenemsComponent
 		implements SymmetricMeter, AsymmetricMeter, OpenemsComponent, EventHandler {
 

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/meter/production/acting/ProductionMeter.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/meter/production/acting/ProductionMeter.java
@@ -30,8 +30,12 @@ import io.openems.edge.simulator.datasource.api.SimulatorDatasource;
 
 @Designate(ocd = Config.class, factory = true)
 @Component(name = "Simulator.ProductionMeter.Acting", //
-		immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, //
-		property = EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_BEFORE_PROCESS_IMAGE)
+		immediate = true, //
+		configurationPolicy = ConfigurationPolicy.REQUIRE, //
+		property = { //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_BEFORE_PROCESS_IMAGE, //
+				"type=PRODUCTION" //
+		})
 public class ProductionMeter extends AbstractOpenemsComponent
 		implements SymmetricMeter, AsymmetricMeter, OpenemsComponent, EventHandler {
 

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/pvinverter/PvInverter.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/pvinverter/PvInverter.java
@@ -32,7 +32,10 @@ import io.openems.edge.simulator.datasource.api.SimulatorDatasource;
 @Designate(ocd = Config.class, factory = true)
 @Component(name = "Simulator.PvInverter", //
 		immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, //
-		property = EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_BEFORE_PROCESS_IMAGE)
+		property = { //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_BEFORE_PROCESS_IMAGE, //
+				"type=PRODUCTION" //
+		})
 public class PvInverter extends AbstractOpenemsComponent
 		implements ManagedSymmetricPvInverter, SymmetricMeter, OpenemsComponent, EventHandler {
 

--- a/io.openems.edge.solaredge/src/io/openems/edge/solaredge/gridmeter/SolarEdgeGridMeter.java
+++ b/io.openems.edge.solaredge/src/io/openems/edge/solaredge/gridmeter/SolarEdgeGridMeter.java
@@ -29,7 +29,8 @@ import io.openems.edge.meter.sunspec.AbstractSunSpecMeter;
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
 		property = { //
-				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE, //
+				"type=GRID" //
 		})
 public class SolarEdgeGridMeter extends AbstractSunSpecMeter
 		implements AsymmetricMeter, SymmetricMeter, OpenemsComponent {

--- a/io.openems.edge.solaredge/src/io/openems/edge/solaredge/pvinverter/SolarEdge.java
+++ b/io.openems.edge.solaredge/src/io/openems/edge/solaredge/pvinverter/SolarEdge.java
@@ -29,7 +29,8 @@ import io.openems.edge.pvinverter.sunspec.AbstractSunSpecPvInverter;
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
 		property = { //
-				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE //
+				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE, //
+				"type=PRODUCTION" //
 		})
 public class SolarEdge extends AbstractSunSpecPvInverter implements SymmetricMeter, OpenemsComponent, EventHandler {
 

--- a/ui/src/app/shared/edge/edgeconfig.ts
+++ b/ui/src/app/shared/edge/edgeconfig.ts
@@ -183,6 +183,7 @@ export class EdgeConfig {
                 if (component.properties['type'] == "PRODUCTION") {
                     return true;
                 }
+                // TODO remove, once all Edges are at least version 2019.15
                 switch (component.factoryId) {
                     case 'Fenecon.Mini.PvMeter':
                     case 'Fenecon.Dess.PvMeter':
@@ -207,6 +208,7 @@ export class EdgeConfig {
         if (component.properties['type'] == "PRODUCTION") {
             return true;
         } else {
+            // TODO remove, once all Edges are at least version 2019.15
             switch (component.factoryId) {
                 case 'Fenecon.Mini.PvMeter':
                 case 'Fenecon.Dess.PvMeter':


### PR DESCRIPTION
- For every Configuration Property (= "Config" annotation) a Channel "_PropertyConfigname" is automatically generated with the configured value
- Channels starting with underscore ("_") are documented as "reserved for internal usage"
- Improve how the value for a String-Channel is set; better handling for Arrays
- EdgeConfig now has every Property; even the ones defined via "@Component" annotation. This allows setting "type=PRODUCTION" for Meters.
- Add "type" property to all existing specific Grid-/Production-Meters 