### PR TITLE
Avoid resolve errors in EdgeApp and BackendApp.bndrun

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
        - openjdk8
       script:
        - ./gradlew build
+       - ./gradlew resolve.BackendApp
+       - git diff --exit-code io.openems.backend.application/BackendApp.bndrun
+       - ./gradlew resolve.EdgeApp
+       - git diff --exit-code io.openems.edge.application/EdgeApp.bndrun
        - ./gradlew buildAggregatedJavadocs --continue
        - ./gradlew buildAntoraDocs --continue
       deploy:

--- a/io.openems.backend.application/BackendApp.bndrun
+++ b/io.openems.backend.application/BackendApp.bndrun
@@ -72,7 +72,7 @@
 	org.apache.servicemix.bundles.ws-commons-util;version='[1.0.2,1.0.3)',\
 	org.apache.servicemix.bundles.xmlrpc-client;version='[3.1.3,3.1.4)',\
 	org.jsr-305;version='[3.0.2,3.0.3)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.5,2.0.6)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.6,2.0.7)',\
 	org.ops4j.pax.logging.pax-logging-log4j1;version='[2.0.6,2.0.7)',\
 	org.osgi.service.jdbc;version='[1.0.0,1.0.1)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\

--- a/tools/prepare-commit.sh
+++ b/tools/prepare-commit.sh
@@ -119,12 +119,9 @@ for D in io.openems.edge.*; do
 done
 runbundles=$(grep -n '\-runbundles:' $bndrun | grep -Eo '^[^:]+' | head -n1)
 tail -n +$(expr $runbundles - 1) "$bndrun" >> "$bndrun.new"
-diff "$bndrun" "$bndrun.new"
-if [ $? -ne 0 ]; then
-	echo "EdgeApp.bndrun changed! Run ./gradlew resolve.EdgeApp"
-	head -n $(grep -n '\-runbundles:' "$bndrun.new" | grep -Eo '^[^:]+' | head -n1) "$bndrun.new" > "$bndrun"
-fi
+head -n $(grep -n '\-runbundles:' "$bndrun.new" | grep -Eo '^[^:]+' | head -n1) "$bndrun.new" > "$bndrun"
 rm "$bndrun.new"
+./gradlew resolve.EdgeApp
 
 # Update BackendApp.bndrun
 bndrun='io.openems.backend.application/BackendApp.bndrun'
@@ -144,10 +141,7 @@ for D in io.openems.backend.*; do
 done
 runbundles=$(grep -n '\-runbundles:' $bndrun | grep -Eo '^[^:]+' | head -n1)
 tail -n +$(expr $runbundles - 1) "$bndrun" >> "$bndrun.new"
-diff "$bndrun" "$bndrun.new"
-if [ $? -ne 0 ]; then
-	echo "BackendApp.bndrun changed! Run ./gradlew resolve.BackendApp"
-	head -n $(grep -n '\-runbundles:' "$bndrun.new" | grep -Eo '^[^:]+' | head -n1) "$bndrun.new" > "$bndrun"
-fi
+head -n $(grep -n '\-runbundles:' "$bndrun.new" | grep -Eo '^[^:]+' | head -n1) "$bndrun.new" > "$bndrun"
 rm "$bndrun.new"
+./gradlew resolve.BackendApp
 


### PR DESCRIPTION
- Let Travis fail if resolving changes the existing bndrun files
- Always update EdgeApp + BackendApp bndrun files in prepare-commit script 
- Fix existing resolve error in BackendApp.bndrun 
