### PR TITLE
fixdigitaloutput modal.component.ts returns a boolean value intead of…

### DIFF
--- a/ui/src/app/edge/live/fixdigitaloutput/modal/modal.component.ts
+++ b/ui/src/app/edge/live/fixdigitaloutput/modal/modal.component.ts
@@ -28,7 +28,10 @@ export class FixDigitalOutputModalComponent {
    */
   updateMode(event: CustomEvent) {
     let oldMode = this.component.properties.isOn;
-    let newMode = event.detail.value;
+    let newMode:boolean = false; 
+    if(event.detail.value === 'true'){
+      newMode = true;
+    }
 
     this.edge.updateComponentConfig(this.websocket, this.component.id, [
       { name: 'isOn', value: newMode }


### PR DESCRIPTION
Bugfix: 
The UI fixdigitaloutput component now sends a boolean value instead of a string. 

Reason: 
The edge fixdigitaloutput component has a boolean property "isOn". When this property is changed using the UI, then the edge property configuration was changed also (from "boolean" to "string"). This completely breaks the influx connection, because it could not write to the database anymore. It will fail with logoutput like this:
`Unable to write to InfluxDB: partial write: field type conflict: input field "ctrlIoFixDigitalOutput0/_PropertyIsOn" on measurement "data" is type string, already exists as type integer `