### PR TITLE
Scheduler: improve handling of errors

### DIFF
--- a/io.openems.edge.scheduler.allalphabetically/src/io/openems/edge/scheduler/allalphabetically/AllAlphabeticallySchedulerImpl.java
+++ b/io.openems.edge.scheduler.allalphabetically/src/io/openems/edge/scheduler/allalphabetically/AllAlphabeticallySchedulerImpl.java
@@ -10,7 +10,6 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.metatype.annotations.Designate;
 
-import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
 import io.openems.edge.common.component.ComponentManager;
 import io.openems.edge.common.component.OpenemsComponent;
@@ -54,23 +53,22 @@ public class AllAlphabeticallySchedulerImpl extends AbstractOpenemsComponent
 	}
 
 	@Override
-	public LinkedHashSet<Controller> getControllers() throws OpenemsNamedException {
-		LinkedHashSet<Controller> result = new LinkedHashSet<>();
+	public LinkedHashSet<String> getControllers() {
+		LinkedHashSet<String> result = new LinkedHashSet<>();
 
 		// add sorted controllers
 		for (String id : this.config.controllers_ids()) {
 			if (id.equals("")) {
 				continue;
 			}
-			Controller controller = this.componentManager.getPossiblyDisabledComponent(id);
-			result.add(controller);
+			result.add(id);
 		}
 
 		// add remaining controllers
 		this.componentManager.getEnabledComponents().stream() //
 				.filter(c -> c instanceof Controller) //
 				.sorted((c1, c2) -> c1.id().compareTo(c2.id())) //
-				.forEach(c -> result.add((Controller) c));
+				.forEach(c -> result.add(c.id()));
 
 		return result;
 	}

--- a/io.openems.edge.scheduler.allalphabetically/test/io/openems/edge/scheduler/allalphabetically/AllAlphabeticallyTest.java
+++ b/io.openems.edge.scheduler.allalphabetically/test/io/openems/edge/scheduler/allalphabetically/AllAlphabeticallyTest.java
@@ -48,7 +48,6 @@ public class AllAlphabeticallyTest {
 
 	private static List<String> getControllerIds(Scheduler scheduler) throws OpenemsNamedException {
 		return scheduler.getControllers().stream() //
-				.map(c -> c.id()) //
 				.collect(Collectors.toList());
 	}
 }

--- a/io.openems.edge.scheduler.api/src/io/openems/edge/scheduler/api/Scheduler.java
+++ b/io.openems.edge.scheduler.api/src/io/openems/edge/scheduler/api/Scheduler.java
@@ -10,13 +10,13 @@ import io.openems.edge.common.channel.Doc;
 import io.openems.edge.common.channel.StateChannel;
 import io.openems.edge.common.channel.value.Value;
 import io.openems.edge.common.component.OpenemsComponent;
-import io.openems.edge.controller.api.Controller;
 
 @ProviderType
 public interface Scheduler extends OpenemsComponent {
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
-		RUN_FAILED(Doc.of(Level.FAULT).text("Running the Scheduler failed"));
+		CONTROLLER_IS_MISSING(Doc.of(Level.INFO) //
+				.text("A configured Controller is missing"));
 
 		private final Doc doc;
 
@@ -31,43 +31,44 @@ public interface Scheduler extends OpenemsComponent {
 	}
 
 	/**
-	 * Gets the Channel for {@link ChannelId#RUN_FAILED}.
+	 * Gets the Channel for {@link ChannelId#CONTROLLER_IS_MISSING}.
 	 * 
 	 * @return the Channel
 	 */
-	public default StateChannel getRunFailedChannel() {
-		return this.channel(ChannelId.RUN_FAILED);
+	public default StateChannel getControllerIsMissingChannel() {
+		return this.channel(ChannelId.CONTROLLER_IS_MISSING);
 	}
 
 	/**
-	 * Gets the Run-Failed State. See {@link ChannelId#RUN_FAILED}.
+	 * Gets the Run-Failed State. See {@link ChannelId#CONTROLLER_IS_MISSING}.
 	 * 
 	 * @return the Channel {@link Value}
 	 */
-	public default Value<Boolean> getRunFailed() {
-		return this.getRunFailedChannel().value();
+	public default Value<Boolean> getControllerIsMissing() {
+		return this.getControllerIsMissingChannel().value();
 	}
 
 	/**
-	 * Internal method to set the 'nextValue' on {@link ChannelId#RUN_FAILED}
-	 * Channel.
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#CONTROLLER_IS_MISSING} Channel.
 	 * 
 	 * @param value the next value
 	 */
-	public default void _setRunFailed(boolean value) {
-		this.getRunFailedChannel().setNextValue(value);
+	public default void _setControllerIsMissing(boolean value) {
+		this.getControllerIsMissingChannel().setNextValue(value);
 	}
 
 	/**
-	 * Returns Controllers ordered by their current execution priority.
+	 * Returns Component-IDs of Controllers ordered by their current execution
+	 * priority.
 	 * 
 	 * <p>
 	 * This method is called once every Cycle, i.e. once per second. The
 	 * {@link LinkedHashSet} is used, as it preserves insertion order
 	 * 
-	 * @return a ordered set of Controllers
+	 * @return a ordered set of Component-IDs of Controllers
 	 * @throws OpenemsNamedException on error
 	 */
-	public LinkedHashSet<Controller> getControllers() throws OpenemsNamedException;
+	public LinkedHashSet<String> getControllers();
 
 }

--- a/io.openems.edge.scheduler.daily/test/io/openems/edge/scheduler/daily/DailySchedulerImplTest.java
+++ b/io.openems.edge.scheduler.daily/test/io/openems/edge/scheduler/daily/DailySchedulerImplTest.java
@@ -80,7 +80,6 @@ public class DailySchedulerImplTest {
 
 	private static List<String> getControllerIds(Scheduler scheduler) throws OpenemsNamedException {
 		return scheduler.getControllers().stream() //
-				.map(c -> c.id()) //
 				.collect(Collectors.toList());
 	}
 

--- a/io.openems.edge.scheduler.fixedorder/src/io/openems/edge/scheduler/fixedorder/FixedOrderSchedulerImpl.java
+++ b/io.openems.edge.scheduler.fixedorder/src/io/openems/edge/scheduler/fixedorder/FixedOrderSchedulerImpl.java
@@ -7,14 +7,10 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.metatype.annotations.Designate;
 
-import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
-import io.openems.edge.common.component.ComponentManager;
 import io.openems.edge.common.component.OpenemsComponent;
-import io.openems.edge.controller.api.Controller;
 import io.openems.edge.scheduler.api.Scheduler;
 
 /**
@@ -29,10 +25,7 @@ import io.openems.edge.scheduler.api.Scheduler;
 )
 public class FixedOrderSchedulerImpl extends AbstractOpenemsComponent implements FixedOrderScheduler, Scheduler {
 
-	@Reference
-	protected ComponentManager componentManager;
-
-	private Config config;
+	private LinkedHashSet<String> controllerIds = new LinkedHashSet<>();
 
 	public FixedOrderSchedulerImpl() {
 		super(//
@@ -45,7 +38,12 @@ public class FixedOrderSchedulerImpl extends AbstractOpenemsComponent implements
 	@Activate
 	void activate(ComponentContext context, Config config) {
 		super.activate(context, config.id(), config.alias(), config.enabled());
-		this.config = config;
+		for (String id : config.controllers_ids()) {
+			if (id.equals("")) {
+				continue;
+			}
+			this.controllerIds.add(id);
+		}
 	}
 
 	@Deactivate
@@ -54,19 +52,8 @@ public class FixedOrderSchedulerImpl extends AbstractOpenemsComponent implements
 	}
 
 	@Override
-	public LinkedHashSet<Controller> getControllers() throws OpenemsNamedException {
-		LinkedHashSet<Controller> result = new LinkedHashSet<>();
-
-		// add sorted controllers
-		for (String id : this.config.controllers_ids()) {
-			if (id.equals("")) {
-				continue;
-			}
-			Controller controller = this.componentManager.getPossiblyDisabledComponent(id);
-			result.add(controller);
-		}
-
-		return result;
+	public LinkedHashSet<String> getControllers() {
+		return this.controllerIds;
 	}
 
 }

--- a/io.openems.edge.scheduler.fixedorder/test/io/openems/edge/scheduler/fixedorder/FixedOrderSchedulerImplTest.java
+++ b/io.openems.edge.scheduler.fixedorder/test/io/openems/edge/scheduler/fixedorder/FixedOrderSchedulerImplTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
 import io.openems.edge.common.test.ComponentTest;
-import io.openems.edge.common.test.DummyComponentManager;
 import io.openems.edge.controller.test.DummyController;
 import io.openems.edge.scheduler.api.Scheduler;
 
@@ -29,7 +28,6 @@ public class FixedOrderSchedulerImplTest {
 	public void test() throws Exception {
 		final FixedOrderScheduler sut = new FixedOrderSchedulerImpl();
 		ComponentTest test = new ComponentTest(sut) //
-				.addReference("componentManager", new DummyComponentManager()) //
 				.addComponent(new DummyController(CTRL0_ID)) //
 				.addComponent(new DummyController(CTRL1_ID)) //
 				.addComponent(new DummyController(CTRL2_ID)) //
@@ -49,7 +47,6 @@ public class FixedOrderSchedulerImplTest {
 
 	private static List<String> getControllerIds(Scheduler scheduler) throws OpenemsNamedException {
 		return scheduler.getControllers().stream() //
-				.map(c -> c.id()) //
 				.collect(Collectors.toList());
 	}
 


### PR DESCRIPTION
- Missing Controller does not anymore cause a fatal Scheduler error
- Scheduler now only returns a sorted set of Controller-IDs
- New Scheduler-Channel "ControllerIsMissing"