### PR TITLE
JSON-RPC Requests: add timeout parameter

### DIFF
--- a/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/jsonrpc/request/SubscribeEdgesChannelsRequest.java
+++ b/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/jsonrpc/request/SubscribeEdgesChannelsRequest.java
@@ -1,7 +1,6 @@
 package io.openems.backend.b2bwebsocket.jsonrpc.request;
 
 import java.util.TreeSet;
-import java.util.UUID;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -36,7 +35,7 @@ public class SubscribeEdgesChannelsRequest extends JsonrpcRequest {
 	public static SubscribeEdgesChannelsRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		int count = JsonUtils.getAsInt(p, "count");
-		SubscribeEdgesChannelsRequest result = new SubscribeEdgesChannelsRequest(r.getId(), count);
+		SubscribeEdgesChannelsRequest result = new SubscribeEdgesChannelsRequest(r, count);
 		JsonArray edgeIds = JsonUtils.getAsJsonArray(p, "ids");
 		for (JsonElement edgeId : edgeIds) {
 			result.addEdgeId(JsonUtils.getAsString(edgeId));
@@ -57,13 +56,14 @@ public class SubscribeEdgesChannelsRequest extends JsonrpcRequest {
 	private final TreeSet<String> edgeIds = new TreeSet<>();
 	private final TreeSet<ChannelAddress> channels = new TreeSet<>();
 
-	public SubscribeEdgesChannelsRequest(UUID id, int count) {
-		super(id, METHOD);
+	private SubscribeEdgesChannelsRequest(JsonrpcRequest request, int count) {
+		super(request, METHOD);
 		this.count = count;
 	}
 
 	public SubscribeEdgesChannelsRequest(int count) {
-		this(UUID.randomUUID(), count);
+		super(METHOD);
+		this.count = count;
 	}
 
 	public void addEdgeId(String edgeId) {

--- a/io.openems.backend.common/src/io/openems/backend/common/jsonrpc/request/GetEdgesChannelsValuesRequest.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/jsonrpc/request/GetEdgesChannelsValuesRequest.java
@@ -1,14 +1,12 @@
 package io.openems.backend.common.jsonrpc.request;
 
 import java.util.TreeSet;
-import java.util.UUID;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
-import io.openems.common.jsonrpc.base.GenericJsonrpcRequest;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
 import io.openems.common.types.ChannelAddress;
 import io.openems.common.utils.JsonUtils;
@@ -30,9 +28,19 @@ import io.openems.common.utils.JsonUtils;
  */
 public class GetEdgesChannelsValuesRequest extends JsonrpcRequest {
 
+	public static final String METHOD = "getEdgesChannelsValues";
+
+	/**
+	 * Create {@link GetEdgesChannelsValuesRequest} from a template
+	 * {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link GetEdgesChannelsValuesRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static GetEdgesChannelsValuesRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
-		GetEdgesChannelsValuesRequest result = new GetEdgesChannelsValuesRequest(r.getId());
+		GetEdgesChannelsValuesRequest result = new GetEdgesChannelsValuesRequest(r);
 		JsonArray edgeIds = JsonUtils.getAsJsonArray(p, "ids");
 		for (JsonElement edgeId : edgeIds) {
 			result.addEdgeId(JsonUtils.getAsString(edgeId));
@@ -45,37 +53,51 @@ public class GetEdgesChannelsValuesRequest extends JsonrpcRequest {
 		return result;
 	}
 
-	public static GetEdgesChannelsValuesRequest from(JsonObject j) throws OpenemsNamedException {
-		return from(GenericJsonrpcRequest.from(j));
-	}
-
-	public static final String METHOD = "getEdgesChannelsValues";
-
 	private final TreeSet<String> edgeIds = new TreeSet<>();
 	private final TreeSet<ChannelAddress> channels = new TreeSet<>();
 
 	public GetEdgesChannelsValuesRequest() {
-		this(UUID.randomUUID());
+		super(METHOD);
 	}
 
-	public GetEdgesChannelsValuesRequest(UUID id) {
-		super(id, METHOD);
+	private GetEdgesChannelsValuesRequest(JsonrpcRequest request) {
+		super(request, METHOD);
 	}
 
+	/**
+	 * Adds a Edge-ID.
+	 * 
+	 * @param edgeId the Edge-ID
+	 */
 	public void addEdgeId(String edgeId) {
 		this.edgeIds.add(edgeId);
 	}
 
+	/**
+	 * Gets the Edge-IDs.
+	 * 
+	 * @return set of Edge-IDs.
+	 */
 	public TreeSet<String> getEdgeIds() {
-		return edgeIds;
+		return this.edgeIds;
 	}
 
+	/**
+	 * Adds a {@link ChannelAddress}.
+	 * 
+	 * @param address the {@link ChannelAddress}
+	 */
 	public void addChannel(ChannelAddress address) {
 		this.channels.add(address);
 	}
 
+	/**
+	 * Gets the {@link ChannelAddress}es.
+	 * 
+	 * @return the {@link ChannelAddress}es
+	 */
 	public TreeSet<ChannelAddress> getChannels() {
-		return channels;
+		return this.channels;
 	}
 
 	@Override

--- a/io.openems.backend.common/src/io/openems/backend/common/jsonrpc/request/GetEdgesStatusRequest.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/jsonrpc/request/GetEdgesStatusRequest.java
@@ -1,9 +1,8 @@
 package io.openems.backend.common.jsonrpc.request;
 
-import java.util.UUID;
-
 import com.google.gson.JsonObject;
 
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
 
@@ -21,18 +20,25 @@ import io.openems.common.jsonrpc.base.JsonrpcRequest;
  */
 public class GetEdgesStatusRequest extends JsonrpcRequest {
 
-	public static GetEdgesStatusRequest from(JsonrpcRequest r) throws OpenemsException {
-		return new GetEdgesStatusRequest(r.getId());
-	}
-
 	public static final String METHOD = "getEdgesStatus";
 
-	public GetEdgesStatusRequest() {
-		this(UUID.randomUUID());
+	/**
+	 * Create {@link GetEdgesStatusRequest} from a template {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link GetEdgesStatusRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
+	public static GetEdgesStatusRequest from(JsonrpcRequest r) throws OpenemsException {
+		return new GetEdgesStatusRequest(r);
 	}
 
-	public GetEdgesStatusRequest(UUID id) {
-		super(id, METHOD);
+	public GetEdgesStatusRequest() {
+		super(METHOD);
+	}
+
+	private GetEdgesStatusRequest(JsonrpcRequest request) {
+		super(request, METHOD);
 	}
 
 	@Override

--- a/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/odoo/jsonrpc/OdooCallRequest.java
+++ b/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/odoo/jsonrpc/OdooCallRequest.java
@@ -1,7 +1,5 @@
 package io.openems.backend.metadata.odoo.odoo.jsonrpc;
 
-import java.util.UUID;
-
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
 
 /**
@@ -20,12 +18,8 @@ public abstract class OdooCallRequest extends JsonrpcRequest {
 
 	public static final String METHOD = "call";
 
-	public OdooCallRequest(UUID id) {
-		super(id, METHOD);
-	}
-
-	public OdooCallRequest() {
-		this(UUID.randomUUID());
+	protected OdooCallRequest() {
+		super(METHOD);
 	}
 
 }

--- a/io.openems.common/src/io/openems/common/jsonrpc/base/GenericJsonrpcRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/base/GenericJsonrpcRequest.java
@@ -1,5 +1,6 @@
 package io.openems.common.jsonrpc.base;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import com.google.gson.JsonObject;
@@ -15,7 +16,8 @@ import io.openems.common.utils.JsonUtils;
  *   "jsonrpc": "2.0",
  *   "id": "UUID",
  *   "method": string,
- *   "params": {}
+ *   "params": {},
+ *   "timeout"?: number, defaults to 60 seconds; negative or zero to disable timeout
  * }
  * </pre>
  * 
@@ -27,24 +29,12 @@ public class GenericJsonrpcRequest extends JsonrpcRequest {
 	/**
 	 * Parses the String to a {@link GenericJsonrpcRequest}.
 	 * 
-	 * @param j the String
+	 * @param json the String
 	 * @return the {@link GenericJsonrpcRequest}
 	 * @throws OpenemsNamedException on error
 	 */
 	public static GenericJsonrpcRequest from(String json) throws OpenemsNamedException {
 		return from(JsonUtils.parseToJsonObject(json));
-	}
-
-	/**
-	 * Parses the String to a {@link GenericJsonrpcRequest}. If the request UUID is
-	 * missing, it is replaced by a random UUID.
-	 * 
-	 * @param j the String
-	 * @return the {@link GenericJsonrpcRequest}
-	 * @throws OpenemsNamedException on error
-	 */
-	public static GenericJsonrpcRequest fromIgnoreId(String json) throws OpenemsNamedException {
-		return fromIgnoreId(JsonUtils.parseToJsonObject(json));
 	}
 
 	/**
@@ -58,7 +48,20 @@ public class GenericJsonrpcRequest extends JsonrpcRequest {
 		UUID id = JsonUtils.getAsUUID(j, "id");
 		String method = JsonUtils.getAsString(j, "method");
 		JsonObject params = JsonUtils.getAsJsonObject(j, "params");
-		return new GenericJsonrpcRequest(id, method, params);
+		Optional<Integer> timeout = JsonUtils.getAsOptionalInt(j, "timeout");
+		return new GenericJsonrpcRequest(id, method, params, timeout);
+	}
+
+	/**
+	 * Parses the String to a {@link GenericJsonrpcRequest}. If the request UUID is
+	 * missing, it is replaced by a random UUID.
+	 * 
+	 * @param json the String
+	 * @return the {@link GenericJsonrpcRequest}
+	 * @throws OpenemsNamedException on error
+	 */
+	public static GenericJsonrpcRequest fromIgnoreId(String json) throws OpenemsNamedException {
+		return fromIgnoreId(JsonUtils.parseToJsonObject(json));
 	}
 
 	/**
@@ -73,13 +76,19 @@ public class GenericJsonrpcRequest extends JsonrpcRequest {
 		UUID id = JsonUtils.getAsOptionalUUID(j, "id").orElse(new UUID(0L, 0L) /* dummy UUID */);
 		String method = JsonUtils.getAsString(j, "method");
 		JsonObject params = JsonUtils.getAsJsonObject(j, "params");
-		return new GenericJsonrpcRequest(id, method, params);
+		Optional<Integer> timeout = JsonUtils.getAsOptionalInt(j, "timeout");
+		return new GenericJsonrpcRequest(id, method, params, timeout);
 	}
 
 	private final JsonObject params;
 
-	public GenericJsonrpcRequest(UUID id, String method, JsonObject params) {
-		super(id, method);
+	public GenericJsonrpcRequest(UUID id, String method, JsonObject params, int timeout) {
+		super(id, method, timeout);
+		this.params = params;
+	}
+
+	public GenericJsonrpcRequest(UUID id, String method, JsonObject params, Optional<Integer> timeout) {
+		super(id, method, timeout);
 		this.params = params;
 	}
 

--- a/io.openems.common/src/io/openems/common/jsonrpc/base/JsonrpcRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/base/JsonrpcRequest.java
@@ -1,9 +1,12 @@
 package io.openems.common.jsonrpc.base;
 
+import java.util.Optional;
 import java.util.UUID;
+
 import com.google.gson.JsonObject;
 
 import io.openems.common.utils.JsonUtils;
+import io.openems.common.utils.JsonUtils.JsonObjectBuilder;
 
 /**
  * Represents a JSON-RPC Request.
@@ -13,7 +16,8 @@ import io.openems.common.utils.JsonUtils;
  *   "jsonrpc": "2.0",
  *   "id": "UUID",
  *   "method": string,
- *   "params": {}
+ *   "params": {},
+ *   "timeout"?: number, defaults to 60 seconds; negative or zero to disable timeout
  * }
  * </pre>
  * 
@@ -22,25 +26,117 @@ import io.openems.common.utils.JsonUtils;
  */
 public abstract class JsonrpcRequest extends AbstractJsonrpcRequest {
 
-	private final UUID id;
+	public static final int DEFAULT_TIMEOUT_SECONDS = 60;
+	public static final int NO_TIMEOUT = -1;
 
+	private final UUID id;
+	private final Optional<Integer> timeout;
+
+	/**
+	 * Creates a {@link JsonrpcRequest} with random {@link UUID} as id and
+	 * {@link #DEFAULT_TIMEOUT_SECONDS} timeout.
+	 * 
+	 * @param method the JSON-RPC method
+	 */
 	public JsonrpcRequest(String method) {
-		this(UUID.randomUUID(), method);
+		this(method, Optional.empty());
 	}
 
-	public JsonrpcRequest(UUID id, String method) {
+	/**
+	 * Creates a {@link JsonrpcRequest} with random {@link UUID} as id.
+	 * 
+	 * @param method  the JSON-RPC method
+	 * @param timeout max time in seconds to wait for the {@link JsonrpcResponse},
+	 *                negative or zero to disable timeout
+	 */
+	public JsonrpcRequest(String method, int timeout) {
+		this(method, Optional.of(timeout));
+	}
+
+	/**
+	 * Creates a {@link JsonrpcRequest} with random {@link UUID} as id.
+	 * 
+	 * @param method  the JSON-RPC method
+	 * @param timeout max time in seconds to wait for the {@link JsonrpcResponse},
+	 *                negative or zero to disable timeout, empty for
+	 *                {@link #DEFAULT_TIMEOUT_SECONDS} timeout
+	 */
+	public JsonrpcRequest(String method, Optional<Integer> timeout) {
+		this(UUID.randomUUID(), method, timeout);
+	}
+
+	/**
+	 * Creates a {@link JsonrpcRequest}.
+	 * 
+	 * @param id      the JSON-RPC id
+	 * @param method  the JSON-RPC method
+	 * @param timeout max time in seconds to wait for the {@link JsonrpcResponse},
+	 *                negative or zero to disable timeout, empty for
+	 *                {@link #DEFAULT_TIMEOUT_SECONDS} timeout
+	 */
+	public JsonrpcRequest(UUID id, String method, Optional<Integer> timeout) {
 		super(method);
 		this.id = id;
+		this.timeout = timeout;
 	}
 
+	/**
+	 * Creates a {@link JsonrpcRequest} by copying and validating header
+	 * information.
+	 * 
+	 * <ul>
+	 * <li>copies id and timeout
+	 * <li>validates that the method names match
+	 * </ul>
+	 *
+	 * @param request the template JSON-RPC Request
+	 * @param method  the JSON-RPC method
+	 */
+	protected JsonrpcRequest(JsonrpcRequest request, String method) {
+		this(request.id, method, request.timeout);
+		if (!request.getMethod().equals(method)) {
+			throw new IllegalArgumentException("JSON-RPC Methods to not match: " + request.getMethod() + ", " + method);
+		}
+	}
+
+	/**
+	 * Creates a {@link JsonrpcRequest}.
+	 *
+	 * @param id      the JSON-RPC id
+	 * @param method  the JSON-RPC method
+	 * @param timeout max time in seconds to wait for the {@link JsonrpcResponse},
+	 *                negative or zero to disable timeout
+	 */
+	public JsonrpcRequest(UUID id, String method, int timeout) {
+		this(id, method, Optional.of(timeout));
+	}
+
+	/**
+	 * Gets the JSON-RPC id.
+	 * 
+	 * @return the {@link UUID} id
+	 */
 	public UUID getId() {
 		return this.id;
 	}
 
+	/**
+	 * Gets the max time in seconds to wait for the {@link JsonrpcResponse},
+	 * negative or zero to disable timeout.
+	 * 
+	 * @return the timeout in seconds
+	 */
+	public Optional<Integer> getTimeout() {
+		return this.timeout;
+	}
+
 	@Override
 	public JsonObject toJsonObject() {
-		return JsonUtils.buildJsonObject(super.toJsonObject()) //
-				.addProperty("id", this.getId().toString()) //
-				.build();
+		JsonObjectBuilder builder = JsonUtils.buildJsonObject(super.toJsonObject()) //
+				.addProperty("id", this.getId().toString());
+		if (this.timeout.isPresent()) {
+			builder.addProperty("timeout", this.timeout.get());
+		}
+		return builder.build();
 	}
 }

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/AuthenticateWithPasswordRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/AuthenticateWithPasswordRequest.java
@@ -1,12 +1,10 @@
 package io.openems.common.jsonrpc.request;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import com.google.gson.JsonObject;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
-import io.openems.common.jsonrpc.base.GenericJsonrpcRequest;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
 import io.openems.common.utils.JsonUtils;
 import io.openems.common.utils.JsonUtils.JsonObjectBuilder;
@@ -14,6 +12,7 @@ import io.openems.common.utils.JsonUtils.JsonObjectBuilder;
 /**
  * Represents a JSON-RPC Request to authenticate with a Password.
  * 
+ * <p>
  * This is used by UI to login with password-only at the Edge.
  * 
  * <pre>
@@ -30,38 +29,54 @@ import io.openems.common.utils.JsonUtils.JsonObjectBuilder;
  */
 public class AuthenticateWithPasswordRequest extends JsonrpcRequest {
 
-	public final static String METHOD = "authenticateWithPassword";
+	public static final String METHOD = "authenticateWithPassword";
 
+	/**
+	 * Create {@link AuthenticateWithPasswordRequest} from a template
+	 * {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link AuthenticateWithPasswordRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static AuthenticateWithPasswordRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		Optional<String> username = JsonUtils.getAsOptionalString(p, "username");
 		String password = JsonUtils.getAsString(p, "password");
-		return new AuthenticateWithPasswordRequest(r.getId(), username, password);
-	}
-
-	public static AuthenticateWithPasswordRequest from(JsonObject j) throws OpenemsNamedException {
-		return from(GenericJsonrpcRequest.from(j));
+		return new AuthenticateWithPasswordRequest(r, username, password);
 	}
 
 	private final Optional<String> username;
 	private final String password;
 
-	public AuthenticateWithPasswordRequest(UUID id, Optional<String> username, String password) {
-		super(id, METHOD);
+	private AuthenticateWithPasswordRequest(JsonrpcRequest request, Optional<String> username, String password) {
+		super(request, METHOD);
 		this.username = username;
 		this.password = password;
 	}
 
 	public AuthenticateWithPasswordRequest(Optional<String> username, String password) {
-		this(UUID.randomUUID(), username, password);
+		super(METHOD);
+		this.username = username;
+		this.password = password;
 	}
 
+	/**
+	 * Gets the Username if given.
+	 * 
+	 * @return Username
+	 */
 	public Optional<String> getUsername() {
-		return username;
+		return this.username;
 	}
 
+	/**
+	 * Gets the Password.
+	 * 
+	 * @return Password
+	 */
 	public String getPassword() {
-		return password;
+		return this.password;
 	}
 
 	@Override

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/AuthenticatedRpcRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/AuthenticatedRpcRequest.java
@@ -1,7 +1,5 @@
 package io.openems.common.jsonrpc.request;
 
-import java.util.UUID;
-
 import com.google.gson.JsonObject;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -31,34 +29,54 @@ import io.openems.common.utils.JsonUtils;
  */
 public class AuthenticatedRpcRequest extends JsonrpcRequest {
 
-	public final static String METHOD = "authenticatedRpc";
+	public static final String METHOD = "authenticatedRpc";
 
+	/**
+	 * Create {@link AuthenticatedRpcRequest} from a template
+	 * {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link AuthenticatedRpcRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static AuthenticatedRpcRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		User user = User.from(JsonUtils.getAsJsonObject(p, "user"));
 		JsonrpcRequest payload = GenericJsonrpcRequest.from(JsonUtils.getAsJsonObject(p, "payload"));
-		return new AuthenticatedRpcRequest(r.getId(), user, payload);
+		return new AuthenticatedRpcRequest(r, user, payload);
 	}
 
 	private final User user;
 	private final JsonrpcRequest payload;
 
 	public AuthenticatedRpcRequest(User user, JsonrpcRequest payload) {
-		this(UUID.randomUUID(), user, payload);
-	}
-
-	public AuthenticatedRpcRequest(UUID id, User user, JsonrpcRequest payload) {
-		super(id, METHOD);
+		super(METHOD);
 		this.user = user;
 		this.payload = payload;
 	}
 
-	public User getUser() {
-		return user;
+	private AuthenticatedRpcRequest(JsonrpcRequest request, User user, JsonrpcRequest payload) {
+		super(request, METHOD);
+		this.user = user;
+		this.payload = payload;
 	}
 
+	/**
+	 * Gets the {@link User}.
+	 * 
+	 * @return User
+	 */
+	public User getUser() {
+		return this.user;
+	}
+
+	/**
+	 * Gets the Payload {@link JsonrpcRequest}.
+	 * 
+	 * @return Payload
+	 */
 	public JsonrpcRequest getPayload() {
-		return payload;
+		return this.payload;
 	}
 
 	@Override

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/ComponentJsonApiRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/ComponentJsonApiRequest.java
@@ -1,7 +1,5 @@
 package io.openems.common.jsonrpc.request;
 
-import java.util.UUID;
-
 import com.google.gson.JsonObject;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -10,7 +8,7 @@ import io.openems.common.jsonrpc.base.JsonrpcRequest;
 import io.openems.common.utils.JsonUtils;
 
 /**
- * Wraps a JSON-RPC Request for an OpenEMS Component that implements JsonApi
+ * Wraps a JSON-RPC Request for an OpenEMS Component that implements JsonApi.
  * 
  * <pre>
  * {
@@ -26,24 +24,34 @@ import io.openems.common.utils.JsonUtils;
  */
 public class ComponentJsonApiRequest extends JsonrpcRequest {
 
+	public static final String METHOD = "componentJsonApi";
+
+	/**
+	 * Create {@link ComponentJsonApiRequest} from a template
+	 * {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link ComponentJsonApiRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static ComponentJsonApiRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		String componentId = JsonUtils.getAsString(p, "componentId");
 		JsonrpcRequest payload = GenericJsonrpcRequest.fromIgnoreId(JsonUtils.getAsJsonObject(p, "payload"));
-		return new ComponentJsonApiRequest(r.getId(), componentId, payload);
+		return new ComponentJsonApiRequest(r, componentId, payload);
 	}
-
-	public final static String METHOD = "componentJsonApi";
 
 	private final String componentId;
 	private final JsonrpcRequest payload;
 
 	public ComponentJsonApiRequest(String componentId, JsonrpcRequest payload) {
-		this(UUID.randomUUID(), componentId, payload);
+		super(METHOD, payload.getTimeout() /* inherit timeout from payload */);
+		this.componentId = componentId;
+		this.payload = payload;
 	}
 
-	public ComponentJsonApiRequest(UUID id, String componentId, JsonrpcRequest payload) {
-		super(id, METHOD);
+	private ComponentJsonApiRequest(JsonrpcRequest request, String componentId, JsonrpcRequest payload) {
+		super(request, METHOD);
 		this.componentId = componentId;
 		this.payload = payload;
 	}
@@ -56,12 +64,22 @@ public class ComponentJsonApiRequest extends JsonrpcRequest {
 				.build();
 	}
 
+	/**
+	 * Gets the Component-ID.
+	 * 
+	 * @return Component-ID
+	 */
 	public String getComponentId() {
-		return componentId;
+		return this.componentId;
 	}
 
+	/**
+	 * Gets the Payload {@link JsonrpcRequest}.
+	 * 
+	 * @return Payload
+	 */
 	public JsonrpcRequest getPayload() {
-		return payload;
+		return this.payload;
 	}
 
 }

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/CreateComponentConfigRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/CreateComponentConfigRequest.java
@@ -1,7 +1,6 @@
 package io.openems.common.jsonrpc.request;
 
 import java.util.List;
-import java.util.UUID;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -31,33 +30,47 @@ import io.openems.common.utils.JsonUtils;
  */
 public class CreateComponentConfigRequest extends JsonrpcRequest {
 
+	public static final String METHOD = "createComponentConfig";
+
+	/**
+	 * Create {@link CreateComponentConfigRequest} from a template
+	 * {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link CreateComponentConfigRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static CreateComponentConfigRequest from(JsonrpcRequest r) throws OpenemsNamedException {
-		return CreateComponentConfigRequest.from(r.getId(), r.getParams());
+		JsonObject p = r.getParams();
+		String factoryPid = JsonUtils.getAsString(p, "factoryPid");
+		List<Property> properties = Property.from(JsonUtils.getAsJsonArray(p, "properties"));
+		return new CreateComponentConfigRequest(r, factoryPid, properties);
 	}
 
-	public static CreateComponentConfigRequest from(UUID id, JsonObject params) throws OpenemsNamedException {
-		String factoryPid = JsonUtils.getAsString(params, "factoryPid");
-		List<Property> properties = Property.from(JsonUtils.getAsJsonArray(params, "properties"));
-		return new CreateComponentConfigRequest(id, factoryPid, properties);
-	}
-
+	/**
+	 * Create {@link CreateComponentConfigRequest} from a {@link JsonObject}.
+	 * 
+	 * @param params the {@link JsonObject}
+	 * @return the {@link CreateComponentConfigRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static CreateComponentConfigRequest from(JsonObject params) throws OpenemsNamedException {
 		String factoryPid = JsonUtils.getAsString(params, "factoryPid");
 		List<Property> properties = Property.from(JsonUtils.getAsJsonArray(params, "properties"));
 		return new CreateComponentConfigRequest(factoryPid, properties);
 	}
 
-	public final static String METHOD = "createComponentConfig";
-
 	private final String factoryPid;
 	private final List<Property> properties;
 
 	public CreateComponentConfigRequest(String factoryPid, List<Property> properties) {
-		this(UUID.randomUUID(), factoryPid, properties);
+		super(METHOD);
+		this.factoryPid = factoryPid;
+		this.properties = properties;
 	}
 
-	public CreateComponentConfigRequest(UUID id, String factoryPid, List<Property> properties) {
-		super(id, METHOD);
+	private CreateComponentConfigRequest(JsonrpcRequest request, String factoryPid, List<Property> properties) {
+		super(request, METHOD);
 		this.factoryPid = factoryPid;
 		this.properties = properties;
 	}
@@ -74,10 +87,20 @@ public class CreateComponentConfigRequest extends JsonrpcRequest {
 				.build();
 	}
 
+	/**
+	 * Gets the Factory-PID.
+	 * 
+	 * @return Factory-PID
+	 */
 	public String getFactoryPid() {
-		return factoryPid;
+		return this.factoryPid;
 	}
 
+	/**
+	 * Gets the Component-ID, or empty String if none is given.
+	 * 
+	 * @return Component-ID
+	 */
 	public String getComponentId() {
 		for (UpdateComponentConfigRequest.Property property : this.properties) {
 			if (property.getName().equals("id")) {
@@ -87,7 +110,12 @@ public class CreateComponentConfigRequest extends JsonrpcRequest {
 		return "";
 	}
 
+	/**
+	 * Gets the List of Properties.
+	 * 
+	 * @return Properties
+	 */
 	public List<UpdateComponentConfigRequest.Property> getProperties() {
-		return properties;
+		return this.properties;
 	}
 }

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/DeleteComponentConfigRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/DeleteComponentConfigRequest.java
@@ -1,7 +1,5 @@
 package io.openems.common.jsonrpc.request;
 
-import java.util.UUID;
-
 import com.google.gson.JsonObject;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -24,22 +22,31 @@ import io.openems.common.utils.JsonUtils;
  */
 public class DeleteComponentConfigRequest extends JsonrpcRequest {
 
+	public static final String METHOD = "deleteComponentConfig";
+
+	/**
+	 * Create {@link DeleteComponentConfigRequest} from a template
+	 * {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link DeleteComponentConfigRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static DeleteComponentConfigRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		String componentId = JsonUtils.getAsString(p, "componentId");
-		return new DeleteComponentConfigRequest(r.getId(), componentId);
+		return new DeleteComponentConfigRequest(r, componentId);
 	}
-
-	public final static String METHOD = "deleteComponentConfig";
 
 	private final String componentId;
 
 	public DeleteComponentConfigRequest(String componentId) {
-		this(UUID.randomUUID(), componentId);
+		super(METHOD);
+		this.componentId = componentId;
 	}
 
-	public DeleteComponentConfigRequest(UUID id, String componentId) {
-		super(id, METHOD);
+	private DeleteComponentConfigRequest(JsonrpcRequest request, String componentId) {
+		super(request, METHOD);
 		this.componentId = componentId;
 	}
 
@@ -50,7 +57,12 @@ public class DeleteComponentConfigRequest extends JsonrpcRequest {
 				.build();
 	}
 
+	/**
+	 * Gets the Component-ID.
+	 * 
+	 * @return Component-ID
+	 */
 	public String getComponentId() {
-		return componentId;
+		return this.componentId;
 	}
 }

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/EdgeRpcRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/EdgeRpcRequest.java
@@ -1,7 +1,5 @@
 package io.openems.common.jsonrpc.request;
 
-import java.util.UUID;
-
 import com.google.gson.JsonObject;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -27,34 +25,53 @@ import io.openems.common.utils.JsonUtils;
  */
 public class EdgeRpcRequest extends JsonrpcRequest {
 
-	public final static String METHOD = "edgeRpc";
+	public static final String METHOD = "edgeRpc";
 
+	/**
+	 * Create {@link EdgeRpcRequest} from a template {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link EdgeRpcRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static EdgeRpcRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		String edgeId = JsonUtils.getAsString(p, "edgeId");
 		JsonrpcRequest payload = GenericJsonrpcRequest.from(JsonUtils.getAsJsonObject(p, "payload"));
-		return new EdgeRpcRequest(r.getId(), edgeId, payload);
+		return new EdgeRpcRequest(r, edgeId, payload);
 	}
 
 	private final String edgeId;
 	private final JsonrpcRequest payload;
 
 	public EdgeRpcRequest(String edgeId, JsonrpcRequest payload) {
-		this(UUID.randomUUID(), edgeId, payload);
-	}
-
-	public EdgeRpcRequest(UUID id, String edgeId, JsonrpcRequest payload) {
-		super(id, METHOD);
+		super(METHOD, payload.getTimeout() /* inherit timeout from payload */);
 		this.edgeId = edgeId;
 		this.payload = payload;
 	}
 
-	public String getEdgeId() {
-		return edgeId;
+	public EdgeRpcRequest(JsonrpcRequest request, String edgeId, JsonrpcRequest payload) {
+		super(request, METHOD);
+		this.edgeId = edgeId;
+		this.payload = payload;
 	}
 
+	/**
+	 * Gets the Edge-ID.
+	 * 
+	 * @return Edge-ID
+	 */
+	public String getEdgeId() {
+		return this.edgeId;
+	}
+
+	/**
+	 * Gets the Payload {@link JsonrpcRequest}.
+	 * 
+	 * @return Payload
+	 */
 	public JsonrpcRequest getPayload() {
-		return payload;
+		return this.payload;
 	}
 
 	@Override

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/GetEdgeConfigRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/GetEdgeConfigRequest.java
@@ -1,9 +1,8 @@
 package io.openems.common.jsonrpc.request;
 
-import java.util.UUID;
-
 import com.google.gson.JsonObject;
 
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
 
@@ -21,18 +20,21 @@ import io.openems.common.jsonrpc.base.JsonrpcRequest;
  */
 public class GetEdgeConfigRequest extends JsonrpcRequest {
 
+	public static final String METHOD = "getEdgeConfig";
+
+	/**
+	 * Create {@link GetEdgeConfigRequest} from a template {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link GetEdgeConfigRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static GetEdgeConfigRequest from(JsonrpcRequest r) throws OpenemsException {
-		return new GetEdgeConfigRequest(r.getId());
+		return new GetEdgeConfigRequest(r);
 	}
 
-	public final static String METHOD = "getEdgeConfig";
-
-	public GetEdgeConfigRequest() {
-		this(UUID.randomUUID());
-	}
-
-	public GetEdgeConfigRequest(UUID id) {
-		super(id, METHOD);
+	private GetEdgeConfigRequest(JsonrpcRequest request) {
+		super(request, METHOD);
 	}
 
 	@Override

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/SetChannelValueRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/SetChannelValueRequest.java
@@ -1,7 +1,5 @@
 package io.openems.common.jsonrpc.request;
 
-import java.util.UUID;
-
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
@@ -28,26 +26,36 @@ import io.openems.common.utils.JsonUtils;
  */
 public class SetChannelValueRequest extends JsonrpcRequest {
 
+	public static final String METHOD = "setChannelValue";
+
+	/**
+	 * Create {@link SetChannelValueRequest} from a template {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link SetChannelValueRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static SetChannelValueRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		String componentId = JsonUtils.getAsString(p, "componentId");
 		String channelId = JsonUtils.getAsString(p, "channelId");
 		JsonElement value = JsonUtils.getSubElement(p, "value");
-		return new SetChannelValueRequest(r.getId(), componentId, channelId, value);
+		return new SetChannelValueRequest(r, componentId, channelId, value);
 	}
-
-	public final static String METHOD = "setChannelValue";
 
 	private final String componentId;
 	private final String channelId;
 	private final JsonElement value;
 
 	public SetChannelValueRequest(String componentId, String channelId, JsonElement value) {
-		this(UUID.randomUUID(), componentId, channelId, value);
+		super(METHOD);
+		this.componentId = componentId;
+		this.channelId = channelId;
+		this.value = value;
 	}
 
-	public SetChannelValueRequest(UUID id, String componentId, String channelId, JsonElement value) {
-		super(id, METHOD);
+	private SetChannelValueRequest(JsonrpcRequest request, String componentId, String channelId, JsonElement value) {
+		super(request, METHOD);
 		this.componentId = componentId;
 		this.channelId = channelId;
 		this.value = value;
@@ -62,19 +70,39 @@ public class SetChannelValueRequest extends JsonrpcRequest {
 				.build();
 	}
 
+	/**
+	 * Gets the Component-ID.
+	 * 
+	 * @return Component-ID
+	 */
 	public String getComponentId() {
-		return componentId;
+		return this.componentId;
 	}
 
+	/**
+	 * Gets the Channel-ID.
+	 * 
+	 * @return Channel-ID
+	 */
 	public String getChannelId() {
-		return channelId;
+		return this.channelId;
 	}
 
+	/**
+	 * Gets the {@link ChannelAddress}.
+	 * 
+	 * @return ChannelAddress
+	 */
 	public ChannelAddress getChannelAddress() {
 		return new ChannelAddress(this.componentId, this.channelId);
 	}
 
+	/**
+	 * Gets the Value.
+	 * 
+	 * @return Value
+	 */
 	public JsonElement getValue() {
-		return value;
+		return this.value;
 	}
 }

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/SetGridConnScheduleRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/SetGridConnScheduleRequest.java
@@ -3,7 +3,6 @@ package io.openems.common.jsonrpc.request;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.UUID;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -34,12 +33,20 @@ import io.openems.common.utils.JsonUtils;
  */
 public class SetGridConnScheduleRequest extends JsonrpcRequest {
 
+	/**
+	 * Create {@link SetGridConnScheduleRequest} from a template
+	 * {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link SetGridConnScheduleRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static SetGridConnScheduleRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		String edgeId = JsonUtils.getAsString(p, "id");
 		JsonArray s = JsonUtils.getAsJsonArray(p, "schedule");
 		List<GridConnSchedule> schedule = GridConnSchedule.from(s);
-		return new SetGridConnScheduleRequest(r.getId(), edgeId, schedule);
+		return new SetGridConnScheduleRequest(r, edgeId, schedule);
 	}
 
 	public static final String METHOD = "setGridConnSchedule";
@@ -48,19 +55,26 @@ public class SetGridConnScheduleRequest extends JsonrpcRequest {
 	private final List<GridConnSchedule> schedule;
 
 	public SetGridConnScheduleRequest(String edgeId) {
-		this(UUID.randomUUID(), edgeId, new ArrayList<>());
+		this(edgeId, new ArrayList<>());
 	}
 
 	public SetGridConnScheduleRequest(String edgeId, List<GridConnSchedule> schedule) {
-		this(UUID.randomUUID(), edgeId, schedule);
-	}
-
-	public SetGridConnScheduleRequest(UUID id, String edgeId, List<GridConnSchedule> schedule) {
-		super(id, METHOD);
+		super(METHOD);
 		this.edgeId = edgeId;
 		this.schedule = schedule;
 	}
 
+	private SetGridConnScheduleRequest(JsonrpcRequest request, String edgeId, List<GridConnSchedule> schedule) {
+		super(request, METHOD);
+		this.edgeId = edgeId;
+		this.schedule = schedule;
+	}
+
+	/**
+	 * Add a {@link GridConnSchedule} entry.
+	 * 
+	 * @param scheduleEntry GridConnSchedule entry
+	 */
 	public void addScheduleEntry(GridConnSchedule scheduleEntry) {
 		this.schedule.add(scheduleEntry);
 	}
@@ -77,16 +91,33 @@ public class SetGridConnScheduleRequest extends JsonrpcRequest {
 				.build();
 	}
 
+	/**
+	 * Gets the Edge-ID.
+	 * 
+	 * @return Edge-ID
+	 */
 	public String getEdgeId() {
 		return this.edgeId;
 	}
 
+	/**
+	 * Gets the list of {@link GridConnSchedule} entries.
+	 * 
+	 * @return entries
+	 */
 	public List<GridConnSchedule> getSchedule() {
 		return this.schedule;
 	}
 
 	public static class GridConnSchedule {
 
+		/**
+		 * Create a list of {@link GridConnSchedule}s from a {@link JsonArray}.
+		 * 
+		 * @param j the {@link JsonArray}
+		 * @return the list of {@link GridConnSchedule}s
+		 * @throws OpenemsNamedException on parse error
+		 */
 		public static List<GridConnSchedule> from(JsonArray j) throws OpenemsNamedException {
 			List<GridConnSchedule> schedule = new ArrayList<>();
 			for (JsonElement se : j) {
@@ -116,19 +147,34 @@ public class SetGridConnScheduleRequest extends JsonrpcRequest {
 			this.activePowerSetPoint = activePowerSetPoint;
 		}
 
+		/**
+		 * Gets the start timestamp in epoch seconds.
+		 * 
+		 * @return start timestamp
+		 */
 		public long getStartTimestamp() {
 			return this.startTimestamp;
 		}
 
+		/**
+		 * Gets the duration in seconds.
+		 * 
+		 * @return duration
+		 */
 		public int getDuration() {
 			return this.duration;
 		}
 
+		/**
+		 * Gets the Active-Power Setpoint.
+		 * 
+		 * @return the setpoint
+		 */
 		public int getActivePowerSetPoint() {
 			return this.activePowerSetPoint;
 		}
 
-		public JsonObject toJson() {
+		protected JsonObject toJson() {
 			return JsonUtils.buildJsonObject() //
 					.addProperty("startTimestamp", this.getStartTimestamp()) //
 					.addProperty("duration", this.getDuration()) //

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/SubscribeChannelsRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/SubscribeChannelsRequest.java
@@ -1,14 +1,12 @@
 package io.openems.common.jsonrpc.request;
 
 import java.util.TreeSet;
-import java.util.UUID;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
-import io.openems.common.jsonrpc.base.GenericJsonrpcRequest;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
 import io.openems.common.types.ChannelAddress;
 import io.openems.common.utils.JsonUtils;
@@ -16,6 +14,7 @@ import io.openems.common.utils.JsonUtils;
 /**
  * Represents a JSON-RPC Request to subscribe to Channels.
  * 
+ * <p>
  * This is used by UI to get regular updates on specific channels.
  * 
  * <pre>
@@ -32,12 +31,20 @@ import io.openems.common.utils.JsonUtils;
  */
 public class SubscribeChannelsRequest extends JsonrpcRequest {
 
-	public final static String METHOD = "subscribeChannels";
+	public static final String METHOD = "subscribeChannels";
 
+	/**
+	 * Create {@link SubscribeChannelsRequest} from a template
+	 * {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link SubscribeChannelsRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static SubscribeChannelsRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		int count = JsonUtils.getAsInt(p, "count");
-		SubscribeChannelsRequest result = new SubscribeChannelsRequest(r.getId(), count);
+		SubscribeChannelsRequest result = new SubscribeChannelsRequest(r, count);
 		JsonArray channels = JsonUtils.getAsJsonArray(p, "channels");
 		for (JsonElement channel : channels) {
 			ChannelAddress address = ChannelAddress.fromString(JsonUtils.getAsString(channel));
@@ -46,32 +53,42 @@ public class SubscribeChannelsRequest extends JsonrpcRequest {
 		return result;
 	}
 
-	public static SubscribeChannelsRequest from(JsonObject j) throws OpenemsNamedException {
-		return from(GenericJsonrpcRequest.from(j));
-	}
-
 	private final int count;
 	private final TreeSet<ChannelAddress> channels = new TreeSet<>();
 
-	public SubscribeChannelsRequest(UUID id, int count) {
-		super(id, METHOD);
+	private SubscribeChannelsRequest(JsonrpcRequest request, int count) {
+		super(request, METHOD);
 		this.count = count;
 	}
 
 	public SubscribeChannelsRequest(int count) {
-		this(UUID.randomUUID(), count);
+		super(METHOD);
+		this.count = count;
 	}
 
 	private void addChannel(ChannelAddress address) {
 		this.channels.add(address);
 	}
 
+	/**
+	 * Gets the Count value.
+	 * 
+	 * <p>
+	 * This value is increased with every request to assure order.
+	 * 
+	 * @return the count value
+	 */
 	public int getCount() {
 		return this.count;
 	}
 
+	/**
+	 * Gets the set of {@link ChannelAddress}es.
+	 * 
+	 * @return the {@link ChannelAddress}es
+	 */
 	public TreeSet<ChannelAddress> getChannels() {
-		return channels;
+		return this.channels;
 	}
 
 	@Override

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/SubscribeSystemLogRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/SubscribeSystemLogRequest.java
@@ -1,11 +1,8 @@
 package io.openems.common.jsonrpc.request;
 
-import java.util.UUID;
-
 import com.google.gson.JsonObject;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
-import io.openems.common.jsonrpc.base.GenericJsonrpcRequest;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
 import io.openems.common.utils.JsonUtils;
 
@@ -32,35 +29,55 @@ public class SubscribeSystemLogRequest extends JsonrpcRequest {
 
 	public static final String METHOD = "subscribeSystemLog";
 
+	/**
+	 * Create {@link SubscribeSystemLogRequest} from a template
+	 * {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link SubscribeSystemLogRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static SubscribeSystemLogRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		boolean subscribe = JsonUtils.getAsBoolean(p, "subscribe");
-		return new SubscribeSystemLogRequest(r.getId(), subscribe);
+		return new SubscribeSystemLogRequest(r, subscribe);
 	}
 
-	public static SubscribeSystemLogRequest from(JsonObject j) throws OpenemsNamedException {
-		return from(GenericJsonrpcRequest.from(j));
-	}
-
+	/**
+	 * Creates a JSON-RPC Request that subscribes the System-Log.
+	 * 
+	 * @return {@link SubscribeSystemLogRequest}
+	 */
 	public static SubscribeSystemLogRequest subscribe() {
 		return new SubscribeSystemLogRequest(true);
 	}
 
+	/**
+	 * Creates a JSON-RPC Request that unsubscribes the System-Log.
+	 * 
+	 * @return {@link SubscribeSystemLogRequest}
+	 */
 	public static SubscribeSystemLogRequest unsubscribe() {
 		return new SubscribeSystemLogRequest(false);
 	}
 
 	private final boolean subscribe;
 
-	private SubscribeSystemLogRequest(UUID id, boolean subscribe) {
-		super(id, METHOD);
+	private SubscribeSystemLogRequest(JsonrpcRequest request, boolean subscribe) {
+		super(request, METHOD);
 		this.subscribe = subscribe;
 	}
 
 	public SubscribeSystemLogRequest(boolean subscribe) {
-		this(UUID.randomUUID(), subscribe);
+		super(METHOD);
+		this.subscribe = subscribe;
 	}
 
+	/**
+	 * Whether to subscribe or unsubscribe.
+	 * 
+	 * @return true for subscribe, false for unsubscribe
+	 */
 	public boolean getSubscribe() {
 		return this.subscribe;
 	}

--- a/io.openems.common/src/io/openems/common/jsonrpc/request/UpdateComponentConfigRequest.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/UpdateComponentConfigRequest.java
@@ -2,7 +2,6 @@ package io.openems.common.jsonrpc.request;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -33,24 +32,34 @@ import io.openems.common.utils.JsonUtils;
  */
 public class UpdateComponentConfigRequest extends JsonrpcRequest {
 
+	public static final String METHOD = "updateComponentConfig";
+
+	/**
+	 * Create {@link UpdateComponentConfigRequest} from a template
+	 * {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link UpdateComponentConfigRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static UpdateComponentConfigRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		String componentId = JsonUtils.getAsString(p, "componentId");
 		List<Property> properties = Property.from(JsonUtils.getAsJsonArray(p, "properties"));
-		return new UpdateComponentConfigRequest(r.getId(), componentId, properties);
+		return new UpdateComponentConfigRequest(r, componentId, properties);
 	}
-
-	public final static String METHOD = "updateComponentConfig";
 
 	private final String componentId;
 	private final List<Property> properties;
 
 	public UpdateComponentConfigRequest(String componentId, List<Property> properties) {
-		this(UUID.randomUUID(), componentId, properties);
+		super(METHOD);
+		this.componentId = componentId;
+		this.properties = properties;
 	}
 
-	public UpdateComponentConfigRequest(UUID id, String componentId, List<Property> properties) {
-		super(id, METHOD);
+	private UpdateComponentConfigRequest(JsonrpcRequest request, String componentId, List<Property> properties) {
+		super(request, METHOD);
 		this.componentId = componentId;
 		this.properties = properties;
 	}
@@ -67,17 +76,27 @@ public class UpdateComponentConfigRequest extends JsonrpcRequest {
 				.build();
 	}
 
+	/**
+	 * Gets the Component-ID.
+	 * 
+	 * @return Component-ID
+	 */
 	public String getComponentId() {
-		return componentId;
+		return this.componentId;
 	}
 
+	/**
+	 * Gets a list of Properties.
+	 * 
+	 * @return the Properties
+	 */
 	public List<Property> getProperties() {
 		return this.properties;
 	}
 
 	public static class Property {
 
-		public static List<Property> from(JsonArray j) throws OpenemsNamedException {
+		protected static List<Property> from(JsonArray j) throws OpenemsNamedException {
 			List<Property> properties = new ArrayList<>();
 			for (JsonElement property : j) {
 				String name = JsonUtils.getAsString(property, "name");
@@ -91,6 +110,8 @@ public class UpdateComponentConfigRequest extends JsonrpcRequest {
 		private final JsonElement value;
 
 		/**
+		 * Initializes a Property.
+		 * 
 		 * @param name  the Property name
 		 * @param value the new value
 		 */
@@ -112,15 +133,25 @@ public class UpdateComponentConfigRequest extends JsonrpcRequest {
 			this(name, new JsonPrimitive(value));
 		}
 
+		/**
+		 * Gets the Name.
+		 * 
+		 * @return Name
+		 */
 		public String getName() {
 			return this.name;
 		}
 
+		/**
+		 * Gets the Value.
+		 * 
+		 * @return Value
+		 */
 		public JsonElement getValue() {
 			return this.value;
 		}
 
-		public JsonObject toJson() {
+		protected JsonObject toJson() {
 			return JsonUtils.buildJsonObject() //
 					.addProperty("name", this.getName()) //
 					.add("value", this.getValue()) //

--- a/io.openems.common/src/io/openems/common/utils/DateUtils.java
+++ b/io.openems.common/src/io/openems/common/utils/DateUtils.java
@@ -1,0 +1,25 @@
+package io.openems.common.utils;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import io.openems.common.exceptions.OpenemsException;
+
+public class DateUtils {
+
+	private DateUtils() {
+	}
+
+	/**
+	 * Asserts that both dates are in the same timezone.
+	 * 
+	 * @param date1 the first Date
+	 * @param date1 the second Date
+	 * @throws OpenemsException if dates are not in the same timezone
+	 */
+	public static void assertSameTimezone(ZonedDateTime date1, ZonedDateTime date2) throws OpenemsException {
+		if (ZoneOffset.from(date1).getTotalSeconds() != ZoneOffset.from(date2).getTotalSeconds()) {
+			throw new OpenemsException("FromDate and ToDate need to be in the same timezone!");
+		}
+	}
+}

--- a/io.openems.common/src/io/openems/common/websocket/OnRequestHandler.java
+++ b/io.openems.common/src/io/openems/common/websocket/OnRequestHandler.java
@@ -2,6 +2,8 @@ package io.openems.common.websocket;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import org.java_websocket.WebSocket;
@@ -38,14 +40,22 @@ public class OnRequestHandler implements Runnable {
 			CompletableFuture<? extends JsonrpcResponseSuccess> responseFuture = this.parent.getOnRequest().run(this.ws,
 					this.request);
 			// Get success response
-			response = responseFuture.get();
+			if (this.request.getTimeout().isPresent() && this.request.getTimeout().get() > 0) {
+				// ...with timeout
+				response = responseFuture.get(this.request.getTimeout().get(), TimeUnit.SECONDS);
+			} else {
+				// ...without timeout
+				response = responseFuture.get();
+			}
 		} catch (OpenemsNamedException e) {
 			// Get Named Exception error response
 			this.parent.logWarn(this.log, "JSON-RPC Error Response: " + e.getMessage());
 			response = new JsonrpcResponseError(request.getId(), e);
-		} catch (ExecutionException | InterruptedException e) {
+		} catch (ExecutionException | InterruptedException | TimeoutException e) {
 			// Get GENERIC error response
-			this.parent.logWarn(this.log, "JSON-RPC Error Response: " + e.getMessage());
+			this.parent.logWarn(this.log, "JSON-RPC Error Response. " + e.getClass().getSimpleName() + ". " //
+					+ "Request: " + this.request.toString() + ". " //
+					+ "Message: " + e.getMessage());
 			response = new JsonrpcResponseError(request.getId(), e.getMessage());
 		}
 

--- a/io.openems.common/test/io/openems/common/jsonrpc/base/GenericJsonrpcRequestTest.java
+++ b/io.openems.common/test/io/openems/common/jsonrpc/base/GenericJsonrpcRequestTest.java
@@ -1,0 +1,45 @@
+package io.openems.common.jsonrpc.base;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import com.google.gson.JsonObject;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.utils.JsonUtils;
+
+public class GenericJsonrpcRequestTest {
+
+	@Test
+	public void test() throws OpenemsNamedException {
+		UUID id = UUID.randomUUID();
+		String method = "dummyMethod";
+		JsonObject params = JsonUtils.buildJsonObject() //
+				.addProperty("hello", "world") //
+				.addProperty("foo", "bar") //
+				.build();
+		int timeout = 10;
+
+		// Test toString()
+		GenericJsonrpcRequest sut = new GenericJsonrpcRequest(id, method, params, timeout);
+		String json = sut.toString();
+
+		assertEquals(
+				"{\"jsonrpc\":\"2.0\",\"method\":\"dummyMethod\",\"params\":{\"hello\":\"world\",\"foo\":\"bar\"},\"id\":\""
+						+ id.toString() + "\",\"timeout\":10}",
+				json);
+
+		// Test from()
+		sut = GenericJsonrpcRequest.from(json);
+		assertEquals(id, sut.getId());
+		assertEquals(method, sut.getMethod());
+		assertEquals(Optional.of(timeout), sut.getTimeout());
+		assertEquals("{\"hello\":\"world\",\"foo\":\"bar\"}", sut.getParams().toString());
+
+	}
+
+}

--- a/io.openems.edge.controller.api.modbus/src/io/openems/edge/controller/api/modbus/jsonrpc/GetModbusProtocolExportXlsxRequest.java
+++ b/io.openems.edge.controller.api.modbus/src/io/openems/edge/controller/api/modbus/jsonrpc/GetModbusProtocolExportXlsxRequest.java
@@ -1,7 +1,5 @@
 package io.openems.edge.controller.api.modbus.jsonrpc;
 
-import java.util.UUID;
-
 import com.google.gson.JsonObject;
 
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
@@ -23,11 +21,11 @@ public class GetModbusProtocolExportXlsxRequest extends JsonrpcRequest {
 	public static final String METHOD = "getModbusProtocolExportXlsx";
 
 	public GetModbusProtocolExportXlsxRequest() {
-		this(UUID.randomUUID());
+		super(METHOD);
 	}
 
-	public GetModbusProtocolExportXlsxRequest(UUID id) {
-		super(id, METHOD);
+	private GetModbusProtocolExportXlsxRequest(JsonrpcRequest request) {
+		super(request, METHOD);
 	}
 
 	@Override

--- a/io.openems.edge.controller.api.modbus/src/io/openems/edge/controller/api/modbus/jsonrpc/GetModbusProtocolRequest.java
+++ b/io.openems.edge.controller.api.modbus/src/io/openems/edge/controller/api/modbus/jsonrpc/GetModbusProtocolRequest.java
@@ -1,7 +1,5 @@
 package io.openems.edge.controller.api.modbus.jsonrpc;
 
-import java.util.UUID;
-
 import com.google.gson.JsonObject;
 
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
@@ -24,11 +22,11 @@ public class GetModbusProtocolRequest extends JsonrpcRequest {
 	public static final String METHOD = "getModbusProtocol";
 
 	public GetModbusProtocolRequest() {
-		this(UUID.randomUUID());
+		super(METHOD);
 	}
 
-	public GetModbusProtocolRequest(UUID id) {
-		super(id, METHOD);
+	private GetModbusProtocolRequest(JsonrpcRequest request) {
+		super(request, METHOD);
 	}
 
 	@Override

--- a/io.openems.edge.core/src/io/openems/edge/core/host/jsonrpc/ExecuteSystemCommandRequest.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/host/jsonrpc/ExecuteSystemCommandRequest.java
@@ -91,7 +91,8 @@ public class ExecuteSystemCommandRequest extends JsonrpcRequest {
 
 	public ExecuteSystemCommandRequest(UUID id, String command, boolean runInBackground, int timeoutSeconds,
 			Optional<String> username, Optional<String> password) {
-		super(id, METHOD);
+		super(id, METHOD,
+				timeoutSeconds + JsonrpcRequest.DEFAULT_TIMEOUT_SECONDS /* reuse timeoutSeconds with some buffer */);
 		this.command = command;
 		this.runInBackground = runInBackground;
 		this.timeoutSeconds = timeoutSeconds;

--- a/io.openems.edge.core/src/io/openems/edge/core/host/jsonrpc/GetNetworkConfigRequest.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/host/jsonrpc/GetNetworkConfigRequest.java
@@ -1,7 +1,5 @@
 package io.openems.edge.core.host.jsonrpc;
 
-import java.util.UUID;
-
 import com.google.gson.JsonObject;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -32,15 +30,15 @@ public class GetNetworkConfigRequest extends JsonrpcRequest {
 	 * @throws OpenemsNamedException on error
 	 */
 	public static GetNetworkConfigRequest from(JsonrpcRequest r) throws OpenemsException {
-		return new GetNetworkConfigRequest(r.getId());
+		return new GetNetworkConfigRequest(r);
 	}
 
 	public GetNetworkConfigRequest() {
-		this(UUID.randomUUID());
+		super(METHOD);
 	}
 
-	public GetNetworkConfigRequest(UUID id) {
-		super(id, METHOD);
+	private GetNetworkConfigRequest(JsonrpcRequest request) {
+		super(request, METHOD);
 	}
 
 	@Override

--- a/io.openems.edge.core/src/io/openems/edge/core/host/jsonrpc/SetNetworkConfigRequest.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/host/jsonrpc/SetNetworkConfigRequest.java
@@ -3,7 +3,6 @@ package io.openems.edge.core.host.jsonrpc;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.UUID;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -52,18 +51,19 @@ public class SetNetworkConfigRequest extends JsonrpcRequest {
 		for (Entry<String, JsonElement> entry : jInterfaces.entrySet()) {
 			interfaces.add(NetworkInterface.from(entry.getKey(), JsonUtils.getAsJsonObject(entry.getValue())));
 		}
-		return new SetNetworkConfigRequest(r.getId(), interfaces);
+		return new SetNetworkConfigRequest(r, interfaces);
 	}
 
 	private final List<NetworkInterface<?>> networkInterfaces;
 
 	public SetNetworkConfigRequest(List<NetworkInterface<?>> interfaces) {
-		this(UUID.randomUUID(), interfaces);
+		super(METHOD);
+		this.networkInterfaces = interfaces;
 	}
 
-	public SetNetworkConfigRequest(UUID id, List<NetworkInterface<?>> networkInterfaces) {
-		super(id, METHOD);
-		this.networkInterfaces = networkInterfaces;
+	private SetNetworkConfigRequest(JsonrpcRequest request, List<NetworkInterface<?>> interfaces) {
+		super(request, METHOD);
+		this.networkInterfaces = interfaces;
 	}
 
 	@Override

--- a/io.openems.edge.core/src/io/openems/edge/core/predictormanager/Get24HoursPredictionRequest.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/predictormanager/Get24HoursPredictionRequest.java
@@ -2,7 +2,6 @@ package io.openems.edge.core.predictormanager;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -31,6 +30,14 @@ public class Get24HoursPredictionRequest extends JsonrpcRequest {
 
 	public static final String METHOD = "get24HoursPrediction";
 
+	/**
+	 * Create {@link Get24HoursPredictionRequest} from a template
+	 * {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link Get24HoursPredictionRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static Get24HoursPredictionRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		JsonArray cs = JsonUtils.getAsJsonArray(p, "channels");
@@ -38,17 +45,18 @@ public class Get24HoursPredictionRequest extends JsonrpcRequest {
 		for (JsonElement c : cs) {
 			channels.add(ChannelAddress.fromString(JsonUtils.getAsString(c)));
 		}
-		return new Get24HoursPredictionRequest(r.getId(), channels);
+		return new Get24HoursPredictionRequest(r, channels);
 	}
 
 	private final List<ChannelAddress> channels;
 
 	public Get24HoursPredictionRequest(List<ChannelAddress> channels) {
-		this(UUID.randomUUID(), channels);
+		super(METHOD);
+		this.channels = channels;
 	}
 
-	public Get24HoursPredictionRequest(UUID id, List<ChannelAddress> channels) {
-		super(id, METHOD);
+	private Get24HoursPredictionRequest(JsonrpcRequest request, List<ChannelAddress> channels) {
+		super(request, METHOD);
 		this.channels = channels;
 	}
 
@@ -63,6 +71,11 @@ public class Get24HoursPredictionRequest extends JsonrpcRequest {
 				.build();
 	}
 
+	/**
+	 * Gets the {@link ChannelAddress}es.
+	 * 
+	 * @return a list of {@link ChannelAddress}
+	 */
 	public List<ChannelAddress> getChannels() {
 		return this.channels;
 	}

--- a/io.openems.edge.core/src/io/openems/edge/core/predictormanager/Get24HoursPredictionResponse.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/predictormanager/Get24HoursPredictionResponse.java
@@ -50,8 +50,13 @@ public class Get24HoursPredictionResponse extends JsonrpcResponseSuccess {
 		return j;
 	}
 
+	/**
+	 * Gets the {@link Prediction24Hours}s per {@link ChannelAddress}.
+	 * 
+	 * @return a map of Predictions
+	 */
 	public Map<ChannelAddress, Prediction24Hours> getPredictions() {
-		return predictions;
+		return this.predictions;
 	}
 
 }

--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/power/api/SolverStrategy.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/power/api/SolverStrategy.java
@@ -21,12 +21,12 @@ public enum SolverStrategy implements OptionsEnum {
 
 	@Override
 	public int getValue() {
-		return value;
+		return this.value;
 	}
 
 	@Override
 	public String getName() {
-		return name;
+		return this.name;
 	}
 
 	@Override

--- a/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/jsonrpc/GetFieldNamesRequest.java
+++ b/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/jsonrpc/GetFieldNamesRequest.java
@@ -1,7 +1,5 @@
 package io.openems.edge.meter.discovergy.jsonrpc;
 
-import java.util.UUID;
-
 import com.google.gson.JsonObject;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -24,24 +22,37 @@ import io.openems.common.utils.JsonUtils;
  */
 public class GetFieldNamesRequest extends JsonrpcRequest {
 
+	public static final String METHOD = "getFieldNames";
+
+	/**
+	 * Create {@link GetFieldNamesRequest} from a template {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link GetFieldNamesRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static GetFieldNamesRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		String meterId = JsonUtils.getAsString(r.getParams(), "meterId");
-		return new GetFieldNamesRequest(r.getId(), meterId);
+		return new GetFieldNamesRequest(r, meterId);
 	}
-
-	public static final String METHOD = "getFieldNames";
 
 	private final String meterId;
 
 	public GetFieldNamesRequest(String meterId) {
-		this(UUID.randomUUID(), meterId);
-	}
-
-	public GetFieldNamesRequest(UUID id, String meterId) {
-		super(id, METHOD);
+		super(METHOD);
 		this.meterId = meterId;
 	}
 
+	private GetFieldNamesRequest(JsonrpcRequest request, String meterId) {
+		super(request, METHOD);
+		this.meterId = meterId;
+	}
+
+	/**
+	 * Gets the Meter-ID.
+	 * 
+	 * @return Meter-ID
+	 */
 	public String getMeterId() {
 		return this.meterId;
 	}

--- a/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/jsonrpc/GetFieldNamesResponse.java
+++ b/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/jsonrpc/GetFieldNamesResponse.java
@@ -48,8 +48,13 @@ public class GetFieldNamesResponse extends JsonrpcResponseSuccess {
 				.build();
 	}
 
+	/**
+	 * Gets the {@link Field}s
+	 * 
+	 * @return a set of Fields
+	 */
 	public Set<Field> getFields() {
-		return fields;
+		return this.fields;
 	}
 
 }

--- a/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/jsonrpc/GetMetersRequest.java
+++ b/io.openems.edge.meter.discovergy/src/io/openems/edge/meter/discovergy/jsonrpc/GetMetersRequest.java
@@ -1,10 +1,9 @@
 package io.openems.edge.meter.discovergy.jsonrpc;
 
-import java.util.UUID;
-
 import com.google.gson.JsonObject;
 
 import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
 
 /**
@@ -21,18 +20,25 @@ import io.openems.common.jsonrpc.base.JsonrpcRequest;
  */
 public class GetMetersRequest extends JsonrpcRequest {
 
-	public static GetMetersRequest from(JsonrpcRequest r) throws OpenemsException {
-		return new GetMetersRequest(r.getId());
-	}
-
 	public static final String METHOD = "getMeters";
 
-	public GetMetersRequest() {
-		this(UUID.randomUUID());
+	/**
+	 * Create {@link GetMetersRequest} from a template {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link GetMetersRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
+	public static GetMetersRequest from(JsonrpcRequest r) throws OpenemsException {
+		return new GetMetersRequest(r);
 	}
 
-	public GetMetersRequest(UUID id) {
-		super(id, METHOD);
+	public GetMetersRequest() {
+		super(METHOD);
+	}
+
+	private GetMetersRequest(JsonrpcRequest request) {
+		super(request, METHOD);
 	}
 
 	@Override

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/app/ExecuteSimulationRequest.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/app/ExecuteSimulationRequest.java
@@ -54,7 +54,17 @@ import io.openems.common.utils.JsonUtils;
  */
 public class ExecuteSimulationRequest extends JsonrpcRequest {
 
+	public static final String METHOD = "executeSimulation";
+
 	public static class Clock {
+
+		/**
+		 * Create {@link Clock} from {@link JsonObject}.
+		 * 
+		 * @param j the {@link JsonObject}
+		 * @return the {@link Clock}
+		 * @throws OpenemsNamedException on parse error
+		 */
 		public static Clock from(JsonObject j) throws OpenemsNamedException {
 			ZonedDateTime start = ZonedDateTime.parse(JsonUtils.getAsString(j, "start"));
 			ZonedDateTime end = ZonedDateTime.parse(JsonUtils.getAsString(j, "end"));
@@ -77,6 +87,14 @@ public class ExecuteSimulationRequest extends JsonrpcRequest {
 	}
 
 	public static class Profile {
+
+		/**
+		 * Create {@link Profile} from {@link JsonArray}.
+		 * 
+		 * @param j the {@link JsonArray}
+		 * @return the {@link Profile}
+		 * @throws OpenemsNamedException on parse error
+		 */
 		public static Profile from(JsonArray j) throws OpenemsNamedException {
 			final List<Integer> values = new ArrayList<>();
 			j.forEach(value -> {
@@ -95,10 +113,18 @@ public class ExecuteSimulationRequest extends JsonrpcRequest {
 			this.values = values;
 		}
 
+		/**
+		 * Gets the currently active value of the {@link Profile}.
+		 * 
+		 * @return the value
+		 */
 		public synchronized Integer getCurrentValue() {
 			return this.values.get(this.currentIndex);
 		}
 
+		/**
+		 * Selects the next active value in the {@link Profile}.
+		 */
 		public synchronized void selectNextValue() {
 			this.currentIndex += 1;
 			if (this.currentIndex > this.values.size() - 1) {
@@ -108,8 +134,14 @@ public class ExecuteSimulationRequest extends JsonrpcRequest {
 
 	}
 
-	public static final String METHOD = "executeSimulation";
-
+	/**
+	 * Create {@link ExecuteSimulationRequest} from a template
+	 * {@link JsonrpcRequest}.
+	 * 
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link ExecuteSimulationRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
 	public static ExecuteSimulationRequest from(JsonrpcRequest r) throws OpenemsNamedException {
 		JsonObject p = r.getParams();
 		List<CreateComponentConfigRequest> components = new ArrayList<>();
@@ -128,7 +160,7 @@ public class ExecuteSimulationRequest extends JsonrpcRequest {
 		for (JsonElement jCollect : jCollects) {
 			collects.add(ChannelAddress.fromString(JsonUtils.getAsString(jCollect)));
 		}
-		return new ExecuteSimulationRequest(r.getId(), components, clock, profiles, collects);
+		return new ExecuteSimulationRequest(r, components, clock, profiles, collects);
 	}
 
 	public final List<CreateComponentConfigRequest> components;
@@ -138,12 +170,16 @@ public class ExecuteSimulationRequest extends JsonrpcRequest {
 
 	public ExecuteSimulationRequest(List<CreateComponentConfigRequest> components, Clock clock,
 			Map<String, Profile> profiles, List<ChannelAddress> collects) {
-		this(UUID.randomUUID(), components, clock, profiles, collects);
+		super(UUID.randomUUID(), METHOD, JsonrpcRequest.NO_TIMEOUT);
+		this.components = components;
+		this.clock = clock;
+		this.profiles = profiles;
+		this.collects = collects;
 	}
 
-	public ExecuteSimulationRequest(UUID id, List<CreateComponentConfigRequest> components, Clock clock,
+	public ExecuteSimulationRequest(JsonrpcRequest request, List<CreateComponentConfigRequest> components, Clock clock,
 			Map<String, Profile> profiles, List<ChannelAddress> collects) {
-		super(id, METHOD);
+		super(request, METHOD);
 		this.components = components;
 		this.clock = clock;
 		this.profiles = profiles;

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/app/SimulatorApp.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/app/SimulatorApp.java
@@ -293,8 +293,8 @@ public class SimulatorApp extends AbstractOpenemsComponent
 	/**
 	 * Apply simulated Time-Leap per Cycle.
 	 * 
-	 * @param clock             the {@link TimeLeapClock}
-	 * @param currentSimulation the current {@link ExecuteSimulationRequest}
+	 * @param clock                    the {@link TimeLeapClock}
+	 * @param currentSimulationRequest the current {@link ExecuteSimulationRequest}
 	 */
 	private void applyTimeLeap(TimeLeapClock clock, ExecuteSimulationRequest currentSimulationRequest) {
 		if (currentSimulationRequest.clock.executeCycleTwice) {
@@ -322,6 +322,7 @@ public class SimulatorApp extends AbstractOpenemsComponent
 	/**
 	 * Delete all non-required Components.
 	 * 
+	 * @param user the {@link User}
 	 * @throws OpenemsNamedException on error
 	 */
 	private void deleteAllConfigurations(User user) throws OpenemsNamedException {
@@ -352,8 +353,6 @@ public class SimulatorApp extends AbstractOpenemsComponent
 
 	/**
 	 * Stop the Simulation.
-	 * 
-	 * @param currentSimulation the current simulation
 	 */
 	private void stopSimulation() {
 		this.logInfo(this.log, "Stopping Simulation");


### PR DESCRIPTION
This non-standard extension of the JSON-RPC protocol adds a "timeout" parameter in seconds. This is the maximum time that we wait for a JSON-RPC Response. Timeout is defined as an `Optional`:

- timeout > 0: use the given timeout in seconds
- timeout <= 0: apply no timeout, i.e. wait forever
- no timeout: use default timeout of 60 seconds