### PR TITLE
OpenEMS Backend: optimize ThreadPools

### DIFF
--- a/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/SubscribedEdgesChannelsWorker.java
+++ b/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/SubscribedEdgesChannelsWorker.java
@@ -3,8 +3,6 @@ package io.openems.backend.b2bwebsocket;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -27,11 +25,6 @@ public class SubscribedEdgesChannelsWorker {
 	protected static final int UPDATE_INTERVAL_IN_SECONDS = 2;
 
 	private final Logger log = LoggerFactory.getLogger(SubscribedEdgesChannelsWorker.class);
-
-	/**
-	 * Executor for subscriptions task.
-	 */
-	private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
 
 	/**
 	 * Holds subscribed edges.
@@ -94,7 +87,7 @@ public class SubscribedEdgesChannelsWorker {
 
 		if (!channels.isEmpty() && !edgeIds.isEmpty()) {
 			// registered channels -> create new thread
-			this.futureOpt = Optional.of(this.executor.scheduleWithFixedDelay(() -> {
+			this.futureOpt = Optional.of(this.parent.executor.scheduleWithFixedDelay(() -> {
 				/*
 				 * This task is executed regularly. Sends data to Websocket.
 				 */

--- a/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/WsData.java
+++ b/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/WsData.java
@@ -3,6 +3,7 @@ package io.openems.backend.b2bwebsocket;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -12,10 +13,12 @@ import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 
 public class WsData extends io.openems.common.websocket.WsData {
 
+	private final B2bWebsocket parent;
 	private final SubscribedEdgesChannelsWorker worker;
 	private CompletableFuture<BackendUser> user = new CompletableFuture<BackendUser>();
 
 	public WsData(B2bWebsocket parent) {
+		this.parent = parent;
 		this.worker = new SubscribedEdgesChannelsWorker(parent, this);
 	}
 
@@ -62,5 +65,11 @@ public class WsData extends io.openems.common.websocket.WsData {
 		} else {
 			return "B2bWebsocket.WsData [user=" + user + "]";
 		}
+	}
+
+	@Override
+	protected ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+			TimeUnit unit) {
+		return this.parent.executor.scheduleWithFixedDelay(command, initialDelay, delay, unit);
 	}
 }

--- a/io.openems.backend.b2bwebsocket/test/io/openems/backend/b2bwebsocket/TestClient.java
+++ b/io.openems.backend.b2bwebsocket/test/io/openems/backend/b2bwebsocket/TestClient.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.openems.common.websocket.AbstractWebsocketClient;
+import io.openems.common.websocket.DummyWsData;
 import io.openems.common.websocket.OnClose;
 import io.openems.common.websocket.OnError;
 import io.openems.common.websocket.OnNotification;
@@ -89,18 +90,9 @@ public class TestClient extends AbstractWebsocketClient<WsData> {
 		this.onNotification = onNotification;
 	}
 
-	private static class TestWsData extends WsData {
-
-		@Override
-		public String toString() {
-			return "TestWsData[]";
-		}
-
-	}
-
 	@Override
 	protected WsData createWsData() {
-		return new TestWsData();
+		return new DummyWsData();
 	}
 
 	@Override
@@ -111,5 +103,10 @@ public class TestClient extends AbstractWebsocketClient<WsData> {
 	@Override
 	protected void logWarn(Logger log, String message) {
 		log.warn(message);
+	}
+
+	@Override
+	protected void execute(Runnable command) {
+		command.run();
 	}
 }

--- a/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/EdgeWebsocketImpl.java
+++ b/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/EdgeWebsocketImpl.java
@@ -33,7 +33,11 @@ import io.openems.common.jsonrpc.response.AuthenticatedRpcResponse;
 import io.openems.common.session.User;
 
 @Designate(ocd = Config.class, factory = false)
-@Component(name = "Edge.Websocket", configurationPolicy = ConfigurationPolicy.REQUIRE, immediate = true)
+@Component(//
+		name = "Edge.Websocket", //
+		configurationPolicy = ConfigurationPolicy.REQUIRE, //
+		immediate = true //
+)
 public class EdgeWebsocketImpl extends AbstractOpenemsBackendComponent implements EdgeWebsocket {
 
 	private final Logger log = LoggerFactory.getLogger(EdgeWebsocketImpl.class);

--- a/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/WebsocketServer.java
+++ b/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/WebsocketServer.java
@@ -7,6 +7,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +51,7 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 
 	@Override
 	protected WsData createWsData() {
-		WsData wsData = new WsData();
+		WsData wsData = new WsData(this);
 		return wsData;
 	}
 
@@ -135,5 +137,11 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 	@Override
 	protected void logWarn(Logger log, String message) {
 		this.parent.logWarn(log, message);
+	}
+
+	@Override
+	protected ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+			TimeUnit unit) {
+		return super.scheduleWithFixedDelay(command, initialDelay, delay, unit);
 	}
 }

--- a/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/WsData.java
+++ b/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/WsData.java
@@ -3,6 +3,7 @@ package io.openems.backend.edgewebsocket;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -14,11 +15,13 @@ import io.openems.common.utils.StringUtils;
 
 public class WsData extends io.openems.common.websocket.WsData {
 
+	private final WebsocketServer parent;
 	private CompletableFuture<Boolean> isAuthenticated = new CompletableFuture<Boolean>();
 	private Optional<String> apikey = Optional.empty();
 	private Optional<String> edgeId = Optional.empty();
 
-	public WsData() {
+	public WsData(WebsocketServer parent) {
+		this.parent = parent;
 	}
 
 	public void setAuthenticated(boolean isAuthenticated) {
@@ -99,5 +102,11 @@ public class WsData extends io.openems.common.websocket.WsData {
 	 */
 	private String getId() {
 		return this.edgeId.orElse(this.apikey.orElse("UNKNOWN"));
+	}
+
+	@Override
+	protected ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+			TimeUnit unit) {
+		return this.parent.scheduleWithFixedDelay(command, initialDelay, delay, unit);
 	}
 }

--- a/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/postgres/PeriodicWriteWorker.java
+++ b/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/postgres/PeriodicWriteWorker.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.zaxxer.hikari.HikariDataSource;
 
 import io.openems.backend.metadata.odoo.Field;
@@ -47,7 +48,8 @@ public class PeriodicWriteWorker {
 	/**
 	 * Executor for subscriptions task.
 	 */
-	private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+	private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1,
+			new ThreadFactoryBuilder().setNameFormat("Metadata.Odoo.PGPeriodic-%d").build());
 
 	public PeriodicWriteWorker(PostgresHandler parent, HikariDataSource dataSource) {
 		this.parent = parent;

--- a/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/postgres/QueueWriteWorker.java
+++ b/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/postgres/QueueWriteWorker.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.zaxxer.hikari.HikariDataSource;
 
 import io.openems.backend.metadata.odoo.postgres.task.DatabaseTask;
@@ -36,7 +37,7 @@ public class QueueWriteWorker {
 	// Executor for subscriptions task. Like a CachedThreadPool, but properly typed
 	// for DEBUG_MODE.
 	private final ThreadPoolExecutor executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS,
-			new SynchronousQueue<Runnable>());
+			new SynchronousQueue<Runnable>(), new ThreadFactoryBuilder().setNameFormat("Metadata.Odoo.PGQueue-%d").build());
 
 	private final ScheduledExecutorService debugLogExecutor;
 

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/WebsocketServer.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/WebsocketServer.java
@@ -1,5 +1,8 @@
 package io.openems.backend.uiwebsocket.impl;
 
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,7 +15,7 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 
 	private final Logger log = LoggerFactory.getLogger(WebsocketServer.class);
 
-	private final UiWebsocketImpl parent;
+	protected final UiWebsocketImpl parent;
 	private final OnOpen onOpen;
 	private final OnRequest onRequest;
 	private final OnNotification onNotification;
@@ -31,7 +34,7 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 
 	@Override
 	protected WsData createWsData() {
-		return new WsData(this.parent);
+		return new WsData(this);
 	}
 
 	@Override
@@ -74,5 +77,11 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 	@Override
 	protected void logWarn(Logger log, String message) {
 		this.parent.logWarn(log, message);
+	}
+
+	@Override
+	protected ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+			TimeUnit unit) {
+		return super.scheduleWithFixedDelay(command, initialDelay, delay, unit);
 	}
 }

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/WsData.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/WsData.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import io.openems.backend.common.metadata.BackendUser;
 import io.openems.backend.common.metadata.Metadata;
@@ -12,12 +14,12 @@ import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 
 public class WsData extends io.openems.common.websocket.WsData {
 
-	private final UiWebsocketImpl parent;
+	private final WebsocketServer parent;
 	private final Map<String, SubscribedChannelsWorker> subscribedChannelsWorkers = new HashMap<>();
 	private Optional<String> userId = Optional.empty();
 	private Optional<UUID> token = Optional.empty();
 
-	public WsData(UiWebsocketImpl parent) {
+	public WsData(WebsocketServer parent) {
 		this.parent = parent;
 	}
 
@@ -88,7 +90,7 @@ public class WsData extends io.openems.common.websocket.WsData {
 	public synchronized SubscribedChannelsWorker getSubscribedChannelsWorker(String edgeId) {
 		SubscribedChannelsWorker result = this.subscribedChannelsWorkers.get(edgeId);
 		if (result == null) {
-			result = new SubscribedChannelsWorker(this.parent, edgeId, this);
+			result = new SubscribedChannelsWorker(this.parent.parent, edgeId, this);
 			this.subscribedChannelsWorkers.put(edgeId, result);
 		}
 		return result;
@@ -103,5 +105,11 @@ public class WsData extends io.openems.common.websocket.WsData {
 			tokenString = "UNKNOWN";
 		}
 		return "UiWebsocket.WsData [userId=" + this.userId.orElse("UNKNOWN") + ", token=" + tokenString + "]";
+	}
+
+	@Override
+	protected ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+			TimeUnit unit) {
+		return this.parent.scheduleWithFixedDelay(command, initialDelay, delay, unit);
 	}
 }

--- a/io.openems.common/src/io/openems/common/utils/ThreadPoolUtils.java
+++ b/io.openems.common/src/io/openems/common/utils/ThreadPoolUtils.java
@@ -1,0 +1,49 @@
+package io.openems.common.utils;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ThreadPoolUtils {
+
+	private final static Logger LOG = LoggerFactory.getLogger(ThreadPoolUtils.class);
+
+	private ThreadPoolUtils() {
+	}
+
+	/**
+	 * Shutdown a {@link ExecutorService}.
+	 * 
+	 * <p>
+	 * Source:
+	 * https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ExecutorService.html
+	 * 
+	 * @param executor       the {@link ExecutorService}
+	 * @param timeoutSeconds the applied timeout (is applied twice in the worst
+	 *                       case)
+	 */
+	public static void shutdownAndAwaitTermination(ExecutorService pool, int timeoutSeconds) {
+		if (pool == null) {
+			return;
+		}
+		pool.shutdown(); // Disable new tasks from being submitted
+		try {
+			// Wait a while for existing tasks to terminate
+			if (!pool.awaitTermination(timeoutSeconds, TimeUnit.SECONDS)) {
+				pool.shutdownNow(); // Cancel currently executing tasks
+				// Wait a while for tasks to respond to being cancelled
+				if (!pool.awaitTermination(timeoutSeconds, TimeUnit.SECONDS)) {
+					LOG.warn("Pool did not terminate");
+				}
+			}
+		} catch (InterruptedException ie) {
+			// (Re-)Cancel if current thread also interrupted
+			pool.shutdownNow();
+			// Preserve interrupt status
+			Thread.currentThread().interrupt();
+		}
+	}
+
+}

--- a/io.openems.common/src/io/openems/common/websocket/AbstractWebsocketClient.java
+++ b/io.openems.common/src/io/openems/common/websocket/AbstractWebsocketClient.java
@@ -38,8 +38,6 @@ public abstract class AbstractWebsocketClient<T extends WsData> extends Abstract
 	public final static Proxy NO_PROXY = null;
 	public final static Draft DEFAULT_DRAFT = new Draft_6455();
 
-	private final static int MAXIMUM_POOL_SIZE = 10;
-
 	protected final WebSocketClient ws;
 
 	private final Logger log = LoggerFactory.getLogger(AbstractWebsocketClient.class);
@@ -60,7 +58,7 @@ public abstract class AbstractWebsocketClient<T extends WsData> extends Abstract
 
 	protected AbstractWebsocketClient(String name, URI serverUri, Draft draft, Map<String, String> httpHeaders,
 			Proxy proxy) {
-		super(name, MAXIMUM_POOL_SIZE, false /* debugMode */);
+		super(name);
 		this.serverUri = serverUri;
 		this.ws = new WebSocketClient(serverUri, draft, httpHeaders) {
 

--- a/io.openems.common/src/io/openems/common/websocket/DummyWebsocketServer.java
+++ b/io.openems.common/src/io/openems/common/websocket/DummyWebsocketServer.java
@@ -7,15 +7,6 @@ import io.openems.common.exceptions.NotImplementedException;
 
 public class DummyWebsocketServer extends AbstractWebsocketServer<WsData> implements AutoCloseable {
 
-	private static class DummyWsData extends WsData {
-
-		@Override
-		public String toString() {
-			return "DummyWsData[]";
-		}
-
-	}
-
 	public static class Builder {
 		private OnOpen onOpen = (ws, handshake) -> {
 		};

--- a/io.openems.common/src/io/openems/common/websocket/DummyWsData.java
+++ b/io.openems.common/src/io/openems/common/websocket/DummyWsData.java
@@ -1,0 +1,26 @@
+package io.openems.common.websocket;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+public class DummyWsData extends WsData {
+
+	private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1,
+			new ThreadFactoryBuilder().setNameFormat("DummyWsData-%d").build());
+
+	@Override
+	public String toString() {
+		return "DummyWsData[]";
+	}
+
+	@Override
+	protected ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+			TimeUnit unit) {
+		return this.executor.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+	}
+
+}

--- a/io.openems.common/src/io/openems/common/websocket/WsData.java
+++ b/io.openems.common/src/io/openems/common/websocket/WsData.java
@@ -3,6 +3,8 @@ package io.openems.common.websocket;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.java_websocket.WebSocket;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
@@ -146,4 +148,11 @@ public abstract class WsData {
 	 * @return a specific string for this instance
 	 */
 	public abstract String toString();
+
+	/**
+	 * Execute a {@link Runnable}.
+	 * 
+	 * @param command the {@link Runnable}
+	 */
+	protected abstract ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit);
 }

--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/SendChannelValuesWorker.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/SendChannelValuesWorker.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Table;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.JsonElement;
 
 import io.openems.common.channel.AccessMode;
@@ -41,7 +42,9 @@ public class SendChannelValuesWorker {
 
 	private final BackendApiImpl parent;
 	private final ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.SECONDS,
-			new ArrayBlockingQueue<>(1), new ThreadPoolExecutor.DiscardOldestPolicy());
+			new ArrayBlockingQueue<>(1), //
+			new ThreadFactoryBuilder().setNameFormat(BackendApiImpl.COMPONENT_NAME + ":SendWorker-%d").build(), //
+			new ThreadPoolExecutor.DiscardOldestPolicy());
 
 	/**
 	 * If true: next 'send' sends all channel values.

--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/WebsocketClient.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/WebsocketClient.java
@@ -3,6 +3,8 @@ package io.openems.edge.controller.api.backend;
 import java.net.Proxy;
 import java.net.URI;
 import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +64,7 @@ public class WebsocketClient extends AbstractWebsocketClient<WsData> {
 
 	@Override
 	protected WsData createWsData() {
-		return new WsData();
+		return new WsData(this);
 	}
 
 	@Override
@@ -77,5 +79,15 @@ public class WebsocketClient extends AbstractWebsocketClient<WsData> {
 
 	public boolean isConnected() {
 		return this.ws.isOpen();
+	}
+
+	@Override
+	protected void execute(Runnable command) {
+		this.parent.executor.execute(command);
+	}
+
+	protected ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+			TimeUnit unit) {
+		return this.parent.executor.scheduleWithFixedDelay(command, initialDelay, delay, unit);
 	}
 }

--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/WsData.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/WsData.java
@@ -1,10 +1,25 @@
 package io.openems.edge.controller.api.backend;
 
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
 public class WsData extends io.openems.common.websocket.WsData {
+
+	private final WebsocketClient parent;
+
+	public WsData(WebsocketClient parent) {
+		this.parent = parent;
+	}
 
 	@Override
 	public String toString() {
 		return "BackendApi.WsData []";
+	}
+
+	@Override
+	protected ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+			TimeUnit unit) {
+		return this.parent.scheduleWithFixedDelay(command, initialDelay, delay, unit);
 	}
 
 }

--- a/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/WsData.java
+++ b/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/WsData.java
@@ -2,6 +2,8 @@ package io.openems.edge.controller.api.websocket;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import io.openems.common.exceptions.OpenemsError;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -9,6 +11,7 @@ import io.openems.edge.common.user.EdgeUser;
 
 public class WsData extends io.openems.common.websocket.WsData {
 
+	private final WebsocketApi parent;
 	private final SubscribedChannelsWorker subscribedChannelsWorker;
 
 	/**
@@ -20,6 +23,7 @@ public class WsData extends io.openems.common.websocket.WsData {
 	private Optional<EdgeUser> user = Optional.empty();
 
 	public WsData(WebsocketApi parent) {
+		this.parent = parent;
 		this.subscribedChannelsWorker = new SubscribedChannelsWorker(parent, this);
 	}
 
@@ -77,6 +81,12 @@ public class WsData extends io.openems.common.websocket.WsData {
 			tokenString = "UNKNOWN";
 		}
 		return "WebsocketApi.WsData [sessionToken=" + tokenString + ", user=" + user + "]";
+	}
+
+	@Override
+	protected ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+			TimeUnit unit) {
+		return this.parent.executor.scheduleWithFixedDelay(command, initialDelay, delay, unit);
 	}
 
 }

--- a/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnector.java
+++ b/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnector.java
@@ -29,6 +29,7 @@ import org.influxdb.dto.QueryResult.Series;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonPrimitive;
@@ -63,7 +64,10 @@ public class InfluxConnector {
 	private final boolean isReadOnly;
 	private final BiConsumer<Iterable<Point>, Throwable> onWriteError;
 	private final ThreadPoolExecutor executor = new ThreadPoolExecutor(EXECUTOR_MIN_THREADS, EXECUTOR_MAX_THREADS, 60L,
-			TimeUnit.SECONDS, new ArrayBlockingQueue<>(EXECUTOR_QUEUE_SIZE), new ThreadPoolExecutor.DiscardPolicy());
+			TimeUnit.SECONDS, //
+			new ArrayBlockingQueue<>(EXECUTOR_QUEUE_SIZE), //
+			new ThreadFactoryBuilder().setNameFormat("InfluxConnector-%d").build(), //
+			new ThreadPoolExecutor.DiscardPolicy());
 	private final ScheduledExecutorService debugLogExecutor = Executors.newSingleThreadScheduledExecutor();
 
 	/**


### PR DESCRIPTION
- Reduce the total number of ThreadPools (before there was one ThreadPool per WebSocket. Now it's one per Component.)
- Set namespace for ThreadPools to simplify debugging