### PR TITLE
Refactor Balancing Schedule Controller

### DIFF
--- a/io.openems.common/src/io/openems/common/jsonrpc/request/SetGridConnScheduleRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/SetGridConnScheduleRequest.java
@@ -1,6 +1,7 @@
 package io.openems.common.jsonrpc.request;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
@@ -41,7 +42,7 @@ public class SetGridConnScheduleRequest extends JsonrpcRequest {
 		return new SetGridConnScheduleRequest(r.getId(), edgeId, schedule);
 	}
 
-	public final static String METHOD = "setGridConnSchedule";
+	public static final String METHOD = "setGridConnSchedule";
 
 	private final String edgeId;
 	private final List<GridConnSchedule> schedule;
@@ -77,11 +78,11 @@ public class SetGridConnScheduleRequest extends JsonrpcRequest {
 	}
 
 	public String getEdgeId() {
-		return edgeId;
+		return this.edgeId;
 	}
 
 	public List<GridConnSchedule> getSchedule() {
-		return schedule;
+		return this.schedule;
 	}
 
 	public static class GridConnSchedule {
@@ -103,6 +104,8 @@ public class SetGridConnScheduleRequest extends JsonrpcRequest {
 		private final int activePowerSetPoint;
 
 		/**
+		 * Construct an instance of {@link GridConnSchedule}.
+		 * 
 		 * @param startTimestamp      epoch in seconds
 		 * @param duration            in seconds
 		 * @param activePowerSetPoint in Watt
@@ -114,15 +117,15 @@ public class SetGridConnScheduleRequest extends JsonrpcRequest {
 		}
 
 		public long getStartTimestamp() {
-			return startTimestamp;
+			return this.startTimestamp;
 		}
 
 		public int getDuration() {
-			return duration;
+			return this.duration;
 		}
 
 		public int getActivePowerSetPoint() {
-			return activePowerSetPoint;
+			return this.activePowerSetPoint;
 		}
 
 		public JsonObject toJson() {

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/SetGridConnScheduleRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/SetGridConnScheduleRequest.java
@@ -94,6 +94,7 @@ public class SetGridConnScheduleRequest extends JsonrpcRequest {
 				int activePowerSetPoint = JsonUtils.getAsInt(se, "activePowerSetPoint");
 				schedule.add(new GridConnSchedule(startTimestamp, duration, activePowerSetPoint));
 			}
+			schedule.sort(Comparator.comparing(GridConnSchedule::getStartTimestamp).reversed());
 			return schedule;
 		}
 

--- a/io.openems.edge.common/src/io/openems/edge/common/component/OpenemsComponent.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/OpenemsComponent.java
@@ -294,8 +294,10 @@ public interface OpenemsComponent {
 		 */
 		// target component must be enabled
 		StringBuilder targetBuilder = new StringBuilder("(&(enabled=true)");
-		// target component must not be the same as the calling component
-		targetBuilder.append("(!(service.pid=" + pid + "))");
+		if (pid != null && !pid.isEmpty()) {
+			// target component must not be the same as the calling component
+			targetBuilder.append("(!(service.pid=" + pid + "))");
+		}
 		// add filter for given Component-IDs
 		targetBuilder.append("(|");
 		for (String id : ids) {

--- a/io.openems.edge.common/src/io/openems/edge/common/test/AbstractComponentConfig.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/test/AbstractComponentConfig.java
@@ -1,6 +1,14 @@
 package io.openems.edge.common.test;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.osgi.framework.Constants;
+import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * Helper class for implementing a @Config-annotation within a Component-Test.
@@ -35,6 +43,52 @@ public class AbstractComponentConfig {
 
 	public String webconsole_configurationFactory_nameHint() {
 		return "";
+	}
+
+	/**
+	 * Gets the configuration attributes in a format suitable for
+	 * {@link ConfigurationAdmin} properties.
+	 * 
+	 * @return the properties
+	 * @throws IllegalAccessException    on error
+	 * @throws IllegalArgumentException  on error
+	 * @throws InvocationTargetException on error
+	 */
+	public Dictionary<String, Object> getAsProperties()
+			throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+		Dictionary<String, Object> result = new Hashtable<>();
+
+		// Default values
+		result.put(Constants.SERVICE_PID, this.id);
+
+		// Parse all class methods to get configuration properties
+		for (Method method : this.getClass().getMethods()) {
+			if (method.getDeclaringClass() != this.getClass()) {
+				switch (method.getName()) {
+				case "id":
+				case "alias":
+				case "enabled":
+					// these methods are specifically allowed
+					break;
+				default:
+					// This method is inherited, e.g. from java.lang.Object and not interesting
+					continue;
+				}
+			}
+			if (method.getParameterCount() > 0) {
+				// We are looking for methods with zero parameters
+				continue;
+			}
+			if (Modifier.isStatic(method.getModifiers())) {
+				// We are looking for non-static methods
+				continue;
+			}
+
+			String key = method.getName().replace("_", ".");
+			Object value = method.invoke(this);
+			result.put(key, value);
+		}
+		return result;
 	}
 
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/test/AbstractComponentTest.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/test/AbstractComponentTest.java
@@ -285,6 +285,14 @@ public abstract class AbstractComponentTest<SELF extends AbstractComponentTest<S
 	 * @throws Exception on error
 	 */
 	public SELF activate(AbstractComponentConfig config) throws Exception {
+		// Add the configuration to ConfigurationAdmin
+		for (Object object : this.references) {
+			if (object instanceof DummyConfigurationAdmin) {
+				DummyConfigurationAdmin cm = (DummyConfigurationAdmin) object;
+				cm.addConfig(config);
+			}
+		}
+
 		int configChangeCount = this.getConfigChangeCount();
 		this.callActivate(config);
 
@@ -328,7 +336,7 @@ public abstract class AbstractComponentTest<SELF extends AbstractComponentTest<S
 
 				if (ComponentContext.class.isAssignableFrom(parameter.getType())) {
 					// ComponentContext
-					arg = null; // TODO create DummyComponentContext
+					arg = DummyComponentContext.from(config);
 
 				} else if (parameter.getType().isInstance(config)) {
 					// Config

--- a/io.openems.edge.common/src/io/openems/edge/common/test/AbstractComponentTest.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/test/AbstractComponentTest.java
@@ -133,8 +133,11 @@ public abstract class AbstractComponentTest<SELF extends AbstractComponentTest<S
 		 * Applies the values for input channels.
 		 * 
 		 * @param components Referenced components
+		 * @throws OpenemsNamedException    on error
+		 * @throws IllegalArgumentException on error
 		 */
-		protected void applyInputs(Map<String, OpenemsComponent> components) {
+		protected void applyInputs(Map<String, OpenemsComponent> components)
+				throws IllegalArgumentException, OpenemsNamedException {
 			for (ChannelValue input : this.inputs) {
 				OpenemsComponent component = components.get(input.address.getComponentId());
 				if (component == null) {
@@ -143,8 +146,12 @@ public abstract class AbstractComponentTest<SELF extends AbstractComponentTest<S
 							+ "was not added to the OpenEMS Component test framework!");
 				}
 				Channel<?> channel = component.channel(input.address.getChannelId());
-				channel.setNextValue(input.getValue());
-				channel.nextProcessImage();
+				if (channel instanceof WriteChannel) {
+					((WriteChannel<?>) channel).setNextWriteValueFromObject(input.getValue());
+				} else {
+					channel.setNextValue(input.getValue());
+					channel.nextProcessImage();
+				}
 			}
 		}
 

--- a/io.openems.edge.common/src/io/openems/edge/common/test/DummyComponentContext.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/test/DummyComponentContext.java
@@ -1,0 +1,80 @@
+package io.openems.edge.common.test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Dictionary;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.ComponentInstance;
+
+/**
+ * Simulates a {@link ComponentContext} for the OpenEMS Component test
+ * framework.
+ */
+public class DummyComponentContext implements ComponentContext {
+
+	public static DummyComponentContext from(AbstractComponentConfig configuration)
+			throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+		return new DummyComponentContext(configuration.getAsProperties());
+	}
+
+	private final Dictionary<String, Object> properties;
+
+	private DummyComponentContext(Dictionary<String, Object> properties) {
+		this.properties = properties;
+		// TODO create DummyBundleContext
+	}
+
+	@Override
+	public Dictionary<String, Object> getProperties() {
+		return this.properties;
+	}
+
+	@Override
+	public <S> S locateService(String name) {
+		return null;
+	}
+
+	@Override
+	public <S> S locateService(String name, ServiceReference<S> reference) {
+		return null;
+	}
+
+	@Override
+	public Object[] locateServices(String name) {
+		return new Object[] {};
+	}
+
+	@Override
+	public BundleContext getBundleContext() {
+		return null;
+	}
+
+	@Override
+	public Bundle getUsingBundle() {
+		return null;
+	}
+
+	@Override
+	public <S> ComponentInstance<S> getComponentInstance() {
+		return null;
+	}
+
+	@Override
+	public void enableComponent(String name) {
+
+	}
+
+	@Override
+	public void disableComponent(String name) {
+
+	}
+
+	@Override
+	public ServiceReference<?> getServiceReference() {
+		return null;
+	}
+
+}

--- a/io.openems.edge.common/src/io/openems/edge/common/test/DummyConfigurationAdmin.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/test/DummyConfigurationAdmin.java
@@ -1,10 +1,13 @@
 package io.openems.edge.common.test;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Dictionary;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.Set;
 
 import org.osgi.framework.InvalidSyntaxException;
@@ -95,41 +98,68 @@ public class DummyConfigurationAdmin implements ConfigurationAdmin {
 		}
 	}
 
-	private final DummyConfiguration dummyConfiguration = new DummyConfiguration();
+	private final Map<String, DummyConfiguration> configurations = new HashMap<>();
 
 	@Override
 	public Configuration createFactoryConfiguration(String factoryPid) throws IOException {
-		return this.dummyConfiguration;
+		return this.getOrCreateEmptyConfiguration(factoryPid);
 	}
 
 	@Override
 	public Configuration createFactoryConfiguration(String factoryPid, String location) throws IOException {
-		return this.dummyConfiguration;
-	}
-
-	@Override
-	public Configuration getConfiguration(String pid, String location) throws IOException {
-		return this.dummyConfiguration;
+		return this.getOrCreateEmptyConfiguration(factoryPid);
 	}
 
 	@Override
 	public Configuration getConfiguration(String pid) throws IOException {
-		return this.dummyConfiguration;
+		return this.configurations.get(pid);
 	}
 
 	@Override
-	public Configuration[] listConfigurations(String filter) throws IOException, InvalidSyntaxException {
-		return new Configuration[] { this.dummyConfiguration };
+	public Configuration getConfiguration(String pid, String location) throws IOException {
+		return this.configurations.get(pid);
+	}
+
+	@Override
+	public synchronized Configuration[] listConfigurations(String filter) throws IOException, InvalidSyntaxException {
+		return this.configurations.values().stream() //
+				.map(c -> (Configuration) c) //
+				.toArray(Configuration[]::new);
 	}
 
 	@Override
 	public Configuration getFactoryConfiguration(String factoryPid, String name, String location) throws IOException {
-		return this.dummyConfiguration;
+		return this.configurations.get(factoryPid);
 	}
 
 	@Override
 	public Configuration getFactoryConfiguration(String factoryPid, String name) throws IOException {
-		return this.dummyConfiguration;
+		return this.configurations.get(factoryPid);
+	}
+
+	private synchronized DummyConfiguration getOrCreateEmptyConfiguration(String id) {
+		return this.configurations.computeIfAbsent(id, (ignore) -> new DummyConfiguration());
+	}
+
+	/**
+	 * Adds a simulated {@link AbstractComponentConfig} with all its properties to
+	 * the configurations.
+	 * 
+	 * @param config the {@link AbstractComponentConfig}
+	 * @throws IllegalAccessException    on error
+	 * @throws IllegalArgumentException  on error
+	 * @throws InvocationTargetException on error
+	 */
+	public void addConfig(AbstractComponentConfig config)
+			throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+		Dictionary<String, Object> properties = config.getAsProperties();
+		Enumeration<String> keys = properties.keys();
+
+		DummyConfiguration c = this.getOrCreateEmptyConfiguration(config.id());
+		while (keys.hasMoreElements()) {
+			String key = keys.nextElement();
+			c.properties.put(key, properties.get(key));
+		}
 	}
 
 }

--- a/io.openems.edge.controller.symmetric.balancingschedule/readme.adoc
+++ b/io.openems.edge.controller.symmetric.balancingschedule/readme.adoc
@@ -1,5 +1,49 @@
 = Symmetric Balancing Schedule
 
-Controls a symmetric energy storage system in self-consumption optimization mode. Allows the definition of a Schedule to set the target power on the grid meter. This Controller can be controlled using the OpenEMS Backend-to-Backend interface.
+Controls a symmetric energy storage system in balancing mode. The control algorithm charges or discharges the battery in order to reach a given power target set-point at the grid connection point. If the target set-point is defined as zero, the behaviour is like with self-consumption optimization.
+
+This controller allows two ways of controlling the power target set-point:
+
+== 1. Definition of a power target set-point Schedule
+
+The static configuration parameter "schedule" takes a Schedule of set-points as a Json-Array. An example schedule looks like this:
+
+[source,json]
+----
+[
+	{
+		"startTimestamp": 1577836800,
+		"duration": 900,
+		"activePowerSetPoint": 0
+	}, {
+		"startTimestamp": 1577837700,
+		"duration": 900,
+		"activePowerSetPoint": -2000
+	}
+]
+----
+
+This schedule will activate a power target set-point of zero starting at the epoch time 1577836800 (i.e. *seconds* since 1st January 2020 00:00:00 *in timezone UTC*), that lasts for 900 seconds (i.e. 15 minutes). 
+Afterwards - from 1577837700 - for another 900 seconds a  set-point of -2000 W (i.e. feeding 2000 W to the grid) is targeted. 
+After the second period passes, no more charging or discharging commands are set on the battery.
+
+The schedule configuration parameter may be updated 
+
+- via a browser using the OpenEMS user interface
+- using the https://openems.github.io/openems.io/openems/latest/backend/backend-to-backend.html#_setgridconnschedule[`SetGridConnSchedule` JSON-RPC Request via OpenEMS Backend]
+- or using the https://github.com/OpenEMS/openems/blob/develop/ui/src/app/shared/jsonrpc/request/updateComponentConfigRequest.ts[`UpdateComponentConfigRequest` JSON-RPC Request]
+
+== 2. Immediate control of the power target set-point
+
+The power target set-point may also be controlled directly via the `GridActivePowerSetPoint` channel. E.g. if the controller component has the Id `ctrlBalancingSchedule0` one can use e.g. the https://openems.github.io/openems.io/openems/latest/edge/controller.html#_rest_api_controller[REST-Api Controller] and write
+
+[source,json]
+----
+{
+	"value": 5000
+}
+----
+
+to the channel `ctrlBalancingSchedule0/GridActivePowerSetPoint` (e.g. ` http://x:user@localhost:8084/rest/channel/ctrlBalancingSchedule0/GridActivePowerSetPoint`), to set a temporary power target set-point of 5000.
 
 https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.controller.symmetric.balancingschedule[Source Code icon:github[]]

--- a/io.openems.edge.controller.symmetric.balancingschedule/readme.adoc
+++ b/io.openems.edge.controller.symmetric.balancingschedule/readme.adoc
@@ -31,7 +31,10 @@ The schedule configuration parameter may be updated
 
 - via a browser using the OpenEMS user interface
 - using the https://openems.github.io/openems.io/openems/latest/backend/backend-to-backend.html#_setgridconnschedule[`SetGridConnSchedule` JSON-RPC Request via OpenEMS Backend]
+- using a direct https://github.com/OpenEMS/openems/blob/develop/io.openems.common/src/io/openems/common/jsonrpc/request/SetGridConnScheduleRequest.java[SetGridConnScheduleRequest] via https://openems.github.io/openems.io/openems/latest/component-communication/index.html#_communicate_with_a_specific_edge_component[JsonApi]
 - or using the https://github.com/OpenEMS/openems/blob/develop/ui/src/app/shared/jsonrpc/request/updateComponentConfigRequest.ts[`UpdateComponentConfigRequest` JSON-RPC Request]
+
+Be aware that an `UpdateComponentConfigRequest` will always result in a actual configuration file being updated by Apache Felix Configuration Admin, so this command should not be used too frequently, e.g. only once per day. The `SetGridConnScheduleRequest` variant runs only in memory and is not persisted. Downside is, that if OpenEMS Edge gets restarted, the schedule is lost.
 
 == 2. Immediate control of the power target set-point
 

--- a/io.openems.edge.controller.symmetric.balancingschedule/src/io/openems/edge/controller/symmetric/balancingschedule/BalancingSchedule.java
+++ b/io.openems.edge.controller.symmetric.balancingschedule/src/io/openems/edge/controller/symmetric/balancingschedule/BalancingSchedule.java
@@ -1,7 +1,11 @@
 package io.openems.edge.controller.symmetric.balancingschedule;
 
+import io.openems.common.channel.AccessMode;
 import io.openems.common.channel.Level;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.types.OpenemsType;
 import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.IntegerWriteChannel;
 import io.openems.edge.common.channel.StateChannel;
 import io.openems.edge.common.channel.value.Value;
 import io.openems.edge.common.component.OpenemsComponent;
@@ -14,7 +18,11 @@ public interface BalancingSchedule extends Controller, OpenemsComponent, JsonApi
 		NO_ACTIVE_SETPOINT(Doc.of(Level.INFO) //
 				.text("No active Set-Point given")), //
 		SCHEDULE_PARSE_FAILED(Doc.of(Level.FAULT) //
-				.text("Unable to parse Schedule"));
+				.text("Unable to parse Schedule")), //
+
+		GRID_ACTIVE_POWER_SET_POINT(Doc.of(OpenemsType.INTEGER) //
+				.accessMode(AccessMode.READ_WRITE) //
+				.text("Target Active-Power Setpoint at the grid connection point"));
 
 		private final Doc doc;
 
@@ -82,5 +90,45 @@ public interface BalancingSchedule extends Controller, OpenemsComponent, JsonApi
 	 */
 	public default void _setScheduleParseFailed(boolean value) {
 		this.getScheduleParseFailedChannel().setNextValue(value);
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#GRID_ACTIVE_POWER_SET_POINT}.
+	 *
+	 * @return the Channel
+	 */
+	public default IntegerWriteChannel getGridActivePowerSetPointChannel() {
+		return this.channel(ChannelId.GRID_ACTIVE_POWER_SET_POINT);
+	}
+
+	/**
+	 * Gets the Active Power Limit in [W]. See
+	 * {@link ChannelId#GRID_ACTIVE_POWER_SET_POINT}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Integer> getGridActivePowerSetPoint() {
+		return this.getGridActivePowerSetPointChannel().value();
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#GRID_ACTIVE_POWER_SET_POINT} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setGridActivePowerSetPoint(Integer value) {
+		this.getGridActivePowerSetPointChannel().setNextValue(value);
+	}
+
+	/**
+	 * Sets the Active Power Limit in [W]. See
+	 * {@link ChannelId#GRID_ACTIVE_POWER_SET_POINT}.
+	 * 
+	 * @return the Channel
+	 * @throws OpenemsNamedException on error
+	 */
+	public default void setGridActivePowerSetPoint(Integer value) throws OpenemsNamedException {
+		this.getGridActivePowerSetPointChannel().setNextWriteValue(value);
 	}
 }

--- a/io.openems.edge.controller.symmetric.balancingschedule/src/io/openems/edge/controller/symmetric/balancingschedule/BalancingSchedule.java
+++ b/io.openems.edge.controller.symmetric.balancingschedule/src/io/openems/edge/controller/symmetric/balancingschedule/BalancingSchedule.java
@@ -1,65 +1,21 @@
 package io.openems.edge.controller.symmetric.balancingschedule;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-
-import org.osgi.service.cm.ConfigurationAdmin;
-import org.osgi.service.component.ComponentContext;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
-import org.osgi.service.metatype.annotations.Designate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-
-import io.openems.common.exceptions.InvalidValueException;
-import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
-import io.openems.common.exceptions.OpenemsException;
-import io.openems.common.jsonrpc.base.GenericJsonrpcResponseSuccess;
-import io.openems.common.jsonrpc.base.JsonrpcRequest;
-import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
-import io.openems.common.jsonrpc.request.SetGridConnScheduleRequest;
-import io.openems.common.jsonrpc.request.SetGridConnScheduleRequest.GridConnSchedule;
-import io.openems.common.session.User;
-import io.openems.common.utils.JsonUtils;
+import io.openems.common.channel.Level;
 import io.openems.edge.common.channel.Doc;
-import io.openems.edge.common.component.AbstractOpenemsComponent;
+import io.openems.edge.common.channel.StateChannel;
+import io.openems.edge.common.channel.value.Value;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.jsonapi.JsonApi;
-import io.openems.edge.common.sum.GridMode;
 import io.openems.edge.controller.api.Controller;
-import io.openems.edge.ess.api.ManagedSymmetricEss;
-import io.openems.edge.ess.power.api.Phase;
-import io.openems.edge.ess.power.api.Pwr;
-import io.openems.edge.ess.power.api.Relationship;
-import io.openems.edge.meter.api.SymmetricMeter;
 
-@Designate(ocd = Config.class, factory = true)
-@Component( //
-		name = "Controller.Symmetric.BalancingSchedule", //
-		immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE)
-public class BalancingSchedule extends AbstractOpenemsComponent implements Controller, OpenemsComponent, JsonApi {
-
-	private final Logger log = LoggerFactory.getLogger(BalancingSchedule.class);
-
-	@Reference
-	protected ConfigurationAdmin cm;
-
-	private List<GridConnSchedule> schedule = new ArrayList<>();
+public interface BalancingSchedule extends Controller, OpenemsComponent, JsonApi {
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
-		;
+		NO_ACTIVE_SETPOINT(Doc.of(Level.INFO) //
+				.text("No active Set-Point given")), //
+		SCHEDULE_PARSE_FAILED(Doc.of(Level.FAULT) //
+				.text("Unable to parse Schedule"));
+
 		private final Doc doc;
 
 		private ChannelId(Doc doc) {
@@ -72,129 +28,59 @@ public class BalancingSchedule extends AbstractOpenemsComponent implements Contr
 		}
 	}
 
-	public BalancingSchedule() {
-		super(//
-				OpenemsComponent.ChannelId.values(), //
-				Controller.ChannelId.values(), //
-				ChannelId.values() //
-		);
-	}
-
-	@Activate
-	void activate(ComponentContext context, Config config) {
-		super.activate(context, config.id(), config.alias(), config.enabled());
-		// update filter for 'ess'
-		if (OpenemsComponent.updateReferenceFilter(cm, this.servicePid(), "ess", config.ess_id())) {
-			return;
-		}
-		// update filter for 'meter'
-		if (OpenemsComponent.updateReferenceFilter(cm, this.servicePid(), "meter", config.meter_id())) {
-			return;
-		}
-		// parse Schedule
-		try {
-			if (!config.schedule().trim().isEmpty()) {
-				JsonElement scheduleElement = JsonUtils.parse(config.schedule());
-				JsonArray scheduleArray = JsonUtils.getAsJsonArray(scheduleElement);
-				this.applySchedule(scheduleArray);
-			}
-		} catch (OpenemsNamedException e) {
-			this.logError(log, "Unable to parse Schedule: " + e.getMessage());
-		}
-	}
-
-	@Reference(policy = ReferencePolicy.STATIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.MANDATORY)
-	private ManagedSymmetricEss ess;
-
-	@Reference(policy = ReferencePolicy.STATIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.MANDATORY)
-	private SymmetricMeter meter;
-
-	@Deactivate
-	protected void deactivate() {
-		super.deactivate();
+	/**
+	 * Gets the Channel for {@link ChannelId#NO_ACTIVE_SETPOINT}.
+	 * 
+	 * @return the Channel
+	 */
+	public default StateChannel getNoActiveSetpointChannel() {
+		return this.channel(ChannelId.NO_ACTIVE_SETPOINT);
 	}
 
 	/**
-	 * Calculates required charge/discharge power
+	 * Gets the Run-Failed State. See {@link ChannelId#NO_ACTIVE_SETPOINT}.
 	 * 
-	 * @throws InvalidValueException
+	 * @return the Channel {@link Value}
 	 */
-	private int calculateRequiredPower(int offset) {
-		return this.meter.getActivePower().orElse(0) /* current buy-from/sell-to grid */
-				+ this.ess.getActivePower().orElse(0) /* current charge/discharge Ess */
-				- offset; /* the offset given by the schedule */
-	}
-
-	@Override
-	public void run() throws OpenemsException {
-		/*
-		 * Get the current grid connection setpoint from the schedule
-		 */
-		Optional<Integer> gridConnSetPointOpt = this.getGridConnSetPoint();
-		if (!gridConnSetPointOpt.isPresent()) {
-			this.logWarn(log, "No valid grid connection Set-Point existing in Schedule.");
-			return;
-		}
-		int gridConnSetPoint = gridConnSetPointOpt.get();
-
-		/*
-		 * Check that we are On-Grid (and warn on undefined Grid-Mode)
-		 */
-		GridMode gridMode = this.ess.getGridMode();
-		if (gridMode.isUndefined()) {
-			this.logWarn(this.log, "Grid-Mode is [" + gridMode + "]");
-		}
-		if (gridMode != GridMode.ON_GRID) {
-			return;
-		}
-		/*
-		 * Calculates required charge/discharge power
-		 */
-		int calculatedPower = this.calculateRequiredPower(gridConnSetPoint);
-
-		// adjust value so that it fits into Min/MaxActivePower
-		calculatedPower = ess.getPower().fitValueIntoMinMaxPower(this.id(), ess, Phase.ALL, Pwr.ACTIVE,
-				calculatedPower);
-
-		/*
-		 * set result
-		 */
-		this.ess.addPowerConstraintAndValidate("Balancing P", Phase.ALL, Pwr.ACTIVE, Relationship.EQUALS,
-				calculatedPower); //
-		this.ess.addPowerConstraintAndValidate("Balancing Q", Phase.ALL, Pwr.REACTIVE, Relationship.EQUALS, 0);
-	}
-
-	@Override
-	public CompletableFuture<JsonrpcResponseSuccess> handleJsonrpcRequest(User user, JsonrpcRequest message)
-			throws OpenemsNamedException {
-		SetGridConnScheduleRequest request = SetGridConnScheduleRequest.from(message);
-		this.schedule = request.getSchedule();
-		return CompletableFuture.completedFuture(new GenericJsonrpcResponseSuccess(request.getId(), new JsonObject()));
+	public default Value<Boolean> getNoActiveSetpoint() {
+		return this.getNoActiveSetpointChannel().value();
 	}
 
 	/**
-	 * Parses the Schedule and applies it to this Controller
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#NO_ACTIVE_SETPOINT} Channel.
 	 * 
-	 * @param j
-	 * @throws OpenemsNamedException
+	 * @param value the next value
 	 */
-	private void applySchedule(JsonArray j) throws OpenemsNamedException {
-		this.schedule = SetGridConnScheduleRequest.GridConnSchedule.from(j);
+	public default void _setNoActiveSetpoint(boolean value) {
+		this.getNoActiveSetpointChannel().setNextValue(value);
 	}
 
 	/**
-	 * Gets the currently valid GridConnSetPoint
+	 * Gets the Channel for {@link ChannelId#SCHEDULE_PARSE_FAILED}.
 	 * 
-	 * @return
+	 * @return the Channel
 	 */
-	private Optional<Integer> getGridConnSetPoint() {
-		long now = System.currentTimeMillis() / 1000; // in seconds
-		for (GridConnSchedule e : this.schedule) {
-			if (now > e.getStartTimestamp() && now < e.getStartTimestamp() + e.getDuration()) {
-				// -> this entry is valid!
-				return Optional.ofNullable(e.getActivePowerSetPoint());
-			}
-		}
-		return Optional.empty();
+	public default StateChannel getScheduleParseFailedChannel() {
+		return this.channel(ChannelId.SCHEDULE_PARSE_FAILED);
+	}
+
+	/**
+	 * Gets the Run-Failed State. See {@link ChannelId#SCHEDULE_PARSE_FAILED}.
+	 * 
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Boolean> getScheduleParseFailed() {
+		return this.getScheduleParseFailedChannel().value();
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#SCHEDULE_PARSE_FAILED} Channel.
+	 * 
+	 * @param value the next value
+	 */
+	public default void _setScheduleParseFailed(boolean value) {
+		this.getScheduleParseFailedChannel().setNextValue(value);
 	}
 }

--- a/io.openems.edge.controller.symmetric.balancingschedule/src/io/openems/edge/controller/symmetric/balancingschedule/BalancingScheduleImpl.java
+++ b/io.openems.edge.controller.symmetric.balancingschedule/src/io/openems/edge/controller/symmetric/balancingschedule/BalancingScheduleImpl.java
@@ -1,0 +1,217 @@
+package io.openems.edge.controller.symmetric.balancingschedule;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.osgi.service.metatype.annotations.Designate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import io.openems.common.exceptions.InvalidValueException;
+import io.openems.common.exceptions.OpenemsError;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.jsonrpc.base.GenericJsonrpcResponseSuccess;
+import io.openems.common.jsonrpc.base.JsonrpcRequest;
+import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
+import io.openems.common.jsonrpc.request.SetGridConnScheduleRequest;
+import io.openems.common.jsonrpc.request.SetGridConnScheduleRequest.GridConnSchedule;
+import io.openems.common.session.Role;
+import io.openems.common.session.User;
+import io.openems.common.utils.JsonUtils;
+import io.openems.edge.common.component.AbstractOpenemsComponent;
+import io.openems.edge.common.component.ComponentManager;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.jsonapi.JsonApi;
+import io.openems.edge.common.sum.GridMode;
+import io.openems.edge.controller.api.Controller;
+import io.openems.edge.ess.api.ManagedSymmetricEss;
+import io.openems.edge.meter.api.SymmetricMeter;
+
+@Designate(ocd = Config.class, factory = true)
+@Component(//
+		name = "Controller.Symmetric.BalancingSchedule", //
+		immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE //
+)
+public class BalancingScheduleImpl extends AbstractOpenemsComponent
+		implements BalancingSchedule, Controller, OpenemsComponent, JsonApi {
+
+	private final Logger log = LoggerFactory.getLogger(BalancingScheduleImpl.class);
+
+	private List<GridConnSchedule> schedule = new CopyOnWriteArrayList<>();
+
+	@Reference
+	protected ConfigurationAdmin cm;
+
+	@Reference
+	protected ComponentManager componentManager;
+
+	@Reference(policy = ReferencePolicy.STATIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.MANDATORY)
+	private ManagedSymmetricEss ess;
+
+	@Reference(policy = ReferencePolicy.STATIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.MANDATORY)
+	private SymmetricMeter meter;
+
+	public BalancingScheduleImpl() {
+		super(//
+				OpenemsComponent.ChannelId.values(), //
+				Controller.ChannelId.values(), //
+				BalancingSchedule.ChannelId.values() //
+		);
+	}
+
+	@Activate
+	void activate(ComponentContext context, Config config) {
+		super.activate(context, config.id(), config.alias(), config.enabled());
+		// update filter for 'ess'
+		if (OpenemsComponent.updateReferenceFilter(this.cm, this.servicePid(), "ess", config.ess_id())) {
+			return;
+		}
+		// update filter for 'meter'
+		if (OpenemsComponent.updateReferenceFilter(this.cm, this.servicePid(), "meter", config.meter_id())) {
+			return;
+		}
+		// parse Schedule
+		try {
+			if (!config.schedule().trim().isEmpty()) {
+				JsonElement scheduleElement = JsonUtils.parse(config.schedule());
+				JsonArray scheduleArray = JsonUtils.getAsJsonArray(scheduleElement);
+				this.applySchedule(scheduleArray);
+			}
+			this._setScheduleParseFailed(false);
+
+		} catch (OpenemsNamedException e) {
+			this._setScheduleParseFailed(true);
+			this.logError(this.log, "Unable to parse Schedule: " + e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		super.deactivate();
+	}
+
+	/**
+	 * Calculates required charge/discharge power.
+	 * 
+	 * @throws InvalidValueException on error
+	 */
+	private int calculateRequiredPower(int offset) throws InvalidValueException {
+		return this.meter.getActivePower().getOrError() /* current buy-from/sell-to grid */
+				+ this.ess.getActivePower().getOrError() /* current charge/discharge Ess */
+				- offset; /* the offset given by the schedule */
+	}
+
+	@Override
+	public void run() throws OpenemsNamedException {
+		/*
+		 * Get the current grid connection setpoint from the schedule
+		 */
+		Optional<Integer> gridConnSetPointOpt = this.getGridConnSetPoint();
+		if (gridConnSetPointOpt.isPresent()) {
+			this._setNoActiveSetpoint(false);
+		} else {
+			this._setNoActiveSetpoint(true);
+			return;
+		}
+		int gridConnSetPoint = gridConnSetPointOpt.get();
+
+		/*
+		 * Check that we are On-Grid (and warn on undefined Grid-Mode)
+		 */
+		GridMode gridMode = this.ess.getGridMode();
+		if (gridMode.isUndefined()) {
+			this.logWarn(this.log, "Grid-Mode is [UNDEFINED]");
+		}
+		switch (gridMode) {
+		case ON_GRID:
+		case UNDEFINED:
+			break;
+		case OFF_GRID:
+			return;
+		}
+
+		/*
+		 * Calculates required charge/discharge power
+		 */
+		int calculatedPower = this.calculateRequiredPower(gridConnSetPoint);
+
+		/*
+		 * set result
+		 */
+		this.ess.setActivePowerEqualsWithPid(calculatedPower);
+		this.ess.setReactivePowerEquals(0);
+	}
+
+	@Override
+	public CompletableFuture<JsonrpcResponseSuccess> handleJsonrpcRequest(User user, JsonrpcRequest request)
+			throws OpenemsNamedException {
+		user.assertRoleIsAtLeast("handleJsonrpcRequest", Role.OWNER);
+
+		switch (request.getMethod()) {
+
+		case SetGridConnScheduleRequest.METHOD:
+			return this.handleSetGridConnScheduleRequest(user, SetGridConnScheduleRequest.from(request));
+
+		default:
+			throw OpenemsError.JSONRPC_UNHANDLED_METHOD.exception(request.getMethod());
+		}
+	}
+
+	/**
+	 * Handles a SetGridConnScheduleRequest.
+	 * 
+	 * @param user    the User
+	 * @param request the SetGridConnScheduleRequest
+	 * @return the Future JSON-RPC Response
+	 * @throws OpenemsNamedException on error
+	 */
+	private CompletableFuture<JsonrpcResponseSuccess> handleSetGridConnScheduleRequest(User user,
+			SetGridConnScheduleRequest request) {
+		this.schedule = request.getSchedule();
+		return CompletableFuture.completedFuture(new GenericJsonrpcResponseSuccess(request.getId(), new JsonObject()));
+	}
+
+	/**
+	 * Parses the Schedule and applies it to this Controller.
+	 * 
+	 * @param j the {@link JsonArray} with the Schedule
+	 * @throws OpenemsNamedException on error
+	 */
+	private void applySchedule(JsonArray j) throws OpenemsNamedException {
+		this.schedule = SetGridConnScheduleRequest.GridConnSchedule.from(j);
+	}
+
+	/**
+	 * Gets the currently valid GridConnSetPoint.
+	 * 
+	 * @return the current setpoint.
+	 */
+	private Optional<Integer> getGridConnSetPoint() {
+		long now = ZonedDateTime.now(this.componentManager.getClock()).toEpochSecond();
+		for (GridConnSchedule e : this.schedule) {
+			if (now >= e.getStartTimestamp() && now <= e.getStartTimestamp() + e.getDuration()) {
+				// -> this entry is valid!
+				return Optional.ofNullable(e.getActivePowerSetPoint());
+			}
+		}
+		return Optional.empty();
+	}
+}

--- a/io.openems.edge.controller.symmetric.balancingschedule/src/io/openems/edge/controller/symmetric/balancingschedule/Config.java
+++ b/io.openems.edge.controller.symmetric.balancingschedule/src/io/openems/edge/controller/symmetric/balancingschedule/Config.java
@@ -3,7 +3,7 @@ package io.openems.edge.controller.symmetric.balancingschedule;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
-@ObjectClassDefinition( //
+@ObjectClassDefinition(//
 		name = "Controller Balancing Schedule Symmetric", //
 		description = "Controls an ESS with the target to keep the grid-meter on a value defined in a Schedule.")
 @interface Config {

--- a/io.openems.edge.controller.symmetric.balancingschedule/test/io/openems/edge/controller/symmetric/balancingschedule/BalancingScheduleImplTest.java
+++ b/io.openems.edge.controller.symmetric.balancingschedule/test/io/openems/edge/controller/symmetric/balancingschedule/BalancingScheduleImplTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import io.openems.common.types.ChannelAddress;
 import io.openems.common.utils.JsonUtils;
+import io.openems.edge.common.sum.GridMode;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
 import io.openems.edge.common.test.DummyComponentManager;
 import io.openems.edge.common.test.DummyConfigurationAdmin;
@@ -23,7 +24,10 @@ public class BalancingScheduleImplTest {
 	private final static String METER_ID = "meter0";
 
 	private final static ChannelAddress CTRL_NO_ACTIVE_SETPOINT = new ChannelAddress(CTRL_ID, "NoActiveSetpoint");
+	private final static ChannelAddress CTRL_GRID_ACTIVE_POWER_SET_POINT = new ChannelAddress(CTRL_ID,
+			"GridActivePowerSetPoint");
 
+	private final static ChannelAddress ESS_GRID_MODE = new ChannelAddress(ESS_ID, "GridMode");
 	private final static ChannelAddress ESS_ACTIVE_POWER = new ChannelAddress(ESS_ID, "ActivePower");
 	private final static ChannelAddress SET_ACTIVE_POWER_EQUALS_WITH_PID = new ChannelAddress(ESS_ID,
 			"SetActivePowerEqualsWithPid");
@@ -58,6 +62,7 @@ public class BalancingScheduleImplTest {
 								).build().toString() //
 						).build()) //
 				.next(new TestCase("No active setpoint") //
+						.input(ESS_GRID_MODE, GridMode.ON_GRID) //
 						.input(GRID_ACTIVE_POWER, 4000) //
 						.input(ESS_ACTIVE_POWER, 1000) //
 						.output(CTRL_NO_ACTIVE_SETPOINT, true)) //
@@ -67,6 +72,11 @@ public class BalancingScheduleImplTest {
 						.input(ESS_ACTIVE_POWER, 1000) //
 						.output(CTRL_NO_ACTIVE_SETPOINT, false) //
 						.output(SET_ACTIVE_POWER_EQUALS_WITH_PID, 5000)) //
+				.next(new TestCase("Balance to -2000 via Channel") //
+						.input(CTRL_GRID_ACTIVE_POWER_SET_POINT, -2000) //
+						.input(GRID_ACTIVE_POWER, 4000) //
+						.input(ESS_ACTIVE_POWER, 1000) //
+						.output(SET_ACTIVE_POWER_EQUALS_WITH_PID, 7000)) //
 				.next(new TestCase("Balance to 3000") //
 						.timeleap(clock, 800, ChronoUnit.SECONDS) //
 						.input(GRID_ACTIVE_POWER, 4000) //

--- a/io.openems.edge.controller.symmetric.balancingschedule/test/io/openems/edge/controller/symmetric/balancingschedule/BalancingScheduleImplTest.java
+++ b/io.openems.edge.controller.symmetric.balancingschedule/test/io/openems/edge/controller/symmetric/balancingschedule/BalancingScheduleImplTest.java
@@ -1,0 +1,78 @@
+package io.openems.edge.controller.symmetric.balancingschedule;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.Test;
+
+import io.openems.common.types.ChannelAddress;
+import io.openems.common.utils.JsonUtils;
+import io.openems.edge.common.test.AbstractComponentTest.TestCase;
+import io.openems.edge.common.test.DummyComponentManager;
+import io.openems.edge.common.test.DummyConfigurationAdmin;
+import io.openems.edge.common.test.TimeLeapClock;
+import io.openems.edge.controller.test.ControllerTest;
+import io.openems.edge.ess.test.DummyManagedSymmetricEss;
+import io.openems.edge.meter.test.DummySymmetricMeter;
+
+public class BalancingScheduleImplTest {
+
+	private final static String CTRL_ID = "ctrl0";
+	private final static String ESS_ID = "ess0";
+	private final static String METER_ID = "meter0";
+
+	private final static ChannelAddress CTRL_NO_ACTIVE_SETPOINT = new ChannelAddress(CTRL_ID, "NoActiveSetpoint");
+
+	private final static ChannelAddress ESS_ACTIVE_POWER = new ChannelAddress(ESS_ID, "ActivePower");
+	private final static ChannelAddress SET_ACTIVE_POWER_EQUALS_WITH_PID = new ChannelAddress(ESS_ID,
+			"SetActivePowerEqualsWithPid");
+
+	private final static ChannelAddress GRID_ACTIVE_POWER = new ChannelAddress(METER_ID, "ActivePower");
+
+	@Test
+	public void test() throws Exception {
+		final long start = 1577836800L;
+		final TimeLeapClock clock = new TimeLeapClock(
+				Instant.ofEpochSecond(start) /* starts at 1. January 2020 00:00:00 */, ZoneOffset.UTC);
+		new ControllerTest(new BalancingScheduleImpl()) //
+				.addReference("cm", new DummyConfigurationAdmin()) //
+				.addReference("componentManager", new DummyComponentManager(clock)) //
+				.addReference("ess", new DummyManagedSymmetricEss(ESS_ID)) //
+				.addReference("meter", new DummySymmetricMeter(METER_ID)) //
+				.activate(MyConfig.create() //
+						.setId(CTRL_ID) //
+						.setEssId(ESS_ID) //
+						.setMeterId(METER_ID) //
+						.setSchedule(JsonUtils.buildJsonArray()//
+								.add(JsonUtils.buildJsonObject()//
+										.addProperty("startTimestamp", start + 500) //
+										.addProperty("duration", 900) //
+										.addProperty("activePowerSetPoint", 0) //
+										.build()) //
+								.add(JsonUtils.buildJsonObject()//
+										.addProperty("startTimestamp", start + 500 + 800) //
+										.addProperty("duration", 900) //
+										.addProperty("activePowerSetPoint", 3000) //
+										.build() //
+								).build().toString() //
+						).build()) //
+				.next(new TestCase("No active setpoint") //
+						.input(GRID_ACTIVE_POWER, 4000) //
+						.input(ESS_ACTIVE_POWER, 1000) //
+						.output(CTRL_NO_ACTIVE_SETPOINT, true)) //
+				.next(new TestCase("Balance to 0") //
+						.timeleap(clock, 500, ChronoUnit.SECONDS) //
+						.input(GRID_ACTIVE_POWER, 4000) //
+						.input(ESS_ACTIVE_POWER, 1000) //
+						.output(CTRL_NO_ACTIVE_SETPOINT, false) //
+						.output(SET_ACTIVE_POWER_EQUALS_WITH_PID, 5000)) //
+				.next(new TestCase("Balance to 3000") //
+						.timeleap(clock, 800, ChronoUnit.SECONDS) //
+						.input(GRID_ACTIVE_POWER, 4000) //
+						.input(ESS_ACTIVE_POWER, 1000) //
+						.output(CTRL_NO_ACTIVE_SETPOINT, false) //
+						.output(SET_ACTIVE_POWER_EQUALS_WITH_PID, 2000)) //
+		;
+	}
+}

--- a/io.openems.edge.controller.symmetric.balancingschedule/test/io/openems/edge/controller/symmetric/balancingschedule/BalancingScheduleImplTest.java
+++ b/io.openems.edge.controller.symmetric.balancingschedule/test/io/openems/edge/controller/symmetric/balancingschedule/BalancingScheduleImplTest.java
@@ -19,20 +19,20 @@ import io.openems.edge.meter.test.DummySymmetricMeter;
 
 public class BalancingScheduleImplTest {
 
-	private final static String CTRL_ID = "ctrl0";
-	private final static String ESS_ID = "ess0";
-	private final static String METER_ID = "meter0";
+	private static final String CTRL_ID = "ctrl0";
+	private static final String ESS_ID = "ess0";
+	private static final String METER_ID = "meter0";
 
-	private final static ChannelAddress CTRL_NO_ACTIVE_SETPOINT = new ChannelAddress(CTRL_ID, "NoActiveSetpoint");
-	private final static ChannelAddress CTRL_GRID_ACTIVE_POWER_SET_POINT = new ChannelAddress(CTRL_ID,
+	private static final ChannelAddress CTRL_NO_ACTIVE_SETPOINT = new ChannelAddress(CTRL_ID, "NoActiveSetpoint");
+	private static final ChannelAddress CTRL_GRID_ACTIVE_POWER_SET_POINT = new ChannelAddress(CTRL_ID,
 			"GridActivePowerSetPoint");
 
-	private final static ChannelAddress ESS_GRID_MODE = new ChannelAddress(ESS_ID, "GridMode");
-	private final static ChannelAddress ESS_ACTIVE_POWER = new ChannelAddress(ESS_ID, "ActivePower");
-	private final static ChannelAddress SET_ACTIVE_POWER_EQUALS_WITH_PID = new ChannelAddress(ESS_ID,
+	private static final ChannelAddress ESS_GRID_MODE = new ChannelAddress(ESS_ID, "GridMode");
+	private static final ChannelAddress ESS_ACTIVE_POWER = new ChannelAddress(ESS_ID, "ActivePower");
+	private static final ChannelAddress SET_ACTIVE_POWER_EQUALS_WITH_PID = new ChannelAddress(ESS_ID,
 			"SetActivePowerEqualsWithPid");
 
-	private final static ChannelAddress GRID_ACTIVE_POWER = new ChannelAddress(METER_ID, "ActivePower");
+	private static final ChannelAddress GRID_ACTIVE_POWER = new ChannelAddress(METER_ID, "ActivePower");
 
 	@Test
 	public void test() throws Exception {

--- a/io.openems.edge.controller.symmetric.balancingschedule/test/io/openems/edge/controller/symmetric/balancingschedule/MyConfig.java
+++ b/io.openems.edge.controller.symmetric.balancingschedule/test/io/openems/edge/controller/symmetric/balancingschedule/MyConfig.java
@@ -1,0 +1,79 @@
+package io.openems.edge.controller.symmetric.balancingschedule;
+
+import io.openems.edge.common.test.AbstractComponentConfig;
+
+@SuppressWarnings("all")
+public class MyConfig extends AbstractComponentConfig implements Config {
+
+	protected static class Builder {
+		private String id;
+		private String essId;
+		private String meterId;
+		private String schedule;
+
+		private Builder() {
+
+		}
+
+		public Builder setId(String id) {
+			this.id = id;
+			return this;
+		}
+
+		public Builder setEssId(String essId) {
+			this.essId = essId;
+			return this;
+		}
+
+		public Builder setMeterId(String meterId) {
+			this.meterId = meterId;
+			return this;
+		}
+
+		public Builder setSchedule(String schedule) {
+			this.schedule = schedule;
+			return this;
+		}
+
+		public MyConfig build() {
+			return new MyConfig(this);
+		}
+	}
+
+	public static Builder create() {
+		return new Builder();
+	}
+
+	private final Builder builder;
+
+	private MyConfig(Builder builder) {
+		super(Config.class, builder.id);
+		this.builder = builder;
+	}
+
+	@Override
+	public String ess_id() {
+		return this.builder.essId;
+	}
+
+	@Override
+	public String meter_id() {
+		return this.builder.meterId;
+	}
+
+	@Override
+	public String schedule() {
+		return this.builder.schedule;
+	}
+
+	@Override
+	public String ess_target() {
+		return "(&(enabled=true)(!(service.pid=ctrl0))(|(id=" + this.ess_id() + ")))";
+	}
+
+	@Override
+	public String meter_target() {
+		return "(&(enabled=true)(!(service.pid=ctrl0))(|(id=" + this.meter_id() + ")))";
+	}
+
+}


### PR DESCRIPTION
This refactoring of the existing "Balancing Schedule Controller" comes with:

- proper documentation (readme.adoc)
- introduction of `GridActivePowerSetPoint` for direct setting of a power target set-point at the grid connection point
- thorough JUnit tests
- applied latest OpenEMS code quality and best practices
- improvements to the OpenEMS JUnit test framework