### PR TITLE
RRD4J: Implement historic energy

### DIFF
--- a/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/RecordWorker.java
+++ b/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/RecordWorker.java
@@ -122,7 +122,6 @@ public class RecordWorker extends AbstractImmediateWorker {
 			}
 		}
 		this.readChannelValuesSince = nextReadChannelValuesSince;
-		this.lastTimestamp = timestamp;
 		this.triggerNextRun();
 	}
 

--- a/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/RecordWorker.java
+++ b/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/RecordWorker.java
@@ -89,6 +89,8 @@ public class RecordWorker extends AbstractImmediateWorker {
 					// Ignore WRITE_ONLY Channels
 					continue;
 				}
+				
+				
 
 				ToDoubleFunction<? super Object> channelMapFunction = this
 						.getChannelMapFunction(channel.channelDoc().getType());
@@ -119,6 +121,7 @@ public class RecordWorker extends AbstractImmediateWorker {
 			}
 		}
 		this.readChannelValuesSince = nextReadChannelValuesSince;
+		this.lastTimestamp = timestamp;
 		this.triggerNextRun();
 	}
 

--- a/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/Rrd4jTimedataImpl.java
+++ b/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/Rrd4jTimedataImpl.java
@@ -383,7 +383,7 @@ public class Rrd4jTimedataImpl extends AbstractOpenemsComponent
 		case VOLT_AMPERE_HOURS:
 		case VOLT_AMPERE_REACTIVE_HOURS:
 		case KILOVOLT_AMPERE_REACTIVE_HOURS:
-			return new ChannelDef(DsType.GAUGE, Double.NaN, 1, ConsolFun.MAX);
+			return new ChannelDef(DsType.GAUGE, Double.NaN, Double.NaN, ConsolFun.MAX);
 		}
 		throw new IllegalArgumentException("Unhandled Channel unit [" + channelUnit + "]");
 	}

--- a/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/Rrd4jTimedataImpl.java
+++ b/io.openems.edge.timedata.rrd4j/src/io/openems/edge/timedata/rrd4j/Rrd4jTimedataImpl.java
@@ -175,8 +175,11 @@ public class Rrd4jTimedataImpl extends AbstractOpenemsComponent
 				ChannelDef chDef = this.getDsDefForChannel(channel.channelDoc().getUnit());
 
 				FetchRequest request = database.createFetchRequest(chDef.consolFun, fromTimestamp, toTimeStamp);
-
+				
 				FetchData data = request.fetchData();
+
+				database.close();
+				
 
 				double first = Double.NaN;
 				double last = Double.NaN;


### PR DESCRIPTION
Implemented queryHistoricEnergy()

- Fixed bug in ChannelDef for energy channels.
- fixed bug where lastTimestamp was never reassigned

Tested with version 2020.16.0 on iot2020 as host
