### PR TITLE
UI: Add HeatPump History Widget

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -28,6 +28,7 @@ import { StorageChartOverviewComponent } from './edge/history/storage/storagecha
 import { SymmetricPeakshavingChartOverviewComponent } from './edge/history/peakshaving/symmetric/symmetricpeakshavingchartoverview/symmetricpeakshavingchartoverview.component';
 import { SystemExecuteComponent as EdgeSettingsSystemExecuteComponent } from './edge/settings/systemexecute/systemexecute.component';
 import { SystemLogComponent as EdgeSettingsSystemLogComponent } from './edge/settings/systemlog/systemlog.component';
+import { HeatPumptChartOverviewComponent } from './edge/history/heatpump/autarchychartoverview/heatpumpchartoverview.component';
 
 
 const routes: Routes = [
@@ -46,6 +47,7 @@ const routes: Routes = [
   { path: 'device/:edgeId/history/:componentId/channelthresholdchart', component: ChannelthresholdChartOverviewComponent },
   { path: 'device/:edgeId/history/:componentId/fixdigitaloutputchart', component: FixDigitalOutputChartOverviewComponent },
   { path: 'device/:edgeId/history/:componentId/heatingelementchart', component: HeatingelementChartOverviewComponent },
+  { path: 'device/:edgeId/history/:componentId/heatpumpchart', component: HeatPumptChartOverviewComponent },
   { path: 'device/:edgeId/history/:componentId/singlethresholdchart', component: SinglethresholdChartOverviewComponent },
   { path: 'device/:edgeId/history/:componentId/symmetricpeakshavingchart', component: SymmetricPeakshavingChartOverviewComponent },
   { path: 'device/:edgeId/history/autarchychart', component: AutarchyChartOverviewComponent },

--- a/ui/src/app/edge/history/heatpump/autarchychartoverview/heatpumpchartoverview.component.html
+++ b/ui/src/app/edge/history/heatpump/autarchychartoverview/heatpumpchartoverview.component.html
@@ -1,0 +1,28 @@
+<ng-container *ngIf="edge">
+    <ion-header>
+        <ion-toolbar color="primary">
+            <ion-title translate>General.autarchy</ion-title>
+            <ion-buttons slot="end">
+                <ion-button routerLink="/device/{{edge.id}}/history">
+                    <ion-icon name="close-outline"></ion-icon>
+                </ion-button>
+            </ion-buttons>
+        </ion-toolbar>
+        <ion-toolbar color="primary">
+            <ion-buttons class="ion-justify-content-center">
+                <pickdate></pickdate>
+            </ion-buttons>
+        </ion-toolbar>
+    </ion-header>
+    <ion-content>
+        <ion-card-content>
+            <table class="full_width">
+                <tr>
+                    <td style="width: 100%" class="ion-padding"></td>
+                </tr>
+            </table>
+            <autarchychart [period]="service.historyPeriod">
+            </autarchychart>
+        </ion-card-content>
+    </ion-content>
+</ng-container>

--- a/ui/src/app/edge/history/heatpump/autarchychartoverview/heatpumpchartoverview.component.ts
+++ b/ui/src/app/edge/history/heatpump/autarchychartoverview/heatpumpchartoverview.component.ts
@@ -1,0 +1,27 @@
+import { ActivatedRoute } from '@angular/router';
+import { Component } from '@angular/core';
+import { ModalController } from '@ionic/angular';
+import { Service, Edge } from '../../../../shared/shared';
+
+@Component({
+    selector: HeatPumptChartOverviewComponent.SELECTOR,
+    templateUrl: './heatpumpchartoverview.component.html'
+})
+export class HeatPumptChartOverviewComponent {
+
+    private static readonly SELECTOR = "heatpumpt-chart-overview";
+
+    public edge: Edge = null;
+
+    constructor(
+        public service: Service,
+        public modalCtrl: ModalController,
+        private route: ActivatedRoute,
+    ) { }
+
+    ngOnInit() {
+        this.service.setCurrentComponent('', this.route).then(edge => {
+            this.edge = edge;
+        });
+    }
+}

--- a/ui/src/app/edge/history/heatpump/chart.component.ts
+++ b/ui/src/app/edge/history/heatpump/chart.component.ts
@@ -1,0 +1,146 @@
+import { AbstractHistoryChart } from '../abstracthistorychart';
+import { ActivatedRoute } from '@angular/router';
+import { ChannelAddress, Service, Utils } from '../../../shared/shared';
+import { ChartOptions, Data, DEFAULT_TIME_CHART_OPTIONS, TooltipItem } from './../shared';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { CurrentData } from 'src/app/shared/edge/currentdata';
+import { DefaultTypes } from 'src/app/shared/service/defaulttypes';
+import { formatNumber } from '@angular/common';
+import { TranslateService } from '@ngx-translate/core';
+
+@Component({
+    selector: 'heatpumpchart',
+    templateUrl: '../abstracthistorychart.html'
+})
+export class HeatPumptChartComponent extends AbstractHistoryChart implements OnInit, OnChanges {
+
+    @Input() private period: DefaultTypes.HistoryPeriod;
+
+    ngOnChanges() {
+        this.updateChart();
+    };
+
+    constructor(
+        protected service: Service,
+        protected translate: TranslateService,
+        private route: ActivatedRoute,
+    ) {
+        super(service, translate);
+    }
+
+
+    ngOnInit() {
+        this.spinnerId = "autarchy-chart";
+        this.service.startSpinner(this.spinnerId);
+        this.service.setCurrentComponent('', this.route);
+    }
+
+    ngOnDestroy() {
+        this.unsubscribeChartRefresh()
+    }
+
+    protected updateChart() {
+        this.autoSubscribeChartRefresh();
+        this.service.startSpinner(this.spinnerId);
+        this.loading = true;
+        this.colors = [];
+        this.queryHistoricTimeseriesData(this.period.from, this.period.to).then(response => {
+            let result = response.result;
+            // convert labels
+            let labels: Date[] = [];
+            for (let timestamp of result.timestamps) {
+                labels.push(new Date(timestamp));
+            }
+            this.labels = labels;
+
+            // convert datasets
+            let datasets = [];
+
+            // required data for autarchy
+            let buyFromGridData: number[] = [];
+            let consumptionData: number[] = [];
+
+            if ('_sum/ConsumptionActivePower' in result.data) {
+                /*
+                 * Consumption
+                 */
+                consumptionData = result.data['_sum/ConsumptionActivePower'].map(value => {
+                    if (value == null) {
+                        return null
+                    } else {
+                        return value;
+                    }
+                });
+            }
+
+            if ('_sum/GridActivePower' in result.data) {
+                /*
+                 * Buy From Grid
+                 */
+                buyFromGridData = result.data['_sum/GridActivePower'].map(value => {
+                    if (value == null) {
+                        return null
+                    } else if (value > 0) {
+                        return value;
+                    } else {
+                        return 0;
+                    }
+                })
+            };
+
+            /*
+            * Autarchy
+            */
+            let autarchy = consumptionData.map((value, index) => {
+                if (value == null) {
+                    return null
+                } else {
+                    return CurrentData.calculateAutarchy(buyFromGridData[index], value);
+                }
+            })
+
+            datasets.push({
+                label: this.translate.instant('General.autarchy'),
+                data: autarchy,
+                hidden: false
+            })
+            this.colors.push({
+                backgroundColor: 'rgba(0,152,204,0.05)',
+                borderColor: 'rgba(0,152,204,1)'
+            })
+            this.datasets = datasets;
+            this.loading = false;
+            this.service.stopSpinner(this.spinnerId);
+        }).catch(reason => {
+            console.error(reason); // TODO error message
+            this.initializeChart();
+            return;
+        });
+    }
+
+    protected getChannelAddresses(): Promise<ChannelAddress[]> {
+        return new Promise((resolve) => {
+            let result: ChannelAddress[] = [
+                new ChannelAddress('_sum', 'GridActivePower'),
+                new ChannelAddress('_sum', 'ConsumptionActivePower')
+            ];
+            resolve(result);
+        })
+    }
+
+    protected setLabel() {
+        let options = <ChartOptions>Utils.deepCopy(DEFAULT_TIME_CHART_OPTIONS);
+        options.scales.yAxes[0].scaleLabel.labelString = this.translate.instant('General.percentage');
+        options.tooltips.callbacks.label = function (tooltipItem: TooltipItem, data: Data) {
+            let label = data.datasets[tooltipItem.datasetIndex].label;
+            let value = tooltipItem.yLabel;
+            return label + ": " + formatNumber(value, 'de', '1.0-0') + " %"; // TODO get locale dynamically
+        }
+        options.scales.yAxes[0].ticks.max = 100;
+        this.options = options;
+    }
+
+    public getChartHeight(): number {
+        return window.innerHeight / 1.3;
+    }
+}

--- a/ui/src/app/edge/history/heatpump/widget.component.html
+++ b/ui/src/app/edge/history/heatpump/widget.component.html
@@ -1,0 +1,50 @@
+<ion-card button routerLink="/device/{{edge.id}}/history/{{componentId}}/heatpumpchart" *ngIf="component && edge">
+    <ion-item lines="full" color="light">
+        <ion-icon slot="start" color="danger" name="flame"></ion-icon>
+        <ion-label>{{ component.alias }}</ion-label>
+    </ion-item>
+    <ng-container *ngIf="component && service.currentEdge | async as edge">
+        <ng-container *ngIf="edge.currentData | async as currentData">
+            <ion-card-content>
+                <table class="full_width">
+                    <tr *ngIf="activeTimeOverPeriodForceOn != null">
+                        <td style="width:65%">Einschaltdauer Normal</td>
+                        <td style="width:35%" class="align_right" *ngIf="activeTimeOverPeriodForceOn / 60 > 59">
+                            {{ activeTimeOverPeriodForceOn * 1000 | date:'H:mm':'UTC' }}&nbsp;h
+                        </td>
+                        <td style="width:35%" class="align_right" *ngIf="activeTimeOverPeriodForceOn / 60 < 59">
+                            {{ activeTimeOverPeriodForceOn * 1000 | date:'m':'UTC' }}&nbsp;m
+                        </td>
+                    <tr>
+                    <tr *ngIf="activeTimeOverPeriodForceOn != null">
+                        <td style="width:65%">Einschaltdauer Einschaltempfehlung</td>
+                        <td style="width:35%" class="align_right" *ngIf="activeTimeOverPeriodRegular / 60 > 59">
+                            {{ activeTimeOverPeriodRegular * 1000 | date:'H:mm':'UTC'}}&nbsp;h
+                        </td>
+                        <td style="width:35%" class="align_right" *ngIf="activeTimeOverPeriodRegular / 60 <= 59">
+                            {{ activeTimeOverPeriodRegular / 60 | date: 'm' }}&nbsp;m
+                        </td>
+                    <tr>
+                    <tr *ngIf="activeTimeOverPeriodForceOn != null">
+                        <td style="width:65%">Einschaltdauer Einschaltbefehl</td>
+                        <td style="width:35%" class="align_right" *ngIf="activeTimeOverPeriodRecommendation / 60 > 59">
+                            {{ activeTimeOverPeriodRecommendation * 1000 | date:'H:mm':'UTC' }}&nbsp;h
+                        </td>
+                        <td style="width:35%" class="align_right" *ngIf="activeTimeOverPeriodForceOn / 60 < 59">
+                            {{ activeTimeOverPeriodRecommendation * 1000 | date:'m':'UTC' }}&nbsp;m
+                        </td>
+                    <tr>
+                    <tr *ngIf="activeTimeOverPeriodForceOn != null">
+                        <td style="width:65%">Einschaltdauer Sperre</td>
+                        <td style="width:35%" class="align_right" *ngIf="activeTimeOverPeriodLock / 60 > 59">
+                            {{ activeTimeOverPeriodLock * 1000 | date:'H:mm':'UTC' }}&nbsp;h
+                        </td>
+                        <td style="width:35%" class="align_right" *ngIf="activeTimeOverPeriodLock / 60 < 59">
+                            {{ activeTimeOverPeriodLock * 1000 | date:'m':'UTC' }}&nbsp;m
+                        </td>
+                    <tr>
+                </table>
+            </ion-card-content>
+        </ng-container>
+    </ng-container>
+</ion-card>

--- a/ui/src/app/edge/history/heatpump/widget.component.ts
+++ b/ui/src/app/edge/history/heatpump/widget.component.ts
@@ -1,0 +1,88 @@
+import { AbstractHistoryWidget } from '../abstracthistorywidget';
+import { ActivatedRoute } from '@angular/router';
+import { calculateActiveTimeOverPeriod } from '../shared';
+import { ChannelAddress, Edge, Service, EdgeConfig } from '../../../shared/shared';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { DefaultTypes } from 'src/app/shared/service/defaulttypes';
+import { ModalController } from '@ionic/angular';
+
+@Component({
+    selector: HeatpumptWidgetComponent.SELECTOR,
+    templateUrl: './widget.component.html'
+})
+export class HeatpumptWidgetComponent extends AbstractHistoryWidget implements OnInit, OnChanges {
+
+    @Input() public period: DefaultTypes.HistoryPeriod;
+    @Input() public componentId: string;
+
+    private static readonly SELECTOR = "heatpumpWidget";
+
+    public component: EdgeConfig.Component | null = null;
+
+    public activeTimeOverPeriodForceOn: number | null = null
+    public activeTimeOverPeriodRegular: number | null = null
+    public activeTimeOverPeriodRecommendation: number | null = null
+    public activeTimeOverPeriodLock: number | null = null
+
+    public edge: Edge = null;
+
+    constructor(
+        public service: Service,
+        private route: ActivatedRoute,
+        public modalCtrl: ModalController,
+    ) {
+        super(service);
+    }
+
+    ngOnInit() {
+        this.service.setCurrentComponent('', this.route).then(edge => {
+            this.edge = edge;
+            this.service.getConfig().then(config => {
+                this.component = config.getComponent(this.componentId);
+            });
+        });
+    }
+
+    ngOnDestroy() {
+        this.unsubscribeWidgetRefresh();
+    }
+
+    ngOnChanges() {
+        this.updateValues();
+    };
+
+    protected updateValues() {
+        this.service.getConfig().then(config => {
+            this.getChannelAddresses(this.edge, config).then(channels => {
+                this.service.queryEnergy(this.period.from, this.period.to, channels).then(response => {
+                    let result = response.result;
+                    if (this.componentId + '/ForceOnStateTime' in result.data) {
+                        this.activeTimeOverPeriodForceOn = result.data[this.componentId + '/ForceOnStateTime'];
+                    }
+                    if (this.componentId + '/RegularStateTime' in result.data) {
+                        this.activeTimeOverPeriodRegular = result.data[this.componentId + '/RegularStateTime'];
+                    }
+                    if (this.componentId + '/RecommendationStateTime' in result.data) {
+                        this.activeTimeOverPeriodRecommendation = result.data[this.componentId + '/RecommendationStateTime'];
+                    }
+                    if (this.componentId + '/LockStateTime' in result.data) {
+                        this.activeTimeOverPeriodLock = result.data[this.componentId + '/LockStateTime'];
+                    }
+                })
+            });
+        })
+    }
+
+    protected getChannelAddresses(edge: Edge, config: EdgeConfig): Promise<ChannelAddress[]> {
+        return new Promise((resolve) => {
+            let channels: ChannelAddress[] = [
+                new ChannelAddress(this.componentId, 'ForceOnStateTime'),
+                new ChannelAddress(this.componentId, 'RegularStateTime'),
+                new ChannelAddress(this.componentId, 'RecommendationStateTime'),
+                new ChannelAddress(this.componentId, 'LockStateTime'),
+            ];
+            resolve(channels);
+        });
+    }
+}
+

--- a/ui/src/app/edge/history/history.component.html
+++ b/ui/src/app/edge/history/history.component.html
@@ -52,6 +52,10 @@
           <heatingelementWidget [componentId]="widget.componentId" [period]="service.historyPeriod">
           </heatingelementWidget>
         </ion-col>
+        <ion-col size="12" size-md="6" size-lg="4" size-xl="3" *ngSwitchCase="'Controller.Io.HeatPump.SgReady'">
+          <heatpumpWidget [componentId]="widget.componentId" [period]="service.historyPeriod">
+          </heatpumpWidget>
+        </ion-col>
         <ion-col size="12" size-md="6" size-lg="4" size-xl="3" *ngSwitchCase="'Controller.CHP.SoC'">
           <chpsocWidget [componentId]="widget.componentId" [period]="service.historyPeriod">
           </chpsocWidget>

--- a/ui/src/app/edge/history/history.module.ts
+++ b/ui/src/app/edge/history/history.module.ts
@@ -29,6 +29,9 @@ import { GridComponent } from './grid/widget.component';
 import { HeatingelementChartComponent } from './heatingelement/chart.component';
 import { HeatingelementChartOverviewComponent } from './heatingelement/heatingelementchartoverview/heatingelementchartoverview.component';
 import { HeatingelementWidgetComponent } from './heatingelement/widget.component';
+import { HeatPumptChartComponent } from './heatpump/chart.component';
+import { HeatPumptChartOverviewComponent } from './heatpump/autarchychartoverview/heatpumpchartoverview.component';
+import { HeatpumptWidgetComponent } from './heatpump/widget.component';
 import { HistoryComponent } from './history.component';
 import { NgModule } from '@angular/core';
 import { ProductionChargerChartComponent } from './production/chargerchart.component';
@@ -96,6 +99,9 @@ import { SymmetricPeakshavingWidgetComponent } from './peakshaving/symmetric/wid
     HeatingelementChartComponent,
     HeatingelementChartOverviewComponent,
     HeatingelementWidgetComponent,
+    HeatPumptChartComponent,
+    HeatPumptChartOverviewComponent,
+    HeatpumptWidgetComponent,
     HistoryComponent,
     ProductionChargerChartComponent,
     ProductionChartOverviewComponent,


### PR DESCRIPTION
Add History Heatpump Widget:
![grafik](https://user-images.githubusercontent.com/37406473/100111351-4bec7500-2e6e-11eb-8cc5-4a186efb7a9b.png)
![grafik](https://user-images.githubusercontent.com/37406473/100111377-53ac1980-2e6e-11eb-97ea-4e071584d90e.png)

Other:
* https://github.com/OpenEMS/openems/issues/1310 fix
* seperated consumption for history consumption widget


