### PR TITLE
WAGO: compatibility with newer fieldbus couplers + all kinds of digital output modules

### DIFF
--- a/io.openems.edge.io.wago/src/io/openems/edge/wago/Fieldbus4xxDI.java
+++ b/io.openems.edge.io.wago/src/io/openems/edge/wago/Fieldbus4xxDI.java
@@ -4,7 +4,7 @@ import io.openems.edge.bridge.modbus.api.element.AbstractModbusElement;
 import io.openems.edge.common.channel.BooleanDoc;
 import io.openems.edge.common.channel.BooleanReadChannel;
 
-public class Fieldbus400DI extends FieldbusModule {
+public class Fieldbus4xxDI extends FieldbusModule {
 
 	private static final String ID_TEMPLATE = "DIGITAL_INPUT_M";
 
@@ -12,7 +12,7 @@ public class Fieldbus400DI extends FieldbusModule {
 	private final AbstractModbusElement<?>[] outputElements;
 	private final BooleanReadChannel[] readChannels;
 
-	public Fieldbus400DI(Wago parent, int moduleCount, int inputOffset, int outputOffset, int channelsCount) {
+	public Fieldbus4xxDI(Wago parent, int moduleCount, int inputOffset, int outputOffset, int channelsCount) {
 		String id = ID_TEMPLATE + moduleCount;
 
 		this.readChannels = new BooleanReadChannel[channelsCount];

--- a/io.openems.edge.io.wago/src/io/openems/edge/wago/Fieldbus5xxDO.java
+++ b/io.openems.edge.io.wago/src/io/openems/edge/wago/Fieldbus5xxDO.java
@@ -7,7 +7,7 @@ import io.openems.edge.common.channel.BooleanReadChannel;
 import io.openems.edge.common.channel.BooleanWriteChannel;
 import io.openems.edge.common.channel.internal.OpenemsTypeDoc;
 
-public class Fieldbus501DO2Ch extends FieldbusModule {
+public class Fieldbus5xxDO extends FieldbusModule {
 
 	private static final String ID_TEMPLATE = "DIGITAL_OUTPUT_M";
 
@@ -15,39 +15,29 @@ public class Fieldbus501DO2Ch extends FieldbusModule {
 	private final AbstractModbusElement<?>[] outputElements;
 	private final BooleanReadChannel[] readChannels;
 
-	public Fieldbus501DO2Ch(Wago parent, int moduleCount, int inputOffset, int outputOffset) {
+	public Fieldbus5xxDO(Wago parent, int moduleCount, int inputOffset, int outputOffset, int channelsCount) {
 		String id = ID_TEMPLATE + moduleCount;
 
-		BooleanWriteChannel channel1;
-		{
+		this.readChannels = new BooleanReadChannel[channelsCount];
+		this.inputElements = new AbstractModbusElement<?>[channelsCount];
+		this.outputElements = new AbstractModbusElement<?>[channelsCount];
+
+		for (int i = 0; i < channelsCount; i++) {
 			OpenemsTypeDoc<Boolean> doc = new BooleanDoc() //
 					.accessMode(AccessMode.READ_WRITE);
-			FieldbusChannelId channelId = new FieldbusChannelId(id + "_C1", doc);
-			channel1 = (BooleanWriteChannel) parent.addChannel(channelId);
-		}
-		BooleanWriteChannel channel2;
-		{
-			OpenemsTypeDoc<Boolean> doc = new BooleanDoc() //
-					.accessMode(AccessMode.READ_WRITE);
-			FieldbusChannelId channelId = new FieldbusChannelId(id + "_C2", doc);
-			channel2 = (BooleanWriteChannel) parent.addChannel(channelId);
-		}
-		this.readChannels = new BooleanReadChannel[] { channel1, channel2 };
+			FieldbusChannelId channelId = new FieldbusChannelId(id + "_C" + (i + 1), doc);
+			BooleanWriteChannel channel = (BooleanWriteChannel) parent.addChannel(channelId);
 
-		this.inputElements = new AbstractModbusElement<?>[] { //
-				parent.createModbusElement(channel1.channelId(), outputOffset), //
-				parent.createModbusElement(channel2.channelId(), outputOffset + 1), //
-		};
+			this.readChannels[i] = channel;
 
-		this.outputElements = new AbstractModbusElement<?>[] { //
-				parent.createModbusElement(channel1.channelId(), outputOffset), //
-				parent.createModbusElement(channel2.channelId(), outputOffset + 1), //
-		};
+			this.inputElements[i] = parent.createModbusElement(channel.channelId(), outputOffset + i);
+			this.outputElements[i] = parent.createModbusElement(channel.channelId(), outputOffset + i);
+		}
 	}
 
 	@Override
 	public String getName() {
-		return "WAGO I/O 750-501 2-channel digital output module";
+		return "WAGO I/O 750-5xx digital output module";
 	}
 
 	@Override
@@ -62,12 +52,12 @@ public class Fieldbus501DO2Ch extends FieldbusModule {
 
 	@Override
 	public int getOutputCoils() {
-		return 2;
+		return this.outputElements.length;
 	}
 
 	@Override
 	public int getInputCoils() {
-		return 0;
+		return this.inputElements.length;
 	}
 
 	@Override

--- a/io.openems.edge.io.wago/src/io/openems/edge/wago/FieldbusModuleFactory.java
+++ b/io.openems.edge.io.wago/src/io/openems/edge/wago/FieldbusModuleFactory.java
@@ -2,9 +2,9 @@ package io.openems.edge.wago;
 
 public class FieldbusModuleFactory {
 
-	private int moduleCount400DI = 0;
+	private int moduleCount4xxDI = 0;
 	private int moduleCount523RO1Ch = 0;
-	private int moduleCount501DO2Ch = 0;
+	private int moduleCount5xxDO = 0;
 
 	public FieldbusModule of(Wago parent, String moduleArtikelnr, String moduleType, FieldbusModuleKanal[] kanals,
 			int inputOffset, int outputOffset) {
@@ -12,7 +12,7 @@ public class FieldbusModuleFactory {
 		case "750-4xx":
 			switch (moduleType) {
 			case "DI":
-				return new Fieldbus400DI(parent, ++this.moduleCount400DI, inputOffset, outputOffset, kanals.length);
+				return new Fieldbus4xxDI(parent, ++this.moduleCount4xxDI, inputOffset, outputOffset, kanals.length);
 			}
 			break;
 
@@ -21,7 +21,7 @@ public class FieldbusModuleFactory {
 			case "DO/DIA":
 				return new Fieldbus523RO1Ch(parent, ++this.moduleCount523RO1Ch, inputOffset, outputOffset);
 			case "DO":
-				return new Fieldbus501DO2Ch(parent, ++this.moduleCount501DO2Ch, inputOffset, outputOffset);
+				return new Fieldbus5xxDO(parent, ++this.moduleCount5xxDO, inputOffset, outputOffset, kanals.length);
 			}
 			break;
 		}


### PR DESCRIPTION
- Tries to read old 'ea-config.xml' and new 'io_config.xml'
- Dynamically reads the number of output channels from xml file for WAGO 750 5xx-modules