### PR TITLE
Fix SunSpec: rounding issues with ScaleFactors

### DIFF
--- a/io.openems.edge.batteryinverter.kaco.blueplanetgridsave/src/io/openems/edge/batteryinverter/kaco/blueplanetgridsave/KacoBlueplanetGridsaveImpl.java
+++ b/io.openems.edge.batteryinverter.kaco.blueplanetgridsave/src/io/openems/edge/batteryinverter/kaco/blueplanetgridsave/KacoBlueplanetGridsaveImpl.java
@@ -43,6 +43,7 @@ import io.openems.edge.bridge.modbus.sunspec.SunSpecPoint;
 import io.openems.edge.common.channel.Channel;
 import io.openems.edge.common.channel.EnumReadChannel;
 import io.openems.edge.common.channel.EnumWriteChannel;
+import io.openems.edge.common.channel.FloatWriteChannel;
 import io.openems.edge.common.channel.IntegerReadChannel;
 import io.openems.edge.common.channel.IntegerWriteChannel;
 import io.openems.edge.common.channel.StateChannel;
@@ -232,30 +233,30 @@ public class KacoBlueplanetGridsaveImpl extends AbstractSunSpecBatteryInverter i
 	 */
 	private void setBatteryLimits(Battery battery) throws OpenemsNamedException {
 		// Discharge Min Voltage
-		IntegerWriteChannel disMinVChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64202.DIS_MIN_V_0);
+		FloatWriteChannel disMinVChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64202.DIS_MIN_V_0);
 		Integer dischargeMinVoltage = battery.getDischargeMinVoltage().get();
 		if (Objects.equal(dischargeMinVoltage, 0)) {
 			dischargeMinVoltage = null; // according to setup manual DIS_MIN_V must not be zero
 		}
-		disMinVChannel.setNextWriteValue(dischargeMinVoltage);
+		disMinVChannel.setNextWriteValueFromObject(dischargeMinVoltage);
 
 		// Charge Max Voltage
-		IntegerWriteChannel chaMaxVChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64202.CHA_MAX_V_0);
+		FloatWriteChannel chaMaxVChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64202.CHA_MAX_V_0);
 		Integer chargeMaxVoltage = battery.getChargeMaxVoltage().get();
 		if (Objects.equal(chargeMaxVoltage, 0)) {
 			chargeMaxVoltage = null; // according to setup manual CHA_MAX_V must not be zero
 		}
-		chaMaxVChannel.setNextWriteValue(chargeMaxVoltage);
+		chaMaxVChannel.setNextWriteValueFromObject(chargeMaxVoltage);
 
 		// Discharge Max Current
 		// negative value is corrected as zero
-		IntegerWriteChannel disMaxAChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64202.DIS_MAX_A_0);
-		disMaxAChannel.setNextWriteValue(Math.max(0, battery.getDischargeMaxCurrent().orElse(0)));
+		FloatWriteChannel disMaxAChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64202.DIS_MAX_A_0);
+		disMaxAChannel.setNextWriteValue(Math.max(0F, battery.getDischargeMaxCurrent().orElse(0)));
 
 		// Charge Max Current
 		// negative value is corrected as zero
-		IntegerWriteChannel chaMaxAChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64202.CHA_MAX_A_0);
-		chaMaxAChannel.setNextWriteValue(Math.max(0, battery.getChargeMaxCurrent().orElse(0)));
+		FloatWriteChannel chaMaxAChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64202.CHA_MAX_A_0);
+		chaMaxAChannel.setNextWriteValue(Math.max(0F, battery.getChargeMaxCurrent().orElse(0)));
 
 		// Activate Battery values
 		EnumWriteChannel enLimitChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64202.EN_LIMIT_0);
@@ -272,16 +273,16 @@ public class KacoBlueplanetGridsaveImpl extends AbstractSunSpecBatteryInverter i
 	private void setDisplayInformation(Battery battery) throws OpenemsNamedException {
 		if (this.hasSunSpecModel64203) {
 			// State-of-Charge
-			IntegerWriteChannel batSocChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64203.BAT_SOC_0);
-			batSocChannel.setNextWriteValue(battery.getSoc().get());
+			FloatWriteChannel batSocChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64203.BAT_SOC_0);
+			batSocChannel.setNextWriteValueFromObject(battery.getSoc().get());
 
 			// State-of-Health
-			IntegerWriteChannel batSohChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64203.BAT_SOH_0);
-			batSohChannel.setNextWriteValue(battery.getSoh().get());
+			FloatWriteChannel batSohChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64203.BAT_SOH_0);
+			batSohChannel.setNextWriteValueFromObject(battery.getSoh().get());
 
 			// Max-Cell-Temperature
-			IntegerWriteChannel batTempChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64203.BAT_TEMP_0);
-			batTempChannel.setNextWriteValue(battery.getMaxCellTemperature().get());
+			FloatWriteChannel batTempChannel = this.getSunSpecChannelOrError(KacoSunSpecModel.S64203.BAT_TEMP_0);
+			batTempChannel.setNextWriteValueFromObject(battery.getMaxCellTemperature().get());
 		}
 	}
 

--- a/io.openems.edge.batteryinverter.kaco.blueplanetgridsave/src/io/openems/edge/batteryinverter/kaco/blueplanetgridsave/KacoSunSpecModel.java
+++ b/io.openems.edge.batteryinverter.kaco.blueplanetgridsave/src/io/openems/edge/batteryinverter/kaco/blueplanetgridsave/KacoSunSpecModel.java
@@ -113,7 +113,7 @@ public enum KacoSunSpecModel implements SunSpecModel {
 				null, //
 				new OptionsEnum[0])), //
 		W_SET_PCT(new PointImpl(//
-				"S101_W_SET_PCT", //
+				"S64201_W_SET_PCT", //
 				"WSetPct", //
 				"Active power output setpoint (in percent of WMax)", //
 				"negative values mean charge", //
@@ -124,7 +124,7 @@ public enum KacoSunSpecModel implements SunSpecModel {
 				"W_SET_PCT_SF", //
 				new OptionsEnum[0])), //
 		VAR_SET_PCT(new PointImpl(//
-				"S101_VAR_SET_PCT", //
+				"S64201_VAR_SET_PCT", //
 				"VarSetPct", //
 				"Reactive power output setpoint (in percent of VAMax)", //
 				"negative values mean charge", //

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/AbstractWordElement.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/AbstractWordElement.java
@@ -74,6 +74,6 @@ public abstract class AbstractWordElement<E, T> extends AbstractModbusRegisterEl
 	 * @param value the value
 	 * @return the ByteBuffer
 	 */
-	protected abstract ByteBuffer toByteBuffer(ByteBuffer buff, T value);
+	protected abstract ByteBuffer toByteBuffer(ByteBuffer buff, Object value);
 
 }

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/SignedWordElement.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/SignedWordElement.java
@@ -3,6 +3,7 @@ package io.openems.edge.bridge.modbus.api.element;
 import java.nio.ByteBuffer;
 
 import io.openems.common.types.OpenemsType;
+import io.openems.edge.common.type.TypeUtils;
 
 /**
  * An SignedWordElement represents a Short value in an
@@ -23,7 +24,8 @@ public class SignedWordElement extends AbstractWordElement<SignedWordElement, Sh
 		return buff.order(getByteOrder()).getShort(0);
 	}
 
-	protected ByteBuffer toByteBuffer(ByteBuffer buff, Short value) {
+	protected ByteBuffer toByteBuffer(ByteBuffer buff, Object object) {
+		Short value = TypeUtils.getAsType(OpenemsType.SHORT, object);
 		return buff.putShort(value.shortValue());
 	}
 

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/UnsignedWordElement.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/UnsignedWordElement.java
@@ -3,6 +3,7 @@ package io.openems.edge.bridge.modbus.api.element;
 import java.nio.ByteBuffer;
 
 import io.openems.common.types.OpenemsType;
+import io.openems.edge.common.type.TypeUtils;
 
 /**
  * An UnsignedWordElement represents an Integer value in an
@@ -23,7 +24,8 @@ public class UnsignedWordElement extends AbstractWordElement<UnsignedWordElement
 		return Short.toUnsignedInt(buff.getShort(0));
 	}
 
-	protected ByteBuffer toByteBuffer(ByteBuffer buff, Integer value) {
+	protected ByteBuffer toByteBuffer(ByteBuffer buff, Object object) {
+		Integer value = TypeUtils.getAsType(OpenemsType.INTEGER, object);
 		return buff.putShort(value.shortValue());
 	}
 

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/SunSpecPoint.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/SunSpecPoint.java
@@ -85,9 +85,10 @@ public interface SunSpecPoint {
 			this.mandatory = mandatory;
 			this.accessMode = accessMode;
 			this.unit = unit;
+			this.scaleFactor = Optional.ofNullable(scaleFactor);
 			if (options.length == 0) {
 				this.channelId = new SunSChannelId<>(channelId, //
-						Doc.of(this.getMatchingOpenemsType()) //
+						Doc.of(this.getMatchingOpenemsType(this.scaleFactor.isPresent())) //
 								.unit(unit) //
 								.accessMode(accessMode));
 			} else {
@@ -95,7 +96,6 @@ public interface SunSpecPoint {
 						new EnumDoc(options) //
 								.accessMode(accessMode));
 			}
-			this.scaleFactor = Optional.ofNullable(scaleFactor);
 			this.options = options;
 		}
 
@@ -168,9 +168,16 @@ public interface SunSpecPoint {
 		/**
 		 * Gets the {@link OpenemsType} that matches this SunSpec-Type.
 		 * 
+		 * @param hasScaleFactor true if this Point has a ScaleFactor. If true, a
+		 *                       floating point type is applied to avoid rounding
+		 *                       errors.
 		 * @return the {@link OpenemsType}
 		 */
-		public final OpenemsType getMatchingOpenemsType() {
+		public final OpenemsType getMatchingOpenemsType(boolean hasScaleFactor) {
+			if(hasScaleFactor) {
+				return OpenemsType.FLOAT;
+			}
+			
 			// TODO: map to floating point OpenemsType when appropriate
 			switch (this.type) {
 			case UINT16:

--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/api/SymmetricEss.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/api/SymmetricEss.java
@@ -52,7 +52,7 @@ public interface SymmetricEss extends OpenemsComponent {
 		 * <ul>
 		 * <li>Interface: Ess
 		 * <li>Type: Integer/Enum
-		 * <li>Range: -1=Undefined, 1=On-Grid, 2=Off-Grid
+		 * <li>Range: 0=Undefined, 1=On-Grid, 2=Off-Grid
 		 * </ul>
 		 */
 		GRID_MODE(Doc.of(GridMode.values())),
@@ -198,6 +198,7 @@ public interface SymmetricEss extends OpenemsComponent {
 				.channel(0, ChannelId.SOC, ModbusType.UINT16) //
 				.channel(1, ChannelId.GRID_MODE, ModbusType.UINT16) //
 				.channel(2, ChannelId.ACTIVE_POWER, ModbusType.FLOAT32) //
+				.channel(4, ChannelId.REACTIVE_POWER, ModbusType.FLOAT32) //
 				.build();
 	}
 

--- a/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/SetPvLimitHandler.java
+++ b/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/SetPvLimitHandler.java
@@ -1,7 +1,7 @@
 package io.openems.edge.pvinverter.sunspec;
 
-import java.time.LocalDateTime;
-import java.util.Objects;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -9,11 +9,15 @@ import io.openems.common.function.ThrowingRunnable;
 import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel;
 import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S123_WMaxLim_Ena;
 import io.openems.edge.common.channel.EnumWriteChannel;
+import io.openems.edge.common.channel.FloatReadChannel;
+import io.openems.edge.common.channel.FloatWriteChannel;
 import io.openems.edge.common.channel.IntegerReadChannel;
 import io.openems.edge.common.channel.IntegerWriteChannel;
 import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 
 public class SetPvLimitHandler implements ThrowingRunnable<OpenemsNamedException> {
+
+	private final static float COMPARE_THRESHOLD = 0.0001F;
 
 	private final AbstractSunSpecPvInverter parent;
 
@@ -21,7 +25,7 @@ public class SetPvLimitHandler implements ThrowingRunnable<OpenemsNamedException
 		this.parent = parent;
 	}
 
-	private LocalDateTime lastWMaxLimPctTime = LocalDateTime.MIN;
+	private Instant lastWMaxLimPctTime = Instant.MIN;
 
 	@Override
 	public void run() throws OpenemsNamedException {
@@ -30,8 +34,8 @@ public class SetPvLimitHandler implements ThrowingRunnable<OpenemsNamedException
 				.channel(ManagedSymmetricPvInverter.ChannelId.ACTIVE_POWER_LIMIT);
 		Optional<Integer> activePowerLimitOpt = activePowerLimitChannel.getNextWriteValueAndReset();
 
-		IntegerWriteChannel wMaxLimPctChannel;
-		IntegerReadChannel wRtgChannel;
+		FloatWriteChannel wMaxLimPctChannel;
+		FloatReadChannel wRtgChannel;
 		EnumWriteChannel wMaxLimEnaChannel;
 
 		try {
@@ -55,6 +59,7 @@ public class SetPvLimitHandler implements ThrowingRunnable<OpenemsNamedException
 			}
 		}
 
+		float wMaxLimPct;
 		if (activePowerLimitOpt.isPresent()) {
 			/*
 			 * A ActivePowerLimit is set
@@ -62,54 +67,48 @@ public class SetPvLimitHandler implements ThrowingRunnable<OpenemsNamedException
 			int activePowerLimit = activePowerLimitOpt.get();
 
 			// calculate limitation in percent
-			int wRtg = wRtgChannel.value().getOrError();
-			Integer wMaxLimPct = (int) (activePowerLimit * 100 / (float) wRtg);
-
-			// Just to be sure: keep percentage in range [1, 100]. Do never set "0" as it
-			// causes some inverters to go to standby mode, which is
-			// generally not what we want.
-			if (wMaxLimPct > 100) {
-				wMaxLimPct = 100;
-			} else if (wMaxLimPct < 1) {
-				wMaxLimPct = 1;
-			}
-
-			// Get Power Limitation Timeout Channel
-			IntegerReadChannel wMaxLimPctRvrtTmsChannel = this.parent
-					.getSunSpecChannelOrError(DefaultSunSpecModel.S123.W_MAX_LIM_PCT_RVRT_TMS);
-			int wMaxLimPctRvrtTms = wMaxLimPctRvrtTmsChannel.value().orElse(0);
-
-			if (
-			// Value changed
-			!Objects.equals(wMaxLimPct, wMaxLimPctChannel.value().get()) //
-					// Value needs to be set again to avoid timeout
-					|| this.lastWMaxLimPctTime.isBefore(LocalDateTime.now().minusSeconds(wMaxLimPctRvrtTms / 2))) {
-
-				// Set Power Limitation
-				wMaxLimPctChannel.setNextWriteValue(wMaxLimPct);
-
-				// Apply Power Limitation Enabled
-				if (wMaxLimEnaChannel.value().asEnum() != S123_WMaxLim_Ena.ENABLED) {
-					wMaxLimEnaChannel.setNextWriteValue(S123_WMaxLim_Ena.ENABLED);
-				}
-
-				// Remember last Set-Time
-				this.lastWMaxLimPctTime = LocalDateTime.now();
-			}
+			float wRtg = wRtgChannel.value().getOrError();
+			wMaxLimPct = activePowerLimit * 100 / wRtg;
 
 		} else {
 			/*
-			 * No ActivePowerLimit is set
+			 * No ActivePowerLimit is set -> reset to 100 %
 			 */
-			// Reset Power Limitation to 100 %
-			if (wMaxLimPctChannel.value().orElse(0) != 100) {
-				wMaxLimPctChannel.setNextWriteValue(100);
-			}
+			wMaxLimPct = 100F;
+		}
+
+		// Just to be sure: keep percentage in range [1, 100]. Do never set "0" as it
+		// causes some inverters to go to standby mode, which is
+		// generally not what we want.
+		if (wMaxLimPct > 100F) {
+			wMaxLimPct = 100F;
+		} else if (wMaxLimPct < 1F) {
+			wMaxLimPct = 1F;
+		}
+
+		// Get Power Limitation Timeout Channel
+		IntegerReadChannel wMaxLimPctRvrtTmsChannel = this.parent
+				.getSunSpecChannelOrError(DefaultSunSpecModel.S123.W_MAX_LIM_PCT_RVRT_TMS);
+		int wMaxLimPctRvrtTms = wMaxLimPctRvrtTmsChannel.value().orElse(0);
+
+		if (
+		// Value is not available
+		!wMaxLimPctChannel.value().isDefined()
+				// Value changed
+				|| Math.abs(wMaxLimPct - wMaxLimPctChannel.value().get()) > COMPARE_THRESHOLD
+				// Value needs to be set again to avoid timeout
+				|| Duration.between(this.lastWMaxLimPctTime, Instant.now()).getSeconds() > wMaxLimPctRvrtTms / 2.) {
+
+			// Set Power Limitation
+			wMaxLimPctChannel.setNextWriteValue(wMaxLimPct);
 
 			// Apply Power Limitation Enabled
 			if (wMaxLimEnaChannel.value().asEnum() != S123_WMaxLim_Ena.ENABLED) {
 				wMaxLimEnaChannel.setNextWriteValue(S123_WMaxLim_Ena.ENABLED);
 			}
+
+			// Remember last Set-Time
+			this.lastWMaxLimPctTime = Instant.now();
 		}
 
 	}


### PR DESCRIPTION
The SunSpec protocol definition uses integer registers with separate scalefactor-definitions in separate registers. Due to the way OpenEMS is setting a register from a Write-Channel, the value was rounded to integer before the scalefactor was applied.

This pull request fixes the behaviour by using FloatWriteChannels instead of IntegerWriteChannels for SunSpec registers with scalefactor.