### PR TITLE
TimeslotPeakshaving + HighLoadTimeslot: improve parsing of LocalDate and LocalTime

### DIFF
--- a/io.openems.edge.controller.highloadtimeslot/src/io/openems/edge/controller/highloadtimeslot/HighLoadTimeslot.java
+++ b/io.openems.edge.controller.highloadtimeslot/src/io/openems/edge/controller/highloadtimeslot/HighLoadTimeslot.java
@@ -32,8 +32,8 @@ import io.openems.edge.ess.power.api.Relationship;
 @Component(name = "Controller.HighLoadTimeslot", immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE)
 public class HighLoadTimeslot extends AbstractOpenemsComponent implements Controller, OpenemsComponent {
 
-	public static final String TIME_FORMAT = "HH:mm";
-	public static final String DATE_FORMAT = "dd.MM.yyyy";
+	public static final String TIME_FORMAT = "H:m";
+	public static final String DATE_FORMAT = "d.M.y";
 
 	/**
 	 * This many minutes before the high-load timeslot force charging is activated.

--- a/io.openems.edge.controller.highloadtimeslot/test/io/openems/edge/controller/highloadtimeslot/ControllerSimpleTests.java
+++ b/io.openems.edge.controller.highloadtimeslot/test/io/openems/edge/controller/highloadtimeslot/ControllerSimpleTests.java
@@ -1,6 +1,9 @@
 package io.openems.edge.controller.highloadtimeslot;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -8,6 +11,8 @@ import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 
 import org.junit.Test;
+
+import io.openems.common.exceptions.OpenemsException;
 
 public class ControllerSimpleTests {
 
@@ -95,14 +100,6 @@ public class ControllerSimpleTests {
 			assertTrue(e instanceof DateTimeParseException);
 		}
 
-		dateString = "1.1.2018";
-		try {
-			HighLoadTimeslot.convertDate(dateString);
-			fail();
-		} catch (DateTimeParseException e) {
-			assertTrue(e instanceof DateTimeParseException);
-		}
-
 		dateString = "31.02.2018";
 		expectedDate = LocalDate.of(2018, 2, 28);
 		assertEquals(expectedDate, HighLoadTimeslot.convertDate(dateString));
@@ -154,16 +151,25 @@ public class ControllerSimpleTests {
 		expectedTime = LocalTime.of(23, 13);
 		assertEquals(expectedTime, HighLoadTimeslot.convertTime(timeString));
 
-		timeString = "0:13";
-		try {
-			HighLoadTimeslot.convertTime(timeString);
-			fail();
-		} catch (DateTimeParseException e) {
-			assertTrue(e instanceof DateTimeParseException);
-		}
-
 		timeString = "00:13";
 		expectedTime = LocalTime.of(0, 13);
 		assertEquals(expectedTime, HighLoadTimeslot.convertTime(timeString));
+	}
+
+	@Test
+	public void testConvertTime() throws OpenemsException {
+		assertEquals(LocalTime.of(0, 0), HighLoadTimeslot.convertTime("0:0"));
+		assertEquals(LocalTime.of(10, 0), HighLoadTimeslot.convertTime("10:0"));
+		assertEquals(LocalTime.of(0, 10), HighLoadTimeslot.convertTime("0:10"));
+		assertEquals(LocalTime.of(0, 10), HighLoadTimeslot.convertTime("00:10"));
+		assertEquals(LocalTime.of(10, 10), HighLoadTimeslot.convertTime("10:10"));
+		assertEquals(LocalTime.of(0, 0), HighLoadTimeslot.convertTime("24:0"));
+	}
+
+	@Test
+	public void testConvertDate() throws OpenemsException {
+		assertEquals(LocalDate.of(2020, 2, 1), HighLoadTimeslot.convertDate("01.02.2020"));
+		assertEquals(LocalDate.of(2020, 2, 1), HighLoadTimeslot.convertDate("1.02.2020"));
+		assertEquals(LocalDate.of(2020, 2, 1), HighLoadTimeslot.convertDate("1.2.2020"));
 	}
 }

--- a/io.openems.edge.controller.symmetric.timeslotpeakshaving/src/io/openems/edge/controller/timeslotpeakshaving/TimeslotPeakshaving.java
+++ b/io.openems.edge.controller.symmetric.timeslotpeakshaving/src/io/openems/edge/controller/timeslotpeakshaving/TimeslotPeakshaving.java
@@ -39,8 +39,8 @@ import io.openems.edge.meter.api.SymmetricMeter;
 @Component(name = "Controller.TimeslotPeakshaving", immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE)
 public class TimeslotPeakshaving extends AbstractOpenemsComponent implements Controller, OpenemsComponent {
 
-	public static final String TIME_FORMAT = "HH:mm";
-	public static final String DATE_FORMAT = "dd.MM.yyyy";
+	public static final String TIME_FORMAT = "H:m";
+	public static final String DATE_FORMAT = "d.M.y";
 
 	private final Logger log = LoggerFactory.getLogger(TimeslotPeakshaving.class);
 

--- a/io.openems.edge.controller.symmetric.timeslotpeakshaving/test/io/openems/edge/controller/timeslotpeakshaving/TimeslotPeakshavingTest.java
+++ b/io.openems.edge.controller.symmetric.timeslotpeakshaving/test/io/openems/edge/controller/timeslotpeakshaving/TimeslotPeakshavingTest.java
@@ -1,11 +1,16 @@
 package io.openems.edge.controller.timeslotpeakshaving;
 
+import static org.junit.Assert.assertEquals;
+
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 
 import org.junit.Test;
 
+import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.types.ChannelAddress;
 import io.openems.edge.common.sum.GridMode;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
@@ -88,5 +93,22 @@ public class TimeslotPeakshavingTest {
 						.timeleap(clock, 75, ChronoUnit.MINUTES)/* current time is 12:02 run in normal state */
 						.input(ESS_ACTIVE_POWER, 5000) //
 						.input(METER_ACTIVE_POWER, 120000)); // nothing set on, Ess's setActivePower
+	}
+
+	@Test
+	public void testConvertTime() throws OpenemsException {
+		assertEquals(LocalTime.of(0, 0), TimeslotPeakshaving.convertTime("0:0"));
+		assertEquals(LocalTime.of(10, 0), TimeslotPeakshaving.convertTime("10:0"));
+		assertEquals(LocalTime.of(0, 10), TimeslotPeakshaving.convertTime("0:10"));
+		assertEquals(LocalTime.of(0, 10), TimeslotPeakshaving.convertTime("00:10"));
+		assertEquals(LocalTime.of(10, 10), TimeslotPeakshaving.convertTime("10:10"));
+		assertEquals(LocalTime.of(0, 0), TimeslotPeakshaving.convertTime("24:0"));
+	}
+
+	@Test
+	public void testConvertDate() throws OpenemsException {
+		assertEquals(LocalDate.of(2020, 2, 1), TimeslotPeakshaving.convertDate("01.02.2020"));
+		assertEquals(LocalDate.of(2020, 2, 1), TimeslotPeakshaving.convertDate("1.02.2020"));
+		assertEquals(LocalDate.of(2020, 2, 1), TimeslotPeakshaving.convertDate("1.2.2020"));
 	}
 }


### PR DESCRIPTION
Do not break if leading zeros are missing. See https://stackoverflow.com/a/57394132/4137113