### PR TITLE
Add DefaultConfigurationWorker. Creates default configurations for deployment.

### DIFF
--- a/io.openems.common/src/io/openems/common/jsonrpc/request/CreateComponentConfigRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/CreateComponentConfigRequest.java
@@ -43,8 +43,8 @@ public class CreateComponentConfigRequest extends JsonrpcRequest {
 	private final String factoryPid;
 	private final List<Property> properties;
 
-	public CreateComponentConfigRequest(String componentId, List<Property> properties) {
-		this(UUID.randomUUID(), componentId, properties);
+	public CreateComponentConfigRequest(String factoryPid, List<Property> properties) {
+		this(UUID.randomUUID(), factoryPid, properties);
 	}
 
 	public CreateComponentConfigRequest(UUID id, String factoryPid, List<Property> properties) {

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/UpdateComponentConfigRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/UpdateComponentConfigRequest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
@@ -96,6 +97,18 @@ public class UpdateComponentConfigRequest extends JsonrpcRequest {
 		public Property(String name, JsonElement value) {
 			this.name = name;
 			this.value = value;
+		}
+
+		public Property(String name, String value) {
+			this(name, new JsonPrimitive(value));
+		}
+
+		public Property(String name, boolean value) {
+			this(name, new JsonPrimitive(value));
+		}
+
+		public Property(String name, Number value) {
+			this(name, new JsonPrimitive(value));
 		}
 
 		public String getName() {

--- a/io.openems.edge.common/src/io/openems/edge/common/component/ComponentManager.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/ComponentManager.java
@@ -21,7 +21,9 @@ public interface ComponentManager extends OpenemsComponent, JsonApi {
 		CONFIG_NOT_ACTIVATED(Doc.of(Level.WARNING) //
 				.text("A configured OpenEMS Component was not activated")), //
 		WAS_OUT_OF_MEMORY(Doc.of(Level.FAULT) //
-				.text("OutOfMemory had happened. Found heap dump files."));
+				.text("OutOfMemory had happened. Found heap dump files.")),
+		DEFAULT_CONFIGURATION_FAILED(Doc.of(Level.FAULT) //
+				.text("Applying the default configuration failed.")),;
 
 		private final Doc doc;
 

--- a/io.openems.edge.core/readme.adoc
+++ b/io.openems.edge.core/readme.adoc
@@ -1,0 +1,30 @@
+= Core services for OpenEMS Edge
+
+== ComponentManager
+
+A service that provides easy access to OpenEMS-Components and Channels. It also provides some sub-services:
+
+DefaultConfigurationWorker::
+Applies a default configuration, i.e. activates certain OpenEMS Components that are to be enabled by default on deployment, like Modbus-TCP-Slave Api and JSON/REST Api.
+
+OsgiValidateWorker::
+Checks if configured Components are actually enabled.
+
+OutOfMemoryHeapDumpWorker::
+Checks for heap-dump files which get created if OpenEMS Edge crashed because of an OutOfMemory-Error in a previous run.
+
+== Cycle
+
+Provides the core runtime Cycle of OpenEMS Edge
+
+== Host
+
+A service that provides host and operating system specific commands like configuration of TCP/IP network.
+
+== Meta
+
+A service that provides 'OpenemsConstants' as Channels so that they are available via Apis; example: _meta/Version for the current version of OpenEMS Edge.
+
+== Sum
+
+A service that holds summed up information on the power and energy flows, like aggregated production, consumption and energy storage charge/discharge. 

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/ComponentManagerImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/ComponentManagerImpl.java
@@ -99,6 +99,7 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 
 	private final OsgiValidateWorker osgiValidateWorker;
 	private final OutOfMemoryHeapDumpWorker outOfMemoryHeapDumpWorker;
+	private final DefaultConfigurationWorker defaultConfigurationWorker;
 
 	private BundleContext bundleContext;
 
@@ -127,6 +128,7 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 		);
 		this.osgiValidateWorker = new OsgiValidateWorker(this);
 		this.outOfMemoryHeapDumpWorker = new OutOfMemoryHeapDumpWorker(this);
+		this.defaultConfigurationWorker = new DefaultConfigurationWorker(this);
 	}
 
 	@Activate
@@ -140,6 +142,9 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 
 		// Start the Out-Of-Memory Worker
 		this.outOfMemoryHeapDumpWorker.activate(this.id());
+
+		// Start the Default-Configuration Worker
+		this.defaultConfigurationWorker.activate(this.id());
 	}
 
 	@Deactivate
@@ -151,6 +156,9 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 
 		// Stop the Out-Of-Memory Worker
 		this.outOfMemoryHeapDumpWorker.deactivate();
+
+		// Stop the Default-Configuration Worker
+		this.defaultConfigurationWorker.deactivate();
 	}
 
 	@Override
@@ -165,6 +173,10 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 
 	protected StateChannel configNotActivatedChannel() {
 		return this.channel(ComponentManager.ChannelId.CONFIG_NOT_ACTIVATED);
+	}
+
+	protected StateChannel defaultConfigurationFailed() {
+		return this.channel(ComponentManager.ChannelId.DEFAULT_CONFIGURATION_FAILED);
 	}
 
 	@Override
@@ -229,7 +241,7 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 	 * @return the Future JSON-RPC Response
 	 * @throws OpenemsNamedException on error
 	 */
-	private CompletableFuture<JsonrpcResponseSuccess> handleCreateComponentConfigRequest(User user,
+	protected CompletableFuture<JsonrpcResponseSuccess> handleCreateComponentConfigRequest(User user,
 			CreateComponentConfigRequest request) throws OpenemsNamedException {
 		// Get Component-ID from Request
 		String componentId = null;
@@ -349,7 +361,13 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 	 */
 	private void applyConfiguration(User user, Configuration config, Dictionary<String, Object> properties)
 			throws IOException {
-		properties.put(OpenemsConstants.PROPERTY_LAST_CHANGE_BY, user.getId() + ": " + user.getName());
+		String lastChangeBy;
+		if (user != null) {
+			lastChangeBy = user.getId() + ": " + user.getName();
+		} else {
+			lastChangeBy = "UNDEFINED";
+		}
+		properties.put(OpenemsConstants.PROPERTY_LAST_CHANGE_BY, lastChangeBy);
 		properties.put(OpenemsConstants.PROPERTY_LAST_CHANGE_AT,
 				LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS).toString());
 		config.update(properties);

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
@@ -1,0 +1,156 @@
+package io.openems.edge.core.componentmanager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
+import io.openems.common.jsonrpc.request.CreateComponentConfigRequest;
+import io.openems.common.jsonrpc.request.UpdateComponentConfigRequest.Property;
+import io.openems.common.worker.AbstractWorker;
+
+/**
+ * This Worker checks if certain OpenEMS-Components are configured and - if not
+ * - configures them. It is used to make sure a set of standard components are
+ * always activated by default on a deployed energy management system.
+ */
+public class DefaultConfigurationWorker extends AbstractWorker {
+
+	/**
+	 * Time to wait before doing the check. This allows the system to completele
+	 * boot and read configurations.
+	 */
+	private final static int INITIAL_CYCLE_TIME = 5_000; // in ms
+
+	private final Logger log = LoggerFactory.getLogger(DefaultConfigurationWorker.class);
+	private final ComponentManagerImpl parent;
+
+	public DefaultConfigurationWorker(ComponentManagerImpl parent) {
+		this.parent = parent;
+	}
+
+	/**
+	 * Creates all default configurations.
+	 * 
+	 * @return true on error, false if default configuration was successfully
+	 *         applied
+	 */
+	private boolean createDefaultConfigurations(List<Config> existingConfigs) {
+		boolean defaultConfigurationFailed = false;
+
+		/**
+		 * Create Controller.Api.Rest.ReadOnly
+		 */
+		if (existingConfigs.stream().noneMatch(c -> //
+		// Check if either "Controller.Api.Rest.ReadOnly" or
+		// "Controller.Api.Rest.ReadWrite" exist
+		"Controller.Api.Rest.ReadOnly".equals(c.factoryPid) || "Controller.Api.Rest.ReadWrite".equals(c.factoryPid))) {
+			// if not -> create configuration for "Controller.Api.Rest.ReadOnly"
+			defaultConfigurationFailed = this.createConfiguration(defaultConfigurationFailed,
+					"Controller.Api.Rest.ReadOnly", Arrays.asList(//
+							new Property("id", "ctrlApiRest0"), //
+							new Property("alias", ""), //
+							new Property("enabled", true), //
+							new Property("port", 8084), //
+							new Property("debugMode", false) //
+					));
+		}
+
+		return defaultConfigurationFailed;
+	}
+
+	@Override
+	protected void forever() {
+		List<Config> existingConfigs = this.readConfigs();
+
+		boolean defaultConfigurationFailed = this.createDefaultConfigurations(existingConfigs);
+
+		// Set DefaultConfigurationFailed channel value
+		this.parent.defaultConfigurationFailed().setNextValue(defaultConfigurationFailed);
+
+		// Execute this worker only once
+		this.deactivate();
+	}
+
+	/**
+	 * Reads all currently active configurations.
+	 * 
+	 * @return
+	 */
+	private List<Config> readConfigs() {
+		List<Config> result = new ArrayList<Config>();
+		try {
+			ConfigurationAdmin cm = this.parent.cm;
+			Configuration[] configs = cm.listConfigurations(null); // NOTE: here we are not filtering for enabled=true
+			if (configs != null) {
+				for (Configuration config : configs) {
+					result.add(Config.from(config));
+				}
+			}
+		} catch (Exception e) {
+			this.parent.logError(this.log, e.getMessage());
+			e.printStackTrace();
+		}
+		return result;
+	}
+
+	/**
+	 * Creates and applies a Component configuration.
+	 * 
+	 * @param lastResult  the result of the last configuration
+	 * @param componentId the Component-ID
+	 * @param properties  the Component properties
+	 * @return false on success; true on error or if lastResult was already true
+	 */
+	private boolean createConfiguration(boolean lastResult, String factoryPid, List<Property> properties) {
+		try {
+			CompletableFuture<JsonrpcResponseSuccess> response = this.parent.handleCreateComponentConfigRequest(
+					null /* no user */, new CreateComponentConfigRequest(factoryPid, properties));
+			response.get(60, TimeUnit.SECONDS);
+			return lastResult;
+
+		} catch (OpenemsNamedException | InterruptedException | ExecutionException | TimeoutException e) {
+			this.parent.logError(this.log,
+					"Unable to create Component configuration for Factory [" + factoryPid + "]: " + e.getMessage());
+			e.printStackTrace();
+			return true;
+		}
+	}
+
+	/**
+	 * Holds a configuration.
+	 */
+	private static class Config {
+		protected static Config from(Configuration config) {
+			return new Config(config.getFactoryPid());
+		}
+
+		protected final String factoryPid;
+
+		private Config(String factoryPid) {
+			this.factoryPid = factoryPid;
+		}
+
+		@Override
+		public String toString() {
+			return this.factoryPid;
+		}
+	}
+
+	@Override
+	protected int getCycleTime() {
+		// initial cycle time
+		return DefaultConfigurationWorker.INITIAL_CYCLE_TIME;
+	}
+
+}


### PR DESCRIPTION
 Add DefaultConfigurationWorker. Creates default configurations for deployment.

By default it makes sure that JSON/REST Api and Modbus/TCP-Slave Api are always configured by default in their read-only variants