### PR TITLE
Fix various typos (cont.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ OpenEMS is generally used in combination with external hardware and software com
 
 ## Open Source philosophy
 
-The OpenEMS project ist driven by the [OpenEMS Association e.V.](https://openems.io/association), a network of users, vendors and scientific institutions from all kinds of areas like hardware manufacturers, software companies, grid operators and more. They share the common target of developing a free and open-source platform for energy management, that supports the 100 % energy transition.
+The OpenEMS project is driven by the [OpenEMS Association e.V.](https://openems.io/association), a network of users, vendors and scientific institutions from all kinds of areas like hardware manufacturers, software companies, grid operators and more. They share the common target of developing a free and open-source platform for energy management, that supports the 100 % energy transition.
 
 We are inviting third parties to use OpenEMS for their own projects and are glad to support them with their first steps. In any case if you are interested in OpenEMS we would be glad to hear from you in the [OpenEMS Community forum](https://community.openems.io).
 

--- a/doc/modules/ROOT/pages/edge/implement.adoc
+++ b/doc/modules/ROOT/pages/edge/implement.adoc
@@ -159,7 +159,7 @@ import io.openems.edge.meter.api.MeterType;
 	@AttributeDefinition(name = "Meter-Type", description = "Grid, Production (=default), Consumption") // <5>
 	MeterType type() default MeterType.PRODUCTION; // <6>
 
-	@AttributeDefinition(name = "Modbus-ID", description = "ID of Modbus brige.")
+	@AttributeDefinition(name = "Modbus-ID", description = "ID of Modbus bridge.")
 	String modbus_id() default "modbus0"; // <7>
 
 	@AttributeDefinition(name = "Modbus Unit-ID", description = "The Unit-ID of the Modbus device.")
@@ -233,7 +233,7 @@ public MeterSimulated() {
 	);
 }
 ----
-. Finally we need to delare the modbus protocol of the simulated meter inside the `defineModbusProtocol` method. Replace the existing method
+. Finally we need to declare the modbus protocol of the simulated meter inside the `defineModbusProtocol` method. Replace the existing method
 +
 [source,java]
 ----
@@ -413,7 +413,7 @@ Using this principle a complete Modbus table consisting of multiple register blo
 
 === Start the device simulator
 
-To start the device simulator, open the btn:[io.openems.edge.bridge.modbus] project and navigate to the btn:[test] -> btn:[io.openems.edge.brige.modbus] folder. There you find the btn:[ModbusSlaveSimulator.java] file. Right-click that file and select btn:[Run As] -> btn:[Java Application].
+To start the device simulator, open the btn:[io.openems.edge.bridge.modbus] project and navigate to the btn:[test] -> btn:[io.openems.edge.bridge.modbus] folder. There you find the btn:[ModbusSlaveSimulator.java] file. Right-click that file and select btn:[Run As] -> btn:[Java Application].
 
 [NOTE]
 ====

--- a/doc/modules/ROOT/pages/gettingstarted.adoc
+++ b/doc/modules/ROOT/pages/gettingstarted.adoc
@@ -144,7 +144,7 @@ INFO  [onent.AbstractOpenemsComponent] [meter0] Activate GridMeter [edge.simulat
 +
 NOTE: This setup causes the simulated grid-meter to take the standardized load-profiles data as input parameter.
 +
-NOTE: 'Acting' referrs to the fact, that this meter actively provides data - in opposite to a 'Reacting' device that is reacting on other components: for example the 'Simulator.EssSymmetric.Reacting' configured below.
+NOTE: 'Acting' refers to the fact, that this meter actively provides data - in opposite to a 'Reacting' device that is reacting on other components: for example the 'Simulator.EssSymmetric.Reacting' configured below.
 
 .. Configure a simulated reacting energy storage system: "Simulator EssSymmetric Reacting". The default values can be accepted without changes. (If you choose an other setup as the one described here you may have to create a new Datasource-Component and provide its ID here. The actual data is ignored, but the Datasource's Time-Delta value is required to calculate values with time-dependant units.)
 +

--- a/io.openems.common/src/io/openems/common/websocket/WsData.java
+++ b/io.openems.common/src/io/openems/common/websocket/WsData.java
@@ -130,7 +130,7 @@ public abstract class WsData {
 			} else {
 				// Undefined Error Response -> cancel future
 				OpenemsNamedException exception = new OpenemsNamedException(OpenemsError.GENERIC,
-						"Reponse is neither JsonrpcResponseSuccess nor JsonrpcResponseError: " + response.toString());
+						"Response is neither JsonrpcResponseSuccess nor JsonrpcResponseError: " + response.toString());
 				future.completeExceptionally(exception);
 			}
 

--- a/io.openems.edge.battery.bydcommercial/src/io/openems/edge/battery/bydcommercial/BatteryBoxC130.java
+++ b/io.openems.edge.battery.bydcommercial/src/io/openems/edge/battery/bydcommercial/BatteryBoxC130.java
@@ -841,7 +841,7 @@ public interface BatteryBoxC130 extends Battery, OpenemsComponent, StartStoppabl
 		ALARM_BCU_NTC(Doc.of(Level.WARNING) //
 				.text("BCU NTC Alarm")), //
 		ALARM_SLAVE_CONTROL_SUMMARY(Doc.of(Level.WARNING) //
-				.text(" Slave Contorl Summary Alarm")), //
+				.text(" Slave Control Summary Alarm")), //
 		FAILURE_INITIALIZATION(Doc.of(Level.FAULT) //
 				.text("Initialization failure")), //
 		FAILURE_EEPROM(Doc.of(Level.FAULT) //

--- a/io.openems.edge.batteryinverter.kaco.blueplanetgridsave/src/io/openems/edge/batteryinverter/kaco/blueplanetgridsave/KacoSunSpecModel.java
+++ b/io.openems.edge.batteryinverter.kaco.blueplanetgridsave/src/io/openems/edge/batteryinverter/kaco/blueplanetgridsave/KacoSunSpecModel.java
@@ -723,7 +723,7 @@ public enum KacoSunSpecModel implements SunSpecModel {
 			STANDBY(2, "Idle state, ready for precharge"), //
 			PRECHARGE_1(3, "Precharge Step 1; close negative power relay before starting precharge"), //
 			PRECHARGE_2(4, "Precharge Step 2; close precharge relay and start precharge"), //
-			PRECHARGE_3(5, "Precharge Step 3; close positiv power relay after successful precharge"), //
+			PRECHARGE_3(5, "Precharge Step 3; close positive power relay after successful precharge"), //
 			RUNNING(6, "Running; precharge finished, ready for operation"), //
 			COOLDOWN(7,
 					"Cooldown of resistor; precharge resistor needs to cooldown bevor new precharge sequence can be started"), //
@@ -768,7 +768,7 @@ public enum KacoSunSpecModel implements SunSpecModel {
 			ERROR_RUNNING_MODE(7, "Error during RUNNING mode"), //
 			I2C_COMM(8, "I2C communication error"), //
 			CAN_COMM(9, "CAN communication error"), //
-			EXT_SWITCHOFF(10, "external swich off, eg. because of gridfault"), //
+			EXT_SWITCHOFF(10, "external switch off, eg. because of gridfault"), //
 			BATTERY_LIMITS_NA(11, "Battery limits never set by EMS"); //
 
 			private final int value;

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/BitsWordElement.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/BitsWordElement.java
@@ -34,7 +34,7 @@ public class BitsWordElement extends UnsignedWordElement {
 	private final AbstractOpenemsModbusComponent component;
 
 	/*
-	 * Holds the ChannelWrapper. 'null' if not explicitely defined!
+	 * Holds the ChannelWrapper. 'null' if not explicitly defined!
 	 */
 	private final ChannelWrapper[] channels = new ChannelWrapper[16];
 

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/DefaultSunSpecModel.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/DefaultSunSpecModel.java
@@ -210,7 +210,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 	), //
 	S_304(//
 			"Inclinometer Model", //
-			"Include to support orienation measurements", //
+			"Include to support orientation measurements", //
 			"", //
 			6, //
 			DefaultSunSpecModel.S304.values(), //
@@ -422,7 +422,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 		UN(new PointImpl(//
 				"S2_UN", //
 				"UN", //
-				"Update Number.  Incrementing nunber each time the mappping is changed.  If the number is not changed from thelast reading the direct access to a specific offset will result in reading the same logical model as before.  Otherwise the entire model must be read to refresh the changes", //
+				"Update Number.  Incrementing number each time the mapping is changed.  If the number is not changed from the last reading the direct access to a specific offset will result in reading the same logical model as before.  Otherwise the entire model must be read to refresh the changes", //
 				"", //
 				PointType.UINT16, //
 				true, //
@@ -4064,7 +4064,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 		AHR_RTG(new PointImpl(//
 				"S120_AHR_RTG", //
 				"AhrRtg", //
-				"The useable capacity of the battery.  Maximum charge minus minimum charge from a technology capability perspective (Amp-hour capacity rating).", //
+				"The usable capacity of the battery.  Maximum charge minus minimum charge from a technology capability perspective (Amp-hour capacity rating).", //
 				"", //
 				PointType.UINT16, //
 				false, //
@@ -10128,7 +10128,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 		LAT(new PointImpl(//
 				"S305_LAT", //
 				"Lat", //
-				"Lattitude with seven degrees of precision", //
+				"Latitude with seven degrees of precision", //
 				"", //
 				PointType.INT32, //
 				false, //
@@ -10186,7 +10186,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 		A(new PointImpl(//
 				"S306_A", //
 				"Amps", //
-				"Current measurment at reference point", //
+				"Current measurement at reference point", //
 				"", //
 				PointType.UINT16, //
 				false, //
@@ -10197,7 +10197,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 		V(new PointImpl(//
 				"S306_V", //
 				"Voltage", //
-				"Voltage  measurment at reference point", //
+				"Voltage  measurement at reference point", //
 				"", //
 				PointType.UINT16, //
 				false, //
@@ -10208,7 +10208,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 		TMP(new PointImpl(//
 				"S306_TMP", //
 				"Temperature", //
-				"Temperature measurment at reference point", //
+				"Temperature measurement at reference point", //
 				"", //
 				PointType.UINT16, //
 				false, //

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/OneWireAccessProvider.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/OneWireAccessProvider.java
@@ -267,7 +267,7 @@ public class OneWireAccessProvider {
 			System.err.println();
 		}
 
-		// try PDK adapater
+		// try PDK adapter
 		try {
 			adapter_class = Class.forName("com.dalsemi.onewire.adapter.PDKAdapterUSB");
 			adapter_instance = (DSPortAdapter) adapter_class.newInstance();
@@ -426,7 +426,7 @@ public class OneWireAccessProvider {
 	}
 
 	/**
-	 * Gets the specfied onewire property. Looks for the property in the following
+	 * Gets the specified onewire property. Looks for the property in the following
 	 * locations:
 	 * <p>
 	 * <ul>

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/OneWireException.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/OneWireException.java
@@ -38,7 +38,7 @@ package com.dalsemi.onewire;
 public class OneWireException extends Exception {
 
 	// --------
-	// -------- Contructor
+	// -------- Constructor
 	// --------
 
 	/**

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/DSPortAdapter.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/DSPortAdapter.java
@@ -1097,7 +1097,7 @@ public abstract class DSPortAdapter {
 	 * they want to ensure exclusive use. If it is not called around several methods
 	 * then it will be called inside each method.
 	 *
-	 * @param blocking <code>true</code> if want to block waiting for an excluse
+	 * @param blocking <code>true</code> if want to block waiting for exclusive
 	 *                 access to the adapter
 	 * @return <code>true</code> if blocking was false and a exclusive session with
 	 *         the adapter was acquired

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/DumbAdapter.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/DumbAdapter.java
@@ -720,7 +720,7 @@ public class DumbAdapter extends DSPortAdapter {
 	/**
 	 * This method does nothing in <code>DumbAdapter</code>.
 	 *
-	 * @param blocking <code>true</code> if want to block waiting for an excluse
+	 * @param blocking <code>true</code> if want to block waiting for exclusive
 	 *                 access to the adapter
 	 * @return <code>true</code>
 	 */

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/LSerialAdapter.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/LSerialAdapter.java
@@ -217,7 +217,7 @@ public class LSerialAdapter extends DSPortAdapter {
 	 */
 	boolean searchOnlyAlarmingButtons;
 
-	/** Flag to indicate next search will not be preceeded by a 1-Wire reset */
+	/** Flag to indicate next search will not be preceded by a 1-Wire reset */
 	private boolean skipResetOnSearch = false;
 
 	/** Flag to indicate next search will be a 'first' */
@@ -589,7 +589,7 @@ public class LSerialAdapter extends DSPortAdapter {
 	 * has not yet been relinquished.
 	 * <p>
 	 *
-	 * @param blocking <code>true</code> if want to block waiting for an excluse
+	 * @param blocking <code>true</code> if want to block waiting for exclusive
 	 *                 access to the adapter
 	 * @return <code>true</code> if blocking was false and a exclusive session with
 	 *         the adapter was acquired
@@ -1176,7 +1176,7 @@ public class LSerialAdapter extends DSPortAdapter {
 	 * Enumeration com_enum = CommPortIdentifier.getPortIdentifiers();
 	 * CommPortIdentifier port_id; SerialService serial_instance;
 	 * 
-	 * // loop throught all of the serial port elements while
+	 * // loop through all of the serial port elements while
 	 * (com_enum.hasMoreElements()) {
 	 * 
 	 * // get the next com port port_id = (CommPortIdentifier)

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/MulticastListener.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/MulticastListener.java
@@ -62,7 +62,7 @@ public class MulticastListener implements Runnable {
 	/**
 	 * Creates a multicast listener on the specified multicast port, bound to the
 	 * specified multicast group. Whenever the byte[] pattern specified by
-	 * "expectedMessage" is received, the byte[] pattern specifed by "returnMessage"
+	 * "expectedMessage" is received, the byte[] pattern specified by "returnMessage"
 	 * is sent to the sender of the "expected message".
 	 *
 	 * @param multicastPort   Port to bind this listener to.

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/NetAdapter.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/NetAdapter.java
@@ -104,7 +104,7 @@ import com.dalsemi.onewire.utils.Convert;
  * <li>NetAdapter.MulticastEnabled=true</li>
  * </ul>
  * The port used and the multicast group used for multicast sockets can also be
- * changed. The group however, must fall withing a valid range. For more
+ * changed. The group however, must fall within a valid range. For more
  * information about multicast sockets in Java, see the Java tutorial on
  * networking at <A HREF="http://java.sun.com/docs/books/tutorial/">
  * http://java.sun.com/docs/books/tutorial/</A>. Change the defaults in the
@@ -259,7 +259,7 @@ public class NetAdapter extends DSPortAdapter implements NetAdapterConstants {
 	 * equal to RET_SUCCESS, then it tries to create an appropriate error message.
 	 * If it is RET_FAILURE, it reads a string representing the error message. If it
 	 * is neither, it wraps an error message indicating that an unspecified error
-	 * occurred and attemps a reconnect.
+	 * occurred and attempts a reconnect.
 	 */
 	private void checkReturnValue(Connection conn) throws IOException, OneWireException, OneWireIOException {
 		byte retVal = conn.input.readByte();
@@ -1137,7 +1137,7 @@ public class NetAdapter extends DSPortAdapter implements NetAdapterConstants {
 	 * they want to ensure exclusive use. If it is not called around several methods
 	 * then it will be called inside each method.
 	 *
-	 * @param blocking <code>true</code> if want to block waiting for an excluse
+	 * @param blocking <code>true</code> if want to block waiting for exclusive
 	 *                 access to the adapter
 	 * @return <code>true</code> if blocking was false and a exclusive session with
 	 *         the adapter was acquired

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/NetAdapterHost.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/NetAdapterHost.java
@@ -178,7 +178,7 @@ public class NetAdapterHost implements Runnable, NetAdapterConstants {
 	 * @param adapter     DSPortAdapter that this NetAdapterHost will proxy commands
 	 *                    to.
 	 * @param multiThread if true, multiple TCP/IP connections are allowed to
-	 *                    interact simulataneously with this adapter.
+	 *                    interact simultaneously with this adapter.
 	 *
 	 * @throws IOException if a network error occurs or the listen socket cannot be
 	 *                     created on the specified port.
@@ -203,7 +203,7 @@ public class NetAdapterHost implements Runnable, NetAdapterConstants {
 	 *                    to.
 	 * @param listenPort  the TCP/IP port to listen on for incoming connections
 	 * @param multiThread if true, multiple TCP/IP connections are allowed to
-	 *                    interact simulataneously with this adapter.
+	 *                    interact simultaneously with this adapter.
 	 *
 	 * @throws IOException if a network error occurs or the listen socket cannot be
 	 *                     created on the specified port.
@@ -269,7 +269,7 @@ public class NetAdapterHost implements Runnable, NetAdapterConstants {
 	 *                    to.
 	 * @param serverSock  the ServerSocket for incoming connections
 	 * @param multiThread if true, multiple TCP/IP connections are allowed to
-	 *                    interact simulataneously with this adapter.
+	 *                    interact simultaneously with this adapter.
 	 *
 	 * @throws IOException if a network error occurs or the listen socket cannot be
 	 *                     created on the specified port.
@@ -588,7 +588,7 @@ public class NetAdapterHost implements Runnable, NetAdapterConstants {
 				adapterCanProgram(conn);
 				break;
 			default:
-				// System.out.println("Unkown command: " + cmd);
+				// System.out.println("Unknown command: " + cmd);
 				break;
 			}
 		} catch (OneWireException owe) {

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/NetAdapterSim.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/NetAdapterSim.java
@@ -197,7 +197,7 @@ public class NetAdapterSim implements Runnable, NetAdapterConstants {
 	 * @param adapter     DSPortAdapter that this NetAdapterSim will proxy commands
 	 *                    to.
 	 * @param multiThread if true, multiple TCP/IP connections are allowed to
-	 *                    interact simulataneously with this adapter.
+	 *                    interact simultaneously with this adapter.
 	 *
 	 * @throws IOException if a network error occurs or the listen socket cannot be
 	 *                     created on the specified port.
@@ -222,7 +222,7 @@ public class NetAdapterSim implements Runnable, NetAdapterConstants {
 	 *                    to.
 	 * @param listenPort  the TCP/IP port to listen on for incoming connections
 	 * @param multiThread if true, multiple TCP/IP connections are allowed to
-	 *                    interact simulataneously with this adapter.
+	 *                    interact simultaneously with this adapter.
 	 *
 	 * @throws IOException if a network error occurs or the listen socket cannot be
 	 *                     created on the specified port.
@@ -312,7 +312,7 @@ public class NetAdapterSim implements Runnable, NetAdapterConstants {
 	 *                    to.
 	 * @param serverSock  the ServerSocket for incoming connections
 	 * @param multiThread if true, multiple TCP/IP connections are allowed to
-	 *                    interact simulataneously with this adapter.
+	 *                    interact simultaneously with this adapter.
 	 *
 	 * @throws IOException if a network error occurs or the listen socket cannot be
 	 *                     created on the specified port.
@@ -431,7 +431,7 @@ public class NetAdapterSim implements Runnable, NetAdapterConstants {
 			try {
 				sock = serverSocket.accept();
 				// reset time of last command, so we don't simulate a bunch of
-				// unneccessary time
+				// unnecessary time
 				timeOfLastCommand = System.currentTimeMillis();
 				handleConnection(sock);
 			} catch (IOException ioe1) {
@@ -673,7 +673,7 @@ public class NetAdapterSim implements Runnable, NetAdapterConstants {
 					break;
 				default:
 					if (SIM_DEBUG && logFile != null)
-						logFile.println("Unkown command received: " + cmd);
+						logFile.println("Unknown command received: " + cmd);
 					break;
 				}
 			} catch (OneWireException owe) {

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/OneWireState.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/OneWireState.java
@@ -151,7 +151,7 @@ class OneWireState {
 	public boolean searchOnlyAlarmingButtons;
 
 	/**
-	 * Flag to indicate next search will not be preceeded by a 1-Wire reset
+	 * Flag to indicate next search will not be preceded by a 1-Wire reset
 	 */
 	public boolean skipResetOnSearch;
 

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/SerialService.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/SerialService.java
@@ -298,7 +298,7 @@ public class SerialService implements SerialPortEventListener {
 
 			// \\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//
 			if (DEBUG)
-				System.out.println("SerialService.openPort: Port Openend (" + comPortName + ")");
+				System.out.println("SerialService.openPort: Port Opened (" + comPortName + ")");
 			// \\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//\\//
 		} catch (Exception e) {
 			// close the port if we have an object
@@ -424,7 +424,7 @@ public class SerialService implements SerialPortEventListener {
 	 * has not yet been relinquished.
 	 * <p>
 	 *
-	 * @param blocking <code>true</code> if want to block waiting for an excluse
+	 * @param blocking <code>true</code> if want to block waiting for exclusive
 	 *                 access to the adapter
 	 * @return <code>true</code> if blocking was false and a exclusive session with
 	 *         the adapter was acquired

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/TMEXAdapter.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/TMEXAdapter.java
@@ -183,7 +183,7 @@ public class TMEXAdapter extends DSPortAdapter {
 	/** Flag to indicate next search will be a 'first' */
 	private boolean resetSearch = true;
 
-	/** Flag to indicate next search will not be preceeded by a 1-Wire reset */
+	/** Flag to indicate next search will not be preceded by a 1-Wire reset */
 	private boolean skipResetOnSearch = false;
 
 	// --------
@@ -651,7 +651,7 @@ public class TMEXAdapter extends DSPortAdapter {
 	 * they want to ensure exclusive use. If it is not called around several methods
 	 * then it will be called inside each method.
 	 *
-	 * @param blocking <code>true</code> if want to block waiting for an excluse
+	 * @param blocking <code>true</code> if want to block waiting for exclusive
 	 *                 access to the adapter
 	 * @return <code>true</code> if blocking was false and a exclusive session with
 	 *         the adapter was acquired
@@ -1088,7 +1088,7 @@ public class TMEXAdapter extends DSPortAdapter {
 	private native String getVersion_Native();
 
 	/**
-	 * Peform a search
+	 * Perform a search
 	 *
 	 * @param skipResetOnSearch boolean, true to skip 1-Wire reset on search
 	 * @param resetSearch       boolean, true to reset search (First)

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/UPacketBuilder.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/UPacketBuilder.java
@@ -220,7 +220,7 @@ class UPacketBuilder {
 
 		packet.returnLength = 0;
 
-		// reset the return cound
+		// reset the return count
 		totalReturnLength = 0;
 	}
 
@@ -382,7 +382,7 @@ class UPacketBuilder {
 	 */
 	public int dataByte(char dataByteValue) {
 
-		// contruct a temporary array of characters of length 1
+		// construct a temporary array of characters of length 1
 		// to use the dataBytes method
 		char[] temp_char_array = new char[1];
 

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/USerialAdapter.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/adapter/USerialAdapter.java
@@ -1140,7 +1140,7 @@ public class USerialAdapter extends DSPortAdapter {
 	 * has not yet been relinquished.
 	 * <p>
 	 *
-	 * @param blocking <code>true</code> if want to block waiting for an excluse
+	 * @param blocking <code>true</code> if want to block waiting for exclusive
 	 *                 access to the adapter
 	 * @return <code>true</code> if blocking was false and a exclusive session with
 	 *         the adapter was acquired
@@ -1959,7 +1959,7 @@ public class USerialAdapter extends DSPortAdapter {
 	// --------
 
 	/**
-	 * Peform a search using the oneWire state provided
+	 * Perform a search using the oneWire state provided
 	 *
 	 * @param mState current OneWire state used to do the search
 	 *
@@ -2442,7 +2442,7 @@ public class USerialAdapter extends DSPortAdapter {
 		 * Enumeration com_enum = CommPortIdentifier.getPortIdentifiers();
 		 * CommPortIdentifier port_id; SerialService serial_instance;
 		 * 
-		 * // loop throught all of the serial port elements while
+		 * // loop through all of the serial port elements while
 		 * (com_enum.hasMoreElements()) {
 		 * 
 		 * // get the next com port port_id = ( CommPortIdentifier )
@@ -2458,7 +2458,7 @@ public class USerialAdapter extends DSPortAdapter {
 		 * port_id.getName()); } }
 		 */
 
-		// check properties to see if max baud set manualy
+		// check properties to see if max baud set manually
 		maxBaud = 115200;
 
 		String max_baud_str = OneWireAccessProvider.getProperty("onewire.serial.maxbaud");

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/file/MemoryCache.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/file/MemoryCache.java
@@ -168,7 +168,7 @@ class MemoryCache {
 	/** Field pbmCache - buffer to cache the page bitmap */
 	private byte[] pbmCache;
 
-	/** Field pbmCacheModified - modifified version of the page bitmap */
+	/** Field pbmCacheModified - modified version of the page bitmap */
 	private byte[] pbmCacheModified;
 
 	/** Field pbmRead - flag indicating that the page bitmap has been read */
@@ -935,7 +935,7 @@ class MemoryCache {
 				pbmBank.read(0, false, temp_buf, 0, numBytes);
 				for (int i = 0; i < numBytes; i++) {
 					if ((temp_buf[i] & 0x00FF) != (pbmCacheModified[i] & 0x00FF))
-						throw new OneWireException("Readback verfication of page bitmap was not correct");
+						throw new OneWireException("Readback verification of page bitmap was not correct");
 				}
 
 				// put new value of bitmap pbmCache
@@ -1192,7 +1192,7 @@ class MemoryCache {
 	}
 
 	/**
-	 * Get's the memory bank object for the specified page. This is significant if
+	 * Gets the memory bank object for the specified page. This is significant if
 	 * the Filesystem spans memory banks on the same or different devices.
 	 */
 	public PagedMemoryBank getMemoryBankForPage(int page) {
@@ -1211,7 +1211,7 @@ class MemoryCache {
 	}
 
 	/**
-	 * Get's the index into the array of Devices where this page resides. This is
+	 * Gets the index into the array of Devices where this page resides. This is
 	 * significant if the Filesystem spans memory banks on the same or different
 	 * devices.
 	 */
@@ -1227,7 +1227,7 @@ class MemoryCache {
 	}
 
 	/**
-	 * Get's the local page number on the memory bank object for the specified page.
+	 * Gets the local page number on the memory bank object for the specified page.
 	 * This is significant if the Filesystem spans memory banks on the same or
 	 * different devices.
 	 */
@@ -1249,7 +1249,7 @@ class MemoryCache {
 	/**
 	 * Clears the lastPageRead global so that a readPage will not try to continue
 	 * where the last page left off. This should be called anytime exclusive access
-	 * to the 1-Wire canot be guaranteed.
+	 * to the 1-Wire cannot be guaranteed.
 	 */
 	public void clearLastPageRead() {
 		// last page can't be used due to redirect read

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/file/OWFile.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/file/OWFile.java
@@ -102,7 +102,7 @@ import com.dalsemi.onewire.container.PagedMemoryBank;
  * the following exceptions
  * <p>
  * <p>
- * Methods provided but of <b> limited </b> functionallity
+ * Methods provided but of <b> limited </b> functionality
  * <ul>
  * <li>public long lastModified() - always returns 0
  * <li>public boolean isAbsolute() - always true
@@ -168,7 +168,7 @@ import com.dalsemi.onewire.container.PagedMemoryBank;
  * the constructor that accepts an array of 1-Wire devices. The first device in
  * the list is the 'root' device and the rest will be designated 'satelite's.
  * Once the <code> format() </code> method is used to link these devices then
- * only the 'root' need be used in future constuctors of this class or the
+ * only the 'root' need be used in future constructors of this class or the
  * 1-Wire file stream classes.
  * <li>Only rewrittable 1-Wire memory devices can be used in multi-device file
  * systems. EPROM and write-once devices can only be used in single device file
@@ -995,7 +995,7 @@ public class OWFile {
 	 * codes. On UNIX systems, the hash code of an abstract pathname is equal to the
 	 * exclusive <em>or</em> of its pathname string and the decimal value
 	 * <code>1234321</code>. On Win32 systems, the hash code is equal to the
-	 * exclusive <em>or</em> of its pathname string, convered to lower case, and the
+	 * exclusive <em>or</em> of its pathname string, converted to lower case, and the
 	 * decimal value <code>1234321</code>.
 	 *
 	 * @return A hash code for this abstract pathname
@@ -1100,7 +1100,7 @@ public class OWFile {
 	}
 
 	/**
-	 * Get's an array of integers that represents the page list of the file or
+	 * Gets an array of integers that represents the page list of the file or
 	 * directory represented by this OWFile.
 	 *
 	 * @return node page list file or directory
@@ -1138,7 +1138,7 @@ public class OWFile {
 	}
 
 	/**
-	 * Get's the memory bank object for the specified page. This is significant if
+	 * Gets the memory bank object for the specified page. This is significant if
 	 * the Filesystem spans memory banks on the same or different devices.
 	 *
 	 * @return PagedMemoryBank for the specified page
@@ -1154,7 +1154,7 @@ public class OWFile {
 	}
 
 	/**
-	 * Get's the local page number on the memory bank object for the specified page.
+	 * Gets the local page number on the memory bank object for the specified page.
 	 * This is significant if the Filesystem spans memory banks on the same or
 	 * different devices.
 	 *

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/file/OWFileDescriptor.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/file/OWFileDescriptor.java
@@ -66,7 +66,7 @@ public class OWFileDescriptor {
 	/** Hashtable to contain MemoryCache instances (one per container) */
 	private static Hashtable<Long, MemoryCache> memoryCacheHash = new Hashtable<>(4);
 
-	/** Field EXT_DIRECTORY entension value */
+	/** Field EXT_DIRECTORY extension value */
 	private static final byte EXT_DIRECTORY = 0x007F;
 
 	/**
@@ -486,7 +486,7 @@ public class OWFileDescriptor {
 	// --------
 
 	/**
-	 * Opens the file for reading. If successfull (no exceptions) then the following
+	 * Opens the file for reading. If successful (no exceptions) then the following
 	 * class member variables will be set:
 	 * <ul>
 	 * <li>fePage - File Entry page number
@@ -553,7 +553,7 @@ public class OWFileDescriptor {
 	/**
 	 * Closes this file descriptor and releases any system resources associated with
 	 * this stream. Any cached writes are flushed into the filesystem. This file
-	 * descriptor may no longer be used for writing bytes. If successfull (no
+	 * descriptor may no longer be used for writing bytes. If successful (no
 	 * exceptions) then the following class member variables will be set:
 	 * <ul>
 	 * <li>fePage - File Entry page number
@@ -622,7 +622,7 @@ public class OWFileDescriptor {
 			// \\//\\//\\//\\//\\//\\//\\//
 			if (doDebugMessages)
 				System.out.println(
-						"===create, appent=" + append + " isDirectory=" + isDirectory + " makeParents=" + makeParents);
+						"===create, append=" + append + " isDirectory=" + isDirectory + " makeParents=" + makeParents);
 
 			// clear last page read flag in the cache
 			cache.clearLastPageRead();
@@ -783,7 +783,7 @@ public class OWFileDescriptor {
 	 * WARNING: all files/directories will be deleted in the process.
 	 *
 	 * @throws OneWireException   when adapter is not setup properly
-	 * @throws OneWireIOException when an IO error occured reading the 1-Wire device
+	 * @throws OneWireIOException when an IO error occurred reading the 1-Wire device
 	 */
 	protected void format() throws OneWireException, OneWireIOException {
 		int i, j, len, next_page, cnt, cdcnt = 0, device_map_pages, dm_bytes = 0;
@@ -1775,7 +1775,7 @@ public class OWFileDescriptor {
 	 */
 	protected boolean renameTo(OWFile dest) {
 		if (dest == null)
-			throw new NullPointerException("Desitination file is null");
+			throw new NullPointerException("Destination file is null");
 
 		synchronized (cache) {
 			// make sure exists (also getting the file entry info)
@@ -2180,7 +2180,7 @@ public class OWFileDescriptor {
 	}
 
 	/**
-	 * Get's an array of integers that represents the page list of the file or
+	 * Gets an array of integers that represents the page list of the file or
 	 * directory represented by this OWFile.
 	 *
 	 * @exception OneWireException if an I/O error occurs.
@@ -2237,7 +2237,7 @@ public class OWFileDescriptor {
 	}
 
 	/**
-	 * Get's the memory bank object for the specified page. This is significant if
+	 * Gets the memory bank object for the specified page. This is significant if
 	 * the Filesystem spans memory banks on the same or different devices.
 	 */
 	protected PagedMemoryBank getMemoryBankForPage(int page) {
@@ -2245,7 +2245,7 @@ public class OWFileDescriptor {
 	}
 
 	/**
-	 * Get's the local page number on the memory bank object for the specified page.
+	 * Gets the local page number on the memory bank object for the specified page.
 	 * This is significant if the Filesystem spans memory banks on the same or
 	 * different devices.
 	 */
@@ -2469,7 +2469,7 @@ public class OWFileDescriptor {
 	 * @param numberPages    number of page of the elements data
 	 * @param prevEntry      previous entry used for back reference in creating new
 	 *                       directories
-	 * @param prevEntryStart previous entry start page for directory back referenece
+	 * @param prevEntryStart previous entry start page for directory back reference
 	 *
 	 * @throws FileNotFoundException if the filesystem runs out of space or if an IO
 	 *                               error occurs
@@ -3055,7 +3055,7 @@ public class OWFileDescriptor {
 
 							// \\//\\//\\//\\//\\//\\//\\//
 							if (doDebugMessages)
-								System.out.println("=Parse ERROR, entension > 102 or spaces detected");
+								System.out.println("=Parse ERROR, extension > 102 or spaces detected");
 
 							return false;
 						}
@@ -3116,7 +3116,7 @@ public class OWFileDescriptor {
 	 * codes. On UNIX systems, the hash code of an abstract pathname is equal to the
 	 * exclusive <em>or</em> of its pathname string and the decimal value
 	 * <code>1234321</code>. On Win32 systems, the hash code is equal to the
-	 * exclusive <em>or</em> of its pathname string, convered to lower case, and the
+	 * exclusive <em>or</em> of its pathname string, converted to lower case, and the
 	 * decimal value <code>1234321</code>.
 	 *
 	 * @return A hash code for this abstract pathname

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/monitor/NetworkDeviceMonitor.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/monitor/NetworkDeviceMonitor.java
@@ -196,7 +196,7 @@ public class NetworkDeviceMonitor extends AbstractDeviceMonitor {
 					while (search_result) {
 						// get the 1-Wire address
 						Long longAddress = new Long(adapter.getAddressAsLong());
-						// check if the device allready exists in our hashtable
+						// check if the device already exists in our hashtable
 						if (!deviceAddressHash.containsKey(longAddress)) {
 							OneWireContainer owc = getDeviceContainer(adapter, longAddress);
 							// check to see if it's a switch and if we are supposed

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/sha/SHAiButtonCopr.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/sha/SHAiButtonCopr.java
@@ -138,7 +138,7 @@ public class SHAiButtonCopr {
 	protected int authPageNumber = -1;
 
 	/**
-	 * Any auxilliary data stored on this coprocessor
+	 * Any auxiliary data stored on this coprocessor
 	 */
 	protected String auxData;
 
@@ -254,7 +254,7 @@ public class SHAiButtonCopr {
 	 *                           installation on user buttons.
 	 * @param l_bindCode         the binding code used to finalize secret
 	 *                           installation on user buttons.
-	 * @param l_auxData          any auxilliary or miscellaneous data to be stored
+	 * @param l_auxData          any auxiliary or miscellaneous data to be stored
 	 *                           on the coprocessor.
 	 * @param l_initialSignature the 20-byte initial MAC placed in user account data
 	 *                           before generating actual MAC.
@@ -604,11 +604,11 @@ public class SHAiButtonCopr {
 
 	/**
 	 * <P>
-	 * Returns a string representing the auxilliary data associated with this
+	 * Returns a string representing the auxiliary data associated with this
 	 * coprocessor's service.
 	 * </P>
 	 *
-	 * @return the auxilliary data of this coprocessor's service
+	 * @return the auxiliary data of this coprocessor's service
 	 */
 	public String getAuxilliaryData() {
 		return auxData;
@@ -740,7 +740,7 @@ public class SHAiButtonCopr {
 	 * account data into the specified array starting at the specified offset.
 	 * </P>
 	 *
-	 * @param data   arry for copying the 20-byte initial signature.
+	 * @param data   array for copying the 20-byte initial signature.
 	 * @param offset the index at which to start copying.
 	 */
 	public void getInitialSignature(byte[] data, int offset) {

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/sha/SHAiButtonCoprVM.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/sha/SHAiButtonCoprVM.java
@@ -134,7 +134,7 @@ public class SHAiButtonCoprVM extends SHAiButtonCopr {
 	 *                           installation on user buttons.
 	 * @param l_bindCode         the binding code used to finalize secret
 	 *                           installation on user buttons.
-	 * @param l_auxData          any auxilliary or miscellaneous data to be stored
+	 * @param l_auxData          any auxiliary or miscellaneous data to be stored
 	 *                           on the coprocessor.
 	 * @param l_initialSignature the 20-byte initial MAC placed in user account data
 	 *                           before generating actual MAC.
@@ -1060,7 +1060,7 @@ public class SHAiButtonCoprVM extends SHAiButtonCopr {
 	 * </p>
 	 *
 	 * @param function          the SHA function code
-	 * @param shaSecret         the secret used in SHA caclulation
+	 * @param shaSecret         the secret used in SHA calculation
 	 * @param shaPage           the 32-byte page used in SHA calculation
 	 * @param scratchpad        the 32-byte scratchpad data used in SHA calculation.
 	 *                          MAC is returned in this buffer starting at offset 8,

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/sha/SHAiButtonUser18.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/sha/SHAiButtonUser18.java
@@ -83,7 +83,7 @@ public class SHAiButtonUser18 extends SHAiButtonUser {
 	 * @param owc          The DS1963S iButton that this object will refer to.
 	 * @param formatDevice If <code>true</code>, the TMEX filesystem will be
 	 *                     formatted before the account service file is created.
-	 * @param authSecret   The master authentication secret for the systm.
+	 * @param authSecret   The master authentication secret for the system.
 	 *
 	 * @throws OneWireIOException on a 1-Wire communication error such as reading an
 	 *                            incorrect CRC from a 1-Wire device. This could be
@@ -163,7 +163,7 @@ public class SHAiButtonUser18 extends SHAiButtonUser {
 	 * @param owc          The DS1963S iButton that this object will refer to.
 	 * @param formatDevice If <code>true</code>, the TMEX filesystem will be
 	 *                     formatted before the account service file is created.
-	 * @param authSecret   The master authentication secret for the systm.
+	 * @param authSecret   The master authentication secret for the system.
 	 *
 	 * @throws OneWireIOException on a 1-Wire communication error such as reading an
 	 *                            incorrect CRC from a 1-Wire device. This could be
@@ -484,7 +484,7 @@ public class SHAiButtonUser18 extends SHAiButtonUser {
 			int wcc = -1;
 
 			// don't worry, this should not happen in the critical path.
-			// so malloc-ing doesnt really matter
+			// so malloc-ing doesn't really matter
 			byte[] wcc_buffer = new byte[32];
 
 			// read the page, 19, containing the write-cycle counters

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/sha/SHAiButtonUser33.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/application/sha/SHAiButtonUser33.java
@@ -113,7 +113,7 @@ public class SHAiButtonUser33 extends SHAiButtonUser {
 	 * @param owc          The DS1963S iButton that this object will refer to.
 	 * @param formatDevice If <code>true</code>, the TMEX filesystem will be
 	 *                     formatted before the account service file is created.
-	 * @param authSecret   The master authentication secret for the systm.
+	 * @param authSecret   The master authentication secret for the system.
 	 *
 	 * @throws OneWireIOException on a 1-Wire communication error such as reading an
 	 *                            incorrect CRC from a 1-Wire device. This could be
@@ -199,7 +199,7 @@ public class SHAiButtonUser33 extends SHAiButtonUser {
 	 * @param owc          The DS1963S iButton that this object will refer to.
 	 * @param formatDevice If <code>true</code>, the TMEX filesystem will be
 	 *                     formatted before the account service file is created.
-	 * @param authSecret   The master authentication secret for the systm.
+	 * @param authSecret   The master authentication secret for the system.
 	 *
 	 * @throws OneWireIOException on a 1-Wire communication error such as reading an
 	 *                            incorrect CRC from a 1-Wire device. This could be

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/CommandAPDU.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/CommandAPDU.java
@@ -66,7 +66,7 @@ package com.dalsemi.onewire.container;
  *                                       (byte)0x01, (byte)0x02, (byte)0x03);</pre></code>
  * </OL>
  * 
- * <H3>Additonal information</H3>
+ * <H3>Additional information</H3>
  * <DL>
  * <DD><A HREF="http://www.opencard.org"> http://www.opencard.org</A>
  * </DL>

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBank.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBank.java
@@ -251,7 +251,7 @@ public interface MemoryBank {
 	 * It is recommended that the data contain some kind of checking (CRC) like in
 	 * the <CODE> readPagePacket </CODE> method in the
 	 * {@link com.dalsemi.onewire.container.PagedMemoryBank PagedMemoryBank}
-	 * interface. Some 1-Wire devices provide thier own CRC as in
+	 * interface. Some 1-Wire devices provide their own CRC as in
 	 * <CODE> readPageCRC </CODE> also found in the
 	 * {@link com.dalsemi.onewire.container.PagedMemoryBank PagedMemoryBank}
 	 * interface. The <CODE> readPageCRC </CODE> method is not supported on all

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankAD.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankAD.java
@@ -120,7 +120,7 @@ class MemoryBankAD implements PagedMemoryBank {
 
 	/**
 	 * Starting physical address in memory bank. Needed for different types of
-	 * memory in the same logical memory bank. This can be used to seperate them
+	 * memory in the same logical memory bank. This can be used to separate them
 	 * into two virtual memory banks. Example: DS2406 status page has mixed EPROM
 	 * and Volatile RAM.
 	 */
@@ -293,7 +293,7 @@ class MemoryBankAD implements PagedMemoryBank {
 	/**
 	 * Query to get Maximum data page length in bytes for a packet read or written
 	 * in the current memory bank. See the 'ReadPagePacket()' and
-	 * 'WritePagePacket()' methods. This method is only usefull if the current
+	 * 'WritePagePacket()' methods. This method is only useful if the current
 	 * memory bank is general purpose memory.
 	 *
 	 * @return max packet page length in bytes in current memory bank
@@ -384,12 +384,12 @@ class MemoryBankAD implements PagedMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting physical address
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -513,12 +513,12 @@ class MemoryBankAD implements PagedMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -541,13 +541,13 @@ class MemoryBankAD implements PagedMemoryBank {
 	 * provide the CRC as in readPageCRC(). readPageCRC() however is not supported
 	 * on all memory types, see 'hasPageAutoCRC()'. If neither is an option then
 	 * this method could be called more then once to at least verify that the same
-	 * thing is read consistantly. See the method 'hasExtraInfo()' for a description
+	 * thing is read consistently. See the method 'hasExtraInfo()' for a description
 	 * of the optional extra information some devices have.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -579,7 +579,7 @@ class MemoryBankAD implements PagedMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -626,7 +626,7 @@ class MemoryBankAD implements PagedMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -688,7 +688,7 @@ class MemoryBankAD implements PagedMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -756,7 +756,7 @@ class MemoryBankAD implements PagedMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -793,7 +793,7 @@ class MemoryBankAD implements PagedMemoryBank {
 				// attempt to set the correct speed and verify device present
 				ib.doSpeed();
 
-				// no execptions so clear flag
+				// no exceptions so clear flag
 				doSetSpeed = false;
 			}
 		}

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankAppReg.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankAppReg.java
@@ -123,7 +123,7 @@ class MemoryBankAppReg implements OTPMemoryBank {
 	protected int extraInfoLength;
 
 	/**
-	 * Extra information descriptoin when reading page in memory bank
+	 * Extra information description when reading page in memory bank
 	 */
 	protected static String extraInfoDescription = "Page Locked flag";
 
@@ -282,7 +282,7 @@ class MemoryBankAppReg implements OTPMemoryBank {
 	/**
 	 * Query to get Maximum data page length in bytes for a packet read or written
 	 * in the current memory bank. See the 'ReadPagePacket()' and
-	 * 'WritePagePacket()' methods. This method is only usefull if the current
+	 * 'WritePagePacket()' methods. This method is only useful if the current
 	 * memory bank is general purpose memory.
 	 *
 	 * @return max packet page length in bytes in current memory bank
@@ -418,12 +418,12 @@ class MemoryBankAppReg implements OTPMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting physical address
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -533,12 +533,12 @@ class MemoryBankAppReg implements OTPMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -565,13 +565,13 @@ class MemoryBankAppReg implements OTPMemoryBank {
 	 * provide the CRC as in readPageCRC(). readPageCRC() however is not supported
 	 * on all memory types, see 'hasPageAutoCRC()'. If neither is an option then
 	 * this method could be called more then once to at least verify that the same
-	 * thing is read consistantly. See the method 'hasExtraInfo()' for a description
+	 * thing is read consistently. See the method 'hasExtraInfo()' for a description
 	 * of the optional extra information some devices have.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -599,7 +599,7 @@ class MemoryBankAppReg implements OTPMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -646,7 +646,7 @@ class MemoryBankAppReg implements OTPMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -722,7 +722,7 @@ class MemoryBankAppReg implements OTPMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -747,7 +747,7 @@ class MemoryBankAppReg implements OTPMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -769,7 +769,7 @@ class MemoryBankAppReg implements OTPMemoryBank {
 	// --------
 
 	/**
-	 * Lock the specifed page in the current memory bank. Not supported by all
+	 * Lock the specified page in the current memory bank. Not supported by all
 	 * devices. See the method 'canLockPage()'.
 	 *
 	 * @param page number of page to lock
@@ -819,7 +819,7 @@ class MemoryBankAppReg implements OTPMemoryBank {
 	}
 
 	/**
-	 * Redirect the specifed page in the current memory bank to a new page. Not
+	 * Redirect the specified page in the current memory bank to a new page. Not
 	 * supported by all devices. See the method 'canRedirectPage()'.
 	 *
 	 * @param page    number of page to redirect
@@ -878,7 +878,7 @@ class MemoryBankAppReg implements OTPMemoryBank {
 	}
 
 	/**
-	 * Lock the redirection option for the specifed page in the current memory bank.
+	 * Lock the redirection option for the specified page in the current memory bank.
 	 * Not supported by all devices. See the method 'canLockRedirectPage()'.
 	 *
 	 * @param page number of page to redirect

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankEE.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankEE.java
@@ -257,7 +257,7 @@ class MemoryBankEE implements PagedMemoryBank {
 	/**
 	 * Query to get Maximum data page length in bytes for a packet read or written
 	 * in the current memory bank. See the 'ReadPagePacket()' and
-	 * 'WritePagePacket()' methods. This method is only usefull if the current
+	 * 'WritePagePacket()' methods. This method is only useful if the current
 	 * memory bank is general purpose memory.
 	 *
 	 * @return max packet page length in bytes in current memory bank
@@ -348,12 +348,12 @@ class MemoryBankEE implements PagedMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting physical address
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -503,12 +503,12 @@ class MemoryBankEE implements PagedMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -534,13 +534,13 @@ class MemoryBankEE implements PagedMemoryBank {
 	 * provide the CRC as in readPageCRC(). readPageCRC() however is not supported
 	 * on all memory types, see 'hasPageAutoCRC()'. If neither is an option then
 	 * this method could be called more then once to at least verify that the same
-	 * thing is read consistantly. See the method 'hasExtraInfo()' for a description
+	 * thing is read consistently. See the method 'hasExtraInfo()' for a description
 	 * of the optional extra information some devices have.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -572,7 +572,7 @@ class MemoryBankEE implements PagedMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -625,7 +625,7 @@ class MemoryBankEE implements PagedMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -687,7 +687,7 @@ class MemoryBankEE implements PagedMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -712,7 +712,7 @@ class MemoryBankEE implements PagedMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -862,7 +862,7 @@ class MemoryBankEE implements PagedMemoryBank {
 				// attempt to set the correct speed and verify device present
 				ib.doSpeed();
 
-				// no execptions so clear flag
+				// no exceptions so clear flag
 				doSetSpeed = false;
 			}
 		}

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankEEPROM.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankEEPROM.java
@@ -136,7 +136,7 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 
 	/**
 	 * Starting physical address in memory bank. Needed for different types of
-	 * memory in the same logical memory bank. This can be used to seperate them
+	 * memory in the same logical memory bank. This can be used to separate them
 	 * into two virtual memory banks. Example: DS2406 status page has mixed EPROM
 	 * and Volatile RAM.
 	 */
@@ -183,7 +183,7 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 	protected int extraInfoLength;
 
 	/**
-	 * Extra information descriptoin when reading page in memory bank
+	 * Extra information description when reading page in memory bank
 	 */
 	protected String extraInfoDescription;
 
@@ -383,7 +383,7 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 	/**
 	 * Query to get Maximum data page length in bytes for a packet read or written
 	 * in the current memory bank. See the 'ReadPagePacket()' and
-	 * 'WritePagePacket()' methods. This method is only usefull if the current
+	 * 'WritePagePacket()' methods. This method is only useful if the current
 	 * memory bank is general purpose memory.
 	 *
 	 * @return max packet page length in bytes in current memory bank
@@ -519,12 +519,12 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting physical address
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -695,12 +695,12 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -721,13 +721,13 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 	 * provide the CRC as in readPageCRC(). readPageCRC() however is not supported
 	 * on all memory types, see 'hasPageAutoCRC()'. If neither is an option then
 	 * this method could be called more then once to at least verify that the same
-	 * thing is read consistantly. See the method 'hasExtraInfo()' for a description
+	 * thing is read consistently. See the method 'hasExtraInfo()' for a description
 	 * of the optional extra information some devices have.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -750,7 +750,7 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -776,7 +776,7 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -862,7 +862,7 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -885,7 +885,7 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -905,7 +905,7 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 	// --------
 
 	/**
-	 * Lock the specifed page in the current memory bank. Not supported by all
+	 * Lock the specified page in the current memory bank. Not supported by all
 	 * devices. See the method 'canLockPage()'.
 	 *
 	 * @param page number of page to lock
@@ -947,7 +947,7 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 	}
 
 	/**
-	 * Redirect the specifed page in the current memory bank to a new page. Not
+	 * Redirect the specified page in the current memory bank to a new page. Not
 	 * supported by all devices. See the method 'canRedirectPage()'.
 	 *
 	 * @param page    number of page to redirect
@@ -1004,7 +1004,7 @@ class MemoryBankEEPROM implements OTPMemoryBank {
 	}
 
 	/**
-	 * Lock the redirection option for the specifed page in the current memory bank.
+	 * Lock the redirection option for the specified page in the current memory bank.
 	 * Not supported by all devices. See the method 'canLockRedirectPage()'.
 	 *
 	 * @param page number of page to redirect

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankEEPROMblock.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankEEPROMblock.java
@@ -79,7 +79,7 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 
 	/**
 	 * Starting physical address in memory bank. Needed for different types of
-	 * memory in the same logical memory bank. This can be used to seperate them
+	 * memory in the same logical memory bank. This can be used to separate them
 	 * into two virtual memory banks. Example: DS2406 status page has mixed EPROM
 	 * and Volatile RAM.
 	 */
@@ -294,7 +294,7 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 	/**
 	 * Query to get Maximum data page length in bytes for a packet read or written
 	 * in the current memory bank. See the 'ReadPagePacket()' and
-	 * 'WritePagePacket()' methods. This method is only usefull if the current
+	 * 'WritePagePacket()' methods. This method is only useful if the current
 	 * memory bank is general purpose memory.
 	 *
 	 * @return max packet page length in bytes in current memory bank
@@ -430,12 +430,12 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting physical address
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -638,7 +638,7 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 						if (buffer[i + 2] != memory[i + 16])
 							throw new OneWireIOException("Error writing EEPROM memory bank");
 
-					/* now perfomr the copy to EEPROM */
+					/* now perform the copy to EEPROM */
 					ib.adapter.reset();
 					ib.adapter.select(ib.address);
 
@@ -663,12 +663,12 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -689,13 +689,13 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 	 * provide the CRC as in readPageCRC(). readPageCRC() however is not supported
 	 * on all memory types, see 'hasPageAutoCRC()'. If neither is an option then
 	 * this method could be called more then once to at least verify that the same
-	 * thing is read consistantly. See the method 'hasExtraInfo()' for a description
+	 * thing is read consistently. See the method 'hasExtraInfo()' for a description
 	 * of the optional extra information some devices have.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -718,7 +718,7 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -744,7 +744,7 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -826,7 +826,7 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -849,7 +849,7 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -869,7 +869,7 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 	// --------
 
 	/**
-	 * Lock the specifed page in the current memory bank. Not supported by all
+	 * Lock the specified page in the current memory bank. Not supported by all
 	 * devices. See the method 'canLockPage()'.
 	 *
 	 * @param page number of page to lock
@@ -930,7 +930,7 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 	}
 
 	/**
-	 * Redirect the specifed page in the current memory bank to a new page. Not
+	 * Redirect the specified page in the current memory bank to a new page. Not
 	 * supported by all devices. See the method 'canRedirectPage()'.
 	 *
 	 * @param page    number of page to redirect
@@ -987,7 +987,7 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 	}
 
 	/**
-	 * Lock the redirection option for the specifed page in the current memory bank.
+	 * Lock the redirection option for the specified page in the current memory bank.
 	 * Not supported by all devices. See the method 'canLockRedirectPage()'.
 	 *
 	 * @param page number of page to redirect
@@ -1034,7 +1034,7 @@ class MemoryBankEEPROMblock implements OTPMemoryBank {
 				// attempt to set the correct speed and verify device present
 				ib.doSpeed();
 
-				// no execptions so clear flag
+				// no exceptions so clear flag
 				doSetSpeed = false;
 			}
 		}

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankEEPROMstatus.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankEEPROMstatus.java
@@ -69,7 +69,7 @@ class MemoryBankEEPROMstatus implements MemoryBank {
 	public static final byte COPY_SCRATCHPAD_COMMAND = (byte) 0x55;
 
 	/**
-	 * Channel acces write to change the property of the channel
+	 * Channel access write to change the property of the channel
 	 */
 	public static final byte CHANNEL_ACCESS_WRITE = (byte) 0x5A;
 
@@ -143,7 +143,7 @@ class MemoryBankEEPROMstatus implements MemoryBank {
 
 	/**
 	 * Starting physical address in memory bank. Needed for different types of
-	 * memory in the same logical memory bank. This can be used to seperate them
+	 * memory in the same logical memory bank. This can be used to separate them
 	 * into two virtual memory banks. Example: DS2406 status page has mixed EPROM
 	 * and Volatile RAM.
 	 */
@@ -343,7 +343,7 @@ class MemoryBankEEPROMstatus implements MemoryBank {
 	/**
 	 * Query to get Maximum data page length in bytes for a packet read or written
 	 * in the current memory bank. See the 'ReadPagePacket()' and
-	 * 'WritePagePacket()' methods. This method is only usefull if the current
+	 * 'WritePagePacket()' methods. This method is only useful if the current
 	 * memory bank is general purpose memory.
 	 *
 	 * @return max packet page length in bytes in current memory bank
@@ -428,12 +428,12 @@ class MemoryBankEEPROMstatus implements MemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting physical address
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -615,7 +615,7 @@ class MemoryBankEEPROMstatus implements MemoryBank {
 				// attempt to set the correct speed and verify device present
 				ib.doSpeed();
 
-				// no execptions so clear flag
+				// no exceptions so clear flag
 				doSetSpeed = false;
 			}
 		}

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankEPROM.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankEPROM.java
@@ -167,7 +167,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 
 	/**
 	 * Starting physical address in memory bank. Needed for different types of
-	 * memory in the same logical memory bank. This can be used to seperate them
+	 * memory in the same logical memory bank. This can be used to separate them
 	 * into two virtual memory banks. Example: DS2406 status page has mixed EPROM
 	 * and Volatile RAM.
 	 */
@@ -214,7 +214,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	protected int extraInfoLength;
 
 	/**
-	 * Extra information descriptoin when reading page in memory bank
+	 * Extra information description when reading page in memory bank
 	 */
 	protected String extraInfoDescription;
 
@@ -457,7 +457,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	/**
 	 * Query to get Maximum data page length in bytes for a packet read or written
 	 * in the current memory bank. See the 'ReadPagePacket()' and
-	 * 'WritePagePacket()' methods. This method is only usefull if the current
+	 * 'WritePagePacket()' methods. This method is only useful if the current
 	 * memory bank is general purpose memory.
 	 *
 	 * @return max packet page length in bytes in current memory bank
@@ -593,12 +593,12 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting physical address
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -756,12 +756,12 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -785,13 +785,13 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	 * provide the CRC as in readPageCRC(). readPageCRC() however is not supported
 	 * on all memory types, see 'hasPageAutoCRC()'. If neither is an option then
 	 * this method could be called more then once to at least verify that the same
-	 * thing is read consistantly. See the method 'hasExtraInfo()' for a description
+	 * thing is read consistently. See the method 'hasExtraInfo()' for a description
 	 * of the optional extra information some devices have.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -819,7 +819,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -873,7 +873,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -959,7 +959,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -982,7 +982,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -1002,7 +1002,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	// --------
 
 	/**
-	 * Lock the specifed page in the current memory bank. Not supported by all
+	 * Lock the specified page in the current memory bank. Not supported by all
 	 * devices. See the method 'canLockPage()'.
 	 *
 	 * @param page number of page to lock
@@ -1063,7 +1063,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	}
 
 	/**
-	 * Redirect the specifed page in the current memory bank to a new page. Not
+	 * Redirect the specified page in the current memory bank to a new page. Not
 	 * supported by all devices. See the method 'canRedirectPage()'.
 	 *
 	 * @param page    number of page to redirect
@@ -1152,7 +1152,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	}
 
 	/**
-	 * Lock the redirection option for the specifed page in the current memory bank.
+	 * Lock the redirection option for the specified page in the current memory bank.
 	 * Not supported by all devices. See the method 'canLockRedirectPage()'.
 	 *
 	 * @param page number of page to redirect
@@ -1225,7 +1225,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -1353,7 +1353,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 	 * @param data          data byte to program
 	 * @param writeContinue if 'true' then device programming is continued without
 	 *                      re-selecting. This can only be used if the new
-	 *                      programByte() continious where the last one stopped and
+	 *                      programByte() continuous where the last one stopped and
 	 *                      it is inside a 'beginExclusive/endExclusive' block.
 	 *
 	 * @return the echo byte after programming. This should be the desired byte to
@@ -1379,7 +1379,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 
 			System.arraycopy(ffBlock, 0, raw_buf, 0, raw_buf.length);
 
-			// contruct packet
+			// construct packet
 			raw_buf[0] = (byte) WRITE_MEMORY_COMMAND;
 			raw_buf[1] = (byte) (addr & 0xFF);
 			raw_buf[2] = (byte) (((addr & 0xFFFF) >>> 8) & 0xFF);
@@ -1463,7 +1463,7 @@ class MemoryBankEPROM implements OTPMemoryBank {
 				// attempt to set the correct speed and verify device present
 				ib.doSpeed();
 
-				// no execptions so clear flag
+				// no exceptions so clear flag
 				doSetSpeed = false;
 			}
 		}

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankNV.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankNV.java
@@ -120,7 +120,7 @@ class MemoryBankNV implements PagedMemoryBank {
 
 	/**
 	 * Starting physical address in memory bank. Needed for different types of
-	 * memory in the same logical memory bank. This can be used to seperate them
+	 * memory in the same logical memory bank. This can be used to separate them
 	 * into two virtual memory banks. Example: DS2406 status page has mixed EPROM
 	 * and Volatile RAM.
 	 */
@@ -167,7 +167,7 @@ class MemoryBankNV implements PagedMemoryBank {
 	protected int extraInfoLength;
 
 	/**
-	 * Extra information descriptoin when reading page in memory bank
+	 * Extra information description when reading page in memory bank
 	 */
 	protected String extraInfoDescription;
 
@@ -180,7 +180,7 @@ class MemoryBankNV implements PagedMemoryBank {
 	 * memory bank resides on. DEFAULT: DS1993 main memory
 	 *
 	 * @param ibutton    ibutton container that this memory bank resides in
-	 * @param scratchPad memory bank referece for scratchpad, used when writing
+	 * @param scratchPad memory bank reference for scratchpad, used when writing
 	 */
 	public MemoryBankNV(OneWireContainer ibutton, ScratchPad scratch) {
 
@@ -351,7 +351,7 @@ class MemoryBankNV implements PagedMemoryBank {
 	/**
 	 * Query to get Maximum data page length in bytes for a packet read or written
 	 * in the current memory bank. See the 'ReadPagePacket()' and
-	 * 'WritePagePacket()' methods. This method is only usefull if the current
+	 * 'WritePagePacket()' methods. This method is only useful if the current
 	 * memory bank is general purpose memory.
 	 *
 	 * @return max packet page length in bytes in current memory bank
@@ -441,12 +441,12 @@ class MemoryBankNV implements PagedMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting physical address
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -598,12 +598,12 @@ class MemoryBankNV implements PagedMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -624,13 +624,13 @@ class MemoryBankNV implements PagedMemoryBank {
 	 * provide the CRC as in readPageCRC(). readPageCRC() however is not supported
 	 * on all memory types, see 'hasPageAutoCRC()'. If neither is an option then
 	 * this method could be called more then once to at least verify that the same
-	 * thing is read consistantly. See the method 'hasExtraInfo()' for a description
+	 * thing is read consistently. See the method 'hasExtraInfo()' for a description
 	 * of the optional extra information some devices have.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -662,7 +662,7 @@ class MemoryBankNV implements PagedMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -707,7 +707,7 @@ class MemoryBankNV implements PagedMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -774,7 +774,7 @@ class MemoryBankNV implements PagedMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -799,7 +799,7 @@ class MemoryBankNV implements PagedMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankNVCRC.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankNVCRC.java
@@ -94,12 +94,12 @@ class MemoryBankNVCRC extends MemoryBankNV {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -122,13 +122,13 @@ class MemoryBankNVCRC extends MemoryBankNV {
 	 * provide the CRC as in readPageCRC(). readPageCRC() however is not supported
 	 * on all memory types, see 'hasPageAutoCRC()'. If neither is an option then
 	 * this method could be called more then once to at least verify that the same
-	 * thing is read consistantly. See the method 'hasExtraInfo()' for a description
+	 * thing is read consistently. See the method 'hasExtraInfo()' for a description
 	 * of the optional extra information some devices have.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -156,7 +156,7 @@ class MemoryBankNVCRC extends MemoryBankNV {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -205,7 +205,7 @@ class MemoryBankNVCRC extends MemoryBankNV {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -228,7 +228,7 @@ class MemoryBankNVCRC extends MemoryBankNV {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -251,7 +251,7 @@ class MemoryBankNVCRC extends MemoryBankNV {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankNVCRCPW.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankNVCRCPW.java
@@ -89,7 +89,7 @@ public class MemoryBankNVCRCPW extends MemoryBankNVCRC {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -112,7 +112,7 @@ public class MemoryBankNVCRCPW extends MemoryBankNVCRC {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -232,12 +232,12 @@ public class MemoryBankNVCRCPW extends MemoryBankNVCRC {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting physical address
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankSBM.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankSBM.java
@@ -70,7 +70,7 @@ class MemoryBankSBM implements MemoryBank {
 
 	/**
 	 * Starting physical address in memory bank. Needed for different types of
-	 * memory in the same logical memory bank. This can be used to seperate them
+	 * memory in the same logical memory bank. This can be used to separate them
 	 * into two virtual memory banks. Example: DS2406 status page has mixed EPROM
 	 * and Volatile RAM.
 	 */
@@ -298,12 +298,12 @@ class MemoryBankSBM implements MemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting physical address
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -482,9 +482,9 @@ class MemoryBankSBM implements MemoryBank {
 	 *
 	 * @param page   the page number
 	 * @param source data to be written to page
-	 * @param offset offset with page to begin writting
+	 * @param offset offset with page to begin writing
 	 *
-	 * @returns 'true' if the write was successfull
+	 * @returns 'true' if the write was successful
 	 *
 	 * @throws OneWireIOException       Error reading data
 	 * @throws OneWireException         Could not find part
@@ -562,7 +562,7 @@ class MemoryBankSBM implements MemoryBank {
 				// attempt to set the correct speed and verify device present
 				ib.doSpeed();
 
-				// no execptions so clear flag
+				// no exceptions so clear flag
 				doSetSpeed = false;
 			}
 		}

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankSHAEE.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankSHAEE.java
@@ -98,7 +98,7 @@ public class MemoryBankSHAEE implements PagedMemoryBank {
 
 	/**
 	 * Starting physical address in memory bank. Needed for different types of
-	 * memory in the same logical memory bank. This can be used to seperate them
+	 * memory in the same logical memory bank. This can be used to separate them
 	 * into two virtual memory banks. Example: DS2406 status page has mixed EPROM
 	 * and Volatile RAM.
 	 */
@@ -394,7 +394,7 @@ public class MemoryBankSHAEE implements PagedMemoryBank {
 	/**
 	 * Query to get Maximum data page length in bytes for a packet read or written
 	 * in the current memory bank. See the 'ReadPagePacket()' and
-	 * 'WritePagePacket()' methods. This method is only usefull if the current
+	 * 'WritePagePacket()' methods. This method is only useful if the current
 	 * memory bank is general purpose memory.
 	 *
 	 * @return max packet page length in bytes in current memory bank
@@ -415,13 +415,13 @@ public class MemoryBankSHAEE implements PagedMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting address, relative to physical address for this
 	 *                     memory bank.
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -625,12 +625,12 @@ public class MemoryBankSHAEE implements PagedMemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -651,13 +651,13 @@ public class MemoryBankSHAEE implements PagedMemoryBank {
 	 * provide the CRC as in readPageCRC(). readPageCRC() however is not supported
 	 * on all memory types, see 'hasPageAutoCRC()'. If neither is an option then
 	 * this method could be called more then once to at least verify that the same
-	 * thing is read consistantly. See the method 'hasExtraInfo()' for a description
+	 * thing is read consistently. See the method 'hasExtraInfo()' for a description
 	 * of the optional extra information some devices have.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -702,7 +702,7 @@ public class MemoryBankSHAEE implements PagedMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -746,7 +746,7 @@ public class MemoryBankSHAEE implements PagedMemoryBank {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -767,7 +767,7 @@ public class MemoryBankSHAEE implements PagedMemoryBank {
 			checked = ib.checkStatus();
 
 		if (!hasPageAutoCRC())
-			throw new OneWireException("This memory bank page doesn't have CRC capabilites.");
+			throw new OneWireException("This memory bank page doesn't have CRC capabilities.");
 
 		// read the page
 		readAuthenticatedPage(page, raw_buf, 0, extraInfo, 0);
@@ -834,7 +834,7 @@ public class MemoryBankSHAEE implements PagedMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -852,7 +852,7 @@ public class MemoryBankSHAEE implements PagedMemoryBank {
 			checked = ib.checkStatus();
 
 		if (!hasPageAutoCRC())
-			throw new OneWireException("This memory bank doesn't have CRC capabilites.");
+			throw new OneWireException("This memory bank doesn't have CRC capabilities.");
 
 		if (!readAuthenticatedPage(page, pg, 0, extra, 0))
 			throw new OneWireException("Read didn't work.");
@@ -869,7 +869,7 @@ public class MemoryBankSHAEE implements PagedMemoryBank {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -933,7 +933,7 @@ public class MemoryBankSHAEE implements PagedMemoryBank {
 				// attempt to set the correct speed and verify device present
 				ib.doSpeed();
 
-				// no execptions so clear flag
+				// no exceptions so clear flag
 				doSetSpeed = false;
 			}
 		}

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankScratch.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankScratch.java
@@ -131,7 +131,7 @@ class MemoryBankScratch implements PagedMemoryBank, ScratchPad {
 
 	/**
 	 * Starting physical address in memory bank. Needed for different types of
-	 * memory in the same logical memory bank. This can be used to seperate them
+	 * memory in the same logical memory bank. This can be used to separate them
 	 * into two virtual memory banks. Example: DS2406 status page has mixed EPROM
 	 * and Volatile RAM.
 	 */
@@ -178,7 +178,7 @@ class MemoryBankScratch implements PagedMemoryBank, ScratchPad {
 	protected int extraInfoLength;
 
 	/**
-	 * Extra information descriptoin when reading page in memory bank
+	 * Extra information description when reading page in memory bank
 	 */
 	protected String extraInfoDescription;
 
@@ -352,7 +352,7 @@ class MemoryBankScratch implements PagedMemoryBank, ScratchPad {
 	/**
 	 * Query to get Maximum data page length in bytes for a packet read or written
 	 * in the current memory bank. See the 'ReadPagePacket()' and
-	 * 'WritePagePacket()' methods. This method is only usefull if the current
+	 * 'WritePagePacket()' methods. This method is only useful if the current
 	 * memory bank is general purpose memory.
 	 *
 	 * @return max packet page length in bytes in current memory bank
@@ -453,12 +453,12 @@ class MemoryBankScratch implements PagedMemoryBank, ScratchPad {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting address
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -552,12 +552,12 @@ class MemoryBankScratch implements PagedMemoryBank, ScratchPad {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -587,13 +587,13 @@ class MemoryBankScratch implements PagedMemoryBank, ScratchPad {
 	 * provide the CRC as in readPageCRC(). readPageCRC() however is not supported
 	 * on all memory types, see 'hasPageAutoCRC()'. If neither is an option then
 	 * this method could be called more then once to at least verify that the same
-	 * thing is read consistantly. See the method 'hasExtraInfo()' for a description
+	 * thing is read consistently. See the method 'hasExtraInfo()' for a description
 	 * of the optional extra information some devices have.
 	 *
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new readPage()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data
@@ -632,7 +632,7 @@ class MemoryBankScratch implements PagedMemoryBank, ScratchPad {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -685,7 +685,7 @@ class MemoryBankScratch implements PagedMemoryBank, ScratchPad {
 	 * @param page         page number to read packet from
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -776,7 +776,7 @@ class MemoryBankScratch implements PagedMemoryBank, ScratchPad {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -801,7 +801,7 @@ class MemoryBankScratch implements PagedMemoryBank, ScratchPad {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -1008,7 +1008,7 @@ class MemoryBankScratch implements PagedMemoryBank, ScratchPad {
 				// attempt to set the correct speed and verify device present
 				ib.doSpeed();
 
-				// no execptions so clear flag
+				// no exceptions so clear flag
 				doSetSpeed = false;
 			}
 		}

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankScratchCRC.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankScratchCRC.java
@@ -72,7 +72,7 @@ class MemoryBankScratchCRC extends MemoryBankScratchEx {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -97,7 +97,7 @@ class MemoryBankScratchCRC extends MemoryBankScratchEx {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankScratchCRCPW.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankScratchCRCPW.java
@@ -43,7 +43,7 @@ import com.dalsemi.onewire.utils.CRC16;
 public class MemoryBankScratchCRCPW extends MemoryBankScratchEx {
 
 	/**
-	 * The Password container to acces the 8 byte passwords
+	 * The Password container to access the 8 byte passwords
 	 */
 	protected PasswordContainer ibPass = null;
 
@@ -84,7 +84,7 @@ public class MemoryBankScratchCRCPW extends MemoryBankScratchEx {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -109,7 +109,7 @@ public class MemoryBankScratchCRCPW extends MemoryBankScratchEx {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankScratchSHAEE.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankScratchSHAEE.java
@@ -101,7 +101,7 @@ public class MemoryBankScratchSHAEE extends MemoryBankScratchEx {
 	protected static final byte[] zeroBlock = OneWireContainer33.zeroBlock;
 
 	/**
-	 * The Password container to acces the 8 byte passwords
+	 * The Password container to access the 8 byte passwords
 	 */
 	protected OneWireContainer33 owc33 = null;
 
@@ -144,7 +144,7 @@ public class MemoryBankScratchSHAEE extends MemoryBankScratchEx {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -184,7 +184,7 @@ public class MemoryBankScratchSHAEE extends MemoryBankScratchEx {
 	 * @param page         page number to read
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new
-	 *                     readPagePacket() continious where the last one stopped
+	 *                     readPagePacket() continuous where the last one stopped
 	 *                     and it is inside a 'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to put data read. Must have at least
 	 *                     'getMaxPacketDataLength()' elements.
@@ -1087,12 +1087,12 @@ public class MemoryBankScratchSHAEE extends MemoryBankScratchEx {
 	 * the CRC as in readPageCRC(). readPageCRC() however is not supported on all
 	 * memory types, see 'hasPageAutoCRC()'. If neither is an option then this
 	 * method could be called more then once to at least verify that the same thing
-	 * is read consistantly.
+	 * is read consistently.
 	 *
 	 * @param startAddr    starting physical address
 	 * @param readContinue if 'true' then device read is continued without
 	 *                     re-selecting. This can only be used if the new read()
-	 *                     continious where the last one led off and it is inside a
+	 *                     continuous where the last one led off and it is inside a
 	 *                     'beginExclusive/endExclusive' block.
 	 * @param readBuf      byte array to place read data into
 	 * @param offset       offset into readBuf to place data

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankScratchTemp.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/MemoryBankScratchTemp.java
@@ -77,7 +77,7 @@ class MemoryBankScratchTemp implements MemoryBank {
 
 	/**
 	 * Starting physical address in memory bank. Needed for different types of
-	 * memory in the same logical memory bank. This can be used to seperate them
+	 * memory in the same logical memory bank. This can be used to separate them
 	 * into two virtual memory banks. Example: DS2406 status page has mixed EPROM
 	 * and Volatile RAM.
 	 */
@@ -306,7 +306,7 @@ class MemoryBankScratchTemp implements MemoryBank {
 	 * readPageCRC(). readPageCRC() however is not supported on all memory types,
 	 * see 'hasPageAutoCRC()'. If neither is an option then this method could be
 	 * called more then once to at least verify that the same thing is read
-	 * consistantly.
+	 * consistently.
 	 *
 	 * @param startAddr    starting physical address
 	 * @param readContinue ignored by method
@@ -654,7 +654,7 @@ class MemoryBankScratchTemp implements MemoryBank {
 				// attempt to set the correct speed and verify device present
 				ib.doSpeed();
 
-				// no execptions so clear flag
+				// no exceptions so clear flag
 				doSetSpeed = false;
 			}
 		}

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OTPMemoryBank.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OTPMemoryBank.java
@@ -171,7 +171,7 @@ public interface OTPMemoryBank extends PagedMemoryBank {
 	// --------
 
 	/**
-	 * Locks the specifed page in this memory bank. Not supported by all devices.
+	 * Locks the specified page in this memory bank. Not supported by all devices.
 	 *
 	 * @param page number of page to lock
 	 *
@@ -214,7 +214,7 @@ public interface OTPMemoryBank extends PagedMemoryBank {
 	public boolean isPageLocked(int page) throws OneWireIOException, OneWireException;
 
 	/**
-	 * Redirects the specifed page to a new page. Not supported by all devices.
+	 * Redirects the specified page to a new page. Not supported by all devices.
 	 *
 	 * @param page    number of page to redirect
 	 * @param newPage new page number to redirect to
@@ -286,7 +286,7 @@ public interface OTPMemoryBank extends PagedMemoryBank {
 	public int getRedirectedPage(int page) throws OneWireIOException, OneWireException;
 
 	/**
-	 * Locks the redirection of the specifed page. Not supported by all devices.
+	 * Locks the redirection of the specified page. Not supported by all devices.
 	 *
 	 * @param page page to redirect
 	 *

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer02.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer02.java
@@ -529,7 +529,7 @@ public class OneWireContainer02 extends OneWireContainer {
 	 *
 	 * @param key    number indicating the key to be written: 0, 1, or 2
 	 * @param addr   address to start writing at ( 0x00 to 0x3F )
-	 * @param passwd passwird for the subkey
+	 * @param passwd password for the subkey
 	 * @param data   data to be written
 	 *
 	 *

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer04.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer04.java
@@ -47,7 +47,7 @@ import com.dalsemi.onewire.utils.Convert;
  *
  * <P>
  * This iButton is primarily used as a read/write portable memory device with
- * real-time-clock, timer and experation features.
+ * real-time-clock, timer and expiration features.
  * </P>
  *
  * <H3>Features</H3>
@@ -75,7 +75,7 @@ import com.dalsemi.onewire.utils.Convert;
  * <P>
  * Appended to the clock page data retrieved with 'readDevice' are 4 bytes that
  * represent a bitmap of changed bytes. These bytes are used in the
- * 'writeDevice' method in conjuction with the 'set' methods to only write back
+ * 'writeDevice' method in conjunction with the 'set' methods to only write back
  * the changed clock register bytes. The 'readDevice' method will clear any
  * pending alarms.
  * </P>
@@ -732,7 +732,7 @@ public class OneWireContainer04 extends OneWireContainer implements ClockContain
 	 * @param state current state of the device returned from
 	 *              <code>readDevice()</code>
 	 *
-	 * @return time in milliseconds that have occured since the interval counter was
+	 * @return time in milliseconds that have occurred since the interval counter was
 	 *         started
 	 *
 	 * @see com.dalsemi.onewire.container.OneWireSensor#readDevice()
@@ -901,13 +901,13 @@ public class OneWireContainer04 extends OneWireContainer implements ClockContain
 	}
 
 	/**
-	 * Check if the device can be read after a write protected alarm has occured.
+	 * Check if the device can be read after a write protected alarm has occurred.
 	 *
 	 * @param state current state of the device returned from
 	 *              <code>readDevice()</code>
 	 *
 	 * @return <code>true</code> if the device can be read after a write protected
-	 *         alarm has occured
+	 *         alarm has occurred
 	 *
 	 * @see com.dalsemi.onewire.container.OneWireSensor#readDevice()
 	 * @see #setReadAfterExpire(boolean, byte[]) setReadAfterExpire
@@ -953,7 +953,7 @@ public class OneWireContainer04 extends OneWireContainer implements ClockContain
 	}
 
 	/**
-	 * Checks if the automatic delay for the Inteval Timer and the Cycle counter is
+	 * Checks if the automatic delay for the Interval Timer and the Cycle counter is
 	 * either 3.5ms (regular) or 123ms (long).
 	 *
 	 * @param state current state of the device returned from
@@ -1125,7 +1125,7 @@ public class OneWireContainer04 extends OneWireContainer implements ClockContain
 	 * must be called to finalize changes to the device. Note that multiple 'set'
 	 * methods can be called before one call to <code>writeDevice(byte[])</code>.
 	 *
-	 * @param time  in milliseconds to set the inverval timer
+	 * @param time  in milliseconds to set the interval timer
 	 * @param state current state of the device returned from
 	 *              <code>readDevice()</code>
 	 *
@@ -1238,7 +1238,7 @@ public class OneWireContainer04 extends OneWireContainer implements ClockContain
 	}
 
 	/**
-	 * Sets the read state of the device after a write protected alarm has occured.
+	 * Sets the read state of the device after a write protected alarm has occurred.
 	 * The method <code>writeDevice(byte[])</code> must be called to finalize
 	 * changes to the device. Note that multiple 'set' methods can be called before
 	 * one call to <code>writeDevice(byte[])</code>.
@@ -1306,7 +1306,7 @@ public class OneWireContainer04 extends OneWireContainer implements ClockContain
 	}
 
 	/**
-	 * Sets the automatic delay for the Inteval Timer and the Cycle counter to
+	 * Sets the automatic delay for the Interval Timer and the Cycle counter to
 	 * either 123ms (long) or 3.5ms (regular). The method
 	 * <code>writeDevice(byte[])</code> must be called to finalize changes to the
 	 * device. Note that multiple 'set' methods can be called before one call to

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer10.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer10.java
@@ -752,7 +752,7 @@ public class OneWireContainer10 extends OneWireContainer implements TemperatureC
 		else
 			throw new OneWireIOException("OneWireContainer10 - Device not found");
 
-		// Check data to ensure correctly recived.
+		// Check data to ensure correctly received.
 		buffer = new byte[8];
 
 		readScratch(buffer);

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer12.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer12.java
@@ -1290,16 +1290,16 @@ public class OneWireContainer12 extends OneWireContainer implements SwitchContai
 			/*
 			 * OK let me explain that last piece of code: The only return values are going
 			 * to be 1 and 3, 1 for a normal increment and 3 if we want to leave space to
-			 * recieve a CRC.
+			 * receive a CRC.
 			 * 
 			 * So the mask gets the bits out that are concerned with the CRC. When its 0 it
 			 * means that the CRC is disabled, so the next location into our destination
 			 * array we need to copy into is just the next available location.
 			 * 
-			 * When it is 1, it means we will recieve a CRC after each transmission, so we
-			 * should leave a 2 byte space for it (thus increament by 3).
+			 * When it is 1, it means we will receive a CRC after each transmission, so we
+			 * should leave a 2 byte space for it (thus increment by 3).
 			 * 
-			 * When it is 2, it means that after every 8 bytes we want to recieve a CRC byte
+			 * When it is 2, it means that after every 8 bytes we want to receive a CRC byte
 			 * pair. When it is a 3, it means that every 32 bytes we want the CRC pair. So
 			 * what we want to check is if the current_index is divisible by 8 or 32 (we do
 			 * not call this method with current_index==0). Since 8 and 32 are powers of 2

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer18.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer18.java
@@ -1455,7 +1455,7 @@ public class OneWireContainer18 extends OneWireContainer {
 		return true;
 	}
 
-	// local cahce to make TINI fast
+	// local cache to make TINI fast
 	private byte[] bind_code_temp = new byte[32];
 	private byte[] bind_code_alt_temp = new byte[32];
 	private byte[] bind_data_temp = new byte[32];

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer1D.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer1D.java
@@ -49,7 +49,7 @@ import com.dalsemi.onewire.utils.CRC16;
  * </P>
  *
  * <P>
- * Each counter is assosciated with a memory page. The counters for pages 12 and
+ * Each counter is associated with a memory page. The counters for pages 12 and
  * 13 are incremented with a write to the memory on that page. The counters for
  * pages 14 and 15 are externally triggered. See the method
  * {@link #readCounter(int) readCounter} to read a counter directly. Note that

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer1F.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer1F.java
@@ -62,7 +62,7 @@ import com.dalsemi.onewire.utils.Bit;
  * channel [Main(0) or Auxillary(1)] to the 1-Wire data line. Note that this is
  * the opposite of the {@link com.dalsemi.onewire.container.OneWireContainer12
  * DS2406} and {@link com.dalsemi.onewire.container.OneWireContainer05 DS2405}
- * which connect thier I/O lines to ground.
+ * which connect their I/O lines to ground.
  * <H3>Usage</H3>
  *
  * <DL>
@@ -112,7 +112,7 @@ public class OneWireContainer1F extends OneWireContainer implements SwitchContai
 	/** Channel flag to indicate smart on. */
 	protected static final int SWITCH_SMART = 2;
 
-	/** Read Write Status register commmand. */
+	/** Read Write Status register command. */
 	protected static final byte READ_WRITE_STATUS_COMMAND = (byte) 0x5A;
 
 	/** All lines off command. */
@@ -778,7 +778,7 @@ public class OneWireContainer1F extends OneWireContainer implements SwitchContai
 	}
 
 	/**
-	 * Sets the control pin channel association. This only makes sense if the contol
+	 * Sets the control pin channel association. This only makes sense if the control
 	 * pin is in automatic mode. The method <code>writeDevice(byte[])</code> must be
 	 * called to finalize changes to the device. Note that multiple 'set' methods
 	 * can be called before one call to <code>writeDevice(byte[])</code>.

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer20.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer20.java
@@ -93,7 +93,7 @@ import com.dalsemi.onewire.utils.Convert;
  *
  * <P>
  * When converting analog voltages to digital, the user of the device must
- * gaurantee that the voltage seen by the channel of the quad A/D does not
+ * guarantee that the voltage seen by the channel of the quad A/D does not
  * exceed the selected input range of the device. If this happens, the device
  * will default to reading 0 volts. There is NO way to know if the device is
  * reading a higher than specified voltage or NO voltage.
@@ -248,7 +248,7 @@ public class OneWireContainer20 extends OneWireContainer implements ADContainer 
 	 */
 	public String getDescription() {
 		return "Four high-impedance inputs for measurement of analog "
-				+ "voltages.  User programable input range.  Very low "
+				+ "voltages.  User programmable input range.  Very low "
 				+ "power.  Built-in multidrop controller.  Channels "
 				+ "not used as input can be configured as outputs " + "through the use of open drain digital outputs. "
 				+ "Capable of use of Overdrive for fast data transfer. "
@@ -367,7 +367,7 @@ public class OneWireContainer20 extends OneWireContainer implements ADContainer 
 	 * from this method with static utility methods to extract the status, alarm and
 	 * other register values. Appended to the data is 2 bytes that represent a
 	 * bitmap of changed bytes. These bytes are used in the
-	 * <CODE>writeADRegisters()</CODE> in conjuction with the 'set' methods to only
+	 * <CODE>writeADRegisters()</CODE> in conjunction with the 'set' methods to only
 	 * write back the changed register bytes.
 	 *
 	 * @return register page contents verified with onboard CRC
@@ -617,7 +617,7 @@ public class OneWireContainer20 extends OneWireContainer implements ADContainer 
 			throws OneWireIOException, OneWireException {
 		byte input_select_mask = 0;
 		byte read_out_control = 0;
-		int time = 160; // Time required in micro Seconds to covert.
+		int time = 160; // Time required in micro Seconds to convert.
 
 		// calculate the input mask, readout control, and conversion time
 		for (int ch = 3; ch >= 0; ch--) {
@@ -825,7 +825,7 @@ public class OneWireContainer20 extends OneWireContainer implements ADContainer 
 	}
 
 	/**
-	 * Detects if this device has seen a Power-On-Reset (POR). If this has occured
+	 * Detects if this device has seen a Power-On-Reset (POR). If this has occurred
 	 * it may be necessary to set the state of the device to the desired values. The
 	 * register buffer is retrieved from the <CODE>readDevice()</CODE> method.
 	 *

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer21.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer21.java
@@ -1869,7 +1869,7 @@ public class OneWireContainer21 extends OneWireContainer implements TemperatureC
 		// check to see if the Oscillator is enabled.
 		byte[] state = readDevice();
 		if (isClockRunning(state)) {
-			// if the osciallator is not enabled, start it
+			// if the oscillator is not enabled, start it
 			setClockRunEnable(true, state);
 			writeDevice(state);
 			// and give it the required time

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer26.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer26.java
@@ -114,7 +114,7 @@ public class OneWireContainer26 extends OneWireContainer
 	/**
 	 * Flag to set/check the Current Accumulator bit with setFlag/getFlag. When this
 	 * bit is true, both the total discharging and charging current are integrated
-	 * into seperate registers and can be used for determining full/empty levels.
+	 * into separate registers and can be used for determining full/empty levels.
 	 * When this bit is zero the memory (page 7) can be used as user memory.
 	 */
 	public static final byte CA_FLAG = 0x02;
@@ -340,7 +340,7 @@ public class OneWireContainer26 extends OneWireContainer
 	public String getDescription() {
 		return "1-Wire device that integrates the total current charging or "
 				+ "discharging through a battery and stores it in a register. "
-				+ "It also returns the temperature (accurate to 2 degrees celcius),"
+				+ "It also returns the temperature (accurate to 2 degrees celsius),"
 				+ " as well as the instantaneous current and voltage and also "
 				+ "provides 40 bytes of EEPROM storage.";
 	}
@@ -450,7 +450,7 @@ public class OneWireContainer26 extends OneWireContainer
 	 *
 	 * @param page   the page number
 	 * @param source data to be written to page
-	 * @param offset offset with page to begin writting
+	 * @param offset offset with page to begin writing
 	 *
 	 * @throws OneWireIOException       Error reading data
 	 * @throws OneWireException         Could not find part
@@ -521,7 +521,7 @@ public class OneWireContainer26 extends OneWireContainer
 	 *
 	 * @param flagValue value to set flag to
 	 *
-	 * @throws OneWireIOException       Error writting data
+	 * @throws OneWireIOException       Error writing data
 	 * @throws OneWireException         Could not find part
 	 * @throws IllegalArgumentException Bad parameters passed
 	 */
@@ -794,7 +794,7 @@ public class OneWireContainer26 extends OneWireContainer
 	 *
 	 * @param state device state
 	 *
-	 * @return time in milliseconds that have occured since 1970
+	 * @return time in milliseconds that have occurred since 1970
 	 */
 	public long getDisconnectTime(byte[] state) {
 		return getTime(state, 16) * 1000;
@@ -806,7 +806,7 @@ public class OneWireContainer26 extends OneWireContainer
 	 *
 	 * @param state device state
 	 *
-	 * @return time in milliseconds that have occured since 1970
+	 * @return time in milliseconds that have occurred since 1970
 	 */
 	public long getEndOfChargeTime(byte[] state) {
 		return getTime(state, 20) * 1000;
@@ -1260,7 +1260,7 @@ public class OneWireContainer26 extends OneWireContainer
 	 *
 	 * @param state device's state
 	 *
-	 * @throws OneWireIOException Error writting data
+	 * @throws OneWireIOException Error writing data
 	 * @throws OneWireException   Could not find part
 	 */
 	public void writeDevice(byte[] state) throws OneWireIOException, OneWireException {
@@ -1342,7 +1342,7 @@ public class OneWireContainer26 extends OneWireContainer
 	 *
 	 * @param state device state
 	 *
-	 * @throws OneWireIOException Error writting data
+	 * @throws OneWireIOException Error writing data
 	 * @throws OneWireException   Could not find part
 	 */
 	public void doTemperatureConvert(byte[] state) throws OneWireIOException, OneWireException {
@@ -1443,7 +1443,7 @@ public class OneWireContainer26 extends OneWireContainer
 	 * @param resolution temperature resolution in degrees C
 	 * @param state      device state
 	 *
-	 * @throws OneWireIOException Error writting data
+	 * @throws OneWireIOException Error writing data
 	 * @throws OneWireException   Could not find part
 	 */
 	public void setTemperatureResolution(double resolution, byte[] state) throws OneWireException, OneWireIOException {
@@ -1493,7 +1493,7 @@ public class OneWireContainer26 extends OneWireContainer
 	 *
 	 * @param state device state
 	 *
-	 * @return time in milliseconds that have occured since 1970
+	 * @return time in milliseconds that have occurred since 1970
 	 */
 	public long getClock(byte[] state) {
 		return getTime(state, 8) * 1000;
@@ -1538,7 +1538,7 @@ public class OneWireContainer26 extends OneWireContainer
 	}
 
 	/**
-	 * This method checks if the device's oscilator is enabled. The clock will not
+	 * This method checks if the device's oscillator is enabled. The clock will not
 	 * increment if the clock is not enabled. This value is read from the provided
 	 * state data retrieved from the <CODE>readDevice()</CODE> method.
 	 *
@@ -1749,7 +1749,7 @@ public class OneWireContainer26 extends OneWireContainer
 			// read the sample voltage
 			vad = getADVoltage(CHANNEL_VAD, state);
 		} catch (OneWireException e) {
-			// know from this implementatin that this will never happen
+			// know from this implementation that this will never happen
 			return 0.0;
 		}
 

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer28.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer28.java
@@ -92,7 +92,7 @@ public class OneWireContainer28 extends OneWireContainer implements TemperatureC
 	/** DS18B20 reads data from scratchpad command */
 	public static final byte READ_SCRATCHPAD_COMMAND = (byte) 0xBE;
 
-	/** DS18B20 copys data from scratchpad to E-squared memory command */
+	/** DS18B20 copies data from scratchpad to E-squared memory command */
 	public static final byte COPY_SCRATCHPAD_COMMAND = (byte) 0x48;
 
 	/** DS18B20 converts temperature command */

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer29.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer29.java
@@ -267,7 +267,7 @@ public class OneWireContainer29 extends OneWireContainer implements SwitchContai
 		// 00 - 4 channels
 		// 01 - 5 channels
 		// 10 - 8 channels
-		// 11 - 16 channes, which hasn't been implemented yet
+		// 11 - 16 channels, which hasn't been implemented yet
 		return 8;
 	}
 

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer2C.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer2C.java
@@ -46,7 +46,7 @@ import com.dalsemi.onewire.adapter.OneWireIOException;
  * <UL>
  * <LI>Single element 256-position linear taper potentiometer
  * <LI>Supports potentiometer terminal working voltages up to 11V
- * <LI>Potentiometer terminal voltage independant of supply voltage
+ * <LI>Potentiometer terminal voltage independent of supply voltage
  * <LI>100k Ohm resistor element value
  * <LI>Operating temperature range from -40@htmlonly &#176C @endhtmlonly to
  * +85@htmlonly &#176C @endhtmlonly
@@ -439,7 +439,7 @@ public class OneWireContainer2C extends OneWireContainer implements Potentiomete
 	 *
 	 * @return the new position of the wiper (0-255)
 	 * @throws OneWireIOException Data was not written correctly
-	 * @throws OneWireException   Counld not find device
+	 * @throws OneWireException   Could not find device
 	 */
 	public int decrement() throws OneWireIOException, OneWireException {
 		return unitChange(DECREMENT, true);
@@ -580,7 +580,7 @@ public class OneWireContainer2C extends OneWireContainer implements Potentiomete
 	/*
 	 * This function handles the increment and decrement operations, including the
 	 * contingent reset. You do not need to call reset between consecutive unit
-	 * change commands. Both operations issue the command byte and then recieve the
+	 * change commands. Both operations issue the command byte and then receive the
 	 * new wiper position.
 	 */
 	private synchronized int unitChange(byte COMMAND, boolean reselect) throws OneWireIOException, OneWireException {

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer2D.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer2D.java
@@ -45,7 +45,7 @@ import com.dalsemi.onewire.adapter.OneWireIOException;
  * <LI>1024 bits of 5V EEPROM memory partitioned into four pages of 256 bits
  * <LI>unique, fatory-lasered and tested 64-bit registration number (8-bit
  * family code + 48-bit serial number + 8-bit CRC tester) assures absolute
- * traceablity because no two parts are alike.
+ * traceability because no two parts are alike.
  * <LI>Built-in multidrop controller ensures compatibility with other 1-Wire net
  * products.
  * <LI>Reduces control, address, data and power to a single data pin.
@@ -73,7 +73,7 @@ import com.dalsemi.onewire.adapter.OneWireIOException;
  */
 public class OneWireContainer2D extends OneWireContainer {
 	/*
-	 * registery memory bank to control write-once (EPROM) mode
+	 * registry memory bank to control write-once (EPROM) mode
 	 */
 	private MemoryBankEEPROM register;
 
@@ -197,7 +197,7 @@ public class OneWireContainer2D extends OneWireContainer {
 	 * Retrieve the Maxim Integrated Products part number of the iButton as a
 	 * string. For example 'DS1992'.
 	 *
-	 * @return string represetation of the iButton name.
+	 * @return string representation of the iButton name.
 	 */
 	public String getName() {
 		return "DS1972";
@@ -217,7 +217,7 @@ public class OneWireContainer2D extends OneWireContainer {
 	/**
 	 * Retrieve a short description of the function of the iButton type.
 	 *
-	 * @return string represetation of the function description.
+	 * @return string representation of the function description.
 	 */
 	public String getDescription() {
 		return "1K-Bit protected 1-Wire EEPROM.";
@@ -317,7 +317,7 @@ public class OneWireContainer2D extends OneWireContainer {
 	}
 
 	/**
-	 * Lock the specifed page in the current memory bank. Not supported by all
+	 * Lock the specified page in the current memory bank. Not supported by all
 	 * devices. See the method 'canLockPage()'.
 	 *
 	 * @param page number of page to lock

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer30.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer30.java
@@ -156,13 +156,13 @@ public class OneWireContainer30 extends OneWireContainer implements ADContainer,
 	public static final byte DC_PIN_STATE_FLAG = 4;
 
 	/**
-	 * PROTECTION REGISTER FLAG: Reseting this flag will disable charging regardless
+	 * PROTECTION REGISTER FLAG: Resetting this flag will disable charging regardless
 	 * of cell or pack conditions. Accessed with <CODE>getFlag()/setFlag()</CODE>.
 	 */
 	public static final byte CHARGE_ENABLE_FLAG = 2;
 
 	/**
-	 * PROTECTION REGISTER FLAG: Reseting this flag will disable discharging.
+	 * PROTECTION REGISTER FLAG: Resetting this flag will disable discharging.
 	 * Accessed with <CODE>getFlag()/setFlag()</CODE>.
 	 */
 	public static final byte DISCHARGE_ENABLE_FLAG = 1;
@@ -671,7 +671,7 @@ public class OneWireContainer30 extends OneWireContainer implements ADContainer,
 	public void setFlag(int memAddr, byte flagToSet, boolean flagValue) throws OneWireIOException, OneWireException {
 
 		// the desired default value for the status register flags has to be
-		// set in a seperate register for some reason, so I treat it specially.
+		// set in a separate register for some reason, so I treat it specially.
 		if (memAddr == STATUS_REGISTER)
 			memAddr = 49;
 
@@ -778,7 +778,7 @@ public class OneWireContainer30 extends OneWireContainer implements ADContainer,
 	 *
 	 * @param on state of the PIO pin to set
 	 *
-	 * @throws OneWireIOException Error writting data
+	 * @throws OneWireIOException Error writing data
 	 * @throws OneWireException   Could not find part
 	 */
 
@@ -807,7 +807,7 @@ public class OneWireContainer30 extends OneWireContainer implements ADContainer,
 	 * overcurrent flags. Each time a violation occurs, these flags stay set until
 	 * reset. This method resets all 4 flags.
 	 *
-	 * @throws OneWireIOException Error writting data
+	 * @throws OneWireIOException Error writing data
 	 * @throws OneWireException   Could not find part
 	 */
 	public void clearConditions() throws OneWireIOException, OneWireException {
@@ -902,7 +902,7 @@ public class OneWireContainer30 extends OneWireContainer implements ADContainer,
 	 * @param state   current state of this device returned from
 	 *                <CODE>readDevice()</CODE>
 	 *
-	 * @throws OneWireIOException Error writting data
+	 * @throws OneWireIOException Error writing data
 	 * @throws OneWireException   Could not find device
 	 */
 	public void doADConvert(int channel, byte[] state) throws OneWireIOException, OneWireException {
@@ -926,7 +926,7 @@ public class OneWireContainer30 extends OneWireContainer implements ADContainer,
 	 * @param state     current state of the device returned from
 	 *                  <CODE>readDevice()</CODE>
 	 *
-	 * @throws OneWireIOException Error writting data
+	 * @throws OneWireIOException Error writing data
 	 * @throws OneWireException   Device does not support multi-channel reading
 	 */
 	public void doADConvert(boolean[] doConvert, byte[] state) throws OneWireIOException, OneWireException {
@@ -944,7 +944,7 @@ public class OneWireContainer30 extends OneWireContainer implements ADContainer,
 	 *
 	 * @return voltage values for all channels
 	 *
-	 * @throws OneWireIOException Error writting data
+	 * @throws OneWireIOException Error writing data
 	 * @throws OneWireException   Device does not support multi-channel reading
 	 */
 	public double[] getADVoltage(byte[] state) throws OneWireIOException, OneWireException {
@@ -1260,7 +1260,7 @@ public class OneWireContainer30 extends OneWireContainer implements ADContainer,
 	 *
 	 * @param state device state
 	 *
-	 * @throws OneWireIOException Error writting data
+	 * @throws OneWireIOException Error writing data
 	 * @throws OneWireException   Could not find device
 	 */
 	public void doTemperatureConvert(byte[] state) throws OneWireIOException, OneWireException {
@@ -1308,7 +1308,7 @@ public class OneWireContainer30 extends OneWireContainer implements ADContainer,
 	 *
 	 * @return alarm trip temperature in degrees C
 	 *
-	 * @throws OneWireException Device does not support temerature alarms
+	 * @throws OneWireException Device does not support temperature alarms
 	 */
 	public double getTemperatureAlarm(int alarmType, byte[] state) throws OneWireException {
 		throw new OneWireException("This device does not have temperature alarms");
@@ -1340,7 +1340,7 @@ public class OneWireContainer30 extends OneWireContainer implements ADContainer,
 	 * @param alarmValue high/low temperature trip value in degrees C
 	 * @param state      device state
 	 *
-	 * @throws OneWireIOException Error writting data
+	 * @throws OneWireIOException Error writing data
 	 * @throws OneWireException   Device does not support temperature alarms
 	 */
 	public void setTemperatureAlarm(int alarmType, double alarmValue, byte[] state)
@@ -1356,7 +1356,7 @@ public class OneWireContainer30 extends OneWireContainer implements ADContainer,
 	 * @param resolution temperature resolution in degrees C
 	 * @param state      device state
 	 *
-	 * @throws OneWireIOException Error writting data
+	 * @throws OneWireIOException Error writing data
 	 * @throws OneWireException   Could not find device
 	 */
 	public void setTemperatureResolution(double resolution, byte[] state) throws OneWireException, OneWireIOException {
@@ -1409,7 +1409,7 @@ public class OneWireContainer30 extends OneWireContainer implements ADContainer,
 	 *
 	 * @param state device state
 	 *
-	 * @throws OneWireIOException Error writting data
+	 * @throws OneWireIOException Error writing data
 	 * @throws OneWireException   Could not find device
 	 */
 	public void writeDevice(byte[] state) throws OneWireIOException, OneWireException {

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer33.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer33.java
@@ -53,7 +53,7 @@ import com.dalsemi.onewire.adapter.OneWireIOException;
  * in EPROM-emulation mode ("write to 0", page0)
  * <LI>unique, fatory-lasered and tested 64-bit registration number (8-bit
  * family code + 48-bit serial number + 8-bit CRC tester) assures absolute
- * traceablity because no two parts are alike.
+ * traceability because no two parts are alike.
  * <LI>Built-in multidrop controller ensures compatibility with other 1-Wire net
  * products.
  * <LI>Reduces control, address, data and power to a single data pin.
@@ -354,7 +354,7 @@ public class OneWireContainer33 extends OneWireContainer {
 	 * Retrieve the Maxim Integrated Products part number of the iButton as a
 	 * string. For example 'DS1992'.
 	 *
-	 * @return string represetation of the iButton name.
+	 * @return string representation of the iButton name.
 	 */
 	public String getName() {
 		return "DS1961S";
@@ -374,7 +374,7 @@ public class OneWireContainer33 extends OneWireContainer {
 	/**
 	 * Retrieve a short description of the function of the iButton type.
 	 *
-	 * @return string represetation of the function description.
+	 * @return string representation of the function description.
 	 */
 	public String getDescription() {
 		return "1K-Bit protected 1-Wire EEPROM with SHA-1 Engine.";

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer37.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer37.java
@@ -181,7 +181,7 @@ public class OneWireContainer37 extends OneWireContainer implements PasswordCont
 	public static final byte COPY_SCRATCHPAD_PW_COMMAND = (byte) 0x99;
 	/** 1-Wire command for Read Memory With Password */
 	public static final byte READ_MEMORY_PW_COMMAND = (byte) 0x69;
-	/** 1-Wire command for Verifing the Password */
+	/** 1-Wire command for Verifying the Password */
 	public static final byte VERIFY_PSW_COMMAND = (byte) 0xC3;
 	/** 1-Wire command for getting Read Version */
 	public static final byte READ_VERSION = (byte) 0xCC;

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer41.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer41.java
@@ -322,7 +322,7 @@ public class OneWireContainer41 extends OneWireContainer implements PasswordCont
 	private byte[] dataLog = null, temperatureLog = null;
 	/** Number of bytes used to store temperature values (0, 1, or 2) */
 	private int temperatureBytes = 0;
-	/** Number of bytes used to stroe data valuas (0, 1, or 2) */
+	/** Number of bytes used to store data valuas (0, 1, or 2) */
 	private int dataBytes = 0;
 	/** indicates whether or not the log has rolled over */
 	private boolean rolledOver = false;

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer42.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer42.java
@@ -103,7 +103,7 @@ public class OneWireContainer42 extends OneWireContainer implements TemperatureC
 	/** DS28EA00 reads data from scratchpad command */
 	public static final byte READ_SCRATCHPAD_COMMAND = (byte) 0xBE;
 
-	/** DS28EA00 copys data from scratchpad to E-squared memory command */
+	/** DS28EA00 copies data from scratchpad to E-squared memory command */
 	public static final byte COPY_SCRATCHPAD_COMMAND = (byte) 0x48;
 
 	/** DS28EA00 converts temperature command */

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer43.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/OneWireContainer43.java
@@ -77,7 +77,7 @@ public class OneWireContainer43 extends OneWireContainer {
 	private MemoryBankScratchEE sp;
 
 	/*
-	 * registery memory bank to control write-once (EPROM) mode
+	 * registry memory bank to control write-once (EPROM) mode
 	 */
 	private MemoryBankEEPROM register;
 
@@ -201,7 +201,7 @@ public class OneWireContainer43 extends OneWireContainer {
 	 * Retrieve the Maxim Integrated Products part number of the iButton as a
 	 * string. For example 'DS1992'.
 	 *
-	 * @return string represetation of the iButton name.
+	 * @return string representation of the iButton name.
 	 */
 	public String getName() {
 		return "DS28EC20";
@@ -221,7 +221,7 @@ public class OneWireContainer43 extends OneWireContainer {
 	/**
 	 * Retrieve a short description of the function of the iButton type.
 	 *
-	 * @return string represetation of the function description.
+	 * @return string representation of the function description.
 	 */
 	public String getDescription() {
 		return "20Kb 1-Wire EEPROM";
@@ -341,7 +341,7 @@ public class OneWireContainer43 extends OneWireContainer {
 	}
 
 	/**
-	 * Lock the specifed page in the current memory bank. Not supported by all
+	 * Lock the specified page in the current memory bank. Not supported by all
 	 * devices. See the method 'canLockPage()'.
 	 *
 	 * @param page number of page to lock

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/PagedMemoryBank.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/PagedMemoryBank.java
@@ -123,7 +123,7 @@ import com.dalsemi.onewire.adapter.OneWireIOException;
  *     // loop to read each page with CRC 
  *     for (int pg = 0; pg < pmb.getNumberPages(); pg++)
  *     {
- *        // use 'readContinue' arguement to only access device on first page
+ *        // use 'readContinue' argument to only access device on first page
  *        pmb.readPageCRC(pg, (pg == 0), read_buf, 0);
  *
  *        // do something with data in read_buf ... 
@@ -184,7 +184,7 @@ public interface PagedMemoryBank extends MemoryBank {
 	 * Gets Maximum data page length in bytes for a packet read or written in this
 	 * memory bank. See the {@link #readPagePacket(int,boolean,byte[],int)
 	 * readPagePacket} and {@link #writePagePacket(int,byte[],int,int)
-	 * writePagePacket} methods. This method is only usefull if this memory bank is
+	 * writePagePacket} methods. This method is only useful if this memory bank is
 	 * general purpose memory.
 	 *
 	 * @return max packet page length in bytes in this memory bank

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/PotentiometerContainer.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/PotentiometerContainer.java
@@ -103,7 +103,7 @@ public interface PotentiometerContainer extends OneWireSensor {
 	// --------
 
 	/**
-	 * Querys to see if this Potentiometer 1-Wire Device has linear potentiometer
+	 * Queries to see if this Potentiometer 1-Wire Device has linear potentiometer
 	 * element(s) or logarithmic potentiometer element(s).
 	 *
 	 * @param state state buffer of the Potentiometer 1-Wire Device (returned by
@@ -115,7 +115,7 @@ public interface PotentiometerContainer extends OneWireSensor {
 	public boolean isLinear(byte[] state);
 
 	/**
-	 * Querys to see if this Potentiometer 1-Wire Device's wiper settings are
+	 * Queries to see if this Potentiometer 1-Wire Device's wiper settings are
 	 * volatile or non-volatile.
 	 *
 	 * @param state state buffer of the Potentiometer 1-Wire Device (returned by
@@ -126,7 +126,7 @@ public interface PotentiometerContainer extends OneWireSensor {
 	public boolean wiperSettingsAreVolatile(byte[] state);
 
 	/**
-	 * Querys to see how many potentiometers this Potentiometer 1-Wire Device has.
+	 * Queries to see how many potentiometers this Potentiometer 1-Wire Device has.
 	 *
 	 * @param state state buffer of the Potentiometer 1-Wire Device (returned by
 	 *              <CODE>readDevice()</CODE>)
@@ -135,7 +135,7 @@ public interface PotentiometerContainer extends OneWireSensor {
 	public int numberOfPotentiometers(byte[] state);
 
 	/**
-	 * Querys to find the number of wiper settings that any wiper on this
+	 * Queries to find the number of wiper settings that any wiper on this
 	 * Potentiometer 1-Wire Device can have.
 	 *
 	 * @param state state buffer of the Potentiometer 1-Wire Device (returned by
@@ -145,7 +145,7 @@ public interface PotentiometerContainer extends OneWireSensor {
 	public int numberOfWiperSettings(byte[] state);
 
 	/**
-	 * Querys to find the resistance value of the potentiometer.
+	 * Queries to find the resistance value of the potentiometer.
 	 *
 	 * @param state state buffer of the Potentiometer 1-Wire Device (returned by
 	 *              <CODE>readDevice()</CODE>)

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/ResponseAPDU.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/container/ResponseAPDU.java
@@ -68,7 +68,7 @@ package com.dalsemi.onewire.container;
  *   ResponseAPDU rapdu = owc16.sendAPDU(capdu, runTime); </pre></code>
  * </OL>
  *
- * <H3>Additonal information</H3>
+ * <H3>Additional information</H3>
  * <DL>
  * <DD><A HREF="http://www.opencard.org"> http://www.opencard.org</A>
  * </DL>

--- a/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/debug/Debug.java
+++ b/io.openems.edge.bridge.onewire/src/com/dalsemi/onewire/debug/Debug.java
@@ -91,7 +91,7 @@ public class Debug {
 	 * Gets the debug printing mode for this application.
 	 *
 	 * @return <code>true</code> indicates debug messages are on, <code>false</code>
-	 *         supresses them.
+	 *         suppresses them.
 	 */
 	public static final boolean getDebugMode() {
 		return DEBUG;
@@ -109,7 +109,7 @@ public class Debug {
 	/**
 	 * Prints the specified <code>java.lang.String</code> object if debug mode is
 	 * enabled. This method calls <code>PrintStream.println(String)</code>, and
-	 * pre-pends the <code>String</code> ">> " to the message, so taht if a program
+	 * pre-pends the <code>String</code> ">> " to the message, so that if a program
 	 * were to call (when debug mode was enabled): <code><pre>
 	 *     com.dalsemi.onewire.debug.Debug.debug("Some notification...");
 	 * </pre></code> the resulting output would look like: <code><pre>
@@ -126,7 +126,7 @@ public class Debug {
 	/**
 	 * Prints the specified array of bytes with a given label if debug mode is
 	 * enabled. This method calls <code>PrintStream.println(String)</code>, and
-	 * pre-pends the <code>String</code> ">> " to the message, so taht if a program
+	 * pre-pends the <code>String</code> ">> " to the message, so that if a program
 	 * were to call (when debug mode was enabled): <code><pre>
 	 *     com.dalsemi.onewire.debug.Debug.debug("Some notification...", myBytes);
 	 * </pre></code> the resulting output would look like: <code><pre>
@@ -145,7 +145,7 @@ public class Debug {
 	/**
 	 * Prints the specified array of bytes with a given label if debug mode is
 	 * enabled. This method calls <code>PrintStream.println(String)</code>, and
-	 * pre-pends the <code>String</code> ">> " to the message, so taht if a program
+	 * pre-pends the <code>String</code> ">> " to the message, so that if a program
 	 * were to call (when debug mode was enabled): <code><pre>
 	 *     com.dalsemi.onewire.debug.Debug.debug("Some notification...", myBytes, 0, 8);
 	 * </pre></code> the resulting output would look like: <code><pre>
@@ -182,7 +182,7 @@ public class Debug {
 	/**
 	 * Prints the specified exception with a given label if debug mode is enabled.
 	 * This method calls <code>PrintStream.println(String)</code>, and pre-pends the
-	 * <code>String</code> ">> " to the message, so taht if a program were to call
+	 * <code>String</code> ">> " to the message, so that if a program were to call
 	 * (when debug mode was enabled): <code><pre>
 	 *     com.dalsemi.onewire.debug.Debug.debug("Some notification...", exception);
 	 * </pre></code> the resulting output would look like: <code><pre>

--- a/io.openems.edge.common/src/io/openems/edge/common/startstop/StartStopConfig.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/startstop/StartStopConfig.java
@@ -6,7 +6,7 @@ package io.openems.edge.common.startstop;
  * logic of the {@link StartStoppable#setStartStop(StartStop)} method:
  * 
  * <pre>
- * 	&#64;AttributeDefinition(name = "Start/stop behaviour?", description = "Should this Component be forced to start or stopp?")
+ * 	&#64;AttributeDefinition(name = "Start/stop behaviour?", description = "Should this Component be forced to start or stop?")
  *	StartStopConfig startStop() default StartStopConfig.AUTO;
  * </pre>
  * 

--- a/io.openems.edge.common/src/io/openems/edge/common/startstop/StartStoppable.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/startstop/StartStoppable.java
@@ -22,7 +22,7 @@ import io.openems.edge.common.modbusslave.ModbusType;
  * of the {@link StartStoppable#setStartStop(StartStop)} method:
  * 
  * <pre>
- * 	&#64;AttributeDefinition(name = "Start/stop behaviour?", description = "Should this Component be forced to start or stopp?")
+ * 	&#64;AttributeDefinition(name = "Start/stop behaviour?", description = "Should this Component be forced to start or stop?")
  *	StartStopConfig startStop() default StartStopConfig.AUTO;
  * </pre>
  * 

--- a/io.openems.edge.controller.ess.onefullcycle/src/io/openems/edge/controller/ess/onefullcycle/EssOneFullCycle.java
+++ b/io.openems.edge.controller.ess.onefullcycle/src/io/openems/edge/controller/ess/onefullcycle/EssOneFullCycle.java
@@ -114,7 +114,7 @@ public class EssOneFullCycle extends AbstractOpenemsComponent implements Control
 		try {
 			this.initializeEnums(ess);
 		} catch (OpenemsException e) {
-			this.logError(this.log, "Unable to initalize Enums: " + e.getMessage());
+			this.logError(this.log, "Unable to initialize Enums: " + e.getMessage());
 			return;
 		}
 

--- a/io.openems.edge.controller.evcs.fixactivepower/src/io/openems/edge/controller/evcs/fixactivepower/Config.java
+++ b/io.openems.edge.controller.evcs.fixactivepower/src/io/openems/edge/controller/evcs/fixactivepower/Config.java
@@ -5,7 +5,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 @ObjectClassDefinition(//
 		name = "Controller Electric Vehicle Charging Station: Fix Active Power", //
-		description = "Defines a fixed charge/discarge power to an Electric Vehicle Charging Station.")
+		description = "Defines a fixed charge/discharge power to an Electric Vehicle Charging Station.")
 @interface Config {
 
 	@AttributeDefinition(name = "Component-ID", description = "Unique ID of this Component")

--- a/io.openems.edge.controller.io.alarm/readme.adoc
+++ b/io.openems.edge.controller.io.alarm/readme.adoc
@@ -22,7 +22,7 @@ Multiple instances can be created in "Apache felix" during the configuration for
 NOTE: ess0/State15 - represents the State15 channels of the ESS0, 
 io0/relay1 = represents the relay 1 of the KM tronic relay board.
 
-The above example configuration describes, if any of the configured three input channels is set to "True" then a signal "True" is sent to output channel, else the "False" signal is sent to outout channel.
+The above example configuration describes, if any of the configured three input channels is set to "True" then a signal "True" is sent to output channel, else the "False" signal is sent to output channel.
 
 
 https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.controller.io.alarm[Source Code icon:github[]]

--- a/io.openems.edge.ess.kaco.blueplanet.gridsave50/src/io/openems/edge/ess/kaco/blueplanet/gridsave50/EssKacoBlueplanetGridsave50.java
+++ b/io.openems.edge.ess.kaco.blueplanet.gridsave50/src/io/openems/edge/ess/kaco/blueplanet/gridsave50/EssKacoBlueplanetGridsave50.java
@@ -67,7 +67,7 @@ import io.openems.edge.timedata.api.utils.CalculateEnergyFromPower;
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
 		property = { EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE, //
 		}) //
-// TODO: drop this Component in favour of KACO blueplanet Battery-Inverter implemention + Generic ESS.
+// TODO: drop this Component in favour of KACO blueplanet Battery-Inverter implementation + Generic ESS.
 public class EssKacoBlueplanetGridsave50 extends AbstractOpenemsModbusComponent
 		implements ManagedSymmetricEss, SymmetricEss, OpenemsComponent, TimedataProvider, EventHandler, ModbusSlave {
 

--- a/io.openems.edge.ess.mr.gridcon/doc/Fehlerliste.csv
+++ b/io.openems.edge.ess.mr.gridcon/doc/Fehlerliste.csv
@@ -1,4 +1,4 @@
-﻿Level;Device;;Trigger;;;Identification;;;;;;;Parameters;;;;;;;;;;Kommentar
+Level;Device;;Trigger;;;Identification;;;;;;;Parameters;;;;;;;;;;Kommentar
 ;;;;;;;;;;;;;Condition;;;;;;Reaction;;;;
 ;Model / Manufacturer;Type;Source;Register / Module;Bit;Code;;;;Namespace;Enumerator;Text;Scope;Type;Trigger;;Acknowledge;;Dera-ting;Auto Ack. / Restart;Level;Target;
 ;;;;;;Main;M;B;Full;;;;;;Level;Delay;Level;Delay;;;;;
@@ -1078,7 +1078,7 @@ Software;MR;Software;Sharc;Measurements;11;0x01;0;0;0x01000B;ERROR_CODES::SW;PQM
 Software;MR;;;;12;0x01;0;0;0x01000C;ERROR_CODES::SW;PQM_PACKET_MISSING;Measurement packet missing;Blackfin;Extern;;;;;;;WARNING;SYSTEM;not implemented
 Software;MR;;;;13;0x01;0;0;0x01000D;ERROR_CODES::SW;PQM_INVALID_DATA;Invalid measurement data;Blackfin;Extern;;;;;;;WARNING;SYSTEM;not implemented
 Software;MR;Software;Sharc;Userinterface;14;0x01;0;0;0x01000E;ERROR_CODES::SW;RTDS_SOFTWARE;Warning: RTDS Version - Do not use on real hardware;SHARC;Extern;;;;;;;INFO;SYSTEM;
-Software;MR;Software;Sharc / Blackfin;;15;0x01;0;0;0x01000F;ERROR_CODES::SW;ARRAY_OVERFLOW;Array oveflow;Common;Extern;;;;;;;SHUTDOWN;SYSTEM;Acknowledge not possible
+Software;MR;Software;Sharc / Blackfin;;15;0x01;0;0;0x01000F;ERROR_CODES::SW;ARRAY_OVERFLOW;Array overflow;Common;Extern;;;;;;;SHUTDOWN;SYSTEM;Acknowledge not possible
 Software;MR;Software;Sharc;;16;0x01;0;0;0x010010;ERROR_CODES::SW;AUTONOM_TEST_SW;Warning: AUTONOM TEST SW ( Autostart );SHARC;Extern;;;;;;;INFO;SYSTEM;
 Software;MR;Software;Sharc;AutarsysFacade;17;0x01;0;0;0x010011;ERROR_CODES::SW;NO_BLACKSTART_OR_SYNC_ENABLED;no Blackstart or SyncV enabled;SHARC;Extern;;;;;;;SHUTDOWN;SYSTEM;
 Software;MR;Software;Sharc;AutarsysFacade;18;0x01;0;0;0x010012;ERROR_CODES::SW;SYNC_V_AND_BLACKSTART_ENABLED;sycnV and Blackstart enabled;SHARC;Extern;;;;;;;SHUTDOWN;SYSTEM;
@@ -1086,7 +1086,7 @@ Software;MR;Software;Sharc;AutarsysFacade;19;0x01;0;0;0x010013;ERROR_CODES::SW;V
 Software;MR;Software;Sharc;AutarsysFacade;20;0x01;0;0;0x010014;ERROR_CODES::SW;VOLTAGE_SYNC_NOT_SUCCEDDED;voltage sync not succedded;SHARC;Extern;;;;;;;SHUTDOWN;SYSTEM;
 Software;MR;Software;Sharc;AutarsysFacade;21;0x01;0;0;0x010015;ERROR_CODES::SW;VOLTAGE_NOT_OK_FOR_SYNC_V;voltage not ok for sync V;SHARC;Extern;;;;;;;SHUTDOWN;SYSTEM;
 Software;MR;Software;Sharc;AutarsysFacade;22;0x01;0;0;0x010016;ERROR_CODES::SW;GENERATOR_CONNECTED_WRONG_PHASE;generator connected wrong phase;SHARC;Extern;;;;;;;SHUTDOWN;SYSTEM;
-Software;MR;Software;Sharc;AutarsysFacade;23;0x01;0;0;0x010017;ERROR_CODES::SW;FRT_FAULT;FRT Error occured;SHARC;Extern;;;;;;;SHUTDOWN;SYSTEM;
+Software;MR;Software;Sharc;AutarsysFacade;23;0x01;0;0;0x010017;ERROR_CODES::SW;FRT_FAULT;FRT Error occurred;SHARC;Extern;;;;;;;SHUTDOWN;SYSTEM;
 Software;MR;Software;Sharc;AutarsysFacade;24;0x01;0;0;0x010018;ERROR_CODES::SW;IDC_OVERCURRENT;DC-Link Overcurrent;Blackfin;HIGH;140;0;;;;;SHUTDOWN;SYSTEM;
 Software;MR;Software;Sharc / Blackfin;Measurements;00;0x03;0;0;0x030000;ERROR_CODES::PQM::CFG;SUMMANDS_OVERFLOW;Summands overflow;SHARC;Extern;;;;;;;SHUTDOWN;SYSTEM;
 Software;MR;Software;Sharc / Blackfin;Measurements;01;0x03;0;0;0x030001;ERROR_CODES::PQM::CFG;CYCLIC_CONFIG;Cyclic current sum configuration;SHARC;Extern;;;;;;;SHUTDOWN;SYSTEM;

--- a/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/ErrorCodeChannelId1.java
+++ b/io.openems.edge.ess.mr.gridcon/src/io/openems/edge/ess/mr/gridcon/enums/ErrorCodeChannelId1.java
@@ -455,7 +455,7 @@ public enum ErrorCodeChannelId1 implements ChannelId {
 			.reactionLevel(ReactionLevel.SHUTDOWN) //
 			.needsHardReset(false) //
 			.code(0x010017) //
-			.text("FRT Error occured")),
+			.text("FRT Error occurred")),
 	STATE_IDC_OVERCURRENT_SOFTWARE_1(new ErrorDoc(Level.WARNING) //
 			.acknowledge(Acknowledge.UNDEFINED) //
 			.reactionLevel(ReactionLevel.SHUTDOWN) //

--- a/io.openems.edge.ess.sinexcel/src/io/openems/edge/ess/sinexcel/EssSinexcel.java
+++ b/io.openems.edge.ess.sinexcel/src/io/openems/edge/ess/sinexcel/EssSinexcel.java
@@ -342,7 +342,7 @@ public interface EssSinexcel extends SymmetricEss, ManagedSymmetricEss, EventHan
 		STATE_70(Doc.of(Level.WARNING) //
 				.text("DC relay short-circuit")), //
 		STATE_71(Doc.of(Level.WARNING) //
-				.text("DC realy short open")), //
+				.text("DC relay short open")), //
 		STATE_72(Doc.of(Level.WARNING) //
 				.text("Battery power over load")), //
 		STATE_73(Doc.of(Level.FAULT) //

--- a/io.openems.edge.ess.sma/src/io/openems/edge/sma/enums/GeneratorStatus.java
+++ b/io.openems.edge.ess.sma/src/io/openems/edge/sma/enums/GeneratorStatus.java
@@ -12,7 +12,7 @@ public enum GeneratorStatus implements OptionsEnum {
 	SYNCHRONIZE(1790, "Synchronize"), //
 	ACTIVATED(1791, "Activated"), //
 	RE_SYNCHRONIZE(1792, "Re-Synchronize"), //
-	GENERATOR_SEPERATION(1793, "Generator Seperation"), //
+	GENERATOR_SEPERATION(1793, "Generator Separation"), //
 	SHUTOFF_DELAY(1794, "Shut-Off Delay"), //
 	BLOCKED(1795, "Blocked"), //
 	BLOCKED_AFTER_ERROR(1796, "Blocked After Error"); //

--- a/io.openems.edge.evcs.keba.kecontact/src/io/openems/edge/evcs/keba/kecontact/ReadHandler.java
+++ b/io.openems.edge.evcs.keba.kecontact/src/io/openems/edge/evcs/keba/kecontact/ReadHandler.java
@@ -17,7 +17,7 @@ import io.openems.edge.evcs.api.Evcs;
 import io.openems.edge.evcs.api.Status;
 
 /**
- * Handles replys to Report Querys sent by {@link ReadWorker}.
+ * Handles replies to Report Queries sent by {@link ReadWorker}.
  */
 public class ReadHandler implements Consumer<String> {
 

--- a/io.openems.edge.evcs.ocpp.abl/src/io/openems/edge/evcs/ocpp/abl/Config.java
+++ b/io.openems.edge.evcs.ocpp.abl/src/io/openems/edge/evcs/ocpp/abl/Config.java
@@ -5,7 +5,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 @ObjectClassDefinition(//
 		name = "EVCS OCPP ABL", //
-		description = "Implements an OCPP capable ABL electric vehicle charging station whithout the smart charging function.")
+		description = "Implements an OCPP capable ABL electric vehicle charging station without the smart charging function.")
 @interface Config {
 
 	@AttributeDefinition(name = "Component-ID", description = "Unique ID of this Component")

--- a/io.openems.edge.evcs.ocpp.ies.keywatt.singleccs/src/io/openems/edge/evcs/ocpp/ies/keywatt/singleccs/Config.java
+++ b/io.openems.edge.evcs.ocpp.ies.keywatt.singleccs/src/io/openems/edge/evcs/ocpp/ies/keywatt/singleccs/Config.java
@@ -5,7 +5,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 @ObjectClassDefinition(//
 		name = "EVCS OCPP Ies KeyWatt", //
-		description = "Implements an OCPP capable Ies KeyWatt electric vehicle charging station whithout the smart charging function.")
+		description = "Implements an OCPP capable Ies KeyWatt electric vehicle charging station without the smart charging function.")
 @interface Config {
 
 	@AttributeDefinition(name = "Component-ID", description = "Unique ID of this Component")

--- a/io.openems.edge.evcs.ocpp.server/src/io/openems/edge/evcs/ocpp/server/CoreEventHandlerImpl.java
+++ b/io.openems.edge.evcs.ocpp.server/src/io/openems/edge/evcs/ocpp/server/CoreEventHandlerImpl.java
@@ -120,7 +120,7 @@ public class CoreEventHandlerImpl implements ServerCoreEventHandler {
 				if (val != null) {
 
 					/*
-					 * Value is formated in RAW data (integer/decimal) or in SignedData (binary data
+					 * Value is formatted in RAW data (integer/decimal) or in SignedData (binary data
 					 * block, encoded as hex data)
 					 */
 					ValueFormat format = value.getFormat();

--- a/io.openems.edge.goodwe.et/src/io/openems/edge/goodwe/et/ess/OperationMode.java
+++ b/io.openems.edge.goodwe.et/src/io/openems/edge/goodwe/et/ess/OperationMode.java
@@ -5,7 +5,7 @@ import io.openems.common.types.OptionsEnum;
 public enum OperationMode implements OptionsEnum {
 	UNDEFINED(-1, "Undefined"), //
 	WAIT(0x01, "cut off all the connection to Inverter"), //
-	ONLINE(0x02, "PV intputs to Inverter,Inverter outputs to Grid"), //
+	ONLINE(0x02, "PV inputs to Inverter,Inverter outputs to Grid"), //
 	BATTERY(0x04, "PV inputs to Inverter(First),Battery inputs to Inverter(Second),Inverter work as AC source"), //
 	FAULT(0x10, "Fault,fault mode,something is in fault mode"); //
 

--- a/io.openems.edge.goodwe.et/src/io/openems/edge/goodwe/et/ess/WorkMode.java
+++ b/io.openems.edge.goodwe.et/src/io/openems/edge/goodwe/et/ess/WorkMode.java
@@ -5,7 +5,7 @@ import io.openems.common.types.OptionsEnum;
 public enum WorkMode implements OptionsEnum {
 	UNDEFINED(-1, "Undefined"), //
 	WAIT(0, "cut off all the connection to Inverter"), //
-	ON_GRID(1, "PV intputs to Inverter,Inverter outputs to Grid"), //
+	ON_GRID(1, "PV inputs to Inverter,Inverter outputs to Grid"), //
 	OFF_GRID(2, "PV inputs to Inverter(First),Battery inputs to Inverter(Second),Inverter work as AC source"), //
 	FAULT(3, "Fault,fault mode,something is in fault mode");
 

--- a/io.openems.edge.meter.socomec/doc/MODBUS tables of DIRIS B30.html
+++ b/io.openems.edge.meter.socomec/doc/MODBUS tables of DIRIS B30.html
@@ -483,7 +483,7 @@
           <td>50066</td>
           <td><text>0x</text>C392</td>
           <td align="center">1</td>
-          <td align="left">Ressource version (Build 2)</td>
+          <td align="left">Resource version (Build 2)</td>
           <td align="center">-</td>
           <td align="center">U16</td>
         </tr>

--- a/io.openems.edge.predictor.persistencemodel/bnd.bnd
+++ b/io.openems.edge.predictor.persistencemodel/bnd.bnd
@@ -3,7 +3,7 @@ Bundle-Vendor: FENECON GmbH
 Bundle-License: https://opensource.org/licenses/EPL-2.0
 Bundle-Version: 1.0.0.${tstamp}
 Bundle-Description: \
-	This Bundle describes the persistant model for predicting values.
+	This Bundle describes the persistent model for predicting values.
 
 -buildpath: \
 	${buildpath},\

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/ess/asymmetric/reacting/Config.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/ess/asymmetric/reacting/Config.java
@@ -22,7 +22,7 @@ import io.openems.edge.common.sum.GridMode;
 	@AttributeDefinition(name = "Datasource-ID", description = "ID of Simulator Datasource.")
 	String datasource_id() default "datasource0";
 
-	@AttributeDefinition(name = "Max Apparant Power [VA]")
+	@AttributeDefinition(name = "Max Apparent Power [VA]")
 	int maxApparentPower() default 10000;
 
 	@AttributeDefinition(name = "Capacity [Wh]")

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/ess/singlephase/reacting/Config.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/ess/singlephase/reacting/Config.java
@@ -26,7 +26,7 @@ import io.openems.edge.ess.api.SinglePhase;
 	@AttributeDefinition(name = "Datasource-ID", description = "ID of Simulator Datasource.")
 	String datasource_id() default "datasource0";
 
-	@AttributeDefinition(name = "Max Apparant Power [VA]")
+	@AttributeDefinition(name = "Max Apparent Power [VA]")
 	int maxApparentPower() default 10000;
 
 	@AttributeDefinition(name = "Capacity [Wh]")

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/ess/symmetric/reacting/Config.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/ess/symmetric/reacting/Config.java
@@ -19,7 +19,7 @@ import io.openems.edge.common.sum.GridMode;
 	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
 	boolean enabled() default true;
 
-	@AttributeDefinition(name = "Max Apparant Power [VA]")
+	@AttributeDefinition(name = "Max Apparent Power [VA]")
 	int maxApparentPower() default 10000;
 
 	@AttributeDefinition(name = "Capacity [Wh]")

--- a/ui/src/app/edge/history/channelthreshold/channelthresholdchartoverview/channelthresholdchartoverview.component.ts
+++ b/ui/src/app/edge/history/channelthreshold/channelthresholdchartoverview/channelthresholdchartoverview.component.ts
@@ -18,7 +18,7 @@ export class ChannelthresholdChartOverviewComponent {
     public showTotal: boolean = null;
     public channelthresholdComponents: string[] = [];
 
-    // referene to the Utils method to access via html
+    // reference to the Utils method to access via html
     public isLastElement = Utils.isLastElement;
 
     constructor(

--- a/ui/src/app/edge/history/consumption/totalchart.component.ts
+++ b/ui/src/app/edge/history/consumption/totalchart.component.ts
@@ -17,7 +17,7 @@ export class ConsumptionTotalChartComponent extends AbstractHistoryChart impleme
     @Input() private period: DefaultTypes.HistoryPeriod;
     @Input() private showPhases: boolean;
 
-    // referene to the Utils method to access via html
+    // reference to the Utils method to access via html
     public isLastElement = Utils.isLastElement;
 
     ngOnChanges() {

--- a/ui/src/app/edge/history/fixdigitaloutput/fixdigitaloutputchartoverview/fixdigitaloutputchartoverview.component.ts
+++ b/ui/src/app/edge/history/fixdigitaloutput/fixdigitaloutputchartoverview/fixdigitaloutputchartoverview.component.ts
@@ -16,7 +16,7 @@ export class FixDigitalOutputChartOverviewComponent {
     public showTotal: boolean = null;
     public fixDigitalOutputComponents: string[] = [];
 
-    // referene to the Utils method to access via html
+    // reference to the Utils method to access via html
     public isLastElement = Utils.isLastElement;
 
     constructor(

--- a/ui/src/app/edge/history/production/productionchartoverview/productionchartoverview.component.ts
+++ b/ui/src/app/edge/history/production/productionchartoverview/productionchartoverview.component.ts
@@ -19,7 +19,7 @@ export class ProductionChartOverviewComponent {
     public showPhases: boolean = false;
     public isOnlyChart: boolean = null;
 
-    // referene to the Utils method to access via html
+    // reference to the Utils method to access via html
     public isLastElement = Utils.isLastElement;
 
     constructor(

--- a/ui/src/app/edge/history/singlethreshold/singlethresholdchartoverview/singlethresholdchartoverview.component.ts
+++ b/ui/src/app/edge/history/singlethreshold/singlethresholdchartoverview/singlethresholdchartoverview.component.ts
@@ -15,7 +15,7 @@ export class SinglethresholdChartOverviewComponent {
     public component: EdgeConfig.Component = null;
     public inputChannel: string;
 
-    // referene to the Utils method to access via html
+    // reference to the Utils method to access via html
     public isLastElement = Utils.isLastElement;
 
     constructor(

--- a/ui/src/app/edge/history/storage/storagechartoverview/storagechartoverview.component.ts
+++ b/ui/src/app/edge/history/storage/storagechartoverview/storagechartoverview.component.ts
@@ -19,7 +19,7 @@ export class StorageChartOverviewComponent {
     public showTotal: boolean = null;
     public isOnlyChart = null;
 
-    // referene to the Utils method to access via html
+    // reference to the Utils method to access via html
     public isLastElement = Utils.isLastElement;
 
     constructor(

--- a/ui/src/app/edge/live/energymonitor/chart/section/abstractsection.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/abstractsection.component.ts
@@ -228,7 +228,7 @@ export abstract class AbstractSection {
      * This method is called on every change of values.
      * 
      * @param valueAbsolute the absolute value of the Section
-     * @param valueRatio    the relative value of the Secion in [-1,1]
+     * @param valueRatio    the relative value of the Section in [-1,1]
      * @param sumRatio      the relative value of the Section compared to the total System.InPower/OutPower [0,1]
      */
     protected updateSectionData(valueAbsolute: number, valueRatio: number, sumRatio: number) {

--- a/ui/src/app/edge/live/evcs/modal/modal.page.ts
+++ b/ui/src/app/edge/live/evcs/modal/modal.page.ts
@@ -223,7 +223,7 @@ export class EvcsModalComponent implements OnInit {
   }
 
   /**
-  * uptdate the state of the toggle whitch renders the minimum charge power
+  * update the state of the toggle which renders the minimum charge power
   * 
   * @param event 
   */
@@ -277,7 +277,7 @@ export class EvcsModalComponent implements OnInit {
   }
 
   /**
-   * uptdate the state of the toggle whitch renders the minimum charge power
+   * update the state of the toggle which renders the minimum charge power
    * 
    * @param event 
    * @param phases 

--- a/ui/src/app/edge/live/evcsCluster/modal/evcsCluster-modal.page.ts
+++ b/ui/src/app/edge/live/evcsCluster/modal/evcsCluster-modal.page.ts
@@ -199,7 +199,7 @@ export class ModalComponentEvcsCluster implements OnInit {
     }
 
     /**
-     * uptdate the state of the toggle whitch renders the minimum charge power
+     * update the state of the toggle which renders the minimum charge power
      * 
      * @param event 
      * @param phases 

--- a/ui/src/app/edge/live/production/modal/modal.component.ts
+++ b/ui/src/app/edge/live/production/modal/modal.component.ts
@@ -9,7 +9,7 @@ import { ModalController } from '@ionic/angular';
 export class ProductionModalComponent {
 
 
-    // referene to the Utils method to access via html
+    // reference to the Utils method to access via html
     public isLastElement = Utils.isLastElement;
 
     @Input() public edge: Edge;

--- a/ui/src/app/edge/live/storage/modal/modal.component.ts
+++ b/ui/src/app/edge/live/storage/modal/modal.component.ts
@@ -15,7 +15,7 @@ export class StorageModalComponent {
     @Input() essComponents: EdgeConfig.Component[];
     @Input() chargerComponents: EdgeConfig.Component[];
 
-    // referene to the Utils method to access via html
+    // reference to the Utils method to access via html
     public isLastElement = Utils.isLastElement;
 
     public outputChannel: ChannelAddress[] = null;

--- a/ui/src/app/shared/service/wsdata.ts
+++ b/ui/src/app/shared/service/wsdata.ts
@@ -81,7 +81,7 @@ export class WsData {
         // TODO use OpenemsError code
         promise.reject(
           new JsonrpcResponseError(response.id, {
-            code: 0, message: "Reponse is neither JsonrpcResponseSuccess nor JsonrpcResponseError: " + response, data: {}
+            code: 0, message: "Response is neither JsonrpcResponseSuccess nor JsonrpcResponseError: " + response, data: {}
           }));
       }
     } else {

--- a/ui/src/global.scss
+++ b/ui/src/global.scss
@@ -77,7 +77,7 @@ button.activated {
     font-family: Roboto, "Helvetica Neue", sans-serif;
 }
 
-// 360px is aproximate min. width of mobile devices
+// 360px is approximate min. width of mobile devices
 ion-toast.container {
     text-align: center;
     --min-width: 360px;

--- a/ui/src/theme/variables.scss
+++ b/ui/src/theme/variables.scss
@@ -13,7 +13,7 @@
     justify-content: center;
   }
 
-  // CSS class is here because ion-label is inside ion-item tag, CSS within ion-item doesnt work with global.scss
+  // CSS class is here because ion-label is inside ion-item tag, CSS within ion-item doesn't work with global.scss
   // this class is used to get the same style like in a html table
   ion-label.regularFont {
     font-family: Roboto, Helvetica Neue, sans-serif;


### PR DESCRIPTION
Found via `codespell v2.0.dev`  
`codespell -q 3 -S *.po,*.pot,./.git -L addess,therefor`