### PR TITLE
added no of cycles option to influxdb module.

### DIFF
--- a/io.openems.edge.timedata.influxdb/src/io/openems/edge/timedata/influxdb/Config.java
+++ b/io.openems.edge.timedata.influxdb/src/io/openems/edge/timedata/influxdb/Config.java
@@ -22,6 +22,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 	@AttributeDefinition(name = "TCP Port", description = "TCP Port of InfluxDB server.")
 	int port() default 8086;
+	
+	@AttributeDefinition(name = "No of Cycles", description = "How many Cycles till data is written to InfluxDB.")
+	int noOfCycles() default 1;
 
 	@AttributeDefinition(name = "Username", description = "Username of InfluxDB server.")
 	String username() default "root";


### PR DESCRIPTION
I added an Option to set a no of cycles to the influxdb module.
With that I can avoid a lot of unnecessary write accesses on the device that hosts the Edge Component.
In my case I don't need to write data every second, but my main cycletime of the scheduler is 1s.
As the smallest intervall in history points in the UI are 5 minutes, I can for example set a no of cycles of 300.
