### PR TITLE
Improvements in EdgeConfig handling

### DIFF
--- a/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/EdgeCache.java
+++ b/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/EdgeCache.java
@@ -26,7 +26,6 @@ import io.openems.common.types.EdgeConfig;
 import io.openems.common.types.EdgeConfigDiff;
 import io.openems.common.types.SemanticVersion;
 import io.openems.common.utils.JsonUtils;
-import io.openems.common.utils.StringUtils;
 
 public class EdgeCache {
 
@@ -196,8 +195,7 @@ public class EdgeCache {
 				return;
 			}
 
-			this.parent.logInfo(this.log,
-					"Edge [" + edge.getId() + "]. Update config: " + StringUtils.toShortString(diff.toString(), 100));
+			this.parent.logInfo(this.log, "Edge [" + edge.getId() + "]. Update config: " + diff.toString());
 
 			QueueWriteWorker queueWriteWorker = this.parent.getPostgresHandler().getQueueWriteWorker();
 			queueWriteWorker.addTask(new UpdateEdgeConfig(edge.getOdooId(), config));

--- a/io.openems.common/src/io/openems/common/types/EdgeConfig.java
+++ b/io.openems.common/src/io/openems/common/types/EdgeConfig.java
@@ -243,45 +243,45 @@ public class EdgeConfig {
 			}
 		}
 
+		private final String servicePid;
 		private final String id;
 		private final String alias;
-		private final boolean isEnabled;
 		private final String factoryId;
 		private final TreeMap<String, JsonElement> properties;
 		private final TreeMap<String, Channel> channels;
 
-		public Component(String id, String alias, boolean isEnabled, String factoryId,
+		public Component(String servicePid, String id, String alias, String factoryId,
 				TreeMap<String, JsonElement> properties, TreeMap<String, Channel> channels) {
+			this.servicePid = servicePid;
 			this.id = id;
 			this.alias = alias;
-			this.isEnabled = isEnabled;
 			this.factoryId = factoryId;
 			this.properties = properties;
 			this.channels = channels;
 		}
 
+		public String getPid() {
+			return this.servicePid;
+		}
+
 		public String getId() {
-			return id;
+			return this.id;
 		}
 
 		public String getAlias() {
-			return alias;
-		}
-
-		public boolean isEnabled() {
-			return isEnabled;
+			return this.alias;
 		}
 
 		public String getFactoryId() {
-			return factoryId;
+			return this.factoryId;
 		}
 
 		public Map<String, JsonElement> getProperties() {
-			return properties;
+			return this.properties;
 		}
 
 		public Map<String, Channel> getChannels() {
-			return channels;
+			return this.channels;
 		}
 
 		public Map<String, Channel> getChannelsOfCategory(ChannelCategory channelCategory) {
@@ -353,7 +353,6 @@ public class EdgeConfig {
 			}
 			JsonObjectBuilder result = JsonUtils.buildJsonObject() //
 					.addProperty("alias", this.getAlias()) //
-					.addProperty("isEnabled", this.isEnabled()) //
 					.addProperty("factoryId", this.getFactoryId()) //
 					.add("properties", properties); //
 			switch (jsonFormat) {
@@ -385,7 +384,6 @@ public class EdgeConfig {
 		 */
 		public static Component fromJson(String componentId, JsonElement json) throws OpenemsNamedException {
 			String alias = JsonUtils.getAsOptionalString(json, "alias").orElse(componentId);
-			boolean isEnabled = JsonUtils.getAsOptionalBoolean(json, "isEnabled").orElse(false);
 			String factoryId = JsonUtils.getAsOptionalString(json, "factoryId").orElse("NO_FACTORY_ID");
 			TreeMap<String, JsonElement> properties = new TreeMap<>();
 			Optional<JsonObject> jPropertiesOpt = JsonUtils.getAsOptionalJsonObject(json, "properties");
@@ -402,9 +400,9 @@ public class EdgeConfig {
 				}
 			}
 			return new Component(//
+					"NO_SERVICE_PID", //
 					componentId, //
 					alias, //
-					isEnabled, //
 					factoryId, //
 					properties, //
 					channels);
@@ -985,6 +983,7 @@ public class EdgeConfig {
 		for (Entry<String, JsonElement> entry : things.entrySet()) {
 			JsonObject config = JsonUtils.getAsJsonObject(entry.getValue());
 			String id = JsonUtils.getAsString(config, "id");
+			String servicePid = "NO";
 			String alias = JsonUtils.getAsOptionalString(config, "alias").orElse(id);
 			String clazz = JsonUtils.getAsString(config, "class");
 			TreeMap<String, JsonElement> properties = new TreeMap<>();
@@ -1003,7 +1002,7 @@ public class EdgeConfig {
 				}
 			}
 			TreeMap<String, Component.Channel> channels = new TreeMap<>();
-			result.addComponent(id, new EdgeConfig.Component(id, alias, true, clazz, properties, channels));
+			result.addComponent(id, new EdgeConfig.Component(servicePid, id, alias, clazz, properties, channels));
 		}
 
 		JsonObject metas = JsonUtils.getAsJsonObject(json, "meta");

--- a/io.openems.edge.common/src/io/openems/edge/common/component/ComponentManager.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/ComponentManager.java
@@ -2,6 +2,8 @@ package io.openems.edge.common.component;
 
 import java.util.List;
 
+import org.osgi.service.cm.ConfigurationEvent;
+
 import io.openems.common.OpenemsConstants;
 import io.openems.common.channel.Level;
 import io.openems.common.exceptions.OpenemsError;
@@ -118,8 +120,10 @@ public interface ComponentManager extends OpenemsComponent, JsonApi {
 	/**
 	 * Gets the complete configuration of this OpenEMS Edge.
 	 * 
+	 * @param event a ConfigurationEvent to incorporate; or null to refresh the
+	 *              config completely
 	 * @return the EdgeConfig object
 	 */
-	public EdgeConfig getEdgeConfig();
+	public EdgeConfig getEdgeConfig(ConfigurationEvent event);
 
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/test/DummyComponentManager.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/test/DummyComponentManager.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.osgi.service.cm.ConfigurationEvent;
 import org.osgi.service.component.ComponentContext;
 
 import io.openems.common.OpenemsConstants;
@@ -51,8 +52,8 @@ public class DummyComponentManager implements ComponentManager {
 	}
 
 	@Override
-	public EdgeConfig getEdgeConfig() {
-		return new EdgeConfig();
+	public EdgeConfig getEdgeConfig(ConfigurationEvent event) {
+		return new EdgeConfig();	
 	}
 
 	@Override
@@ -87,7 +88,7 @@ public class DummyComponentManager implements ComponentManager {
 
 	@Override
 	public CompletableFuture<JsonrpcResponseSuccess> handleJsonrpcRequest(User user, JsonrpcRequest request)
-			throws OpenemsNamedException {		
+			throws OpenemsNamedException {
 		return null;
 	}
 

--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/BackendApi.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/BackendApi.java
@@ -59,7 +59,7 @@ public class BackendApi extends AbstractOpenemsComponent
 	protected final BackendWorker worker = new BackendWorker(this);
 
 	protected final ApiWorker apiWorker = new ApiWorker();
-	
+
 	private final Logger log = LoggerFactory.getLogger(BackendApi.class);
 
 	protected WebsocketClient websocket = null;
@@ -200,7 +200,7 @@ public class BackendApi extends AbstractOpenemsComponent
 
 	@Override
 	public void configurationEvent(ConfigurationEvent event) {
-		EdgeConfig config = this.componentManager.getEdgeConfig();
+		EdgeConfig config = this.componentManager.getEdgeConfig(event);
 		EdgeConfigNotification message = new EdgeConfigNotification(config);
 		WebsocketClient ws = this.websocket;
 		if (ws == null) {

--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/OnOpen.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/OnOpen.java
@@ -23,7 +23,7 @@ public class OnOpen implements io.openems.common.websocket.OnOpen {
 		this.parent.logInfo(this.log, "Connected to OpenEMS Backend");
 
 		// Immediately send Config
-		EdgeConfig config = this.parent.componentManager.getEdgeConfig();
+		EdgeConfig config = this.parent.componentManager.getEdgeConfig(null);
 		EdgeConfigNotification message = new EdgeConfigNotification(config);
 		this.parent.websocket.sendMessage(message);
 

--- a/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/WebsocketApi.java
+++ b/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/WebsocketApi.java
@@ -189,7 +189,11 @@ public class WebsocketApi extends AbstractOpenemsComponent
 
 	@Override
 	public void configurationEvent(ConfigurationEvent event) {
-		EdgeConfig config = this.componentManager.getEdgeConfig();
+		if (this.server.getConnections().isEmpty()) {
+			// No Connections? It's not required to build the EdgeConfig.
+			return;
+		}
+		EdgeConfig config = this.componentManager.getEdgeConfig(event);
 		EdgeConfigNotification message = new EdgeConfigNotification(config);
 		this.server.broadcastMessage(new EdgeRpcNotification(WebsocketApi.EDGE_ID, message));
 	}

--- a/io.openems.edge.controller.ess.limitdischargecellvoltage/test/io/openems/edge/controller/ess/limitdischargecellvoltage/helper/DummyComponentManager.java
+++ b/io.openems.edge.controller.ess.limitdischargecellvoltage/test/io/openems/edge/controller/ess/limitdischargecellvoltage/helper/DummyComponentManager.java
@@ -1,23 +1,13 @@
 package io.openems.edge.controller.ess.limitdischargecellvoltage.helper;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
-import org.osgi.service.component.ComponentContext;
-
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
-import io.openems.common.jsonrpc.base.JsonrpcRequest;
-import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
-import io.openems.common.session.User;
-import io.openems.common.types.EdgeConfig;
-import io.openems.edge.common.channel.Channel;
 import io.openems.edge.common.component.ComponentManager;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.ess.api.ManagedSymmetricEss;
 import io.openems.edge.ess.api.SymmetricEss;
 
-public class DummyComponentManager implements ComponentManager {
+public class DummyComponentManager extends io.openems.edge.common.test.DummyComponentManager
+		implements ComponentManager {
 
 	private ManagedSymmetricEss ess = createEss();
 
@@ -36,57 +26,6 @@ public class DummyComponentManager implements ComponentManager {
 				SymmetricEss.ChannelId.values(), //
 				ManagedSymmetricEss.ChannelId.values() // ;
 		);
-	}
-
-	@Override
-	public CompletableFuture<JsonrpcResponseSuccess> handleJsonrpcRequest(User user, JsonrpcRequest request)
-			throws OpenemsNamedException {
-		return null;
-	}
-
-	@Override
-	public boolean isEnabled() {
-		return false;
-	}
-
-	@Override
-	public String id() {
-		return null;
-	}
-
-	@Override
-	public ComponentContext getComponentContext() {
-		return null;
-	}
-
-	@Override
-	public Collection<Channel<?>> channels() {
-		return null;
-	}
-
-	@Override
-	public String alias() {
-		return null;
-	}
-
-	@Override
-	public Channel<?> _channel(String channelName) {
-		return null;
-	}
-
-	@Override
-	public List<OpenemsComponent> getEnabledComponents() {
-		return null;
-	}
-
-	@Override
-	public EdgeConfig getEdgeConfig() {
-		return null;
-	}
-
-	@Override
-	public List<OpenemsComponent> getAllComponents() {
-		return null;
 	}
 
 	public void destroyEss() {

--- a/io.openems.edge.core/bnd.bnd
+++ b/io.openems.edge.core/bnd.bnd
@@ -6,6 +6,7 @@ Bundle-Version: 1.0.0.${tstamp}
 -buildpath: \
 	${buildpath},\
 	com.google.gson,\
+	com.google.guava,\
 	io.openems.common,\
 	io.openems.edge.common,\
 	io.openems.edge.controller.api,\

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/ComponentManagerImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/ComponentManagerImpl.java
@@ -1,36 +1,21 @@
 package io.openems.edge.core.componentmanager;
 
 import java.io.IOException;
-import java.net.URL;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Dictionary;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.jar.Manifest;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.cm.ConfigurationEvent;
 import org.osgi.service.cm.ConfigurationListener;
-import org.osgi.service.component.ComponentConstants;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -39,22 +24,10 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
-import org.osgi.service.metatype.MetaTypeInformation;
 import org.osgi.service.metatype.MetaTypeService;
-import org.osgi.service.metatype.ObjectClassDefinition;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
-
-import com.google.gson.JsonElement;
-import com.google.gson.JsonPrimitive;
 
 import io.openems.common.OpenemsConstants;
-import io.openems.common.channel.Level;
 import io.openems.common.exceptions.OpenemsError;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
@@ -70,16 +43,8 @@ import io.openems.common.jsonrpc.response.GetEdgeConfigResponse;
 import io.openems.common.session.Role;
 import io.openems.common.session.User;
 import io.openems.common.types.EdgeConfig;
-import io.openems.common.types.EdgeConfig.Component.Channel.ChannelDetail;
-import io.openems.common.types.EdgeConfig.Component.Channel.ChannelDetailOpenemsType;
-import io.openems.common.types.EdgeConfig.Component.Channel.ChannelDetailState;
-import io.openems.common.types.OptionsEnum;
 import io.openems.common.utils.JsonUtils;
-import io.openems.edge.common.channel.Channel;
-import io.openems.edge.common.channel.Doc;
-import io.openems.edge.common.channel.EnumDoc;
 import io.openems.edge.common.channel.StateChannel;
-import io.openems.edge.common.channel.StateChannelDoc;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
 import io.openems.edge.common.component.ComponentManager;
 import io.openems.edge.common.component.OpenemsComponent;
@@ -95,11 +60,10 @@ import io.openems.edge.common.jsonapi.JsonApi;
 public class ComponentManagerImpl extends AbstractOpenemsComponent
 		implements ComponentManager, OpenemsComponent, JsonApi, ConfigurationListener {
 
-	private final Logger log = LoggerFactory.getLogger(ComponentManagerImpl.class);
-
 	private final OsgiValidateWorker osgiValidateWorker;
 	private final OutOfMemoryHeapDumpWorker outOfMemoryHeapDumpWorker;
 	private final DefaultConfigurationWorker defaultConfigurationWorker;
+	private final EdgeConfigFactory edgeConfigFactory;
 
 	private BundleContext bundleContext;
 
@@ -129,6 +93,7 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 		this.osgiValidateWorker = new OsgiValidateWorker(this);
 		this.outOfMemoryHeapDumpWorker = new OutOfMemoryHeapDumpWorker(this);
 		this.defaultConfigurationWorker = new DefaultConfigurationWorker(this);
+		this.edgeConfigFactory = new EdgeConfigFactory();
 	}
 
 	@Activate
@@ -228,7 +193,7 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 	 */
 	private CompletableFuture<JsonrpcResponseSuccess> handleGetEdgeConfigRequest(User user,
 			GetEdgeConfigRequest request) throws OpenemsNamedException {
-		EdgeConfig config = this.getEdgeConfig();
+		EdgeConfig config = this.getEdgeConfig(null);
 		GetEdgeConfigResponse response = new GetEdgeConfigResponse(request.getId(), config);
 		return CompletableFuture.completedFuture(response);
 	}
@@ -401,219 +366,16 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 	}
 
 	@Override
-	public EdgeConfig getEdgeConfig() {
-		EdgeConfig result = new EdgeConfig();
-
-		/*
-		 * Read Factories
-		 */
-		final Bundle[] bundles = this.bundleContext.getBundles();
-		for (Bundle bundle : bundles) {
-			final MetaTypeInformation mti = this.metaTypeService.getMetaTypeInformation(bundle);
-
-			// read Bundle Manifest
-			URL manifestUrl = bundle.getResource("META-INF/MANIFEST.MF");
-			Manifest manifest;
-			try {
-				manifest = new Manifest(manifestUrl.openStream());
-			} catch (IOException e) {
-				// unable to read manifest
-				continue;
-			}
-
-			// get Factory-PIDs in this Bundle
-			String[] factoryPids = mti.getFactoryPids();
-			for (String factoryPid : factoryPids) {
-				switch (factoryPid) {
-				case "osgi.executor.provider":
-					// ignore these Factory-PIDs
-					break;
-				default:
-					// Get ObjectClassDefinition (i.e. the main annotation on the Config class)
-					ObjectClassDefinition objectClassDefinition = mti.getObjectClassDefinition(factoryPid, null);
-					// Get Natures implemented by this Factory-PID
-					String[] natures = this.getNatures(bundle, manifest, factoryPid);
-					// Add Factory to config
-					result.addFactory(factoryPid,
-							EdgeConfig.Factory.create(factoryPid, objectClassDefinition, natures));
-				}
-			}
-		}
-
-		/*
-		 * Create Components-Map with Component-ID -> Configuration
-		 */
-		Map<String, Map<String, JsonElement>> componentsMap = new HashMap<>();
-		for (OpenemsComponent component : this.allComponents) {
-			String componentId = component.id();
-			TreeMap<String, JsonElement> propertyMap = new TreeMap<>();
-			String factoryPid = component.serviceFactoryPid();
-			Dictionary<String, Object> properties = component.getComponentContext().getProperties();
-
-			// get configuration properties
-			EdgeConfig.Factory factory = result.getFactories().get(factoryPid);
-			Enumeration<String> keys = properties.keys();
-			while (keys.hasMoreElements()) {
-				String key = keys.nextElement();
-
-				if (!EdgeConfig.ignorePropertyKey(key)) {
-
-					JsonElement value = getPropertyAsJsonElement(properties.get(key));
-					if (factory != null) {
-						Optional<EdgeConfig.Factory.Property> propertyOpt = factory.getProperty(key);
-						if (propertyOpt.isPresent()) {
-							EdgeConfig.Factory.Property property = propertyOpt.get();
-							// hide Password fields
-							if (property.isPassword()) {
-								value = new JsonPrimitive("xxx");
-							}
-						}
-					}
-
-					propertyMap.put(key, value);
-				}
-			}
-
-			// get Alias and Channels
-			TreeMap<String, EdgeConfig.Component.Channel> channelMap = new TreeMap<>();
-			for (Channel<?> channel : component.channels()) {
-				io.openems.edge.common.channel.ChannelId channelId = channel.channelId();
-				Doc doc = channelId.doc();
-				ChannelDetail detail = null;
-				switch (doc.getChannelCategory()) {
-				case ENUM: {
-					Map<String, JsonElement> values = new HashMap<>();
-					EnumDoc d = (EnumDoc) doc;
-					for (OptionsEnum option : d.getOptions()) {
-						values.put(option.getName(), new JsonPrimitive(option.getValue()));
-					}
-					detail = new EdgeConfig.Component.Channel.ChannelDetailEnum(values);
-					break;
-				}
-				case OPENEMS_TYPE:
-					detail = new ChannelDetailOpenemsType();
-					break;
-				case STATE:
-					StateChannelDoc d = (StateChannelDoc) doc;
-					Level level = d.getLevel();
-					detail = new ChannelDetailState(level);
-					break;
-				}
-				channelMap.put(channelId.id(), new EdgeConfig.Component.Channel(//
-						channelId.id(), //
-						doc.getType(), //
-						doc.getAccessMode(), //
-						doc.getText(), //
-						doc.getUnit(), //
-						detail //
-				));
-			}
-			// Create EdgeConfig.Component and add it to Result
-			result.addComponent(componentId, new EdgeConfig.Component(componentId, component.alias(),
-					component.isEnabled(), factoryPid, propertyMap, channelMap));
-		}
-		// Add myself
-		componentsMap.put(this.id(), null);
-
-		return result;
-
-	}
-
-	/**
-	 * Reads Natures from an XML:
-	 * 
-	 * <pre>
-	 * <scr:component>
-	 *   <service>
-	 *     <provide interface="...">
-	 *   </service>
-	 * </scr:component>
-	 * </pre>
-	 * 
-	 * @return
-	 */
-	private String[] getNatures(Bundle bundle, Manifest manifest, String factoryPid) {
-		try {
-			// get "Service-Component"-Entry of Manifest
-			String serviceComponentsString = manifest.getMainAttributes()
-					.getValue(ComponentConstants.SERVICE_COMPONENT);
-			if (serviceComponentsString == null) {
-				return new String[0];
-			}
-			String[] serviceComponents = serviceComponentsString.split(",");
-
-			// read Service-Component XML files from OSGI-INF folder
-			for (String serviceComponent : serviceComponents) {
-				if (!serviceComponent.contains(factoryPid)) {
-					// search for correct XML file
-					continue;
-				}
-
-				URL componentUrl = bundle.getResource(serviceComponent);
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(componentUrl.openStream());
-				doc.getDocumentElement().normalize();
-
-				NodeList serviceNodes = doc.getElementsByTagName("service");
-				for (int i = 0; i < serviceNodes.getLength(); i++) {
-					Node serviceNode = serviceNodes.item(i);
-					if (serviceNode.getNodeType() == Node.ELEMENT_NODE) {
-						NodeList provideNodes = serviceNode.getChildNodes();
-
-						// Read "interface" attributes and return them
-						Set<String> result = new HashSet<>();
-						for (int j = 0; j < provideNodes.getLength(); j++) {
-							Node provideNode = provideNodes.item(j);
-							NamedNodeMap attributes = provideNode.getAttributes();
-							if (attributes != null) {
-								Node interfaceNode = attributes.getNamedItem("interface");
-								String nature = interfaceNode.getNodeValue();
-								switch (nature) {
-								case "org.osgi.service.event.EventHandler":
-								case "org.ops4j.pax.logging.spi.PaxAppender":
-									// ignore these natures;
-									break;
-								default:
-									result.add(nature);
-								}
-							}
-						}
-						return result.toArray(new String[result.size()]);
-					}
-				}
-			}
-
-		} catch (ParserConfigurationException | SAXException | IOException e) {
-			this.logWarn(this.log, "Unable to get Natures. " + e.getClass().getSimpleName() + ": " + e.getMessage());
-		}
-		return new String[0];
+	public synchronized EdgeConfig getEdgeConfig(ConfigurationEvent event) {
+		return this.edgeConfigFactory.getEdgeConfig(this.bundleContext, this.metaTypeService, this.cm,
+				this.allComponents, event);
 	}
 
 	@Override
 	public void configurationEvent(ConfigurationEvent event) {
 		// trigger immediate validation on configuration event
 		this.osgiValidateWorker.triggerNextRun();
-	}
 
-	/**
-	 * Gets a component Property as JsonElement. Uses some more techniques to find
-	 * the proper type than {@link JsonUtils#getAsJsonElement(Object)}.
-	 * 
-	 * @param value the property value
-	 * @return the value as JsonElement
-	 */
-	private static JsonElement getPropertyAsJsonElement(Object valueObj) {
-		if (valueObj != null && valueObj instanceof String) {
-			String value = (String) valueObj;
-			// find boolean
-			if (value.equalsIgnoreCase("true")) {
-				return new JsonPrimitive(true);
-			} else if (value.equalsIgnoreCase("false")) {
-				return new JsonPrimitive(false);
-			}
-		}
-		// falback to JsonUtils
-		return JsonUtils.getAsJsonElement(valueObj);
+		// Update EdgeConfig and send Event
 	}
 }

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/EdgeConfigFactory.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/EdgeConfigFactory.java
@@ -1,0 +1,462 @@
+package io.openems.edge.core.componentmanager;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.jar.Manifest;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationEvent;
+import org.osgi.service.component.ComponentConstants;
+import org.osgi.service.metatype.MetaTypeInformation;
+import org.osgi.service.metatype.MetaTypeService;
+import org.osgi.service.metatype.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+import io.openems.common.channel.Level;
+import io.openems.common.types.EdgeConfig;
+import io.openems.common.types.EdgeConfig.Component.Channel.ChannelDetail;
+import io.openems.common.types.EdgeConfig.Component.Channel.ChannelDetailOpenemsType;
+import io.openems.common.types.EdgeConfig.Component.Channel.ChannelDetailState;
+import io.openems.common.types.OptionsEnum;
+import io.openems.common.utils.JsonUtils;
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.EnumDoc;
+import io.openems.edge.common.channel.StateChannelDoc;
+import io.openems.edge.common.component.OpenemsComponent;
+
+/**
+ * Static helper class to create an {@link EdgeConfig}.
+ */
+public class EdgeConfigFactory {
+
+	private final static Logger log = LoggerFactory.getLogger(EdgeConfigFactory.class);
+
+	private EdgeConfig cache = null;
+
+	/**
+	 * Build an {@link EdgeConfig}.
+	 * 
+	 * @param bundleContext   the {@link BundleContext}
+	 * @param metaTypeService the {@link MetaTypeService}
+	 * @param cm              the {@link ConfigurationAdmin}
+	 * @param allComponents   a list of all active {@link OpenemsComponent}s
+	 * @param event           the event, or null to not use the Cache and create new
+	 *                        EdgeConfig
+	 * @return an {@link EdgeConfig} instance
+	 */
+	public synchronized EdgeConfig getEdgeConfig(BundleContext bundleContext, MetaTypeService metaTypeService,
+			ConfigurationAdmin cm, List<OpenemsComponent> allComponents, ConfigurationEvent event) {
+		EdgeConfig result;
+
+		if (event != null && this.cache != null) {
+			// Use Cache
+			this.updateCacheFromEvent(bundleContext, metaTypeService, cm, allComponents, event);
+			result = this.cache;
+
+		} else {
+			result = buildNewEdgeConfig(bundleContext, metaTypeService, cm, allComponents, event);
+			this.cache = result;
+		}
+
+		return result;
+	}
+
+	/**
+	 * Update the local EdgeConfig cache from event.
+	 * 
+	 * @param bundleContext   the {@link BundleContext}
+	 * @param metaTypeService the {@link MetaTypeService}
+	 * @param cm              the {@link ConfigurationAdmin}
+	 * @param allComponents   a list of all active {@link OpenemsComponent}s
+	 * @param event           the event, or null to not use the Cache and create new
+	 *                        EdgeConfig
+	 */
+	private synchronized void updateCacheFromEvent(BundleContext bundleContext, MetaTypeService metaTypeService,
+			ConfigurationAdmin cm, List<OpenemsComponent> allComponents, ConfigurationEvent event) {
+		String pid = event.getPid();
+		for (OpenemsComponent component : allComponents) {
+			if (pid.equals(component.servicePid())) {
+				// Found active Component
+				readComponent(this.cache, component);
+				return;
+			}
+		}
+		// No active Component; use Configuration object
+		boolean wasReadConfigSuccessful = readConfigurations(this.cache, cm, "(service.pid=" + pid + ")");
+		if (wasReadConfigSuccessful) {
+			return;
+		}
+
+		// No success -> build from scratch without cache
+		this.cache = buildNewEdgeConfig(bundleContext, metaTypeService, cm, allComponents, event);
+	}
+
+	/**
+	 * Build a new EdgeConfig without using Cache.
+	 * 
+	 * @param bundleContext   the {@link BundleContext}
+	 * @param metaTypeService the {@link MetaTypeService}
+	 * @param cm              the {@link ConfigurationAdmin}
+	 * @param allComponents   a list of all active {@link OpenemsComponent}s
+	 * @param event           the event, or null to not use the Cache and create new
+	 *                        EdgeConfig
+	 * @return the {@link EdgeConfig}
+	 */
+	private static EdgeConfig buildNewEdgeConfig(BundleContext bundleContext, MetaTypeService metaTypeService,
+			ConfigurationAdmin cm, List<OpenemsComponent> allComponents, ConfigurationEvent event) {
+		EdgeConfig result = new EdgeConfig();
+		readFactories(result, bundleContext, metaTypeService);
+		readComponents(result, allComponents);
+		readConfigurations(result, cm, null /* no filter: read all */);
+		return result;
+	}
+
+	/**
+	 * Read active, properly initialized Components.
+	 * 
+	 * @param result        the {@link EdgeConfig}
+	 * @param allComponents a list of all Components
+	 */
+	private static void readComponents(EdgeConfig result, List<OpenemsComponent> allComponents) {
+		for (OpenemsComponent component : allComponents) {
+			readComponent(result, component);
+		}
+	}
+
+	/**
+	 * Read this Component.
+	 * 
+	 * @param result    the {@link EdgeConfig}
+	 * @param component the Component
+	 */
+	private static void readComponent(EdgeConfig result, OpenemsComponent component) {
+		String componentId = component.id();
+		String factoryPid = component.serviceFactoryPid();
+
+		// get configuration properties
+		TreeMap<String, JsonElement> properties = convertProperties( //
+				component.getComponentContext().getProperties(), //
+				result.getFactories().get(factoryPid));
+
+		// get Channels
+		TreeMap<String, EdgeConfig.Component.Channel> channels = new TreeMap<>();
+		for (Channel<?> channel : component.channels()) {
+			io.openems.edge.common.channel.ChannelId channelId = channel.channelId();
+			Doc doc = channelId.doc();
+			ChannelDetail detail = null;
+			switch (doc.getChannelCategory()) {
+			case ENUM: {
+				Map<String, JsonElement> values = new HashMap<>();
+				EnumDoc d = (EnumDoc) doc;
+				for (OptionsEnum option : d.getOptions()) {
+					values.put(option.getName(), new JsonPrimitive(option.getValue()));
+				}
+				detail = new EdgeConfig.Component.Channel.ChannelDetailEnum(values);
+				break;
+			}
+			case OPENEMS_TYPE:
+				detail = new ChannelDetailOpenemsType();
+				break;
+			case STATE:
+				StateChannelDoc d = (StateChannelDoc) doc;
+				Level level = d.getLevel();
+				detail = new ChannelDetailState(level);
+				break;
+			}
+			channels.put(channelId.id(), new EdgeConfig.Component.Channel(//
+					channelId.id(), //
+					doc.getType(), //
+					doc.getAccessMode(), //
+					doc.getText(), //
+					doc.getUnit(), //
+					detail //
+			));
+		}
+		// Create EdgeConfig.Component and add it to Result
+		result.addComponent(componentId, new EdgeConfig.Component(component.servicePid(), componentId,
+				component.alias(), factoryPid, properties, channels));
+	}
+
+	/**
+	 * Read all remaining, existing configurations, even those that are not properly
+	 * initialized.
+	 * 
+	 * @param result the {@link EdgeConfig}
+	 * @param cm     the {@link ConfigurationAdmin}
+	 * @param filter the filter string for
+	 *               {@link ConfigurationAdmin#listConfigurations(String)}, null for
+	 *               no filter
+	 * @return true on success, false if no configuration has been added
+	 */
+	private static boolean readConfigurations(EdgeConfig result, ConfigurationAdmin cm, String filter) {
+		Configuration[] configs = null;
+		try {
+			configs = cm.listConfigurations(filter);
+		} catch (IOException | InvalidSyntaxException e) {
+			return false;
+		}
+
+		if (configs == null || configs.length == 0) {
+			return false;
+		}
+
+		for (Configuration config : configs) {
+			Dictionary<String, Object> properties = config.getProperties();
+			TreeMap<String, JsonElement> propertyMap = new TreeMap<>();
+
+			// Read Component-ID
+			Object componentIdObj = properties.get("id");
+			if (componentIdObj == null || !(componentIdObj instanceof String)) {
+				continue;
+			}
+			String componentId = (String) componentIdObj;
+
+			// Has this Component already been added?
+			if (result.getComponents().containsKey(componentId)) {
+				continue;
+			}
+
+			// Read Alias
+			String componentAlias = componentId;
+			{
+				Object componentAliasObj = properties.get("alias");
+				if (componentAliasObj != null && componentAliasObj instanceof String
+						&& !((String) componentAliasObj).trim().isEmpty()) {
+					componentAlias = (String) componentAliasObj;
+				}
+			}
+
+			// Get Factory; only if this is not a singleton Component
+			String factoryPid = null;
+			EdgeConfig.Factory factory = null;
+			{
+				Object factoryPidObj = properties.get("service.factoryPid");
+				if (factoryPidObj != null && factoryPidObj instanceof String) {
+					factoryPid = (String) factoryPidObj;
+					factory = result.getFactories().get(factoryPid);
+				}
+			}
+
+			// Read all properties
+			Enumeration<String> keys = properties.keys();
+			while (keys.hasMoreElements()) {
+				String key = keys.nextElement();
+				if (!EdgeConfig.ignorePropertyKey(key)) {
+					JsonElement value = getPropertyAsJsonElement(properties, key);
+					if (factory != null) {
+						Optional<EdgeConfig.Factory.Property> propertyOpt = factory.getProperty(key);
+						if (propertyOpt.isPresent()) {
+							EdgeConfig.Factory.Property property = propertyOpt.get();
+							// hide Password fields
+							if (property.isPassword()) {
+								value = new JsonPrimitive("xxx");
+							}
+						}
+					}
+					propertyMap.put(key, value);
+				}
+			}
+
+			// Create EdgeConfig.Component and add it to Result
+			result.addComponent(componentId, new EdgeConfig.Component(config.getPid(), componentId, componentAlias,
+					factoryPid, propertyMap, new TreeMap<>() /* no channels available */));
+		}
+		return true;
+	}
+
+	/**
+	 * Read Factories.
+	 * 
+	 * @param result          the {@link EdgeConfig}
+	 * @param bundleContext   the {@link BundleContext}
+	 * @param metaTypeService the {@link MetaTypeService}
+	 */
+	private static void readFactories(EdgeConfig result, BundleContext bundleContext, MetaTypeService metaTypeService) {
+		final Bundle[] bundles = bundleContext.getBundles();
+		for (Bundle bundle : bundles) {
+			final MetaTypeInformation mti = metaTypeService.getMetaTypeInformation(bundle);
+
+			// read Bundle Manifest
+			URL manifestUrl = bundle.getResource("META-INF/MANIFEST.MF");
+			Manifest manifest;
+			try {
+				manifest = new Manifest(manifestUrl.openStream());
+			} catch (IOException e) {
+				// unable to read manifest
+				continue;
+			}
+
+			// get Factory-PIDs in this Bundle
+			String[] factoryPids = mti.getFactoryPids();
+			for (String factoryPid : factoryPids) {
+				switch (factoryPid) {
+				case "osgi.executor.provider":
+					// ignore these Factory-PIDs
+					break;
+				default:
+					// Get ObjectClassDefinition (i.e. the main annotation on the Config class)
+					ObjectClassDefinition objectClassDefinition = mti.getObjectClassDefinition(factoryPid, null);
+					// Get Natures implemented by this Factory-PID
+					String[] natures = getNatures(bundle, manifest, factoryPid);
+					// Add Factory to config
+					result.addFactory(factoryPid,
+							EdgeConfig.Factory.create(factoryPid, objectClassDefinition, natures));
+				}
+			}
+		}
+	}
+
+	/**
+	 * Reads Natures from an XML:
+	 * 
+	 * <pre>
+	 * <scr:component>
+	 *   <service>
+	 *     <provide interface="...">
+	 *   </service>
+	 * </scr:component>
+	 * </pre>
+	 * 
+	 * @return
+	 */
+	private static String[] getNatures(Bundle bundle, Manifest manifest, String factoryPid) {
+		try {
+			// get "Service-Component"-Entry of Manifest
+			String serviceComponentsString = manifest.getMainAttributes()
+					.getValue(ComponentConstants.SERVICE_COMPONENT);
+			if (serviceComponentsString == null) {
+				return new String[0];
+			}
+			String[] serviceComponents = serviceComponentsString.split(",");
+
+			// read Service-Component XML files from OSGI-INF folder
+			for (String serviceComponent : serviceComponents) {
+				if (!serviceComponent.contains(factoryPid)) {
+					// search for correct XML file
+					continue;
+				}
+
+				URL componentUrl = bundle.getResource(serviceComponent);
+				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				Document doc = dBuilder.parse(componentUrl.openStream());
+				doc.getDocumentElement().normalize();
+
+				NodeList serviceNodes = doc.getElementsByTagName("service");
+				for (int i = 0; i < serviceNodes.getLength(); i++) {
+					Node serviceNode = serviceNodes.item(i);
+					if (serviceNode.getNodeType() == Node.ELEMENT_NODE) {
+						NodeList provideNodes = serviceNode.getChildNodes();
+
+						// Read "interface" attributes and return them
+						Set<String> result = new HashSet<>();
+						for (int j = 0; j < provideNodes.getLength(); j++) {
+							Node provideNode = provideNodes.item(j);
+							NamedNodeMap attributes = provideNode.getAttributes();
+							if (attributes != null) {
+								Node interfaceNode = attributes.getNamedItem("interface");
+								String nature = interfaceNode.getNodeValue();
+								switch (nature) {
+								case "org.osgi.service.event.EventHandler":
+								case "org.ops4j.pax.logging.spi.PaxAppender":
+									// ignore these natures;
+									break;
+								default:
+									result.add(nature);
+								}
+							}
+						}
+						return result.toArray(new String[result.size()]);
+					}
+				}
+			}
+
+		} catch (ParserConfigurationException | SAXException | IOException e) {
+			log.warn("Unable to get Natures. " + e.getClass().getSimpleName() + ": " + e.getMessage());
+		}
+		return new String[0];
+	}
+
+	/**
+	 * Gets a component Property as JsonElement. Uses some more techniques to find
+	 * the proper type than {@link JsonUtils#getAsJsonElement(Object)}.
+	 * 
+	 * @param properties the properties
+	 * @param value      the property key
+	 * @return the value as JsonElement
+	 */
+	private static JsonElement getPropertyAsJsonElement(Dictionary<String, Object> properties, String key) {
+		Object valueObj = properties.get(key);
+		if (valueObj != null && valueObj instanceof String) {
+			String value = (String) valueObj;
+			// find boolean
+			if (value.equalsIgnoreCase("true")) {
+				return new JsonPrimitive(true);
+			} else if (value.equalsIgnoreCase("false")) {
+				return new JsonPrimitive(false);
+			}
+		}
+		// fallback to JsonUtils
+		return JsonUtils.getAsJsonElement(valueObj);
+	}
+
+	/**
+	 * Convert properties to a String/JsonElement Map.
+	 * 
+	 * @param properties the component properties
+	 * @param factory    the {@link EdgeConfig.Factory}
+	 * @return converted properties
+	 */
+	private static TreeMap<String, JsonElement> convertProperties(Dictionary<String, Object> properties,
+			EdgeConfig.Factory factory) {
+		TreeMap<String, JsonElement> result = new TreeMap<>();
+		Enumeration<String> keys = properties.keys();
+		while (keys.hasMoreElements()) {
+			String key = keys.nextElement();
+			if (!EdgeConfig.ignorePropertyKey(key)) {
+
+				JsonElement value = getPropertyAsJsonElement(properties, key);
+				if (factory != null) {
+					Optional<EdgeConfig.Factory.Property> propertyOpt = factory.getProperty(key);
+					if (propertyOpt.isPresent()) {
+						EdgeConfig.Factory.Property property = propertyOpt.get();
+						// hide Password fields
+						if (property.isPassword()) {
+							value = new JsonPrimitive("xxx");
+						}
+					}
+				}
+
+				result.put(key, value);
+			}
+		}
+		return result;
+	}
+}

--- a/ui/src/app/shared/edge/edgeconfig.ts
+++ b/ui/src/app/shared/edge/edgeconfig.ts
@@ -28,7 +28,13 @@ export class EdgeConfig {
 
         // initialize Components
         for (let componentId in this.components) {
-            this.components[componentId].id = componentId;
+            let component = this.components[componentId];
+            component.id = componentId;
+            if ('enabled' in component.properties) {
+                component.isEnabled = component.properties['enabled']
+            } else {
+                component.isEnabled = true;
+            }
         }
 
         // initialize Factorys


### PR DESCRIPTION
- remove "isEnabled"; it's already covered by the 'enabled' property
- improve "getAsText" method
- Websocket.Api: do not collect EdgeConfig if no websocket is connected
- Create EdgeConfigFactory that takes care of building and caching EdgeConfig
- Cache EdgeConfig and only incorporate ConfigurationEvents on Change; improves speed a lot