### PR TITLE
Fix Discovergy implementation with latest API for Production meters

### DIFF
--- a/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
@@ -392,6 +392,79 @@ public class TypeUtils {
 	}
 
 	/**
+	 * Safely multiply Integers.
+	 * 
+	 * @param factors the factors of the multiplication
+	 * @return the result, possibly null if all factors are null
+	 */
+	public static Integer multiply(Integer... factors) {
+		Integer result = null;
+		for (Integer factor : factors) {
+			if (result == null) {
+				result = factor;
+			} else if (factor != null) {
+				result *= factor;
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Safely divides Integers.
+	 * 
+	 * <ul>
+	 * <li>if dividend is null -> result is null
+	 * </ul>
+	 * 
+	 * @param minuend    the dividend of the division
+	 * @param subtrahend the divisor of the division
+	 * @return the result, possibly null
+	 */
+	public static Integer divide(Integer dividend, int divisor) {
+		if (dividend == null) {
+			return null;
+		}
+		return dividend / divisor;
+	}
+
+	/**
+	 * Safely divides Longs.
+	 * 
+	 * <ul>
+	 * <li>if dividend is null -> result is null
+	 * </ul>
+	 * 
+	 * @param minuend    the dividend of the division
+	 * @param subtrahend the divisor of the division
+	 * @return the result, possibly null
+	 */
+	public static Long divide(Long dividend, long divisor) {
+		if (dividend == null) {
+			return null;
+		}
+		return dividend / divisor;
+	}
+
+	/**
+	 * Safely finds the max value of all values.
+	 * 
+	 * @return the max value; or null if all values are null
+	 */
+	public static Integer max(Integer... values) {
+		Integer result = null;
+		for (Integer value : values) {
+			if (value != null) {
+				if (result == null) {
+					result = value;
+				} else {
+					result = Math.max(result, value);
+				}
+			}
+		}
+		return result;
+	}
+
+	/**
 	 * Throws an descriptive exception if the object is null.
 	 * 
 	 * @param description text that is added to the exception
@@ -403,4 +476,5 @@ public class TypeUtils {
 			throw new OpenemsException(description + " value is null!");
 		}
 	}
+
 }

--- a/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/DiscovergyApiClient.java
+++ b/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/DiscovergyApiClient.java
@@ -78,7 +78,7 @@ public class DiscovergyApiClient {
 		String endpoint = String.format("/last_reading?meterId=%s&fields=%s", //
 				meterId, //
 				Arrays.stream(fields) //
-						.map(field -> field.getName()) //
+						.map(field -> field.n()) //
 						.collect(Collectors.joining(",")));
 		return JsonUtils.getAsJsonObject(//
 				this.sendGetRequest(endpoint));
@@ -113,7 +113,7 @@ public class DiscovergyApiClient {
 			}
 			if (status < 300) {
 				// Parse response to JSON
-				return JsonUtils.parseToJsonObject(body);
+				return JsonUtils.parse(body);
 			} else {
 				throw new OpenemsException(
 						"Error while reading from Discovergy API. Response code: " + status + ". " + body);

--- a/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/DiscovergyWorker.java
+++ b/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/DiscovergyWorker.java
@@ -14,6 +14,9 @@ import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.utils.JsonUtils;
 import io.openems.common.worker.AbstractCycleWorker;
+import io.openems.edge.common.channel.IntegerReadChannel;
+import io.openems.edge.common.channel.LongReadChannel;
+import io.openems.edge.common.type.TypeUtils;
 import io.openems.edge.meter.discovergy.MeterDiscovergy.ChannelId;
 import io.openems.edge.meter.discovergy.jsonrpc.DiscovergyMeter;
 import io.openems.edge.meter.discovergy.jsonrpc.Field;
@@ -43,15 +46,20 @@ public class DiscovergyWorker extends AbstractCycleWorker {
 
 	@Override
 	protected void forever() throws OpenemsNamedException {
-		Integer activePower = null;
-		Integer activePowerL1 = null;
-		Integer activePowerL2 = null;
-		Integer activePowerL3 = null;
-		Integer voltageL1 = null;
-		Integer voltageL2 = null;
-		Integer voltageL3 = null;
-		Long productionEnergy = null;
-		Long consumptionEnergy = null;
+		Integer rawPower = null;
+		Integer rawPower1 = null;
+		Integer rawPower2 = null;
+		Integer rawPower3 = null;
+		Integer rawVoltage1 = null;
+		Integer rawVoltage2 = null;
+		Integer rawVoltage3 = null;
+		Long rawEnergy = null;
+		Long rawEnergy1 = null;
+		Long rawEnergy2 = null;
+		Long rawEnergyOut = null;
+		Long rawEnergyOut1 = null;
+		Long rawEnergyOut2 = null;
+
 		boolean restApiFailed = true;
 		boolean lastReadingTooOld = false;
 
@@ -61,22 +69,29 @@ public class DiscovergyWorker extends AbstractCycleWorker {
 
 			// Retrieve Channel-Values
 			JsonObject reading = this.apiClient.getLastReading(this.meterId, //
-					Field.POWER, Field.POWER_L1, Field.POWER_L2, Field.POWER_L3, //
-					Field.VOLTAGE_L1, Field.VOLTAGE_L2, Field.VOLTAGE_L3, //
-					Field.ENERGY_IN, Field.ENERGY_OUT);
+					Field.POWER, Field.POWER1, Field.POWER2, Field.POWER3, //
+					Field.VOLTAGE1, Field.VOLTAGE2, Field.VOLTAGE3, //
+					Field.ENERGY, Field.ENERGY1, Field.ENERGY2, //
+					Field.ENERGY_OUT, Field.ENERGY_OUT1, Field.ENERGY_OUT2);
+
 			Long time = JsonUtils.getAsLong(reading, "time");
 			if (System.currentTimeMillis() / 1000 - LAST_READING_TOO_OLD_SECONDS < time) {
 				// Values are valid
 				JsonObject values = JsonUtils.getAsJsonObject(reading, "values");
-				activePower = JsonUtils.getAsInt(values, "power") / 1000;
-				activePowerL1 = JsonUtils.getAsInt(values, "power1") / 1000;
-				activePowerL2 = JsonUtils.getAsInt(values, "power2") / 1000;
-				activePowerL3 = JsonUtils.getAsInt(values, "power3") / 1000;
-				voltageL1 = JsonUtils.getAsInt(values, "voltage1");
-				voltageL2 = JsonUtils.getAsInt(values, "voltage2");
-				voltageL3 = JsonUtils.getAsInt(values, "voltage3");
-				productionEnergy = JsonUtils.getAsLong(values, "energy") / 10_000_000;
-				consumptionEnergy = JsonUtils.getAsLong(values, "energyOut") / 10_000_000;
+				rawPower = JsonUtils.getAsInt(values, Field.POWER.n());
+				rawPower1 = JsonUtils.getAsInt(values, Field.POWER1.n());
+				rawPower2 = JsonUtils.getAsInt(values, Field.POWER2.n());
+				rawPower3 = JsonUtils.getAsInt(values, Field.POWER3.n());
+				rawVoltage1 = JsonUtils.getAsInt(values, Field.VOLTAGE1.n());
+				rawVoltage2 = JsonUtils.getAsInt(values, Field.VOLTAGE2.n());
+				rawVoltage3 = JsonUtils.getAsInt(values, Field.VOLTAGE3.n());
+				rawEnergy = JsonUtils.getAsLong(values, Field.ENERGY.n());
+				rawEnergy1 = JsonUtils.getAsLong(values, Field.ENERGY1.n());
+				rawEnergy2 = JsonUtils.getAsLong(values, Field.ENERGY2.n());
+				rawEnergyOut = JsonUtils.getAsLong(values, Field.ENERGY_OUT.n());
+				rawEnergyOut1 = JsonUtils.getAsLong(values, Field.ENERGY_OUT1.n());
+				rawEnergyOut2 = JsonUtils.getAsLong(values, Field.ENERGY_OUT2.n());
+
 				lastReadingTooOld = false;
 
 			} else {
@@ -90,18 +105,56 @@ public class DiscovergyWorker extends AbstractCycleWorker {
 			this.parent.logError(this.log, "REST-Api failed: " + e.getMessage());
 
 		} finally {
-			this.parent.getActivePower().setNextValue(activePower);
-			this.parent.getActivePowerL1().setNextValue(activePowerL1);
-			this.parent.getActivePowerL2().setNextValue(activePowerL2);
-			this.parent.getActivePowerL3().setNextValue(activePowerL3);
-			this.parent.getVoltage().setNextValue(voltageL1);
-			this.parent.getVoltageL1().setNextValue(voltageL1);
-			this.parent.getVoltageL2().setNextValue(voltageL2);
-			this.parent.getVoltageL3().setNextValue(voltageL3);
-			this.parent.getActiveProductionEnergy().setNextValue(productionEnergy);
-			this.parent.getActiveConsumptionEnergy().setNextValue(consumptionEnergy);
+			// Raw Channels
+			((IntegerReadChannel) this.parent.channel(ChannelId.RAW_POWER)).setNextValue(rawPower);
+			((IntegerReadChannel) this.parent.channel(ChannelId.RAW_POWER1)).setNextValue(rawPower1);
+			((IntegerReadChannel) this.parent.channel(ChannelId.RAW_POWER2)).setNextValue(rawPower2);
+			((IntegerReadChannel) this.parent.channel(ChannelId.RAW_POWER3)).setNextValue(rawPower3);
+			((IntegerReadChannel) this.parent.channel(ChannelId.RAW_VOLTAGE1)).setNextValue(rawVoltage1);
+			((IntegerReadChannel) this.parent.channel(ChannelId.RAW_VOLTAGE2)).setNextValue(rawVoltage2);
+			((IntegerReadChannel) this.parent.channel(ChannelId.RAW_VOLTAGE3)).setNextValue(rawVoltage3);
+			((LongReadChannel) this.parent.channel(ChannelId.RAW_ENERGY)).setNextValue(rawEnergy);
+			((LongReadChannel) this.parent.channel(ChannelId.RAW_ENERGY1)).setNextValue(rawEnergy1);
+			((LongReadChannel) this.parent.channel(ChannelId.RAW_ENERGY2)).setNextValue(rawEnergy2);
+			((LongReadChannel) this.parent.channel(ChannelId.RAW_ENERGY_OUT)).setNextValue(rawEnergyOut);
+			((LongReadChannel) this.parent.channel(ChannelId.RAW_ENERGY_OUT1)).setNextValue(rawEnergyOut1);
+			((LongReadChannel) this.parent.channel(ChannelId.RAW_ENERGY_OUT2)).setNextValue(rawEnergyOut2);
+
+			// State Channels
 			this.parent.channel(ChannelId.REST_API_FAILED).setNextValue(restApiFailed);
 			this.parent.channel(ChannelId.LAST_READING_TOO_OLD).setNextValue(lastReadingTooOld);
+
+			// Nature Channels
+			Integer activePower = TypeUtils.divide(rawPower, 1_000);
+			Integer activePowerL1 = TypeUtils.divide(rawPower1, 1_000);
+			Integer activePowerL2 = TypeUtils.divide(rawPower2, 1_000);
+			Integer activePowerL3 = TypeUtils.divide(rawPower3, 1_000);
+			switch (config.type()) {
+			case GRID:
+				this.parent.getActivePower().setNextValue(activePower);
+				this.parent.getActivePowerL1().setNextValue(activePowerL1);
+				this.parent.getActivePowerL2().setNextValue(activePowerL2);
+				this.parent.getActivePowerL3().setNextValue(activePowerL3);
+				this.parent.getActiveProductionEnergy().setNextValue(TypeUtils.divide(rawEnergy, 10_000_000));
+				this.parent.getActiveConsumptionEnergy().setNextValue(TypeUtils.divide(rawEnergyOut, 10_000_000));
+				break;
+			case CONSUMPTION_NOT_METERED: // to be validated
+			case CONSUMPTION_METERED: // to be validated
+			case PRODUCTION_AND_CONSUMPTION:
+			case PRODUCTION:
+				this.parent.getActivePower().setNextValue(TypeUtils.multiply(activePower, -1)); // invert
+				this.parent.getActivePowerL1().setNextValue(TypeUtils.multiply(activePowerL1, -1)); // invert
+				this.parent.getActivePowerL2().setNextValue(TypeUtils.multiply(activePowerL2, -1)); // invert
+				this.parent.getActivePowerL3().setNextValue(TypeUtils.multiply(activePowerL3, -1)); // invert
+				this.parent.getActiveProductionEnergy().setNextValue(TypeUtils.divide(rawEnergyOut, 10_000_000));
+				this.parent.getActiveConsumptionEnergy().setNextValue(0 /* always zero for production-only meters */);
+				break;
+			}
+
+			this.parent.getVoltage().setNextValue(TypeUtils.max(rawVoltage1, rawVoltage2, rawVoltage3));
+			this.parent.getVoltageL1().setNextValue(rawVoltage1);
+			this.parent.getVoltageL2().setNextValue(rawVoltage2);
+			this.parent.getVoltageL3().setNextValue(rawVoltage3);
 		}
 	}
 

--- a/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/MeterDiscovergy.java
+++ b/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/MeterDiscovergy.java
@@ -25,6 +25,7 @@ import io.openems.common.jsonrpc.base.JsonrpcRequest;
 import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
 import io.openems.common.session.Role;
 import io.openems.common.session.User;
+import io.openems.common.types.OpenemsType;
 import io.openems.common.utils.JsonUtils;
 import io.openems.edge.common.channel.Doc;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
@@ -89,6 +90,26 @@ public class MeterDiscovergy extends AbstractOpenemsComponent
 	}
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+		/*
+		 * Raw values from Discovergy API
+		 */
+		RAW_POWER(Doc.of(OpenemsType.INTEGER)), //
+		RAW_POWER1(Doc.of(OpenemsType.INTEGER)), //
+		RAW_POWER2(Doc.of(OpenemsType.INTEGER)), //
+		RAW_POWER3(Doc.of(OpenemsType.INTEGER)), //
+		RAW_VOLTAGE1(Doc.of(OpenemsType.INTEGER)), //
+		RAW_VOLTAGE2(Doc.of(OpenemsType.INTEGER)), //
+		RAW_VOLTAGE3(Doc.of(OpenemsType.INTEGER)), //
+		RAW_ENERGY(Doc.of(OpenemsType.LONG)), //
+		RAW_ENERGY1(Doc.of(OpenemsType.LONG)), //
+		RAW_ENERGY2(Doc.of(OpenemsType.LONG)), //
+		RAW_ENERGY_OUT(Doc.of(OpenemsType.LONG)), //
+		RAW_ENERGY_OUT1(Doc.of(OpenemsType.LONG)), //
+		RAW_ENERGY_OUT2(Doc.of(OpenemsType.LONG)), //
+
+		/*
+		 * StateChannels
+		 */
 		REST_API_FAILED(Doc.of(Level.FAULT)), //
 		LAST_READING_TOO_OLD(Doc.of(Level.FAULT));
 

--- a/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/jsonrpc/Field.java
+++ b/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/jsonrpc/Field.java
@@ -3,14 +3,18 @@ package io.openems.edge.meter.discovergy.jsonrpc;
 public enum Field {
 
 	POWER("power"), //
-	POWER_L1("power1"), //
-	POWER_L2("power2"), //
-	POWER_L3("power3"), //
-	VOLTAGE_L1("voltage1"), //
-	VOLTAGE_L2("voltage2"), //
-	VOLTAGE_L3("voltage3"), //
-	ENERGY_IN("energy"), //
-	ENERGY_OUT("energyOut");
+	POWER1("power1"), //
+	POWER2("power2"), //
+	POWER3("power3"), //
+	VOLTAGE1("voltage1"), //
+	VOLTAGE2("voltage2"), //
+	VOLTAGE3("voltage3"), //
+	ENERGY("energy"), //
+	ENERGY1("energy1"), //
+	ENERGY2("energy2"), //
+	ENERGY_OUT("energyOut"), //
+	ENERGY_OUT1("energyOut1"), //
+	ENERGY_OUT2("energyOut2");
 
 	private final String name;
 
@@ -18,7 +22,7 @@ public enum Field {
 		this.name = name;
 	}
 
-	public String getName() {
+	public String n() {
 		return name;
 	}
 

--- a/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/jsonrpc/GetFieldNamesResponse.java
+++ b/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/jsonrpc/GetFieldNamesResponse.java
@@ -41,7 +41,7 @@ public class GetFieldNamesResponse extends JsonrpcResponseSuccess {
 	public JsonObject getResult() {
 		JsonArray fieldNames = new JsonArray();
 		for (Field field : this.fields) {
-			fieldNames.add(field.getName());
+			fieldNames.add(field.n());
 		}
 		return JsonUtils.buildJsonObject() //
 				.add("fieldNames", fieldNames) //


### PR DESCRIPTION
Discovergy started to invert their power values for Production. See https://forum.discovergy.com/t/wieso-werden-meine-ertragsdaten-der-solaranlage-negativ-dargestellt/998/22

This Pull-Request fixes this by inverting the value when needed. It also adds the raw data as channels for easier debugging