### PR TITLE
Improvements to ComponentManager workers

### DIFF
--- a/io.openems.common/src/io/openems/common/types/EdgeConfig.java
+++ b/io.openems.common/src/io/openems/common/types/EdgeConfig.java
@@ -1050,9 +1050,6 @@ public class EdgeConfig {
 	 * @return true if it should get ignored
 	 */
 	public static boolean ignorePropertyKey(String key) {
-		if (key.endsWith(".target")) {
-			return true;
-		}
 		switch (key) {
 		case OpenemsConstants.PROPERTY_COMPONENT_ID:
 		case OpenemsConstants.PROPERTY_OSGI_COMPONENT_ID:

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
@@ -170,6 +170,10 @@ public class DefaultConfigurationWorker extends ComponentManagerWorker {
 	protected void createConfiguration(AtomicBoolean defaultConfigurationFailed, String factoryPid,
 			List<Property> properties) {
 		try {
+			this.parent.logInfo(this.log,
+					"Creating Component configuration [" + factoryPid + "]: " + properties.stream() //
+							.map(p -> p.getName() + ":" + p.getValue().toString()) //
+							.collect(Collectors.joining(", ")));
 			CompletableFuture<JsonrpcResponseSuccess> response = this.parent.handleCreateComponentConfigRequest(
 					null /* no user */, new CreateComponentConfigRequest(factoryPid, properties));
 			response.get(60, TimeUnit.SECONDS);
@@ -193,6 +197,11 @@ public class DefaultConfigurationWorker extends ComponentManagerWorker {
 	protected void updateConfiguration(AtomicBoolean defaultConfigurationFailed, String componentId,
 			List<Property> properties) {
 		try {
+			this.parent.logInfo(this.log,
+					"Updating Component configuration [" + componentId + "]: " + properties.stream() //
+							.map(p -> p.getName() + ":" + p.getValue().toString()) //
+							.collect(Collectors.joining(", ")));
+
 			CompletableFuture<JsonrpcResponseSuccess> response = this.parent.handleUpdateComponentConfigRequest(
 					null /* no user */, new UpdateComponentConfigRequest(componentId, properties));
 			response.get(60, TimeUnit.SECONDS);
@@ -214,6 +223,8 @@ public class DefaultConfigurationWorker extends ComponentManagerWorker {
 	 */
 	protected void deleteConfiguration(AtomicBoolean defaultConfigurationFailed, String componentId) {
 		try {
+			this.parent.logInfo(this.log, "Deleting Component [" + componentId + "]");
+
 			CompletableFuture<JsonrpcResponseSuccess> response = this.parent.handleDeleteComponentConfigRequest(
 					null /* no user */, new DeleteComponentConfigRequest(componentId));
 			response.get(60, TimeUnit.SECONDS);

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/OsgiValidateWorker.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/OsgiValidateWorker.java
@@ -75,9 +75,12 @@ public class OsgiValidateWorker extends ComponentManagerWorker {
 
 	@Override
 	protected void forever() {
-		final Configuration[] configs = this.readEnabledConfigurations();
+		this.findDuplicatedComponentIds();
+		this.findDefectiveComponents();
+	}
 
-		// Handle duplicated Component-IDs
+	private void findDuplicatedComponentIds() {
+		final Configuration[] configs = this.readAllConfigurations();
 		final Set<String> duplicatedComponentIds = new HashSet<String>();
 		updateDuplicatedComponentIds(duplicatedComponentIds, configs);
 		this.parent._setDuplicatedComponentId(!this.duplicatedComponentIds.isEmpty());
@@ -85,8 +88,10 @@ public class OsgiValidateWorker extends ComponentManagerWorker {
 			this.duplicatedComponentIds.clear();
 			this.duplicatedComponentIds.addAll(duplicatedComponentIds);
 		}
+	}
 
-		// Handle defective Components
+	private void findDefectiveComponents() {
+		final Configuration[] configs = this.readEnabledConfigurations();
 		final Map<String, String> defectiveComponents = new HashMap<>();
 		updateInactiveComponentsUsingScr(defectiveComponents, this.parent.serviceComponentRuntime);
 		updateInactiveComponentsUsingConfigurationAdmin(defectiveComponents, this.parent.getEnabledComponents(),
@@ -175,6 +180,29 @@ public class OsgiValidateWorker extends ComponentManagerWorker {
 					defectiveComponents.putIfAbsent(componentId, "Missing Bundle");
 				}
 			}
+		}
+	}
+
+	/**
+	 * Read all configurations from ConfigurationAdmin - no matter if enabled or
+	 * not.
+	 * 
+	 * @return {@link Configuration}s from {@link ConfigurationAdmin}; empty array
+	 *         on error
+	 */
+	private Configuration[] readAllConfigurations() {
+		try {
+			ConfigurationAdmin cm = this.parent.cm;
+			Configuration[] configs = cm.listConfigurations(null);
+			if (configs != null) {
+				return configs;
+			} else {
+				return new Configuration[0];
+			}
+		} catch (Exception e) {
+			this.parent.logError(this.log, e.getMessage());
+			e.printStackTrace();
+			return new Configuration[0];
 		}
 	}
 


### PR DESCRIPTION
- DefaultConfigurationWorker: add logging on action
- OsgiValidateWorker: search for duplicated Component-IDs in all configurations, not only enabled ones
- EdgeConfig: allow setting ".target" properties