### PR TITLE
update CHPSoC widget % thresholds

### DIFF
--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -156,7 +156,6 @@ export class AppComponent {
     if (urlArray.length >= 4) {
       file = urlArray[3];
     }
-    console.log("file", file, "urlArray", urlArray)
     // Enable Segment Navigation for Edge-Index-Page
     if ((file == 'history' || file == 'live') && urlArray.length == 3) {
       if (file == 'history') {

--- a/ui/src/app/edge/live/chpsoc/chpsoc.component.html
+++ b/ui/src/app/edge/live/chpsoc/chpsoc.component.html
@@ -48,14 +48,14 @@
                                     <rect attr.x="{{ component.properties['lowThreshold'] }}%" y="2" rx="5" ry="5"
                                         attr.width="{{ component.properties['highThreshold'] - component.properties['lowThreshold'] }}%"
                                         height="16" style="fill:#2d8fab" />
-                                    <rect y="2" rx="5" ry="5" attr.x="{{currentData.channel[inputChannel]}}%" width="1%"
-                                        height="16" style="fill:#bdbdbd" />
-                                    <text attr.x="{{ component.properties['lowThreshold'] - 7 }}%" y="58%"
-                                        dominant-baseline="middle" text-anchor="middle"
-                                        style="font-weight: 500">{{ component.properties['lowThreshold'] + " %" }}</text>
-                                    <text attr.x="{{ component.properties['highThreshold'] + 7 }}%" y="58%"
-                                        dominant-baseline="middle" text-anchor="middle"
-                                        style="font-weight: 500">{{ component.properties['highThreshold'] + " %" }}</text>
+                                    <rect y="2" rx="5" ry="5" attr.x="{{currentData.channel[inputChannel] + 2}}%"
+                                        width="1%" height="16" style="fill:#bdbdbd" />
+                                    <text attr.x="{{ component.properties['lowThreshold'] }}%" y="58%"
+                                        dominant-baseline="middle" text-anchor="start"
+                                        style="font-weight: 500; fill: white">{{ component.properties['lowThreshold'] + " %" }}</text>
+                                    <text attr.x="{{ component.properties['highThreshold'] }}%" y="58%"
+                                        dominant-baseline="middle" text-anchor="end"
+                                        style="font-weight: 500; fill: white">{{ component.properties['highThreshold'] + " %" }}</text>
                                 </svg>
                             </td>
                         </tr>

--- a/ui/src/app/edge/live/chpsoc/modal/modal.component.html
+++ b/ui/src/app/edge/live/chpsoc/modal/modal.component.html
@@ -79,13 +79,13 @@
                 </table>
                 <table class="full_width">
                     <tr>
-                        <ion-range (ionChange)="updateThresholds()" dual-knobs pin color="dark" min="15" max="85"
+                        <ion-range (ionChange)="updateThresholds()" dual-knobs pin color="dark" min="0" max="100"
                             [(ngModel)]="thresholds" debounce="500">
                             <ion-label slot="start">
-                                {{ 15 | unitvalue:'%' }}
+                                {{ 0 | unitvalue:'%' }}
                             </ion-label>
                             <ion-label slot="end">
-                                {{ 85 | unitvalue:'%' }}
+                                {{ 100 | unitvalue:'%' }}
                             </ion-label>
                         </ion-range>
                     </tr>

--- a/ui/src/app/edge/live/chpsoc/modal/modal.component.ts
+++ b/ui/src/app/edge/live/chpsoc/modal/modal.component.ts
@@ -86,7 +86,8 @@ export class ChpsocModalComponent implements OnInit {
         let newLowerThreshold = this.thresholds['lower'];
         let newUpperThreshold = this.thresholds['upper'];
 
-        if (this.edge != null) {
+        // prevents automatic update when no values have changed
+        if (this.edge != null && (oldLowerThreshold != newLowerThreshold || oldUpperThreshold != newUpperThreshold)) {
             this.edge.updateComponentConfig(this.websocket, this.component.id, [
                 { name: 'lowThreshold', value: newLowerThreshold },
                 { name: 'highThreshold', value: newUpperThreshold }

--- a/ui/src/app/edge/live/evcsCluster/modal/evcs-chart/evcs.chart.ts
+++ b/ui/src/app/edge/live/evcsCluster/modal/evcs-chart/evcs.chart.ts
@@ -81,13 +81,10 @@ export class EvcsChart implements OnInit, OnChanges {
     let minPower = 22;
     let maxHW = this.currentData[this.componentId + '/MaximumHardwarePower'];
     let chargePower = this.currentData[this.componentId + '/ChargePower'];
-    console.log("Maximale HW: " + maxHW);
-    console.log("Ladeleistung: " + chargePower);
     maxHW = maxHW == null ? minPower : maxHW / 1000;
     chargePower = chargePower == null ? 0 : chargePower / 1000;
-    
+
     maxPower = chargePower < minPower || maxPower < minPower ? minPower : maxHW;
-    console.log("Chart größe: "+ maxPower);
     return Math.round(maxPower);
   }
 }


### PR DESCRIPTION
- change adjustable thresholds from 15-85 to 0-100
- adjust flat widget svg to be able to show new thresholds
- remove console.logs

Before with 5-95 (configured manually via fems settings):
![grafik](https://user-images.githubusercontent.com/37406473/88797500-b8e34d00-d1a3-11ea-9a4c-ba9d3c5f3522.png)

After with 5-95:
![grafik](https://user-images.githubusercontent.com/37406473/88797545-c7316900-d1a3-11ea-8729-500757be73a2.png)

Before with regular settings: (between 15-85):
![grafik](https://user-images.githubusercontent.com/37406473/88797622-e7f9be80-d1a3-11ea-81e5-44be78cb04e6.png)

After with regular settings:
![grafik](https://user-images.githubusercontent.com/37406473/88797668-f942cb00-d1a3-11ea-9f91-02fa543d7342.png)

