### PR TITLE
Downgrade apache.felix.scr to 2.1.20

### DIFF
--- a/cnf/pom.xml
+++ b/cnf/pom.xml
@@ -154,7 +154,7 @@
 			<!-- Changelog: https://github.com/apache/felix-dev/blob/master/scr/changelog.txt -->
 			<groupId>org.apache.felix</groupId>
 			<artifactId>org.apache.felix.scr</artifactId>
-			<version>2.1.26</version>
+			<version>2.1.20</version>
 		</dependency>
 		<dependency>
 			<!-- Apache Felix Web Management Console -->

--- a/io.openems.backend.application/BackendApp.bndrun
+++ b/io.openems.backend.application/BackendApp.bndrun
@@ -67,7 +67,7 @@
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.inventory;version='[1.0.6,1.0.7)',\
 	org.apache.felix.metatype;version='[1.2.4,1.2.5)',\
-	org.apache.felix.scr;version='[2.1.26,2.1.27)',\
+	org.apache.felix.scr;version='[2.1.20,2.1.21)',\
 	org.apache.felix.webconsole;version='[4.6.0,4.6.1)',\
 	org.apache.felix.webconsole.plugins.ds;version='[2.1.0,2.1.1)',\
 	org.apache.servicemix.bundles.ws-commons-util;version='[1.0.2,1.0.3)',\

--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -294,7 +294,7 @@
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.inventory;version='[1.0.6,1.0.7)',\
 	org.apache.felix.metatype;version='[1.2.4,1.2.5)',\
-	org.apache.felix.scr;version='[2.1.26,2.1.27)',\
+	org.apache.felix.scr;version='[2.1.20,2.1.21)',\
 	org.apache.felix.webconsole;version='[4.6.0,4.6.1)',\
 	org.apache.felix.webconsole.plugins.ds;version='[2.1.0,2.1.1)',\
 	org.jsr-305;version='[3.0.2,3.0.3)',\


### PR DESCRIPTION
It seems like https://github.com/apache/felix-dev/commit/4102a86b92d26e64a91fcb0e8e4eaa24f561dad9 was breaking empty target filters