### PR TITLE
Update PAX Logging to 2.0.2

### DIFF
--- a/cnf/pom.xml
+++ b/cnf/pom.xml
@@ -143,12 +143,12 @@
 		<dependency>
 			<groupId>org.ops4j.pax.logging</groupId>
 			<artifactId>pax-logging-api</artifactId>
-			<version>1.11.2</version>
+			<version>2.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ops4j.pax.logging</groupId>
-			<artifactId>pax-logging-service</artifactId>
-			<version>1.11.2</version>
+			<artifactId>pax-logging-log4j1</artifactId>
+			<version>2.0.2</version>
 		</dependency>
 		<dependency>
 			<!-- Used by io.openems.backend.metadata.odoo -->

--- a/io.openems.backend.application/BackendApp.bndrun
+++ b/io.openems.backend.application/BackendApp.bndrun
@@ -13,11 +13,10 @@
 
 -runrequires: \
 	bnd.identity;id='org.ops4j.pax.logging.pax-logging-api',\
-	bnd.identity;id='org.ops4j.pax.logging.pax-logging-service',\
+	bnd.identity;id='org.ops4j.pax.logging.pax-logging-log4j1',\
 	bnd.identity;id='org.osgi.service.jdbc',\
 	bnd.identity;id='org.apache.felix.http.jetty',\
 	bnd.identity;id='org.apache.felix.webconsole',\
-	bnd.identity;id='org.eclipse.equinox.metatype',\
 	bnd.identity;id='io.openems.backend.application',\
 	bnd.identity;id='io.openems.backend.b2brest',\
 	bnd.identity;id='io.openems.backend.b2bwebsocket',\
@@ -67,10 +66,9 @@
 	org.apache.felix.webconsole;version='[4.3.4,4.3.5)',\
 	org.apache.servicemix.bundles.ws-commons-util;version='[1.0.2,1.0.3)',\
 	org.apache.servicemix.bundles.xmlrpc-client;version='[3.1.3,3.1.4)',\
-	org.eclipse.equinox.metatype;version='[1.4.500,1.4.501)',\
 	org.jsr-305;version='[3.0.2,3.0.3)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[1.11.2,1.11.3)',\
-	org.ops4j.pax.logging.pax-logging-service;version='[1.11.2,1.11.3)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.2,2.0.3)',\
+	org.ops4j.pax.logging.pax-logging-log4j1;version='[2.0.2,2.0.3)',\
 	org.osgi.service.jdbc;version='[1.0.0,1.0.1)',\
 	org.osgi.service.metatype;version='[1.4.0,1.4.1)',\
 	org.postgresql.jdbc42;version='[42.2.12,42.2.13)'

--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -10,16 +10,18 @@
 	openems.data.dir=c:/openems/data,\
 	org.ops4j.pax.logging.DefaultServiceLog.level=INFO
 
--runbundles+: \
-    org.ops4j.pax.logging.pax-logging-api;startlevel=10
-
 -runsystempackages:\
 	sun.misc,\
 	com.sun.net.httpserver
 
+-runbundles+: \
+	org.apache.felix.scr;startlevel=10,\
+	org.eclipse.equinox.event;startlevel=11,\
+    org.ops4j.pax.logging.pax-logging-log4j1;startlevel=12
+
 -runrequires: \
 	bnd.identity;id='org.ops4j.pax.logging.pax-logging-api',\
-	bnd.identity;id='org.ops4j.pax.logging.pax-logging-service',\
+	bnd.identity;id='org.ops4j.pax.logging.pax-logging-log4j1',\
 	bnd.identity;id='org.apache.felix.http.jetty',\
 	bnd.identity;id='org.apache.felix.webconsole',\
 	bnd.identity;id='io.openems.edge.application',\
@@ -248,8 +250,8 @@
 	org.jsr-305;version='[3.0.2,3.0.3)',\
 	org.openmuc.jmbus;version='[3.2.1,3.2.2)',\
 	org.openmuc.jrxtx;version='[1.0.1,1.0.2)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[1.11.2,1.11.3)',\
-	org.ops4j.pax.logging.pax-logging-service;version='[1.11.2,1.11.3)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.2,2.0.3)',\
+	org.ops4j.pax.logging.pax-logging-log4j1;version='[2.0.2,2.0.3)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.osgi.service.metatype;version='[1.4.0,1.4.1)',\
 	rrd4j;version='[3.6.0,3.6.1)'

--- a/tools/prepare-commit.sh
+++ b/tools/prepare-commit.sh
@@ -102,7 +102,7 @@ done
 bndrun='io.openems.edge.application/EdgeApp.bndrun'
 head -n $(grep -n '\-runrequires:' $bndrun | grep -Eo '^[^:]+' | head -n1) "$bndrun" > "$bndrun.new"
 echo "	bnd.identity;id='org.ops4j.pax.logging.pax-logging-api',\\" >> "$bndrun.new"
-echo "	bnd.identity;id='org.ops4j.pax.logging.pax-logging-service',\\" >> "$bndrun.new"
+echo "	bnd.identity;id='org.ops4j.pax.logging.pax-logging-log4j1',\\" >> "$bndrun.new"
 echo "	bnd.identity;id='org.apache.felix.http.jetty',\\" >> "$bndrun.new"
 echo "	bnd.identity;id='org.apache.felix.webconsole',\\" >> "$bndrun.new"
 for D in io.openems.edge.*; do
@@ -124,11 +124,10 @@ rm "$bndrun.new"
 bndrun='io.openems.backend.application/BackendApp.bndrun'
 head -n $(grep -n '\-runrequires:' $bndrun | grep -Eo '^[^:]+' | head -n1) "$bndrun" > "$bndrun.new"
 echo "	bnd.identity;id='org.ops4j.pax.logging.pax-logging-api',\\" >> "$bndrun.new"
-echo "	bnd.identity;id='org.ops4j.pax.logging.pax-logging-service',\\" >> "$bndrun.new"
+echo "	bnd.identity;id='org.ops4j.pax.logging.pax-logging-log4j1',\\" >> "$bndrun.new"
 echo "	bnd.identity;id='org.osgi.service.jdbc',\\" >> "$bndrun.new"
 echo "	bnd.identity;id='org.apache.felix.http.jetty',\\" >> "$bndrun.new"
 echo "	bnd.identity;id='org.apache.felix.webconsole',\\" >> "$bndrun.new"
-echo "	bnd.identity;id='org.eclipse.equinox.metatype',\\" >> "$bndrun.new"
 for D in io.openems.backend.*; do
 	if [[ "$D" == *api ]]; then
 		continue # ignore api bundle


### PR DESCRIPTION
Fixes an issue that caused an exception at startup which caused all components listed in 'runbundles' after org.ops4j.pax.logging.pax-logging-service to stop working.

The problem came up in OpenEMS Community Forum: https://community.openems.io/t/cannot-activate-template-controller/198/10. Thanks to Valentin and @clehne for helping to track it down and fix it.