### PR TITLE
Fix cookie HTTP header field name being case sensitive

### DIFF
--- a/io.openems.common/src/io/openems/common/utils/JsonUtils.java
+++ b/io.openems.common/src/io/openems/common/utils/JsonUtils.java
@@ -365,6 +365,14 @@ public class JsonUtils {
 		}
 	}
 
+	public static Optional<String> getAsOptionalString(JsonElement jElement) {
+		try {
+			return Optional.of(getAsString(jElement));
+		} catch (OpenemsNamedException e) {
+			return Optional.empty();
+		}
+	}
+
 	public static Optional<String> getAsOptionalString(JsonElement jElement, String memberName) {
 		try {
 			return Optional.of(getAsString(jElement, memberName));

--- a/io.openems.common/src/io/openems/common/websocket/OnOpen.java
+++ b/io.openems.common/src/io/openems/common/websocket/OnOpen.java
@@ -31,7 +31,10 @@ public interface OnOpen {
 	public static Optional<String> getFieldFromHandshakeCookie(JsonObject handshake, String fieldname) {
 		Optional<String> cookieOpt = JsonUtils.getAsOptionalString(handshake, "Cookie");
 		if (!cookieOpt.isPresent()) {
-			return Optional.empty();
+			cookieOpt = JsonUtils.getAsOptionalString(handshake, "cookie");
+			if (!cookieOpt.isPresent()) {
+				return Optional.empty();
+			}
 		}
 		String cookie = cookieOpt.get();
 		for (String cookieVariable : cookie.split("; ")) {

--- a/io.openems.common/src/io/openems/common/websocket/OnOpen.java
+++ b/io.openems.common/src/io/openems/common/websocket/OnOpen.java
@@ -27,7 +27,6 @@ public interface OnOpen {
 	 * Get field from the 'cookie' field in the handshake.
 	 * 
 	 * <p>
-	 * 
 	 * Per <a href=
 	 * "https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2">specification</a>
 	 * all variants of 'cookie' are accepted.

--- a/io.openems.common/src/io/openems/common/websocket/OnOpen.java
+++ b/io.openems.common/src/io/openems/common/websocket/OnOpen.java
@@ -1,9 +1,11 @@
 package io.openems.common.websocket;
 
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import org.java_websocket.WebSocket;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -23,25 +25,30 @@ public interface OnOpen {
 
 	/**
 	 * Get field from the 'cookie' field in the handshake.
-	 *
+	 * 
+	 * <p>
+	 * 
+	 * Per <a href=
+	 * "https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2">specification</a>
+	 * all variants of 'cookie' are accepted.
+	 * 
 	 * @param handshake the Handshake
 	 * @param fieldname the field name
 	 * @return value as optional
 	 */
 	public static Optional<String> getFieldFromHandshakeCookie(JsonObject handshake, String fieldname) {
-		Optional<String> cookieOpt = JsonUtils.getAsOptionalString(handshake, "Cookie");
-		if (!cookieOpt.isPresent()) {
-			cookieOpt = JsonUtils.getAsOptionalString(handshake, "cookie");
-			if (!cookieOpt.isPresent()) {
-				return Optional.empty();
-			}
-		}
-		String cookie = cookieOpt.get();
-		for (String cookieVariable : cookie.split("; ")) {
-			String[] keyValue = cookieVariable.split("=");
-			if (keyValue.length == 2) {
-				if (keyValue[0].equals(fieldname)) {
-					return Optional.ofNullable(keyValue[1]);
+		for (Entry<String, JsonElement> entry : handshake.entrySet()) {
+			if (entry.getKey().equalsIgnoreCase("cookie")) {
+				Optional<String> cookieOpt = JsonUtils.getAsOptionalString(entry.getValue());
+				if (cookieOpt.isPresent()) {
+					for (String cookieVariable : cookieOpt.get().split("; ")) {
+						String[] keyValue = cookieVariable.split("=");
+						if (keyValue.length == 2) {
+							if (keyValue[0].equals(fieldname)) {
+								return Optional.ofNullable(keyValue[1]);
+							}
+						}
+					}
 				}
 			}
 		}

--- a/io.openems.common/test/io/openems/common/websocket/OnOpenTest.java
+++ b/io.openems.common/test/io/openems/common/websocket/OnOpenTest.java
@@ -1,0 +1,59 @@
+package io.openems.common.websocket;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import com.google.gson.JsonObject;
+
+import io.openems.common.utils.JsonUtils;
+
+public class OnOpenTest {
+
+	private static JsonObject createJsonObject(String key, String value) {
+		return JsonUtils.buildJsonObject() //
+				.addProperty(key, value) //
+				.build();
+	}
+
+	@Test
+	public void testGetFieldFromHandshakeCookie() {
+		assertEquals(Optional.of("bar"), //
+				OnOpen.getFieldFromHandshakeCookie(//
+						createJsonObject("cookie", "foo=bar"), //
+						"foo"));
+
+		assertEquals(Optional.of("bar"), //
+				OnOpen.getFieldFromHandshakeCookie(//
+						createJsonObject("COOKIE", "foo=bar"), //
+						"foo"));
+
+		assertEquals(Optional.of("bar"), //
+				OnOpen.getFieldFromHandshakeCookie(//
+						createJsonObject("cOOkIe", "foo=bar"), //
+						"foo"));
+
+		assertEquals(Optional.empty(), //
+				OnOpen.getFieldFromHandshakeCookie(//
+						createJsonObject("spooky", "foo=bar"), //
+						"foo"));
+
+		assertEquals(Optional.empty(), //
+				OnOpen.getFieldFromHandshakeCookie(//
+						createJsonObject("cookie", "foobar"), //
+						"foo"));
+
+		assertEquals(Optional.empty(), //
+				OnOpen.getFieldFromHandshakeCookie(//
+						createJsonObject("cookie", "foo=bar"), //
+						"bar"));
+
+		assertEquals(Optional.empty(), //
+				OnOpen.getFieldFromHandshakeCookie(//
+						JsonUtils.buildJsonObject().add("cookie", new JsonObject()).build(), //
+						"bar"));
+	}
+
+}


### PR DESCRIPTION
HTTP header field names shouldn't be case sensitive as per [specification](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).

This is not the most elegant solution, but it will fix errors with APIs that force using lowercase characters. If someone can think of more elegant approaches, feel free to comment.
