### PR TITLE
Backend: move handling of JSON-RPC requests to separate handler component

### DIFF
--- a/cnf/checkstyle.xml
+++ b/cnf/checkstyle.xml
@@ -13,6 +13,7 @@
   <property name="charset" value="UTF-8"/>
   <property name="fileExtensions" value="java, properties, xml"/>
   <module name="TreeWalker">
+    <module name="RequireThis"/>
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/io.openems.backend.application/BackendApp.bndrun
+++ b/io.openems.backend.application/BackendApp.bndrun
@@ -21,6 +21,7 @@
 	bnd.identity;id='io.openems.backend.timedata.influx',\
 	bnd.identity;id='io.openems.backend.b2brest',\
 	bnd.identity;id='io.openems.backend.b2bwebsocket',\
+	bnd.identity;id='io.openems.backend.core',\
 	bnd.identity;id='io.openems.backend.edgewebsocket.impl',\
 	bnd.identity;id='io.openems.backend.metadata.dummy',\
 	bnd.identity;id='io.openems.backend.metadata.file',\
@@ -69,4 +70,5 @@
 	org.ops4j.pax.logging.pax-logging-service;version='[1.11.2,1.11.3)',\
 	org.osgi.service.event;version='[1.3.1,1.3.2)',\
 	org.osgi.service.metatype;version='[1.3.0,1.3.1)',\
-	org.postgresql.jdbc42;version='[42.2.7,42.2.8)'
+	org.postgresql.jdbc42;version='[42.2.7,42.2.8)',\
+	io.openems.backend.core;version=snapshot

--- a/io.openems.backend.b2brest/src/io/openems/backend/b2brest/B2bRest.java
+++ b/io.openems.backend.b2brest/src/io/openems/backend/b2brest/B2bRest.java
@@ -13,9 +13,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.openems.backend.common.component.AbstractOpenemsBackendComponent;
-import io.openems.backend.edgewebsocket.api.EdgeWebsocket;
+import io.openems.backend.common.jsonrpc.JsonRpcRequestHandler;
 import io.openems.backend.metadata.api.Metadata;
-import io.openems.backend.timedata.api.Timedata;
 import io.openems.common.exceptions.OpenemsException;
 
 @Designate(ocd = Config.class, factory = true)
@@ -33,13 +32,10 @@ public class B2bRest extends AbstractOpenemsBackendComponent {
 	private Server server = null;
 
 	@Reference(cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.DYNAMIC)
-	protected volatile EdgeWebsocket edgeWebsocket;
+	protected volatile JsonRpcRequestHandler jsonRpcRequestHandler;
 
 	@Reference(cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.DYNAMIC)
 	protected volatile Metadata metadata;
-
-	@Reference(cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.DYNAMIC)
-	protected volatile Timedata timeData;
 
 	public B2bRest() {
 		super("Backend2Backend.Rest");

--- a/io.openems.backend.b2brest/src/io/openems/backend/b2brest/RestHandler.java
+++ b/io.openems.backend.b2brest/src/io/openems/backend/b2brest/RestHandler.java
@@ -6,11 +6,7 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.StringTokenizer;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -26,33 +22,17 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
-import io.openems.backend.common.jsonrpc.request.GetEdgesChannelsValuesRequest;
-import io.openems.backend.common.jsonrpc.request.GetEdgesStatusRequest;
-import io.openems.backend.common.jsonrpc.response.GetEdgesChannelsValuesResponse;
-import io.openems.backend.common.jsonrpc.response.GetEdgesStatusResponse;
-import io.openems.backend.common.jsonrpc.response.GetEdgesStatusResponse.EdgeInfo;
 import io.openems.backend.metadata.api.BackendUser;
-import io.openems.backend.metadata.api.Edge;
 import io.openems.common.exceptions.OpenemsError;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
-import io.openems.common.jsonrpc.base.GenericJsonrpcResponseSuccess;
 import io.openems.common.jsonrpc.base.JsonrpcMessage;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
 import io.openems.common.jsonrpc.base.JsonrpcResponseError;
 import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
-import io.openems.common.jsonrpc.request.ComponentJsonApiRequest;
-import io.openems.common.jsonrpc.request.EdgeRpcRequest;
-import io.openems.common.jsonrpc.request.SetGridConnScheduleRequest;
-import io.openems.common.jsonrpc.response.EdgeRpcResponse;
-import io.openems.common.session.Role;
-import io.openems.common.session.User;
-import io.openems.common.types.ChannelAddress;
 import io.openems.common.utils.JsonUtils;
 
 public class RestHandler extends AbstractHandler {
@@ -219,8 +199,8 @@ public class RestHandler extends AbstractHandler {
 			JsonrpcRequest request = (JsonrpcRequest) message;
 
 			// handle the request
-			CompletableFuture<? extends JsonrpcResponseSuccess> responseFuture = this.handleJsonRpcRequest(user,
-					request);
+			CompletableFuture<? extends JsonrpcResponseSuccess> responseFuture = this.parent.jsonRpcRequestHandler
+					.handleRequest(this.parent.getName(), user, request);
 
 			// wait for response
 			JsonrpcResponseSuccess response;
@@ -241,185 +221,4 @@ public class RestHandler extends AbstractHandler {
 		}
 	}
 
-	/**
-	 * Handles an JSON-RPC Request.
-	 * 
-	 * @param user    the User
-	 * @param request the JsonrpcRequest
-	 * @return the JSON-RPC Success Response Future
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<? extends JsonrpcResponseSuccess> handleJsonRpcRequest(BackendUser user,
-			JsonrpcRequest request) throws OpenemsNamedException {
-		switch (request.getMethod()) {
-
-		case EdgeRpcRequest.METHOD:
-			return this.handleEdgeRpcRequest(user, request.getId(), EdgeRpcRequest.from(request));
-
-		case GetEdgesStatusRequest.METHOD:
-			return this.handleGetStatusOfEdgesRequest(user, request.getId(), GetEdgesStatusRequest.from(request));
-
-		case GetEdgesChannelsValuesRequest.METHOD:
-			return this.handleGetChannelsValuesRequest(user, request.getId(),
-					GetEdgesChannelsValuesRequest.from(request));
-
-		case SetGridConnScheduleRequest.METHOD:
-			return this.handleSetGridConnScheduleRequest(user, request.getId(),
-					SetGridConnScheduleRequest.from(request));
-
-		default:
-			this.parent.logWarn(this.log, "Unhandled Request: " + request);
-			throw OpenemsError.JSONRPC_UNHANDLED_METHOD.exception(request.getMethod());
-		}
-	}
-
-	/**
-	 * Handles an EdgeRpcRequest.
-	 * 
-	 * @param backendUser    the {@link BackendUser}
-	 * @param edgeRpcRequest the {@link EdgeRpcRequest}
-	 * @param messageId      the JSON-RPC Message-ID
-	 * @return the JSON-RPC Success Response Future
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<EdgeRpcResponse> handleEdgeRpcRequest(BackendUser backendUser, UUID messageId,
-			EdgeRpcRequest edgeRpcRequest) throws OpenemsNamedException {
-		String edgeId = edgeRpcRequest.getEdgeId();
-		JsonrpcRequest request = edgeRpcRequest.getPayload();
-		User user = backendUser.getAsCommonUser(edgeId);
-		user.assertRoleIsAtLeast(EdgeRpcRequest.METHOD, Role.GUEST);
-
-		CompletableFuture<JsonrpcResponseSuccess> resultFuture;
-		switch (request.getMethod()) {
-
-		case ComponentJsonApiRequest.METHOD:
-			resultFuture = this.handleComponentJsonApiRequest(edgeId, user, ComponentJsonApiRequest.from(request));
-			break;
-
-		default:
-			throw OpenemsError.JSONRPC_UNHANDLED_METHOD.exception(request.getMethod());
-		}
-
-		// Wrap reply in EdgeRpcResponse
-		CompletableFuture<EdgeRpcResponse> result = new CompletableFuture<EdgeRpcResponse>();
-		resultFuture.whenComplete((r, ex) -> {
-			if (ex != null) {
-				result.completeExceptionally(ex);
-			} else if (r != null) {
-				result.complete(new EdgeRpcResponse(edgeRpcRequest.getId(), r));
-			} else {
-				result.completeExceptionally(
-						new OpenemsNamedException(OpenemsError.JSONRPC_UNHANDLED_METHOD, request.getMethod()));
-			}
-		});
-		return result;
-	}
-
-	/**
-	 * Handles a ComponentJsonApiRequest.
-	 * 
-	 * @param edgeId                  the Edge-ID
-	 * @param user                    the User - Installer-level required
-	 * @param componentJsonApiRequest the ComponentJsonApiRequest
-	 * @return the Future JSON-RPC Response
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<JsonrpcResponseSuccess> handleComponentJsonApiRequest(String edgeId, User user,
-			ComponentJsonApiRequest componentJsonApiRequest) throws OpenemsNamedException {
-		user.assertRoleIsAtLeast(ComponentJsonApiRequest.METHOD, Role.GUEST);
-
-		return this.parent.edgeWebsocket.send(edgeId, user, componentJsonApiRequest);
-	}
-
-	/**
-	 * Handles a GetStatusOfEdgesRequest.
-	 * 
-	 * @param user      the User
-	 * @param messageId the JSON-RPC Message-ID
-	 * @param request   the GetStatusOfEdgesRequest
-	 * @return the JSON-RPC Success Response Future
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<GetEdgesStatusResponse> handleGetStatusOfEdgesRequest(BackendUser user, UUID messageId,
-			GetEdgesStatusRequest request) throws OpenemsNamedException {
-		Map<String, EdgeInfo> result = new HashMap<>();
-		for (Entry<String, Role> entry : user.getEdgeRoles().entrySet()) {
-			String edgeId = entry.getKey();
-
-			// assure read permissions of this User for this Edge.
-			if (!user.edgeRoleIsAtLeast(edgeId, Role.GUEST)) {
-				continue;
-			}
-
-			Optional<Edge> edgeOpt = this.parent.metadata.getEdge(edgeId);
-			if (edgeOpt.isPresent()) {
-				Edge edge = edgeOpt.get();
-				EdgeInfo info = new EdgeInfo(edge.isOnline());
-				result.put(edge.getId(), info);
-			}
-		}
-		return CompletableFuture.completedFuture(new GetEdgesStatusResponse(messageId, result));
-	}
-
-	/**
-	 * Handles a GetChannelsValuesRequest.
-	 * 
-	 * @param user      the User
-	 * @param messageId the JSON-RPC Message-ID
-	 * @param request   the GetChannelsValuesRequest
-	 * @return the JSON-RPC Success Response Future
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<GetEdgesChannelsValuesResponse> handleGetChannelsValuesRequest(BackendUser user,
-			UUID messageId, GetEdgesChannelsValuesRequest request) throws OpenemsNamedException {
-		GetEdgesChannelsValuesResponse response = new GetEdgesChannelsValuesResponse(messageId);
-		for (String edgeId : request.getEdgeIds()) {
-			// assure read permissions of this User for this Edge.
-			if (!user.edgeRoleIsAtLeast(edgeId, Role.GUEST)) {
-				continue;
-			}
-
-			for (ChannelAddress channel : request.getChannels()) {
-				Optional<JsonElement> value = this.parent.timeData.getChannelValue(edgeId, channel);
-				response.addValue(edgeId, channel, value.orElse(JsonNull.INSTANCE));
-			}
-		}
-		return CompletableFuture.completedFuture(response);
-	}
-
-	/**
-	 * Handles a SetGridConnScheduleRequest.
-	 * 
-	 * @param backendUser                the User
-	 * @param messageId                  the JSON-RPC Message-ID
-	 * @param setGridConnScheduleRequest the SetGridConnScheduleRequest
-	 * @return the JSON-RPC Success Response Future
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<GenericJsonrpcResponseSuccess> handleSetGridConnScheduleRequest(BackendUser backendUser,
-			UUID messageId, SetGridConnScheduleRequest setGridConnScheduleRequest) throws OpenemsNamedException {
-		String edgeId = setGridConnScheduleRequest.getEdgeId();
-		User user = backendUser.getAsCommonUser(edgeId);
-		user.assertRoleIsAtLeast(SetGridConnScheduleRequest.METHOD, Role.ADMIN);
-
-		// wrap original request inside ComponentJsonApiRequest
-		String componentId = "ctrlBalancingSchedule0"; // TODO find dynamic Component-ID of BalancingScheduleController
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(componentId, setGridConnScheduleRequest);
-
-		CompletableFuture<JsonrpcResponseSuccess> resultFuture = this.parent.edgeWebsocket.send(edgeId, user, request);
-
-		// Wrap reply in GenericJsonrpcResponseSuccess
-		CompletableFuture<GenericJsonrpcResponseSuccess> result = new CompletableFuture<GenericJsonrpcResponseSuccess>();
-		resultFuture.whenComplete((r, ex) -> {
-			if (ex != null) {
-				result.completeExceptionally(ex);
-			} else if (r != null) {
-				result.complete(new GenericJsonrpcResponseSuccess(messageId, r.toJsonObject()));
-			} else {
-				result.completeExceptionally(new OpenemsNamedException(OpenemsError.JSONRPC_UNHANDLED_METHOD,
-						SetGridConnScheduleRequest.METHOD));
-			}
-		});
-		return result;
-	}
 }

--- a/io.openems.backend.b2bwebsocket/bnd.bnd
+++ b/io.openems.backend.b2bwebsocket/bnd.bnd
@@ -15,7 +15,6 @@ Private-Package: \
 
 -buildpath: ${buildpath},\
 	io.openems.backend.common;version=latest,\
-	io.openems.backend.edgewebsocket.api;version=latest,\
 	io.openems.backend.metadata.api;version=latest,\
 	io.openems.backend.timedata.api;version=latest,\
 	io.openems.common;version=latest,\

--- a/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/B2bWebsocket.java
+++ b/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/B2bWebsocket.java
@@ -11,7 +11,7 @@ import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 
 import io.openems.backend.common.component.AbstractOpenemsBackendComponent;
-import io.openems.backend.edgewebsocket.api.EdgeWebsocket;
+import io.openems.backend.common.jsonrpc.JsonRpcRequestHandler;
 import io.openems.backend.metadata.api.Metadata;
 import io.openems.backend.timedata.api.Timedata;
 
@@ -28,7 +28,7 @@ public class B2bWebsocket extends AbstractOpenemsBackendComponent {
 	private WebsocketServer server = null;
 
 	@Reference(cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.DYNAMIC)
-	protected volatile EdgeWebsocket edgeWebsocket;
+	protected volatile JsonRpcRequestHandler jsonRpcRequestHandler;
 
 	@Reference(cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.DYNAMIC)
 	protected volatile Metadata metadata;

--- a/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/OnRequest.java
+++ b/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/OnRequest.java
@@ -1,43 +1,22 @@
 package io.openems.backend.b2bwebsocket;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.java_websocket.WebSocket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
 
 import io.openems.backend.b2bwebsocket.jsonrpc.request.SubscribeEdgesChannelsRequest;
-import io.openems.backend.common.jsonrpc.request.GetEdgesChannelsValuesRequest;
-import io.openems.backend.common.jsonrpc.request.GetEdgesStatusRequest;
-import io.openems.backend.common.jsonrpc.response.GetEdgesChannelsValuesResponse;
-import io.openems.backend.common.jsonrpc.response.GetEdgesStatusResponse;
-import io.openems.backend.common.jsonrpc.response.GetEdgesStatusResponse.EdgeInfo;
 import io.openems.backend.metadata.api.BackendUser;
-import io.openems.backend.metadata.api.Edge;
-import io.openems.common.exceptions.OpenemsError;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.jsonrpc.base.GenericJsonrpcResponseSuccess;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
 import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
-import io.openems.common.jsonrpc.request.ComponentJsonApiRequest;
-import io.openems.common.jsonrpc.request.SetGridConnScheduleRequest;
 import io.openems.common.session.Role;
-import io.openems.common.session.User;
-import io.openems.common.types.ChannelAddress;
 
 public class OnRequest implements io.openems.common.websocket.OnRequest {
 
-	private final Logger log = LoggerFactory.getLogger(OnRequest.class);
 	private final B2bWebsocket parent;
 
 	public OnRequest(B2bWebsocket parent) {
@@ -52,81 +31,13 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 
 		switch (request.getMethod()) {
 
-		case GetEdgesStatusRequest.METHOD:
-			return this.handleGetStatusOfEdgesRequest(user, request.getId(), GetEdgesStatusRequest.from(request));
-
-		case GetEdgesChannelsValuesRequest.METHOD:
-			return this.handleGetChannelsValuesRequest(user, request.getId(),
-					GetEdgesChannelsValuesRequest.from(request));
-
 		case SubscribeEdgesChannelsRequest.METHOD:
 			return this.handleSubscribeEdgesChannelsRequest(wsData, user, request.getId(),
 					SubscribeEdgesChannelsRequest.from(request));
-
-		case SetGridConnScheduleRequest.METHOD:
-			return this.handleSetGridConnScheduleRequest(user, request.getId(),
-					SetGridConnScheduleRequest.from(request));
-
-		default:
-			this.parent.logWarn(this.log, "Unhandled Request: " + request);
-			throw OpenemsError.JSONRPC_UNHANDLED_METHOD.exception(request.getMethod());
 		}
-	}
 
-	/**
-	 * Handles a GetStatusOfEdgesRequest.
-	 * 
-	 * @param user      the User
-	 * @param messageId the JSON-RPC Message-ID
-	 * @param request   the GetStatusOfEdgesRequest
-	 * @return the JSON-RPC Success Response Future
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<GetEdgesStatusResponse> handleGetStatusOfEdgesRequest(BackendUser user, UUID messageId,
-			GetEdgesStatusRequest request) throws OpenemsNamedException {
-		Map<String, EdgeInfo> result = new HashMap<>();
-		for (Entry<String, Role> entry : user.getEdgeRoles().entrySet()) {
-			String edgeId = entry.getKey();
-
-			// assure read permissions of this User for this Edge.
-			if (!user.edgeRoleIsAtLeast(edgeId, Role.GUEST)) {
-				continue;
-			}
-
-			Optional<Edge> edgeOpt = this.parent.metadata.getEdge(edgeId);
-			if (edgeOpt.isPresent()) {
-				Edge edge = edgeOpt.get();
-				EdgeInfo info = new EdgeInfo(edge.isOnline());
-				result.put(edge.getId(), info);
-			}
-		}
-		return CompletableFuture.completedFuture(new GetEdgesStatusResponse(messageId, result));
-	}
-
-	/**
-	 * Handles a GetChannelsValuesRequest.
-	 * 
-	 * @param user      the User
-	 * @param messageId the JSON-RPC Message-ID
-	 * @param request   the GetChannelsValuesRequest
-	 * @return the JSON-RPC Success Response Future
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<GetEdgesChannelsValuesResponse> handleGetChannelsValuesRequest(BackendUser user,
-			UUID messageId, GetEdgesChannelsValuesRequest request) throws OpenemsNamedException {
-		GetEdgesChannelsValuesResponse response = new GetEdgesChannelsValuesResponse(messageId);
-		for (String edgeId : request.getEdgeIds()) {
-			// assure read permissions of this User for this Edge.
-			if (!user.edgeRoleIsAtLeast(edgeId, Role.GUEST)) {
-				continue;
-			}
-
-			for (ChannelAddress channel : request.getChannels()) {
-				Optional<JsonElement> value = this.parent.timeData.getChannelValue(edgeId, channel);
-				response.addValue(edgeId, channel, value.orElse(JsonNull.INSTANCE));
-			}
-		}
-		return CompletableFuture.completedFuture(response);
+		// Forward to generic handler
+		return this.parent.jsonRpcRequestHandler.handleRequest(this.parent.getName(), user, request);
 	}
 
 	/**
@@ -152,42 +63,6 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 
 		// JSON-RPC response
 		return CompletableFuture.completedFuture(new GenericJsonrpcResponseSuccess(request.getId()));
-	}
-
-	/**
-	 * Handles a SetGridConnScheduleRequest.
-	 * 
-	 * @param backendUser                the User
-	 * @param messageId                  the JSON-RPC Message-ID
-	 * @param setGridConnScheduleRequest the SetGridConnScheduleRequest
-	 * @return the JSON-RPC Success Response Future
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<GenericJsonrpcResponseSuccess> handleSetGridConnScheduleRequest(BackendUser backendUser,
-			UUID messageId, SetGridConnScheduleRequest setGridConnScheduleRequest) throws OpenemsNamedException {
-		String edgeId = setGridConnScheduleRequest.getEdgeId();
-		User user = backendUser.getAsCommonUser(edgeId);
-		user.assertRoleIsAtLeast(SetGridConnScheduleRequest.METHOD, Role.ADMIN);
-
-		// wrap original request inside ComponentJsonApiRequest
-		String componentId = "ctrlBalancingSchedule0"; // TODO find dynamic Component-ID of BalancingScheduleController
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(componentId, setGridConnScheduleRequest);
-
-		CompletableFuture<JsonrpcResponseSuccess> resultFuture = this.parent.edgeWebsocket.send(edgeId, user, request);
-
-		// Wrap reply in GenericJsonrpcResponseSuccess
-		CompletableFuture<GenericJsonrpcResponseSuccess> result = new CompletableFuture<GenericJsonrpcResponseSuccess>();
-		resultFuture.whenComplete((r, ex) -> {
-			if (ex != null) {
-				result.completeExceptionally(ex);
-			} else if (r != null) {
-				result.complete(new GenericJsonrpcResponseSuccess(messageId, r.toJsonObject()));
-			} else {
-				result.completeExceptionally(new OpenemsNamedException(OpenemsError.JSONRPC_UNHANDLED_METHOD,
-						SetGridConnScheduleRequest.METHOD));
-			}
-		});
-		return result;
 	}
 
 }

--- a/io.openems.backend.common/bnd.bnd
+++ b/io.openems.backend.common/bnd.bnd
@@ -1,16 +1,19 @@
-Bundle-Name: OpenEMS Backend Commons
+Bundle-Name: OpenEMS Backend Common
 Bundle-Vendor: FENECON GmbH
 Bundle-License: https://opensource.org/licenses/EPL-2.0
 Bundle-Version:	1.0.0.${tstamp}
 Export-Package: \
 	io.openems.backend.common.session,\
 	io.openems.backend.common.component,\
+	io.openems.backend.common.jsonrpc,\
 	io.openems.backend.common.jsonrpc.request,\
 	io.openems.backend.common.jsonrpc.response
 
 -includeresource: {readme.md}
 
--buildpath: ${buildpath},\
+-buildpath: \
+	${buildpath},\
+	io.openems.backend.metadata.api;version=latest,\
 	io.openems.common;version=latest,\
 	com.google.gson,\
 	com.google.guava,\

--- a/io.openems.backend.common/src/io/openems/backend/common/jsonrpc/JsonRpcRequestHandler.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/jsonrpc/JsonRpcRequestHandler.java
@@ -1,0 +1,24 @@
+package io.openems.backend.common.jsonrpc;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.openems.backend.metadata.api.BackendUser;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.jsonrpc.base.JsonrpcRequest;
+import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
+
+public interface JsonRpcRequestHandler {
+
+	/**
+	 * Handles a JSON-RPC Request.
+	 * 
+	 * @param context the Logger context, i.e. the name of the parent source
+	 * @param user    the User
+	 * @param request the JsonrpcRequest
+	 * @return the JSON-RPC Success Response Future
+	 * @throws OpenemsNamedException on error
+	 */
+	public CompletableFuture<? extends JsonrpcResponseSuccess> handleRequest(String context, BackendUser user,
+			JsonrpcRequest request) throws OpenemsNamedException;
+
+}

--- a/io.openems.backend.core/.classpath
+++ b/io.openems.backend.core/.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="src" output="bin_test" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/io.openems.backend.core/.gitignore
+++ b/io.openems.backend.core/.gitignore
@@ -1,0 +1,2 @@
+/bin_test/
+/generated/

--- a/io.openems.backend.core/.project
+++ b/io.openems.backend.core/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openems.backend.core</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/io.openems.backend.core/bnd.bnd
+++ b/io.openems.backend.core/bnd.bnd
@@ -1,24 +1,21 @@
-Bundle-Name: OpenEMS Backend-to-Backend REST-Api
+Bundle-Name: OpenEMS Backend Core
 Bundle-Vendor: FENECON GmbH
 Bundle-License: https://opensource.org/licenses/EPL-2.0
-Bundle-Version: 1.0.0.${tstamp}
-
-Private-Package: \
-	io.openems.backend.b2brest
+Bundle-Version:	1.0.0.${tstamp}
+Export-Package: io.openems.backend.core.jsonrpcrequesthandler
 
 -includeresource: {readme.md}
 
--buildpath: ${buildpath},\
+-buildpath: \
+	${buildpath},\
 	io.openems.backend.common;version=latest,\
+	io.openems.backend.edgewebsocket.api;version=latest,\
 	io.openems.backend.metadata.api;version=latest,\
+	io.openems.backend.timedata.api;version=latest,\
 	io.openems.common;version=latest,\
-	io.openems.wrapper.websocket;version=latest,\
-	com.google.gson;version=2.8,\
+	com.google.gson,\
 	com.google.guava,\
-	slf4j.api,\
-	org.eclipse.jetty.server,\
-	org.apache.felix.http.jetty,\
-	javax.servlet-api
+	slf4j.api
 
 -testpath: ${testpath}
 

--- a/io.openems.backend.core/readme.md
+++ b/io.openems.backend.core/readme.md
@@ -1,0 +1,5 @@
+# Backend Core
+
+Supportive services that are used throughout OpenEMS Backend
+
+- JsonRpcRequestHandler: handles JSON-RPC requests

--- a/io.openems.backend.core/src/io/openems/backend/core/jsonrpcrequesthandler/EdgeRpcRequestHandler.java
+++ b/io.openems.backend.core/src/io/openems/backend/core/jsonrpcrequesthandler/EdgeRpcRequestHandler.java
@@ -1,0 +1,277 @@
+package io.openems.backend.core.jsonrpcrequesthandler;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.gson.JsonElement;
+
+import io.openems.backend.metadata.api.BackendUser;
+import io.openems.common.exceptions.OpenemsError;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.jsonrpc.base.JsonrpcRequest;
+import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
+import io.openems.common.jsonrpc.request.ComponentJsonApiRequest;
+import io.openems.common.jsonrpc.request.CreateComponentConfigRequest;
+import io.openems.common.jsonrpc.request.DeleteComponentConfigRequest;
+import io.openems.common.jsonrpc.request.EdgeRpcRequest;
+import io.openems.common.jsonrpc.request.GetEdgeConfigRequest;
+import io.openems.common.jsonrpc.request.QueryHistoricTimeseriesDataRequest;
+import io.openems.common.jsonrpc.request.QueryHistoricTimeseriesEnergyRequest;
+import io.openems.common.jsonrpc.request.QueryHistoricTimeseriesExportXlxsRequest;
+import io.openems.common.jsonrpc.request.SetChannelValueRequest;
+import io.openems.common.jsonrpc.request.UpdateComponentConfigRequest;
+import io.openems.common.jsonrpc.response.EdgeRpcResponse;
+import io.openems.common.jsonrpc.response.GetEdgeConfigResponse;
+import io.openems.common.jsonrpc.response.QueryHistoricTimeseriesDataResponse;
+import io.openems.common.jsonrpc.response.QueryHistoricTimeseriesEnergyResponse;
+import io.openems.common.session.Role;
+import io.openems.common.session.User;
+import io.openems.common.types.ChannelAddress;
+import io.openems.common.types.EdgeConfig;
+
+public class EdgeRpcRequestHandler {
+
+	private final JsonRpcRequestHandlerImpl parent;
+
+	protected EdgeRpcRequestHandler(JsonRpcRequestHandlerImpl parent) {
+		this.parent = parent;
+	}
+
+	/**
+	 * Handles an EdgeRpcRequest.
+	 * 
+	 * @param backendUser    the {@link BackendUser}
+	 * @param edgeRpcRequest the {@link EdgeRpcRequest}
+	 * @param messageId      the JSON-RPC Message-ID
+	 * @return the JSON-RPC Success Response Future
+	 * @throws OpenemsNamedException on error
+	 */
+	protected CompletableFuture<EdgeRpcResponse> handleRequest(BackendUser backendUser, UUID messageId,
+			EdgeRpcRequest edgeRpcRequest) throws OpenemsNamedException {
+		String edgeId = edgeRpcRequest.getEdgeId();
+		JsonrpcRequest request = edgeRpcRequest.getPayload();
+		User user = backendUser.getAsCommonUser(edgeId);
+		user.assertRoleIsAtLeast(EdgeRpcRequest.METHOD, Role.GUEST);
+
+		CompletableFuture<JsonrpcResponseSuccess> resultFuture;
+		switch (request.getMethod()) {
+
+		case QueryHistoricTimeseriesDataRequest.METHOD:
+			resultFuture = this.handleQueryHistoricDataRequest(edgeId, user,
+					QueryHistoricTimeseriesDataRequest.from(request));
+			break;
+
+		case QueryHistoricTimeseriesEnergyRequest.METHOD:
+			resultFuture = this.handleQueryHistoricEnergyRequest(edgeId, user,
+					QueryHistoricTimeseriesEnergyRequest.from(request));
+			break;
+
+		case QueryHistoricTimeseriesExportXlxsRequest.METHOD:
+			resultFuture = this.handleQueryHistoricTimeseriesExportXlxsRequest(edgeId, user,
+					QueryHistoricTimeseriesExportXlxsRequest.from(request));
+			break;
+
+		case GetEdgeConfigRequest.METHOD:
+			resultFuture = this.handleGetEdgeConfigRequest(edgeId, user, GetEdgeConfigRequest.from(request));
+			break;
+
+		case CreateComponentConfigRequest.METHOD:
+			resultFuture = this.handleCreateComponentConfigRequest(edgeId, user,
+					CreateComponentConfigRequest.from(request));
+			break;
+
+		case UpdateComponentConfigRequest.METHOD:
+			resultFuture = this.handleUpdateComponentConfigRequest(edgeId, user,
+					UpdateComponentConfigRequest.from(request));
+			break;
+
+		case DeleteComponentConfigRequest.METHOD:
+			resultFuture = this.handleDeleteComponentConfigRequest(edgeId, user,
+					DeleteComponentConfigRequest.from(request));
+			break;
+
+		case SetChannelValueRequest.METHOD:
+			resultFuture = this.handleSetChannelValueRequest(edgeId, user, SetChannelValueRequest.from(request));
+			break;
+
+		case ComponentJsonApiRequest.METHOD:
+			resultFuture = this.handleComponentJsonApiRequest(edgeId, user, ComponentJsonApiRequest.from(request));
+			break;
+
+		default:
+			throw OpenemsError.JSONRPC_UNHANDLED_METHOD.exception(request.getMethod());
+		}
+
+		// Wrap reply in EdgeRpcResponse
+		CompletableFuture<EdgeRpcResponse> result = new CompletableFuture<EdgeRpcResponse>();
+		resultFuture.whenComplete((r, ex) -> {
+			if (ex != null) {
+				result.completeExceptionally(ex);
+			} else if (r != null) {
+				result.complete(new EdgeRpcResponse(edgeRpcRequest.getId(), r));
+			} else {
+				result.completeExceptionally(
+						new OpenemsNamedException(OpenemsError.JSONRPC_UNHANDLED_METHOD, request.getMethod()));
+			}
+		});
+		return result;
+	}
+
+	/**
+	 * Handles a QueryHistoricTimeseriesDataRequest.
+	 * 
+	 * @param edgeId  the Edge-ID
+	 * @param user    the User - no specific level required
+	 * @param request the QueryHistoricDataRequest
+	 * @return the Future JSON-RPC Response
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<JsonrpcResponseSuccess> handleQueryHistoricDataRequest(String edgeId, User user,
+			QueryHistoricTimeseriesDataRequest request) throws OpenemsNamedException {
+		SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> historicData = this.parent.timeData
+				.queryHistoricData(//
+						edgeId, //
+						request.getFromDate(), //
+						request.getToDate(), //
+						request.getChannels());
+
+		// JSON-RPC response
+		return CompletableFuture
+				.completedFuture(new QueryHistoricTimeseriesDataResponse(request.getId(), historicData));
+	}
+
+	/**
+	 * Handles a QueryHistoricTimeseriesEnergyRequest.
+	 * 
+	 * @param edgeId  the Edge-ID
+	 * @param user    the User - no specific level required
+	 * @param request the QueryHistoricEnergyRequest
+	 * @return the Future JSON-RPC Response
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<JsonrpcResponseSuccess> handleQueryHistoricEnergyRequest(String edgeId, User user,
+			QueryHistoricTimeseriesEnergyRequest request) throws OpenemsNamedException {
+		Map<ChannelAddress, JsonElement> data;
+		data = this.parent.timeData.queryHistoricEnergy(//
+				edgeId, /* ignore Edge-ID */
+				request.getFromDate(), request.getToDate(), request.getChannels());
+
+		// JSON-RPC response
+		return CompletableFuture.completedFuture(new QueryHistoricTimeseriesEnergyResponse(request.getId(), data));
+	}
+
+	/**
+	 * Handles a QueryHistoricTimeseriesExportXlxsRequest.
+	 * 
+	 * @param edgeId  the Edge-ID
+	 * @param user    the User
+	 * @param request the QueryHistoricTimeseriesExportXlxsRequest
+	 * @return the Future JSON-RPC Response
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<JsonrpcResponseSuccess> handleQueryHistoricTimeseriesExportXlxsRequest(String edgeId,
+			User user, QueryHistoricTimeseriesExportXlxsRequest request) throws OpenemsNamedException {
+		return CompletableFuture
+				.completedFuture(this.parent.timeData.handleQueryHistoricTimeseriesExportXlxsRequest(edgeId, request));
+	}
+
+	/**
+	 * Handles a GetEdgeConfigRequest.
+	 * 
+	 * @param edgeId  the Edge-ID
+	 * @param user    the User - no specific level required
+	 * @param request the GetEdgeConfigRequest
+	 * @return the Future JSON-RPC Response
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<JsonrpcResponseSuccess> handleGetEdgeConfigRequest(String edgeId, User user,
+			GetEdgeConfigRequest request) throws OpenemsNamedException {
+		EdgeConfig config = this.parent.metadata.getEdgeOrError(edgeId).getConfig();
+
+		// JSON-RPC response
+		return CompletableFuture.completedFuture(new GetEdgeConfigResponse(request.getId(), config));
+	}
+
+	/**
+	 * Handles a CreateComponentConfigRequest.
+	 * 
+	 * @param edgeId  the Edge-ID
+	 * @param user    the User - Installer-level required
+	 * @param request the CreateComponentConfigRequest
+	 * @return the Future JSON-RPC Response
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<JsonrpcResponseSuccess> handleCreateComponentConfigRequest(String edgeId, User user,
+			CreateComponentConfigRequest request) throws OpenemsNamedException {
+		user.assertRoleIsAtLeast(CreateComponentConfigRequest.METHOD, Role.INSTALLER);
+
+		return this.parent.edgeWebsocket.send(edgeId, user, request);
+	}
+
+	/**
+	 * Handles a UpdateComponentConfigRequest.
+	 * 
+	 * @param edgeId  the Edge-ID
+	 * @param user    the User - Installer-level required
+	 * @param request the UpdateComponentConfigRequest
+	 * @return the Future JSON-RPC Response
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<JsonrpcResponseSuccess> handleUpdateComponentConfigRequest(String edgeId, User user,
+			UpdateComponentConfigRequest request) throws OpenemsNamedException {
+		user.assertRoleIsAtLeast(UpdateComponentConfigRequest.METHOD, Role.OWNER);
+
+		return this.parent.edgeWebsocket.send(edgeId, user, request);
+	}
+
+	/**
+	 * Handles a DeleteComponentConfigRequest.
+	 * 
+	 * @param edgeId  the Edge-ID
+	 * @param user    the User - Installer-level required
+	 * @param request the DeleteComponentConfigRequest
+	 * @return the Future JSON-RPC Response
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<JsonrpcResponseSuccess> handleDeleteComponentConfigRequest(String edgeId, User user,
+			DeleteComponentConfigRequest request) throws OpenemsNamedException {
+		user.assertRoleIsAtLeast(DeleteComponentConfigRequest.METHOD, Role.INSTALLER);
+
+		return this.parent.edgeWebsocket.send(edgeId, user, request);
+	}
+
+	/**
+	 * Handles a SetChannelValueRequest.
+	 * 
+	 * @param edgeId  the Edge-ID
+	 * @param user    the User
+	 * @param request the SetChannelValueRequest
+	 * @return the Future JSON-RPC Response
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<JsonrpcResponseSuccess> handleSetChannelValueRequest(String edgeId, User user,
+			SetChannelValueRequest request) throws OpenemsNamedException {
+		user.assertRoleIsAtLeast(SetChannelValueRequest.METHOD, Role.ADMIN);
+
+		return this.parent.edgeWebsocket.send(edgeId, user, request);
+	}
+
+	/**
+	 * Handles a UpdateComponentConfigRequest.
+	 * 
+	 * @param edgeId                  the Edge-ID
+	 * @param user                    the User - Installer-level required
+	 * @param componentJsonApiRequest the ComponentJsonApiRequest
+	 * @return the Future JSON-RPC Response
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<JsonrpcResponseSuccess> handleComponentJsonApiRequest(String edgeId, User user,
+			ComponentJsonApiRequest componentJsonApiRequest) throws OpenemsNamedException {
+		user.assertRoleIsAtLeast(ComponentJsonApiRequest.METHOD, Role.GUEST);
+
+		return this.parent.edgeWebsocket.send(edgeId, user, componentJsonApiRequest);
+	}
+}

--- a/io.openems.backend.core/src/io/openems/backend/core/jsonrpcrequesthandler/JsonRpcRequestHandlerImpl.java
+++ b/io.openems.backend.core/src/io/openems/backend/core/jsonrpcrequesthandler/JsonRpcRequestHandlerImpl.java
@@ -1,0 +1,222 @@
+package io.openems.backend.core.jsonrpcrequesthandler;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+
+import io.openems.backend.common.component.AbstractOpenemsBackendComponent;
+import io.openems.backend.common.jsonrpc.JsonRpcRequestHandler;
+import io.openems.backend.common.jsonrpc.request.GetEdgesChannelsValuesRequest;
+import io.openems.backend.common.jsonrpc.request.GetEdgesStatusRequest;
+import io.openems.backend.common.jsonrpc.response.GetEdgesChannelsValuesResponse;
+import io.openems.backend.common.jsonrpc.response.GetEdgesStatusResponse;
+import io.openems.backend.common.jsonrpc.response.GetEdgesStatusResponse.EdgeInfo;
+import io.openems.backend.edgewebsocket.api.EdgeWebsocket;
+import io.openems.backend.metadata.api.BackendUser;
+import io.openems.backend.metadata.api.Edge;
+import io.openems.backend.metadata.api.Metadata;
+import io.openems.backend.timedata.api.Timedata;
+import io.openems.common.exceptions.OpenemsError;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.jsonrpc.base.GenericJsonrpcResponseSuccess;
+import io.openems.common.jsonrpc.base.JsonrpcRequest;
+import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
+import io.openems.common.jsonrpc.request.ComponentJsonApiRequest;
+import io.openems.common.jsonrpc.request.EdgeRpcRequest;
+import io.openems.common.jsonrpc.request.SetGridConnScheduleRequest;
+import io.openems.common.session.Role;
+import io.openems.common.session.User;
+import io.openems.common.types.ChannelAddress;
+
+@Component(//
+		name = "Core.JsonRpcRequestHandler", //
+		immediate = true //
+)
+public class JsonRpcRequestHandlerImpl extends AbstractOpenemsBackendComponent implements JsonRpcRequestHandler {
+
+	private final Logger log = LoggerFactory.getLogger(JsonRpcRequestHandler.class);
+
+	@Reference(cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.DYNAMIC)
+	protected volatile EdgeWebsocket edgeWebsocket;
+
+	@Reference(cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.DYNAMIC)
+	protected volatile Metadata metadata;
+
+	@Reference(cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.DYNAMIC)
+	protected volatile Timedata timeData;
+
+	private final EdgeRpcRequestHandler edgeRpcRequestHandler;
+
+	public JsonRpcRequestHandlerImpl() {
+		super("Core.JsonRpcRequestHandler");
+		this.edgeRpcRequestHandler = new EdgeRpcRequestHandler(this);
+	}
+
+	/**
+	 * Handles a JSON-RPC Request.
+	 * 
+	 * @param context the Logger context, i.e. the name of the parent source
+	 * @param user    the User
+	 * @param request the JsonrpcRequest
+	 * @return the JSON-RPC Success Response Future
+	 * @throws OpenemsNamedException on error
+	 */
+	public CompletableFuture<? extends JsonrpcResponseSuccess> handleRequest(String context, BackendUser user,
+			JsonrpcRequest request) throws OpenemsNamedException {
+		switch (request.getMethod()) {
+
+		case EdgeRpcRequest.METHOD:
+			return this.edgeRpcRequestHandler.handleRequest(user, request.getId(), EdgeRpcRequest.from(request));
+
+		case GetEdgesStatusRequest.METHOD:
+			return this.handleGetStatusOfEdgesRequest(user, request.getId(), GetEdgesStatusRequest.from(request));
+
+		case GetEdgesChannelsValuesRequest.METHOD:
+			return this.handleGetChannelsValuesRequest(user, request.getId(),
+					GetEdgesChannelsValuesRequest.from(request));
+
+		case SetGridConnScheduleRequest.METHOD:
+			return this.handleSetGridConnScheduleRequest(user, request.getId(),
+					SetGridConnScheduleRequest.from(request));
+
+		default:
+			this.logWarn(context, "Unhandled Request: " + request);
+			throw OpenemsError.JSONRPC_UNHANDLED_METHOD.exception(request.getMethod());
+		}
+	}
+
+	/**
+	 * Handles a GetStatusOfEdgesRequest.
+	 * 
+	 * @param user      the User
+	 * @param messageId the JSON-RPC Message-ID
+	 * @param request   the GetStatusOfEdgesRequest
+	 * @return the JSON-RPC Success Response Future
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<GetEdgesStatusResponse> handleGetStatusOfEdgesRequest(BackendUser user, UUID messageId,
+			GetEdgesStatusRequest request) throws OpenemsNamedException {
+		Map<String, EdgeInfo> result = new HashMap<>();
+		for (Entry<String, Role> entry : user.getEdgeRoles().entrySet()) {
+			String edgeId = entry.getKey();
+
+			// assure read permissions of this User for this Edge.
+			if (!user.edgeRoleIsAtLeast(edgeId, Role.GUEST)) {
+				continue;
+			}
+
+			Optional<Edge> edgeOpt = this.metadata.getEdge(edgeId);
+			if (edgeOpt.isPresent()) {
+				Edge edge = edgeOpt.get();
+				EdgeInfo info = new EdgeInfo(edge.isOnline());
+				result.put(edge.getId(), info);
+			}
+		}
+		return CompletableFuture.completedFuture(new GetEdgesStatusResponse(messageId, result));
+	}
+
+	/**
+	 * Handles a GetChannelsValuesRequest.
+	 * 
+	 * @param user      the User
+	 * @param messageId the JSON-RPC Message-ID
+	 * @param request   the GetChannelsValuesRequest
+	 * @return the JSON-RPC Success Response Future
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<GetEdgesChannelsValuesResponse> handleGetChannelsValuesRequest(BackendUser user,
+			UUID messageId, GetEdgesChannelsValuesRequest request) throws OpenemsNamedException {
+		GetEdgesChannelsValuesResponse response = new GetEdgesChannelsValuesResponse(messageId);
+		for (String edgeId : request.getEdgeIds()) {
+			// assure read permissions of this User for this Edge.
+			if (!user.edgeRoleIsAtLeast(edgeId, Role.GUEST)) {
+				continue;
+			}
+
+			for (ChannelAddress channel : request.getChannels()) {
+				Optional<JsonElement> value = this.timeData.getChannelValue(edgeId, channel);
+				response.addValue(edgeId, channel, value.orElse(JsonNull.INSTANCE));
+			}
+		}
+		return CompletableFuture.completedFuture(response);
+	}
+
+	/**
+	 * Handles a SetGridConnScheduleRequest.
+	 * 
+	 * @param backendUser                the User
+	 * @param messageId                  the JSON-RPC Message-ID
+	 * @param setGridConnScheduleRequest the SetGridConnScheduleRequest
+	 * @return the JSON-RPC Success Response Future
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<GenericJsonrpcResponseSuccess> handleSetGridConnScheduleRequest(BackendUser backendUser,
+			UUID messageId, SetGridConnScheduleRequest setGridConnScheduleRequest) throws OpenemsNamedException {
+		String edgeId = setGridConnScheduleRequest.getEdgeId();
+		User user = backendUser.getAsCommonUser(edgeId);
+		user.assertRoleIsAtLeast(SetGridConnScheduleRequest.METHOD, Role.ADMIN);
+
+		// wrap original request inside ComponentJsonApiRequest
+		String componentId = "ctrlBalancingSchedule0"; // TODO find dynamic Component-ID of BalancingScheduleController
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(componentId, setGridConnScheduleRequest);
+
+		CompletableFuture<JsonrpcResponseSuccess> resultFuture = this.edgeWebsocket.send(edgeId, user, request);
+
+		// Wrap reply in GenericJsonrpcResponseSuccess
+		CompletableFuture<GenericJsonrpcResponseSuccess> result = new CompletableFuture<GenericJsonrpcResponseSuccess>();
+		resultFuture.whenComplete((r, ex) -> {
+			if (ex != null) {
+				result.completeExceptionally(ex);
+			} else if (r != null) {
+				result.complete(new GenericJsonrpcResponseSuccess(messageId, r.toJsonObject()));
+			} else {
+				result.completeExceptionally(new OpenemsNamedException(OpenemsError.JSONRPC_UNHANDLED_METHOD,
+						SetGridConnScheduleRequest.METHOD));
+			}
+		});
+		return result;
+	}
+
+	/**
+	 * Log an info message including the Handler name.
+	 * 
+	 * @param context the Logger context, i.e. the name of the parent source
+	 * @param message the Info-message
+	 */
+	protected void logInfo(String context, String message) {
+		this.log.info("[" + context + "] " + message);
+	}
+
+	/**
+	 * Log a warn message including the Handler name.
+	 * 
+	 * @param context the Logger context, i.e. the name of the parent source
+	 * @param message the Warn-message
+	 */
+	protected void logWarn(String context, String message) {
+		this.log.warn("[" + context + "] " + message);
+	}
+
+	/**
+	 * Log an error message including the Handler name.
+	 * 
+	 * @param context the Logger context, i.e. the name of the parent source
+	 * @param message the Error-message
+	 */
+	protected void logError(String context, String message) {
+		this.log.error("[" + context + "] " + message);
+	}
+}

--- a/io.openems.backend.metadata.api/bnd.bnd
+++ b/io.openems.backend.metadata.api/bnd.bnd
@@ -9,7 +9,6 @@ Require-Capability: \
 -includeresource: {readme.md}
 
 -buildpath: ${buildpath},\
-	io.openems.backend.common;version=latest,\
 	io.openems.backend.edgewebsocket.api;version=latest,\
 	io.openems.common;version=latest,\
 	com.google.gson,\

--- a/io.openems.backend.uiwebsocket.impl/src/io/openems/backend/uiwebsocket/impl/OnRequest.java
+++ b/io.openems.backend.uiwebsocket.impl/src/io/openems/backend/uiwebsocket/impl/OnRequest.java
@@ -1,17 +1,10 @@
 package io.openems.backend.uiwebsocket.impl;
 
-import java.time.ZonedDateTime;
-import java.util.Map;
 import java.util.Optional;
-import java.util.SortedMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.java_websocket.WebSocket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.gson.JsonElement;
 
 import io.openems.backend.metadata.api.BackendUser;
 import io.openems.common.exceptions.OpenemsError;
@@ -19,30 +12,15 @@ import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.jsonrpc.base.GenericJsonrpcResponseSuccess;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
 import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
-import io.openems.common.jsonrpc.request.ComponentJsonApiRequest;
-import io.openems.common.jsonrpc.request.CreateComponentConfigRequest;
-import io.openems.common.jsonrpc.request.DeleteComponentConfigRequest;
 import io.openems.common.jsonrpc.request.EdgeRpcRequest;
-import io.openems.common.jsonrpc.request.GetEdgeConfigRequest;
-import io.openems.common.jsonrpc.request.QueryHistoricTimeseriesDataRequest;
-import io.openems.common.jsonrpc.request.QueryHistoricTimeseriesEnergyRequest;
-import io.openems.common.jsonrpc.request.QueryHistoricTimeseriesExportXlxsRequest;
-import io.openems.common.jsonrpc.request.SetChannelValueRequest;
 import io.openems.common.jsonrpc.request.SubscribeChannelsRequest;
 import io.openems.common.jsonrpc.request.SubscribeSystemLogRequest;
-import io.openems.common.jsonrpc.request.UpdateComponentConfigRequest;
 import io.openems.common.jsonrpc.response.EdgeRpcResponse;
-import io.openems.common.jsonrpc.response.GetEdgeConfigResponse;
-import io.openems.common.jsonrpc.response.QueryHistoricTimeseriesDataResponse;
-import io.openems.common.jsonrpc.response.QueryHistoricTimeseriesEnergyResponse;
 import io.openems.common.session.Role;
 import io.openems.common.session.User;
-import io.openems.common.types.ChannelAddress;
-import io.openems.common.types.EdgeConfig;
 
 public class OnRequest implements io.openems.common.websocket.OnRequest {
 
-	private final Logger log = LoggerFactory.getLogger(OnRequest.class);
 	private final UiWebsocketImpl parent;
 
 	public OnRequest(UiWebsocketImpl parent) {
@@ -55,14 +33,19 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 		WsData wsData = ws.getAttachment();
 		BackendUser user = this.assertUser(wsData, request);
 
+		CompletableFuture<EdgeRpcResponse> result = null;
 		switch (request.getMethod()) {
 		case EdgeRpcRequest.METHOD:
-			return this.handleEdgeRpcRequest(wsData, user, EdgeRpcRequest.from(request));
-
-		default:
-			this.parent.logWarn(this.log, "Unhandled Request: " + request);
-			throw OpenemsError.JSONRPC_UNHANDLED_METHOD.exception(request.getMethod());
+			result = this.handleEdgeRpcRequest(wsData, user, EdgeRpcRequest.from(request));
 		}
+
+		if (result != null) {
+			// was able to handle request directly
+			return result;
+		}
+
+		// forward to generic request handler
+		return this.parent.jsonRpcRequestHandler.handleRequest(this.parent.getName(), user, request);
 	}
 
 	/**
@@ -117,51 +100,9 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 					SubscribeSystemLogRequest.from(request));
 			break;
 
-		case QueryHistoricTimeseriesDataRequest.METHOD:
-			resultFuture = this.handleQueryHistoricDataRequest(edgeId, user,
-					QueryHistoricTimeseriesDataRequest.from(request));
-			break;
-
-		case QueryHistoricTimeseriesEnergyRequest.METHOD:
-			resultFuture = this.handleQueryHistoricEnergyRequest(edgeId, user,
-					QueryHistoricTimeseriesEnergyRequest.from(request));
-			break;
-
-		case QueryHistoricTimeseriesExportXlxsRequest.METHOD:
-			resultFuture = this.handleQueryHistoricTimeseriesExportXlxsRequest(edgeId, user,
-					QueryHistoricTimeseriesExportXlxsRequest.from(request));
-			break;
-
-		case GetEdgeConfigRequest.METHOD:
-			resultFuture = this.handleGetEdgeConfigRequest(edgeId, user, GetEdgeConfigRequest.from(request));
-			break;
-
-		case CreateComponentConfigRequest.METHOD:
-			resultFuture = this.handleCreateComponentConfigRequest(edgeId, user,
-					CreateComponentConfigRequest.from(request));
-			break;
-
-		case UpdateComponentConfigRequest.METHOD:
-			resultFuture = this.handleUpdateComponentConfigRequest(edgeId, user,
-					UpdateComponentConfigRequest.from(request));
-			break;
-
-		case DeleteComponentConfigRequest.METHOD:
-			resultFuture = this.handleDeleteComponentConfigRequest(edgeId, user,
-					DeleteComponentConfigRequest.from(request));
-			break;
-
-		case SetChannelValueRequest.METHOD:
-			resultFuture = this.handleSetChannelValueRequest(edgeId, user, SetChannelValueRequest.from(request));
-			break;
-
-		case ComponentJsonApiRequest.METHOD:
-			resultFuture = this.handleComponentJsonApiRequest(edgeId, user, ComponentJsonApiRequest.from(request));
-			break;
-
 		default:
-			this.parent.logWarn(this.log, "Unhandled EdgeRpcRequest: " + request);
-			throw OpenemsError.JSONRPC_UNHANDLED_METHOD.exception(request.getMethod());
+			// unable to handle; try generic handler
+			return null;
 		}
 
 		// Wrap reply in EdgeRpcResponse
@@ -217,159 +158,6 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 
 		// Forward to Edge
 		return this.parent.edgeWebsocket.handleSubscribeSystemLogRequest(edgeId, user, token, request);
-	}
-
-	/**
-	 * Handles a QueryHistoricTimeseriesDataRequest.
-	 * 
-	 * @param edgeId  the Edge-ID
-	 * @param user    the User - no specific level required
-	 * @param request the QueryHistoricDataRequest
-	 * @return the Future JSON-RPC Response
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<JsonrpcResponseSuccess> handleQueryHistoricDataRequest(String edgeId, User user,
-			QueryHistoricTimeseriesDataRequest request) throws OpenemsNamedException {
-		SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> historicData = this.parent.timeData
-				.queryHistoricData(//
-						edgeId, //
-						request.getFromDate(), //
-						request.getToDate(), //
-						request.getChannels());
-
-		// JSON-RPC response
-		return CompletableFuture
-				.completedFuture(new QueryHistoricTimeseriesDataResponse(request.getId(), historicData));
-	}
-
-	/**
-	 * Handles a QueryHistoricTimeseriesEnergyRequest.
-	 * 
-	 * @param edgeId  the Edge-ID
-	 * @param user    the User - no specific level required
-	 * @param request the QueryHistoricEnergyRequest
-	 * @return the Future JSON-RPC Response
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<JsonrpcResponseSuccess> handleQueryHistoricEnergyRequest(String edgeId, User user,
-			QueryHistoricTimeseriesEnergyRequest request) throws OpenemsNamedException {
-		Map<ChannelAddress, JsonElement> data;
-		data = this.parent.timeData.queryHistoricEnergy(//
-				edgeId, /* ignore Edge-ID */
-				request.getFromDate(), request.getToDate(), request.getChannels());
-
-		// JSON-RPC response
-		return CompletableFuture.completedFuture(new QueryHistoricTimeseriesEnergyResponse(request.getId(), data));
-	}
-
-	/**
-	 * Handles a QueryHistoricTimeseriesExportXlxsRequest.
-	 * 
-	 * @param user    the User
-	 * @param request the QueryHistoricTimeseriesExportXlxsRequest
-	 * @return the Future JSON-RPC Response
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<JsonrpcResponseSuccess> handleQueryHistoricTimeseriesExportXlxsRequest(String edgeId,
-			User user, QueryHistoricTimeseriesExportXlxsRequest request) throws OpenemsNamedException {
-		return CompletableFuture
-				.completedFuture(this.parent.timeData.handleQueryHistoricTimeseriesExportXlxsRequest(edgeId, request));
-	}
-
-	/**
-	 * Handles a GetEdgeConfigRequest.
-	 * 
-	 * @param edgeId  the Edge-ID
-	 * @param user    the User - no specific level required
-	 * @param request the GetEdgeConfigRequest
-	 * @return the Future JSON-RPC Response
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<JsonrpcResponseSuccess> handleGetEdgeConfigRequest(String edgeId, User user,
-			GetEdgeConfigRequest request) throws OpenemsNamedException {
-		EdgeConfig config = this.parent.metadata.getEdgeOrError(edgeId).getConfig();
-
-		// JSON-RPC response
-		return CompletableFuture.completedFuture(new GetEdgeConfigResponse(request.getId(), config));
-	}
-
-	/**
-	 * Handles a CreateComponentConfigRequest.
-	 * 
-	 * @param edgeId                       the Edge-ID
-	 * @param user                         the User - Installer-level required
-	 * @param createComponentConfigRequest the CreateComponentConfigRequest
-	 * @return the Future JSON-RPC Response
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<JsonrpcResponseSuccess> handleCreateComponentConfigRequest(String edgeId, User user,
-			CreateComponentConfigRequest request) throws OpenemsNamedException {
-		user.assertRoleIsAtLeast(CreateComponentConfigRequest.METHOD, Role.INSTALLER);
-
-		return this.parent.edgeWebsocket.send(edgeId, user, request);
-	}
-
-	/**
-	 * Handles a UpdateComponentConfigRequest.
-	 * 
-	 * @param edgeId                       the Edge-ID
-	 * @param user                         the User - Installer-level required
-	 * @param updateComponentConfigRequest the UpdateComponentConfigRequest
-	 * @return the Future JSON-RPC Response
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<JsonrpcResponseSuccess> handleUpdateComponentConfigRequest(String edgeId, User user,
-			UpdateComponentConfigRequest request) throws OpenemsNamedException {
-		user.assertRoleIsAtLeast(UpdateComponentConfigRequest.METHOD, Role.OWNER);
-
-		return this.parent.edgeWebsocket.send(edgeId, user, request);
-	}
-
-	/**
-	 * Handles a DeleteComponentConfigRequest.
-	 * 
-	 * @param edgeId                       the Edge-ID
-	 * @param user                         the User - Installer-level required
-	 * @param updateComponentConfigRequest the DeleteComponentConfigRequest
-	 * @return the Future JSON-RPC Response
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<JsonrpcResponseSuccess> handleDeleteComponentConfigRequest(String edgeId, User user,
-			DeleteComponentConfigRequest request) throws OpenemsNamedException {
-		user.assertRoleIsAtLeast(DeleteComponentConfigRequest.METHOD, Role.INSTALLER);
-
-		return this.parent.edgeWebsocket.send(edgeId, user, request);
-	}
-
-	/**
-	 * Handles a SetChannelValueRequest.
-	 * 
-	 * @param user    the User
-	 * @param request the SetChannelValueRequest
-	 * @return the Future JSON-RPC Response
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<JsonrpcResponseSuccess> handleSetChannelValueRequest(String edgeId, User user,
-			SetChannelValueRequest request) throws OpenemsNamedException {
-		user.assertRoleIsAtLeast(SetChannelValueRequest.METHOD, Role.ADMIN);
-
-		return this.parent.edgeWebsocket.send(edgeId, user, request);
-	}
-
-	/**
-	 * Handles a UpdateComponentConfigRequest.
-	 * 
-	 * @param edgeId                  the Edge-ID
-	 * @param user                    the User - Installer-level required
-	 * @param componentJsonApiRequest the ComponentJsonApiRequest
-	 * @return the Future JSON-RPC Response
-	 * @throws OpenemsNamedException on error
-	 */
-	private CompletableFuture<JsonrpcResponseSuccess> handleComponentJsonApiRequest(String edgeId, User user,
-			ComponentJsonApiRequest componentJsonApiRequest) throws OpenemsNamedException {
-		user.assertRoleIsAtLeast(ComponentJsonApiRequest.METHOD, Role.GUEST);
-
-		return this.parent.edgeWebsocket.send(edgeId, user, componentJsonApiRequest);
 	}
 
 }

--- a/io.openems.backend.uiwebsocket.impl/src/io/openems/backend/uiwebsocket/impl/UiWebsocketImpl.java
+++ b/io.openems.backend.uiwebsocket.impl/src/io/openems/backend/uiwebsocket/impl/UiWebsocketImpl.java
@@ -18,6 +18,7 @@ import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 
 import io.openems.backend.common.component.AbstractOpenemsBackendComponent;
+import io.openems.backend.common.jsonrpc.JsonRpcRequestHandler;
 import io.openems.backend.edgewebsocket.api.EdgeWebsocket;
 import io.openems.backend.metadata.api.BackendUser;
 import io.openems.backend.metadata.api.Metadata;
@@ -37,6 +38,9 @@ public class UiWebsocketImpl extends AbstractOpenemsBackendComponent implements 
 	// private final Logger log = LoggerFactory.getLogger(UiWebsocket.class);
 
 	protected WebsocketServer server = null;
+
+	@Reference
+	protected volatile JsonRpcRequestHandler jsonRpcRequestHandler;
 
 	@Reference
 	protected volatile Metadata metadata;


### PR DESCRIPTION
This assures that all JSON-RPC requests are available from every API interface and avoids duplicated code.