### PR TITLE
Make default Api ports configurable

### DIFF
--- a/io.openems.common/src/io/openems/common/OpenemsConstants.java
+++ b/io.openems.common/src/io/openems/common/OpenemsConstants.java
@@ -108,6 +108,8 @@ public class OpenemsConstants {
 	public final static String PROPERTY_LAST_CHANGE_AT = "_lastChangeAt";
 
 	public final static String OPENEMS_DATA_DIR_KEY = "io.openems.data.dir";
+	public final static String API_REST_PORT_KEY = "io.openems.api.rest.port";
+	public final static String API_MODBUS_TCP_PORT_KEY = "io.openems.api.modbustcp.port";
 
 	/**
 	 * Gets the path of the OpenEMS Data Directory, configured by "io.openems.data.dir"
@@ -117,6 +119,26 @@ public class OpenemsConstants {
 	 */
 	public final static String getOpenemsDataDir() {
 		return Optional.ofNullable(System.getProperty(OPENEMS_DATA_DIR_KEY)).orElse("");
+	}
+
+	/**
+	 * Gets the port of the Controller Api Rest, configured by "io.openems.api.rest.port"
+	 * command line parameter.
+	 * 
+	 * @return the port of the Controller Api Rest
+	 */
+	public final static int getApiRestPort() {
+		return Integer.parseInt(System.getProperty(API_REST_PORT_KEY, "8084"));
+	}
+
+	/**
+	 * Gets the port of the Controller Api ModbusTcp, configured by "io.openems.api.modbustcp.port"
+	 * command line parameter.
+	 * 
+	 * @return the port of the Controller Api ModbusTcp
+	 */
+	public final static int getApiModbusTcpPort() {
+		return Integer.parseInt(System.getProperty(API_MODBUS_TCP_PORT_KEY, "502"));
 	}
 
 }

--- a/io.openems.common/src/io/openems/common/OpenemsConstants.java
+++ b/io.openems.common/src/io/openems/common/OpenemsConstants.java
@@ -107,16 +107,16 @@ public class OpenemsConstants {
 	public final static String PROPERTY_LAST_CHANGE_BY = "_lastChangeBy";
 	public final static String PROPERTY_LAST_CHANGE_AT = "_lastChangeAt";
 
-	private static final String OPENEMS_DATA_DIR = "openems.data.dir";
+	public final static String OPENEMS_DATA_DIR_KEY = "io.openems.data.dir";
 
 	/**
-	 * Gets the path of the OpenEMS Data Directory, configured by "openems.data.dir"
+	 * Gets the path of the OpenEMS Data Directory, configured by "io.openems.data.dir"
 	 * command line parameter.
 	 * 
 	 * @return the path of the OpenEMS Data Directory
 	 */
 	public final static String getOpenemsDataDir() {
-		return Optional.ofNullable(System.getProperty(OPENEMS_DATA_DIR)).orElse("");
+		return Optional.ofNullable(System.getProperty(OPENEMS_DATA_DIR_KEY)).orElse("");
 	}
 
 }

--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -7,7 +7,7 @@
 -runproperties:\
 	org.osgi.service.http.port=8080,\
 	felix.cm.dir=c:/openems/config,\
-	openems.data.dir=c:/openems/data,\
+	io.openems.data.dir=c:/openems/data,\
 	org.apache.felix.eventadmin.Timeout=0,\
 	org.ops4j.pax.logging.DefaultServiceLog.level=INFO
 

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
@@ -100,11 +100,11 @@ public class DefaultConfigurationWorker extends ComponentManagerWorker {
 		 * Create Controller.Api.Modbus.ReadOnly
 		 */
 		if (existingConfigs.stream().noneMatch(c -> //
-		// Check if either "Controller.Api.Rest.ReadOnly" or
-		// "Controller.Api.Rest.ReadWrite" exist
+		// Check if either "Controller.Api.ModbusTcp.ReadOnly" or
+		// "Controller.Api.ModbusTcp.ReadWrite" exist
 		"Controller.Api.ModbusTcp.ReadOnly".equals(c.factoryPid)
 				|| "Controller.Api.ModbusTcp.ReadWrite".equals(c.factoryPid))) {
-			// if not -> create configuration for "Controller.Api.Rest.ReadOnly"
+			// if not -> create configuration for "Controller.Api.ModbusTcp.ReadOnly"
 			this.createConfiguration(defaultConfigurationFailed, "Controller.Api.ModbusTcp.ReadOnly", Arrays.asList(//
 					new Property("id", "ctrlApiModbusTcp0"), //
 					new Property("alias", ""), //

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
@@ -18,6 +18,7 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.openems.common.OpenemsConstants;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
 import io.openems.common.jsonrpc.request.CreateComponentConfigRequest;
@@ -90,7 +91,7 @@ public class DefaultConfigurationWorker extends ComponentManagerWorker {
 					new Property("id", "ctrlApiRest0"), //
 					new Property("alias", ""), //
 					new Property("enabled", true), //
-					new Property("port", 8084), //
+					new Property("port", OpenemsConstants.getApiRestPort()), //
 					new Property("debugMode", false) //
 			));
 		}
@@ -108,7 +109,7 @@ public class DefaultConfigurationWorker extends ComponentManagerWorker {
 					new Property("id", "ctrlApiModbusTcp0"), //
 					new Property("alias", ""), //
 					new Property("enabled", true), //
-					new Property("port", 502), //
+					new Property("port", OpenemsConstants.getApiModbusTcpPort()), //
 					new Property("component.ids", JsonUtils.buildJsonArray().add("_sum").build()), //
 					new Property("maxConcurrentConnections", 5) //
 			));


### PR DESCRIPTION
It would be nice to be able to override those hard-coded ports. Especially because opening port 502 requires me to be connected as root, which is not ideal (https://www.staldal.nu/tech/2007/10/31/why-can-only-root-listen-to-ports-below-1024/).

I included a change to the naming of the existing parameter openems.data.dir to conform to the namespace conventions: io.openems.*. I am open to change it back if we don't want to break backward compatibility.