### PR TITLE
Use MetaTypeInformation for `_Property` Channels

### DIFF
--- a/io.openems.common/src/io/openems/common/types/EdgeConfig.java
+++ b/io.openems.common/src/io/openems/common/types/EdgeConfig.java
@@ -11,6 +11,8 @@ import java.util.stream.Collectors;
 
 import org.osgi.service.metatype.AttributeDefinition;
 import org.osgi.service.metatype.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.CaseFormat;
 import com.google.gson.JsonArray;
@@ -35,6 +37,8 @@ import io.openems.common.utils.JsonUtils.JsonObjectBuilder;
  */
 public class EdgeConfig {
 
+	private static Logger LOG = LoggerFactory.getLogger(EdgeConfig.class);
+
 	/**
 	 * Represents an instance of an OpenEMS Component.
 	 */
@@ -46,9 +50,19 @@ public class EdgeConfig {
 		public static class Channel {
 
 			public static interface ChannelDetail {
-				ChannelCategory getCategory();
+				/**
+				 * Gets the {@link ChannelCategory} of the Channel.
+				 * 
+				 * @return the {@link ChannelCategory}
+				 */
+				public ChannelCategory getCategory();
 
-				JsonObject toJson();
+				/**
+				 * Gets the {@link ChannelDetail} as {@link JsonObject}.
+				 * 
+				 * @return the {@link JsonObject}
+				 */
+				public JsonObject toJson();
 			}
 
 			/**
@@ -86,8 +100,13 @@ public class EdgeConfig {
 					return ChannelCategory.ENUM;
 				}
 
+				/**
+				 * Gets a Map of all the options of an EnumChannel.
+				 * 
+				 * @return the Map of options
+				 */
 				public Map<String, JsonElement> getOptions() {
-					return options;
+					return this.options;
 				}
 
 				@Override
@@ -113,8 +132,13 @@ public class EdgeConfig {
 					this.level = level;
 				}
 
+				/**
+				 * Gets the {@link Level} of the StateChannel.
+				 * 
+				 * @return the {@link Level}
+				 */
 				public Level getLevel() {
-					return level;
+					return this.level;
 				}
 
 				@Override
@@ -203,28 +227,58 @@ public class EdgeConfig {
 				this.detail = detail;
 			}
 
+			/**
+			 * Gets the Channel-ID.
+			 * 
+			 * @return the Channel-ID.
+			 */
 			public String getId() {
-				return id;
+				return this.id;
 			}
 
+			/**
+			 * Gets the {@link OpenemsType} of the Channel.
+			 * 
+			 * @return the {@link OpenemsType}
+			 */
 			public OpenemsType getType() {
-				return type;
+				return this.type;
 			}
 
+			/**
+			 * Gets the {@link AccessMode} of the Channel.
+			 * 
+			 * @return the {@link AccessMode}
+			 */
 			public AccessMode getAccessMode() {
-				return accessMode;
+				return this.accessMode;
 			}
 
+			/**
+			 * Gets the descriptive text of the Channel.
+			 * 
+			 * @return the descriptive text
+			 */
 			public String getText() {
-				return text;
+				return this.text;
 			}
 
+			/**
+			 * Gets the {@link Unit} of the Channel.
+			 * 
+			 * @return the {@link Unit}
+			 */
 			public Unit getUnit() {
-				return unit;
+				return this.unit;
 			}
 
+			/**
+			 * Gets the specific {@link ChannelDetail} object of the Channel.
+			 * 
+			 * @return the {@link ChannelDetail}
+			 */
 			public ChannelDetail getDetail() {
-				return detail;
+				return this.detail;
 			}
 
 			/**
@@ -260,30 +314,66 @@ public class EdgeConfig {
 			this.channels = channels;
 		}
 
+		/**
+		 * Gets the PID of the {@link Component}.
+		 * 
+		 * @return the PID
+		 */
 		public String getPid() {
 			return this.servicePid;
 		}
 
+		/**
+		 * Gets the ID of the {@link Component}, e.g. 'ctrlDebugLog0'.
+		 * 
+		 * @return the Component-ID
+		 */
 		public String getId() {
 			return this.id;
 		}
 
+		/**
+		 * Gets the Alias of the {@link Component}.
+		 * 
+		 * @return the Alias
+		 */
 		public String getAlias() {
 			return this.alias;
 		}
 
+		/**
+		 * Gets the Factory-ID of the {@link Component}, e.g. 'Controller.Debug.Log'.
+		 * 
+		 * @return the Factory-ID
+		 */
 		public String getFactoryId() {
 			return this.factoryId;
 		}
 
+		/**
+		 * Gets the Properties of the {@link Component}.
+		 * 
+		 * @return the Properties
+		 */
 		public Map<String, JsonElement> getProperties() {
 			return this.properties;
 		}
 
+		/**
+		 * Gets the Property with the given ID.
+		 * 
+		 * @param propertyId the Property-ID
+		 * @return the Property as {@link Optional}
+		 */
 		public Optional<JsonElement> getProperty(String propertyId) {
 			return Optional.ofNullable(this.properties.get(propertyId));
 		}
 
+		/**
+		 * Gets a map of {@link Channel}s of the {@link Component}.
+		 * 
+		 * @return the map of {@link Channel}s by their Channel-IDs.
+		 */
 		public Map<String, Channel> getChannels() {
 			return this.channels;
 		}
@@ -293,12 +383,23 @@ public class EdgeConfig {
 			this.channels.putAll(channels);
 		}
 
+		/**
+		 * Gets the Channels of the given {@link ChannelCategory}.
+		 * 
+		 * @param channelCategory the {@link ChannelCategory}
+		 * @return a map of {@link Channel}s
+		 */
 		public Map<String, Channel> getChannelsOfCategory(ChannelCategory channelCategory) {
 			return this.channels.entrySet().stream()
 					.filter(entry -> entry.getValue().getDetail().getCategory() == channelCategory) //
 					.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 		}
 
+		/**
+		 * Gets the StateChannels.
+		 * 
+		 * @return the StateChannels
+		 */
 		public Map<String, Channel> getStateChannels() {
 			return this.getChannelsOfCategory(ChannelCategory.STATE);
 		}
@@ -423,25 +524,32 @@ public class EdgeConfig {
 	 */
 	public static class Factory {
 
+		/**
+		 * Creates a {@link Factory} from an {@link ObjectClassDefinition}.
+		 * 
+		 * @param factoryId the Factory-ID
+		 * @param ocd       the {@link ObjectClassDefinition}
+		 * @param natureIds the Nature-IDs
+		 * @return a {@link Factory}
+		 */
 		public static Factory create(String factoryId, ObjectClassDefinition ocd, String[] natureIds) {
 			String name = ocd.getName();
 			String description = ocd.getDescription();
 			List<Property> properties = new ArrayList<>();
-			properties.addAll(Factory.toProperties(ocd, true));
-			properties.addAll(Factory.toProperties(ocd, false));
+			properties.addAll(Factory.toProperties(ocd));
 			return new Factory(factoryId, name, description, properties.toArray(new Property[properties.size()]),
 					natureIds);
 		}
 
-		private static List<Property> toProperties(ObjectClassDefinition ocd, boolean isRequired) {
-			int filter;
-			if (isRequired) {
-				filter = ObjectClassDefinition.REQUIRED;
-			} else {
-				filter = ObjectClassDefinition.OPTIONAL;
-			}
+		/**
+		 * Parses a {@link ObjectClassDefinition} to a list of {@link Property}s.
+		 * 
+		 * @param ocd the {@link ObjectClassDefinition}
+		 * @return a list of {@link Property}s
+		 */
+		public static List<Property> toProperties(ObjectClassDefinition ocd) {
 			List<Property> properties = new ArrayList<>();
-			AttributeDefinition[] ads = ocd.getAttributeDefinitions(filter);
+			AttributeDefinition[] ads = ocd.getAttributeDefinitions(ObjectClassDefinition.ALL);
 			if (ads != null) {
 				for (AttributeDefinition ad : ads) {
 					if (ad.getID().endsWith(".target")) {
@@ -451,12 +559,8 @@ public class EdgeConfig {
 						case "webconsole.configurationFactory.nameHint":
 							// ignore ID
 							break;
-						case "alias":
-							// Set alias as not-required. If no alias is given it falls back to id.
-							properties.add(Property.from(ad, false));
-							break;
 						default:
-							properties.add(Property.from(ad, isRequired));
+							properties.add(Property.from(ad));
 							break;
 						}
 					}
@@ -473,26 +577,65 @@ public class EdgeConfig {
 			private final String id;
 			private final String name;
 			private final String description;
+			private final OpenemsType type;
 			private final boolean isRequired;
 			private final boolean isPassword;
 			private final JsonElement defaultValue;
 			private final JsonObject schema;
 
-			public Property(String id, String name, String description, boolean isRequired, boolean isPassword,
-					JsonElement defaultValue, JsonObject schema) {
+			public Property(String id, String name, String description, OpenemsType type, boolean isRequired,
+					boolean isPassword, JsonElement defaultValue, JsonObject schema) {
 				this.id = id;
 				this.name = name;
 				this.description = description;
+				this.type = type;
 				this.isRequired = isRequired;
 				this.isPassword = isPassword;
 				this.defaultValue = defaultValue;
 				this.schema = schema;
 			}
 
-			public static Property from(AttributeDefinition ad, boolean isRequired) {
+			/**
+			 * Creates a {@link Property} from an {@link AttributeDefinition}.
+			 * 
+			 * @param ad the {@link AttributeDefinition}
+			 * @return the {@link Property}
+			 */
+			public static Property from(AttributeDefinition ad) {
 				String description = ad.getDescription();
 				if (description == null) {
 					description = "";
+				}
+
+				final OpenemsType type;
+				switch (ad.getType()) {
+				case AttributeDefinition.LONG:
+					type = OpenemsType.LONG;
+					break;
+				case AttributeDefinition.INTEGER:
+					type = OpenemsType.INTEGER;
+					break;
+				case AttributeDefinition.SHORT:
+				case AttributeDefinition.BYTE:
+					type = OpenemsType.SHORT;
+					break;
+				case AttributeDefinition.DOUBLE:
+					type = OpenemsType.DOUBLE;
+					break;
+				case AttributeDefinition.FLOAT:
+					type = OpenemsType.FLOAT;
+					break;
+				case AttributeDefinition.BOOLEAN:
+					type = OpenemsType.BOOLEAN;
+					break;
+				case AttributeDefinition.STRING:
+				case AttributeDefinition.CHARACTER:
+				case AttributeDefinition.PASSWORD:
+					type = OpenemsType.STRING;
+					break;
+				default:
+					LOG.warn("AttributeDefinition type [" + ad.getType() + "] is unknown!");
+					type = OpenemsType.STRING;
 				}
 
 				String[] defaultValues = ad.getDefaultValue();
@@ -537,8 +680,16 @@ public class EdgeConfig {
 
 				String id = ad.getID();
 				String name = ad.getName();
-
-				return new Property(id, name, description, isRequired, isPassword, defaultValue, schema);
+				final boolean isRequired;
+				switch (id) {
+				case "alias":
+					// Set alias as not-required. If no alias is given it falls back to id.
+					isRequired = false;
+					break;
+				default:
+					isRequired = ad.getCardinality() == 0;
+				}
+				return new Property(id, name, description, type, isRequired, isPassword, defaultValue, schema);
 			}
 
 			private static JsonObject getSchema(AttributeDefinition ad) {
@@ -617,12 +768,14 @@ public class EdgeConfig {
 				String id = JsonUtils.getAsString(json, "id");
 				String name = JsonUtils.getAsString(json, "name");
 				String description = JsonUtils.getAsString(json, "description");
+				OpenemsType type = JsonUtils.getAsOptionalEnum(OpenemsType.class, json, "type")
+						.orElse(OpenemsType.STRING);
 				boolean isRequired = JsonUtils.getAsBoolean(json, "isRequired");
 				boolean isPassword = JsonUtils.getAsOptionalBoolean(json, "isPassword").orElse(false);
 				JsonElement defaultValue = JsonUtils.getOptionalSubElement(json, "defaultValue")
 						.orElse(JsonNull.INSTANCE);
 				JsonObject schema = JsonUtils.getAsJsonObject(json, "schema");
-				return new Property(id, name, description, isRequired, isPassword, defaultValue, schema);
+				return new Property(id, name, description, type, isRequired, isPassword, defaultValue, schema);
 			}
 
 			/**
@@ -649,6 +802,7 @@ public class EdgeConfig {
 						.addProperty("id", this.id) //
 						.addProperty("name", this.name) //
 						.addProperty("description", this.description) //
+						.addProperty("type", this.type.toString().toLowerCase()) //
 						.addProperty("isRequired", this.isRequired) //
 						.addProperty("isPassword", this.isPassword) //
 						.add("defaultValue", this.defaultValue) //
@@ -656,28 +810,67 @@ public class EdgeConfig {
 						.build();
 			}
 
+			/**
+			 * Gets the ID of the {@link Property}.
+			 * 
+			 * @return the Property-ID
+			 */
 			public String getId() {
-				return id;
+				return this.id;
 			}
 
+			/**
+			 * Gets the Name of the {@link Property}.
+			 * 
+			 * @return the Name
+			 */
 			public String getName() {
-				return name;
+				return this.name;
 			}
 
+			/**
+			 * Gets the Description of the {@link Property}.
+			 * 
+			 * @return the Description
+			 */
 			public String getDescription() {
-				return description;
+				return this.description;
 			}
 
+			/**
+			 * Gets the {@link OpenemsType} of the {@link Property}.
+			 * 
+			 * @return the {@link OpenemsType}
+			 */
+			public OpenemsType getType() {
+				return this.type;
+			}
+
+			/**
+			 * Does this Property represent a password?.
+			 * 
+			 * @return true if it is a password
+			 */
 			public boolean isPassword() {
-				return isPassword;
+				return this.isPassword;
 			}
 
+			/**
+			 * Is this Property required?.
+			 * 
+			 * @return true if it is required
+			 */
 			public boolean isRequired() {
-				return isRequired;
+				return this.isRequired;
 			}
 
+			/**
+			 * Gets the default value of the Property.
+			 * 
+			 * @return the default value
+			 */
 			public JsonElement getDefaultValue() {
-				return defaultValue;
+				return this.defaultValue;
 			}
 		}
 
@@ -695,18 +888,38 @@ public class EdgeConfig {
 			this.natureIds = natureIds;
 		}
 
+		/**
+		 * Gets the ID of the {@link Factory}.
+		 * 
+		 * @return the ID
+		 */
 		public String getId() {
 			return this.id;
 		}
 
+		/**
+		 * Gets the Name of the {@link Factory}.
+		 * 
+		 * @return the name
+		 */
 		public String getName() {
 			return this.name;
 		}
 
+		/**
+		 * Gets the Description of the {@link Factory}.
+		 * 
+		 * @return the description
+		 */
 		public String getDescription() {
 			return this.description;
 		}
 
+		/**
+		 * Gets the {@link Property}s of the {@link Factory}.
+		 * 
+		 * @return an array of {@link Property}s
+		 */
 		public Property[] getProperties() {
 			return this.properties;
 		}
@@ -726,8 +939,13 @@ public class EdgeConfig {
 			return Optional.empty();
 		}
 
+		/**
+		 * Gets the Nature-IDs of the {@link Factory}.
+		 * 
+		 * @return the Nature-IDs
+		 */
 		public String[] getNatureIds() {
-			return natureIds;
+			return this.natureIds;
 		}
 
 		/**
@@ -797,14 +1015,31 @@ public class EdgeConfig {
 	public EdgeConfig() {
 	}
 
+	/**
+	 * Adds a {@link Component} to the {@link EdgeConfig}.
+	 * 
+	 * @param id        the Component-ID
+	 * @param component the {@link Component}
+	 */
 	public void addComponent(String id, Component component) {
 		this.components.put(id, component);
 	}
 
+	/**
+	 * Removes a {@link Component} from the {@link EdgeConfig}.
+	 * 
+	 * @param id the Component-ID
+	 */
 	public void removeComponent(String id) {
 		this.components.remove(id);
 	}
 
+	/**
+	 * Gets a {@link Component} by its Component-ID.
+	 * 
+	 * @param componentId the Component-ID
+	 * @return the {@link Component} as {@link Optional}
+	 */
 	public Optional<Component> getComponent(String componentId) {
 		return Optional.ofNullable(this.components.get(componentId));
 	}
@@ -820,10 +1055,20 @@ public class EdgeConfig {
 		return this.factories.put(id, factory) != null;
 	}
 
+	/**
+	 * Gets the {@link Component}s.
+	 * 
+	 * @return the {@link Component}s
+	 */
 	public TreeMap<String, Component> getComponents() {
 		return this.components;
 	}
 
+	/**
+	 * Gets the {@link Factory}s.
+	 * 
+	 * @return the {@link Factory}s
+	 */
 	public TreeMap<String, Factory> getFactories() {
 		return this.factories;
 	}

--- a/io.openems.common/src/io/openems/common/utils/JsonUtils.java
+++ b/io.openems.common/src/io/openems/common/utils/JsonUtils.java
@@ -4,12 +4,7 @@ import java.net.Inet4Address;
 import java.net.UnknownHostException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 import org.slf4j.Logger;
@@ -29,11 +24,558 @@ import io.openems.common.exceptions.NotImplementedException;
 import io.openems.common.exceptions.OpenemsError;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.types.OpenemsType;
 
 public class JsonUtils {
 
-	private static final Logger log = LoggerFactory.getLogger(JsonUtils.class);
+	/**
+	 * A temporary builder class for JsonArrays.
+	 */
+	public static class JsonArrayBuilder {
 
+		private final JsonArray j;
+
+		protected JsonArrayBuilder() {
+			this(new JsonArray());
+		}
+
+		protected JsonArrayBuilder(JsonArray j) {
+			this.j = j;
+		}
+
+		/**
+		 * Add a boolean value to the {@link JsonArray}.
+		 * 
+		 * @param value the value
+		 * @return the {@link JsonArrayBuilder}
+		 */
+		public JsonArrayBuilder add(boolean value) {
+			this.j.add(value);
+			return this;
+		}
+
+		/**
+		 * Add a int value to the {@link JsonArray}.
+		 * 
+		 * @param value the value
+		 * @return the {@link JsonArrayBuilder}
+		 */
+		public JsonArrayBuilder add(int value) {
+			this.j.add(value);
+			return this;
+		}
+
+		/**
+		 * Add a {@link JsonElement} value to the {@link JsonArray}.
+		 * 
+		 * @param value the value
+		 * @return the {@link JsonArrayBuilder}
+		 */
+		public JsonArrayBuilder add(JsonElement value) {
+			this.j.add(value);
+			return this;
+		}
+
+		/**
+		 * Add a long value to the {@link JsonArray}.
+		 * 
+		 * @param value the value
+		 * @return the {@link JsonArrayBuilder}
+		 */
+		public JsonArrayBuilder add(long value) {
+			this.j.add(value);
+			return this;
+		}
+
+		/**
+		 * Add a String value to the {@link JsonArray}.
+		 * 
+		 * @param value the value
+		 * @return the {@link JsonArrayBuilder}
+		 */
+		public JsonArrayBuilder add(String value) {
+			this.j.add(value);
+			return this;
+		}
+
+		/**
+		 * Return the built {@link JsonArray}.
+		 * 
+		 * @return the {@link JsonArray}
+		 */
+		public JsonArray build() {
+			return this.j;
+		}
+
+	}
+
+	/**
+	 * A temporary builder class for JsonObjects.
+	 */
+	public static class JsonObjectBuilder {
+
+		private final JsonObject j;
+
+		protected JsonObjectBuilder() {
+			this(new JsonObject());
+		}
+
+		protected JsonObjectBuilder(JsonObject j) {
+			this.j = j;
+		}
+
+		/**
+		 * Add a {@link JsonElement} value to the {@link JsonObject}.
+		 * 
+		 * @param property the key
+		 * @param value    the value
+		 * @return the {@link JsonObjectBuilder}
+		 */
+		public JsonObjectBuilder add(String property, JsonElement value) {
+			this.j.add(property, value);
+			return this;
+		}
+
+		/**
+		 * Add a boolean value to the {@link JsonObject}.
+		 * 
+		 * @param property the key
+		 * @param value    the value
+		 * @return the {@link JsonObjectBuilder}
+		 */
+		public JsonObjectBuilder addProperty(String property, boolean value) {
+			this.j.addProperty(property, value);
+			return this;
+		}
+
+		/**
+		 * Add a double value to the {@link JsonObject}.
+		 * 
+		 * @param property the key
+		 * @param value    the value
+		 * @return the {@link JsonObjectBuilder}
+		 */
+		public JsonObjectBuilder addProperty(String property, double value) {
+			this.j.addProperty(property, value);
+			return this;
+		}
+
+		/**
+		 * Add a int value to the {@link JsonObject}.
+		 * 
+		 * @param property the key
+		 * @param value    the value
+		 * @return the {@link JsonObjectBuilder}
+		 */
+		public JsonObjectBuilder addProperty(String property, int value) {
+			this.j.addProperty(property, value);
+			return this;
+		}
+
+		/**
+		 * Add a long value to the {@link JsonObject}.
+		 * 
+		 * @param property the key
+		 * @param value    the value
+		 * @return the {@link JsonObjectBuilder}
+		 */
+		public JsonObjectBuilder addProperty(String property, long value) {
+			this.j.addProperty(property, value);
+			return this;
+		}
+
+		/**
+		 * Add a String value to the {@link JsonObject}.
+		 * 
+		 * @param property the key
+		 * @param value    the value
+		 * @return the {@link JsonObjectBuilder}
+		 */
+		public JsonObjectBuilder addProperty(String property, String value) {
+			this.j.addProperty(property, value);
+			return this;
+		}
+
+		/**
+		 * Add a {@link Boolean} value to the {@link JsonObject}.
+		 * 
+		 * @param property the key
+		 * @param value    the value
+		 * @return the {@link JsonObjectBuilder}
+		 */
+		public JsonObjectBuilder addPropertyIfNotNull(String property, Boolean value) {
+			if (value != null) {
+				this.j.addProperty(property, value);
+			}
+			return this;
+		}
+
+		/**
+		 * Add a {@link Double} value to the {@link JsonObject} if it is not null.
+		 * 
+		 * @param property the key
+		 * @param value    the value
+		 * @return the {@link JsonObjectBuilder}
+		 */
+		public JsonObjectBuilder addPropertyIfNotNull(String property, Double value) {
+			if (value != null) {
+				this.j.addProperty(property, value);
+			}
+			return this;
+		}
+
+		/**
+		 * Add an {@link Integer} value to the {@link JsonObject} if it is not null.
+		 * 
+		 * @param property the key
+		 * @param value    the value
+		 * @return the {@link JsonObjectBuilder}
+		 */
+		public JsonObjectBuilder addPropertyIfNotNull(String property, Integer value) {
+			if (value != null) {
+				this.j.addProperty(property, value);
+			}
+			return this;
+		}
+
+		/**
+		 * Add a {@link Long} value to the {@link JsonObject} if it is not null.
+		 * 
+		 * @param property the key
+		 * @param value    the value
+		 * @return the {@link JsonObjectBuilder}
+		 */
+		public JsonObjectBuilder addPropertyIfNotNull(String property, Long value) {
+			if (value != null) {
+				this.j.addProperty(property, value);
+			}
+			return this;
+		}
+
+		/**
+		 * Add a {@link String} value to the {@link JsonObject} if it is not null.
+		 * 
+		 * @param property the key
+		 * @param value    the value
+		 * @return the {@link JsonObjectBuilder}
+		 */
+		public JsonObjectBuilder addPropertyIfNotNull(String property, String value) {
+			if (value != null) {
+				this.j.addProperty(property, value);
+			}
+			return this;
+		}
+
+		/**
+		 * Return the built {@link JsonObject}.
+		 * 
+		 * @return the {@link JsonObject}
+		 */
+		public JsonObject build() {
+			return this.j;
+		}
+
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger(JsonUtils.class);
+
+	/**
+	 * Creates a JsonArray using a Builder.
+	 * 
+	 * @return the Builder
+	 */
+	public static JsonArrayBuilder buildJsonArray() {
+		return new JsonArrayBuilder();
+	}
+
+	/**
+	 * Creates a JsonArray using a Builder. Initialized from an existing JsonArray.
+	 * 
+	 * @param j the initial JsonArray
+	 * @return the Builder
+	 */
+	public static JsonArrayBuilder buildJsonArray(JsonArray j) {
+		return new JsonArrayBuilder(j);
+	}
+
+	/**
+	 * Creates a JsonObject using a Builder.
+	 * 
+	 * @return the Builder
+	 */
+	public static JsonObjectBuilder buildJsonObject() {
+		return new JsonObjectBuilder();
+	}
+
+	/**
+	 * Creates a JsonObject using a Builder. Initialized from an existing
+	 * JsonObject.
+	 * 
+	 * @param j the initial JsonObject
+	 * @return the Builder
+	 */
+	public static JsonObjectBuilder buildJsonObject(JsonObject j) {
+		return new JsonObjectBuilder(j);
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as {@link JsonPrimitive}.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the {@link JsonPrimitive} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static JsonPrimitive getAsPrimitive(JsonElement jElement) throws OpenemsNamedException {
+		if (!jElement.isJsonPrimitive()) {
+			throw OpenemsError.JSON_NO_PRIMITIVE.exception(jElement.toString().replaceAll("%", "%%"));
+		}
+		return jElement.getAsJsonPrimitive();
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link JsonPrimitive}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link JsonPrimitive} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static JsonPrimitive getAsPrimitive(JsonElement jElement, String memberName) throws OpenemsNamedException {
+		JsonElement jSubElement = getSubElement(jElement, memberName);
+		return getAsPrimitive(jSubElement);
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Optional}
+	 * {@link JsonElement}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Optional} {@link JsonElement} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static Optional<JsonElement> getOptionalSubElement(JsonElement jElement, String memberName) {
+		try {
+			return Optional.of(getSubElement(jElement, memberName));
+		} catch (OpenemsNamedException e) {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link JsonElement}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link JsonElement} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static JsonElement getSubElement(JsonElement jElement, String memberName) throws OpenemsNamedException {
+		JsonObject jObject = getAsJsonObject(jElement);
+		if (!jObject.has(memberName)) {
+			throw OpenemsError.JSON_HAS_NO_MEMBER.exception(memberName,
+					StringUtils.toShortString(jElement, 100).replaceAll("%", "%%"));
+		}
+		return jObject.get(memberName);
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as {@link JsonObject}.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the {@link JsonObject} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static JsonObject getAsJsonObject(JsonElement jElement) throws OpenemsNamedException {
+		if (!jElement.isJsonObject()) {
+			throw OpenemsError.JSON_NO_OBJECT.exception(jElement.toString().replaceAll("%", "%%"));
+		}
+		return jElement.getAsJsonObject();
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link JsonObject}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link JsonObject} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static JsonObject getAsJsonObject(JsonElement jElement, String memberName) throws OpenemsNamedException {
+		JsonElement subElement = getSubElement(jElement, memberName);
+		if (!subElement.isJsonObject()) {
+			throw OpenemsError.JSON_NO_OBJECT_MEMBER.exception(memberName,
+					StringUtils.toShortString(subElement, 100).replaceAll("%", "%%"));
+		}
+		return subElement.getAsJsonObject();
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as {@link Optional} {@link JsonObject}.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the {@link Optional} {@link JsonObject} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static Optional<JsonObject> getAsOptionalJsonObject(JsonElement jElement) {
+		try {
+			return Optional.of(getAsJsonObject(jElement));
+		} catch (OpenemsNamedException e) {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Optional}
+	 * {@link JsonObject}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Optional} {@link JsonObject} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static Optional<JsonObject> getAsOptionalJsonObject(JsonElement jElement, String memberName) {
+		try {
+			return Optional.of(getAsJsonObject(jElement, memberName));
+		} catch (OpenemsNamedException e) {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as {@link JsonArray}.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the {@link JsonArray} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static JsonArray getAsJsonArray(JsonElement jElement) throws OpenemsNamedException {
+		if (!jElement.isJsonArray()) {
+			throw OpenemsError.JSON_NO_ARRAY.exception(jElement.toString().replaceAll("%", "%%"));
+		}
+		return jElement.getAsJsonArray();
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link JsonArray}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link JsonArray} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static JsonArray getAsJsonArray(JsonElement jElement, String memberName) throws OpenemsNamedException {
+		JsonElement jSubElement = getSubElement(jElement, memberName);
+		if (!jSubElement.isJsonArray()) {
+			throw OpenemsError.JSON_NO_ARRAY_MEMBER.exception(memberName, jSubElement.toString().replaceAll("%", "%%"));
+		}
+		return jSubElement.getAsJsonArray();
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Optional}
+	 * {@link JsonArray}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Optional} {@link JsonArray} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static Optional<JsonArray> getAsOptionalJsonArray(JsonElement jElement, String memberName) {
+		try {
+			return Optional.of(getAsJsonArray(jElement, memberName));
+		} catch (OpenemsNamedException e) {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as {@link String}.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the {@link String} value
+	 * @throws OpenemsNamedException on error
+	 */
+
+	public static String getAsString(JsonElement jElement) throws OpenemsNamedException {
+		JsonPrimitive jPrimitive = getAsPrimitive(jElement);
+		if (!jPrimitive.isString()) {
+			throw OpenemsError.JSON_NO_STRING.exception(jPrimitive.toString().replaceAll("%", "%%"));
+		}
+		return jPrimitive.getAsString();
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link String}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link String} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static String getAsString(JsonElement jElement, String memberName) throws OpenemsNamedException {
+		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
+		if (!jPrimitive.isString()) {
+			throw OpenemsError.JSON_NO_STRING_MEMBER.exception(memberName, jPrimitive.toString().replaceAll("%", "%%"));
+		}
+		return jPrimitive.getAsString();
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as {@link Optional} {@link String}.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the {@link Optional} {@link String} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static Optional<String> getAsOptionalString(JsonElement jElement) {
+		try {
+			return Optional.of(getAsString(jElement));
+		} catch (OpenemsNamedException e) {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Optional}
+	 * {@link String}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Optional} {@link String} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static Optional<String> getAsOptionalString(JsonElement jElement, String memberName) {
+		try {
+			return Optional.of(getAsString(jElement, memberName));
+		} catch (OpenemsNamedException e) {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Converts a {@link JsonArray} to a String Array.
+	 * 
+	 * @param json the {@link JsonArray}
+	 * @return a String Array
+	 * @throws OpenemsNamedException on error
+	 */
+	public static String[] getAsStringArray(JsonArray json) throws OpenemsNamedException {
+		String[] result = new String[json.size()];
+		int i = 0;
+		for (JsonElement element : json) {
+			result[i++] = JsonUtils.getAsString(element);
+		}
+		return result;
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as {@link Boolean}.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the {@link Boolean} value
+	 * @throws OpenemsNamedException on error
+	 */
 	public static boolean getAsBoolean(JsonElement jElement) throws OpenemsNamedException {
 		JsonPrimitive jPrimitive = getAsPrimitive(jElement);
 		if (!jPrimitive.isBoolean()) {
@@ -42,6 +584,14 @@ public class JsonUtils {
 		return jPrimitive.getAsBoolean();
 	}
 
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Boolean}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Boolean} value
+	 * @throws OpenemsNamedException on error
+	 */
 	public static boolean getAsBoolean(JsonElement jElement, String memberName) throws OpenemsNamedException {
 		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
 		if (!jPrimitive.isBoolean()) {
@@ -51,24 +601,265 @@ public class JsonUtils {
 		return jPrimitive.getAsBoolean();
 	}
 
-	public static Optional<Boolean> getAsOptionalBoolean(JsonElement element, String memberName) {
+	/**
+	 * Gets the member of the {@link JsonElement} as an {@link Optional}
+	 * {@link Boolean}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Optional} {@link Boolean} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static Optional<Boolean> getAsOptionalBoolean(JsonElement jElement, String memberName) {
 		try {
-			return Optional.of(getAsBoolean(element, memberName));
+			return Optional.of(getAsBoolean(jElement, memberName));
 		} catch (OpenemsNamedException e) {
 			return Optional.empty();
 		}
 	}
 
-	public static <E extends Enum<E>> E getAsEnum(Class<E> enumType, JsonElement jElement, String memberName)
-			throws OpenemsNamedException {
-		String element = getAsString(jElement, memberName);
+	/**
+	 * Gets the {@link JsonElement} as short.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the short value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static short getAsShort(JsonElement jElement) throws OpenemsNamedException {
+		JsonPrimitive jPrimitive = getAsPrimitive(jElement);
+		if (jPrimitive.isNumber()) {
+			return jPrimitive.getAsShort();
+		} else if (jPrimitive.isString()) {
+			String string = jPrimitive.getAsString();
+			return Short.parseShort(string);
+		}
+		throw OpenemsError.JSON_NO_INTEGER.exception(jPrimitive.toString().replaceAll("%", "%%"));
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as short.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the short value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static short getAsShort(JsonElement jElement, String memberName) throws OpenemsNamedException {
+		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
+		if (jPrimitive.isNumber()) {
+			return jPrimitive.getAsShort();
+		} else if (jPrimitive.isString()) {
+			String string = jPrimitive.getAsString();
+			return Short.parseShort(string);
+		}
+		throw OpenemsError.JSON_NO_INTEGER_MEMBER.exception(memberName, jPrimitive.toString().replaceAll("%", "%%"));
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as int.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the int value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static int getAsInt(JsonElement jElement) throws OpenemsNamedException {
+		JsonPrimitive jPrimitive = getAsPrimitive(jElement);
+		if (jPrimitive.isNumber()) {
+			return jPrimitive.getAsInt();
+		} else if (jPrimitive.isString()) {
+			String string = jPrimitive.getAsString();
+			return Integer.parseInt(string);
+		}
+		throw OpenemsError.JSON_NO_INTEGER.exception(jPrimitive.toString().replaceAll("%", "%%"));
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as int.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the int value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static int getAsInt(JsonElement jElement, String memberName) throws OpenemsNamedException {
+		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
+		if (jPrimitive.isNumber()) {
+			return jPrimitive.getAsInt();
+		} else if (jPrimitive.isString()) {
+			String string = jPrimitive.getAsString();
+			return Integer.parseInt(string);
+		}
+		throw OpenemsError.JSON_NO_INTEGER_MEMBER.exception(memberName, jPrimitive.toString().replaceAll("%", "%%"));
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as {@link Optional} {@link Integer}.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the {@link Optional} {@link Integer} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static Optional<Integer> getAsOptionalInt(JsonElement jElement) {
 		try {
-			return (E) Enum.valueOf(enumType, element);
-		} catch (IllegalArgumentException e) {
-			throw OpenemsError.JSON_NO_ENUM_MEMBER.exception(memberName, element);
+			return Optional.of(getAsInt(jElement));
+		} catch (OpenemsNamedException e) {
+			return Optional.empty();
 		}
 	}
 
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Optional}
+	 * {@link Integer}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Optional} {@link Integer} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static Optional<Integer> getAsOptionalInt(JsonElement jElement, String memberName) {
+		try {
+			return Optional.of(getAsInt(jElement, memberName));
+		} catch (OpenemsNamedException e) {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as long.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the long value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static long getAsLong(JsonElement jElement) throws OpenemsNamedException {
+		JsonPrimitive jPrimitive = getAsPrimitive(jElement);
+		if (jPrimitive.isNumber()) {
+			return jPrimitive.getAsLong();
+		} else if (jPrimitive.isString()) {
+			String string = jPrimitive.getAsString();
+			return Integer.parseInt(string);
+		}
+		throw OpenemsError.JSON_NO_NUMBER.exception(jPrimitive.toString().replaceAll("%", "%%"));
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as long.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the long value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static long getAsLong(JsonElement jElement, String memberName) throws OpenemsNamedException {
+		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
+		if (jPrimitive.isNumber()) {
+			return jPrimitive.getAsLong();
+		} else if (jPrimitive.isString()) {
+			String string = jPrimitive.getAsString();
+			return Long.parseLong(string);
+		}
+		throw OpenemsError.JSON_NO_NUMBER.exception(jPrimitive.toString().replaceAll("%", "%%"));
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Optional} {@link Long}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Optional} {@link Long} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static Optional<Long> getAsOptionalLong(JsonElement jElement, String memberName) {
+		try {
+			return Optional.of(getAsLong(jElement, memberName));
+		} catch (OpenemsNamedException e) {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as {@link Float}.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the {@link Float} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static float getAsFloat(JsonElement jElement) throws OpenemsNamedException {
+		JsonPrimitive jPrimitive = getAsPrimitive(jElement);
+		if (jPrimitive.isNumber()) {
+			return jPrimitive.getAsFloat();
+		} else if (jPrimitive.isString()) {
+			String string = jPrimitive.getAsString();
+			return Float.parseFloat(string);
+		}
+		throw OpenemsError.JSON_NO_FLOAT.exception(jPrimitive.toString().replaceAll("%", "%%"));
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Float}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Float} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static float getAsFloat(JsonElement jElement, String memberName) throws OpenemsNamedException {
+		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
+		if (jPrimitive.isNumber()) {
+			return jPrimitive.getAsFloat();
+		} else if (jPrimitive.isString()) {
+			String string = jPrimitive.getAsString();
+			return Float.parseFloat(string);
+		}
+		throw OpenemsError.JSON_NO_FLOAT_MEMBER.exception(memberName, jPrimitive.toString().replaceAll("%", "%%"));
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as {@link Double}.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the {@link Double} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static double getAsDouble(JsonElement jElement) throws OpenemsNamedException {
+		JsonPrimitive jPrimitive = getAsPrimitive(jElement);
+		if (jPrimitive.isNumber()) {
+			return jPrimitive.getAsDouble();
+		} else if (jPrimitive.isString()) {
+			String string = jPrimitive.getAsString();
+			return Double.parseDouble(string);
+		}
+		throw OpenemsError.JSON_NO_INTEGER.exception(jPrimitive.toString().replaceAll("%", "%%"));
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Double}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Double} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static double getAsDouble(JsonElement jElement, String memberName) throws OpenemsNamedException {
+		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
+		if (jPrimitive.isNumber()) {
+			return jPrimitive.getAsDouble();
+		} else if (jPrimitive.isString()) {
+			String string = jPrimitive.getAsString();
+			return Double.parseDouble(string);
+		}
+		throw OpenemsError.JSON_NO_INTEGER_MEMBER.exception(memberName, jPrimitive.toString().replaceAll("%", "%%"));
+	}
+
+	/**
+	 * Gets the {@link JsonElement} as {@link Enum}.
+	 * 
+	 * @param <E>      the {@link Enum} type
+	 * @param enumType the class of the {@link Enum}
+	 * @param jElement the {@link JsonElement}
+	 * @return the {@link Enum} value
+	 * @throws OpenemsNamedException on error
+	 */
 	public static <E extends Enum<E>> E getAsEnum(Class<E> enumType, JsonElement jElement)
 			throws OpenemsNamedException {
 		String element = getAsString(jElement);
@@ -79,6 +870,36 @@ public class JsonUtils {
 		}
 	}
 
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Enum}.
+	 * 
+	 * @param <E>        the {@link Enum} type
+	 * @param enumType   the class of the {@link Enum}
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Enum} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static <E extends Enum<E>> E getAsEnum(Class<E> enumType, JsonElement jElement, String memberName)
+			throws OpenemsNamedException {
+		String element = getAsString(jElement, memberName);
+		try {
+			return (E) Enum.valueOf(enumType, element);
+		} catch (IllegalArgumentException e) {
+			throw OpenemsError.JSON_NO_ENUM_MEMBER.exception(memberName, element);
+		}
+	}
+
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Optional} {@link Enum}.
+	 * 
+	 * @param <E>        the {@link Enum} type
+	 * @param enumType   the class of the {@link Enum}
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Optional} {@link Enum} value
+	 * @throws OpenemsNamedException on error
+	 */
 	public static <E extends Enum<E>> Optional<E> getAsOptionalEnum(Class<E> enumType, JsonElement jElement,
 			String memberName) {
 		Optional<String> elementOpt = getAsOptionalString(jElement, memberName);
@@ -92,94 +913,13 @@ public class JsonUtils {
 		}
 	}
 
-	public static int getAsInt(JsonElement jElement) throws OpenemsNamedException {
-		JsonPrimitive jPrimitive = getAsPrimitive(jElement);
-		if (jPrimitive.isNumber()) {
-			return jPrimitive.getAsInt();
-		} else if (jPrimitive.isString()) {
-			String string = jPrimitive.getAsString();
-			return Integer.parseInt(string);
-		}
-		throw OpenemsError.JSON_NO_INTEGER.exception(jPrimitive.toString().replaceAll("%", "%%"));
-	}
-
-	public static int getAsInt(JsonElement jElement, String memberName) throws OpenemsNamedException {
-		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
-		if (jPrimitive.isNumber()) {
-			return jPrimitive.getAsInt();
-		} else if (jPrimitive.isString()) {
-			String string = jPrimitive.getAsString();
-			return Integer.parseInt(string);
-		}
-		throw OpenemsError.JSON_NO_INTEGER_MEMBER.exception(memberName, jPrimitive.toString().replaceAll("%", "%%"));
-	}
-
-	public static double getAsDouble(JsonElement jElement) throws OpenemsNamedException {
-		JsonPrimitive jPrimitive = getAsPrimitive(jElement);
-		if (jPrimitive.isNumber()) {
-			return jPrimitive.getAsDouble();
-		} else if (jPrimitive.isString()) {
-			String string = jPrimitive.getAsString();
-			return Double.parseDouble(string);
-		}
-		throw OpenemsError.JSON_NO_INTEGER.exception(jPrimitive.toString().replaceAll("%", "%%"));
-	}
-
-	public static double getAsDouble(JsonElement jElement, String memberName) throws OpenemsNamedException {
-		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
-		if (jPrimitive.isNumber()) {
-			return jPrimitive.getAsDouble();
-		} else if (jPrimitive.isString()) {
-			String string = jPrimitive.getAsString();
-			return Double.parseDouble(string);
-		}
-		throw OpenemsError.JSON_NO_INTEGER_MEMBER.exception(memberName, jPrimitive.toString().replaceAll("%", "%%"));
-	}
-	
-	public static double getAsShort(JsonElement jElement) throws OpenemsNamedException {
-		JsonPrimitive jPrimitive = getAsPrimitive(jElement);
-		if (jPrimitive.isNumber()) {
-			return jPrimitive.getAsShort();
-		} else if (jPrimitive.isString()) {
-			String string = jPrimitive.getAsString();
-			return Short.parseShort(string);
-		}
-		throw OpenemsError.JSON_NO_INTEGER.exception(jPrimitive.toString().replaceAll("%", "%%"));
-	}
-
-	public static double getAsShort(JsonElement jElement, String memberName) throws OpenemsNamedException {
-		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
-		if (jPrimitive.isNumber()) {
-			return jPrimitive.getAsShort();
-		} else if (jPrimitive.isString()) {
-			String string = jPrimitive.getAsString();
-			return Short.parseShort(string);
-		}
-		throw OpenemsError.JSON_NO_INTEGER_MEMBER.exception(memberName, jPrimitive.toString().replaceAll("%", "%%"));
-	}
-	
-	public static float getAsFloat(JsonElement jElement) throws OpenemsNamedException {
-		JsonPrimitive jPrimitive = getAsPrimitive(jElement);
-		if (jPrimitive.isNumber()) {
-			return jPrimitive.getAsFloat();
-		} else if (jPrimitive.isString()) {
-			String string = jPrimitive.getAsString();
-			return Float.parseFloat(string);
-		}
-		throw OpenemsError.JSON_NO_FLOAT.exception(jPrimitive.toString().replaceAll("%", "%%"));
-	}
-
-	public static float getAsFloat(JsonElement jElement, String memberName) throws OpenemsNamedException {
-		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
-		if (jPrimitive.isNumber()) {
-			return jPrimitive.getAsFloat();
-		} else if (jPrimitive.isString()) {
-			String string = jPrimitive.getAsString();
-			return Float.parseFloat(string);
-		}
-		throw OpenemsError.JSON_NO_FLOAT_MEMBER.exception(memberName, jPrimitive.toString().replaceAll("%", "%%"));
-	}
-
+	/**
+	 * Gets the {@link JsonElement} as {@link Inet4Address}.
+	 * 
+	 * @param jElement the {@link JsonElement}
+	 * @return the {@link Inet4Address} value
+	 * @throws OpenemsNamedException on error
+	 */
 	public static Inet4Address getAsInet4Address(JsonElement jElement) throws OpenemsNamedException {
 		try {
 			return (Inet4Address) Inet4Address.getByName(getAsString(jElement));
@@ -188,37 +928,145 @@ public class JsonUtils {
 		}
 	}
 
-	public static JsonArray getAsJsonArray(JsonElement jElement) throws OpenemsNamedException {
-		if (!jElement.isJsonArray()) {
-			throw OpenemsError.JSON_NO_ARRAY.exception(jElement.toString().replaceAll("%", "%%"));
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Optional}
+	 * {@link Inet4Address}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Optional} {@link Inet4Address} value
+	 * @throws OpenemsNamedException on error
+	 */
+	public static Optional<Inet4Address> getAsOptionalInet4Address(JsonElement jElement, String memberName) {
+		try {
+			return Optional.ofNullable((Inet4Address) Inet4Address.getByName(getAsString(jElement, memberName)));
+		} catch (OpenemsNamedException | UnknownHostException e) {
+			return Optional.empty();
 		}
-		return jElement.getAsJsonArray();
-	}
-
-	public static JsonArray getAsJsonArray(JsonElement jElement, String memberName) throws OpenemsNamedException {
-		JsonElement jSubElement = getSubElement(jElement, memberName);
-		if (!jSubElement.isJsonArray()) {
-			throw OpenemsError.JSON_NO_ARRAY_MEMBER.exception(memberName, jSubElement.toString().replaceAll("%", "%%"));
-		}
-		return jSubElement.getAsJsonArray();
 	}
 
 	/**
-	 * Converts JSON Array to a String Array.
+	 * Gets the member of the {@link JsonElement} as {@link UUID}.
 	 * 
-	 * @param json the JSON Array
-	 * @return a String Array
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link UUID} value
 	 * @throws OpenemsNamedException on error
 	 */
-	public static String[] getAsStringArray(JsonArray json) throws OpenemsNamedException {
-		String[] result = new String[json.size()];
-		int i = 0;
-		for (JsonElement element : json) {
-			result[i++] = JsonUtils.getAsString(element);
+	// CHECKSTYLE:OFF
+	public static UUID getAsUUID(JsonElement jElement, String memberName) throws OpenemsNamedException {
+		// CHECKSTYLE:ON
+		try {
+			return UUID.fromString(getAsString(jElement, memberName));
+		} catch (IllegalArgumentException e) {
+			throw new OpenemsException("Unable to parse UUID: " + e.getMessage());
 		}
-		return result;
 	}
 
+	/**
+	 * Gets the member of the {@link JsonElement} as {@link Optional} {@link UUID}.
+	 * 
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member
+	 * @return the {@link Optional} {@link UUID} value
+	 * @throws OpenemsNamedException on error
+	 */
+	// CHECKSTYLE:OFF
+	public static Optional<UUID> getAsOptionalUUID(JsonElement jElement, String memberName) {
+		// CHECKSTYLE:ON
+		Optional<String> uuid = getAsOptionalString(jElement, memberName);
+		if (uuid.isPresent()) {
+			return Optional.ofNullable(UUID.fromString(uuid.get()));
+		} else {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Tries to find the best matching Object representation of the given
+	 * {@link JsonElement}.
+	 * 
+	 * @param j the {@link JsonElement}
+	 * @return the Object
+	 * @throws OpenemsNamedException on error
+	 */
+	public static Object getAsBestType(JsonElement j) throws OpenemsNamedException {
+		try {
+			if (j.isJsonArray()) {
+				JsonArray jA = (JsonArray) j;
+				if (jA.size() == 0) {
+					return new Object[0];
+				}
+				// identify the array type (boolean, int or String)
+				boolean isBoolean = true;
+				boolean isInt = true;
+				for (JsonElement jE : jA) {
+					if (jE.isJsonPrimitive()) {
+						JsonPrimitive jP = jE.getAsJsonPrimitive();
+						if (isBoolean && !jP.isBoolean()) {
+							isBoolean = false;
+						}
+						if (isInt && !jP.isNumber()) {
+							isInt = false;
+						}
+					} else {
+						isBoolean = false;
+						isInt = false;
+						break;
+					}
+				}
+				if (isBoolean) {
+					// convert to boolean array
+					boolean[] result = new boolean[jA.size()];
+					for (int i = 0; i < jA.size(); i++) {
+						result[i] = jA.get(i).getAsBoolean();
+					}
+					return result;
+				} else if (isInt) {
+					// convert to int array
+					int[] result = new int[jA.size()];
+					for (int i = 0; i < jA.size(); i++) {
+						result[i] = jA.get(i).getAsInt();
+					}
+					return result;
+				} else {
+					// convert to string array
+					String[] result = new String[jA.size()];
+					for (int i = 0; i < jA.size(); i++) {
+						JsonElement jE = jA.get(i);
+						if (!jE.isJsonPrimitive()) {
+							result[i] = jE.toString();
+						} else {
+							result[i] = jE.getAsString();
+						}
+					}
+					return result;
+				}
+			}
+			if (!j.isJsonPrimitive()) {
+				return j.toString();
+			}
+			JsonPrimitive jP = j.getAsJsonPrimitive();
+			if (jP.isBoolean()) {
+				return jP.getAsBoolean();
+			}
+			if (jP.isNumber()) {
+				Number n = jP.getAsNumber();
+				return n.intValue();
+			}
+			return j.getAsString();
+		} catch (Exception e) {
+			throw OpenemsError.JSON_PARSE_ELEMENT_FAILED.exception(j.toString().replaceAll("%", "%%"),
+					e.getClass().getSimpleName(), e.getMessage());
+		}
+	}
+
+	/**
+	 * Gets a {@link JsonElement} representing the Object value.
+	 * 
+	 * @param value the {@link Object} value
+	 * @return the {@link JsonElement}
+	 */
 	public static JsonElement getAsJsonElement(Object value) {
 		// null
 		if (value == null) {
@@ -339,182 +1187,19 @@ public class JsonUtils {
 			/*
 			 * Use toString()-method
 			 */
-			log.warn("Converter for [" + value + "]" + " of type [" + value.getClass().getSimpleName()
+			LOG.warn("Converter for [" + value + "]" + " of type [" + value.getClass().getSimpleName()
 					+ "] to JSON is not implemented.");
 			return new JsonPrimitive(value.toString());
 		}
 	}
 
-	public static JsonObject getAsJsonObject(JsonElement jElement) throws OpenemsNamedException {
-		if (!jElement.isJsonObject()) {
-			throw OpenemsError.JSON_NO_OBJECT.exception(jElement.toString().replaceAll("%", "%%"));
-		}
-		return jElement.getAsJsonObject();
-	}
-
-	public static JsonObject getAsJsonObject(JsonElement jElement, String memberName) throws OpenemsNamedException {
-		JsonElement subElement = getSubElement(jElement, memberName);
-		if (!subElement.isJsonObject()) {
-			throw OpenemsError.JSON_NO_OBJECT_MEMBER.exception(memberName,
-					StringUtils.toShortString(subElement, 100).replaceAll("%", "%%"));
-		}
-		return subElement.getAsJsonObject();
-	}
-
-	public static long getAsLong(JsonElement jElement, String memberName) throws OpenemsNamedException {
-		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
-		if (jPrimitive.isNumber()) {
-			return jPrimitive.getAsLong();
-		} else if (jPrimitive.isString()) {
-			String string = jPrimitive.getAsString();
-			return Long.parseLong(string);
-		}
-		throw OpenemsError.JSON_NO_NUMBER.exception(jPrimitive.toString().replaceAll("%", "%%"));
-	}
-
-	public static Optional<Integer> getAsOptionalInt(JsonElement jElement) {
-		try {
-			return Optional.of(getAsInt(jElement));
-		} catch (OpenemsNamedException e) {
-			return Optional.empty();
-		}
-	}
-
-	public static Optional<Integer> getAsOptionalInt(JsonElement jElement, String memberName) {
-		try {
-			return Optional.of(getAsInt(jElement, memberName));
-		} catch (OpenemsNamedException e) {
-			return Optional.empty();
-		}
-	}
-
-	public static Optional<JsonArray> getAsOptionalJsonArray(JsonElement jElement, String memberName) {
-		try {
-			return Optional.of(getAsJsonArray(jElement, memberName));
-		} catch (OpenemsNamedException e) {
-			return Optional.empty();
-		}
-	}
-
-	public static Optional<JsonObject> getAsOptionalJsonObject(JsonElement jElement) {
-		try {
-			return Optional.of(getAsJsonObject(jElement));
-		} catch (OpenemsNamedException e) {
-			return Optional.empty();
-		}
-	}
-
-	public static Optional<JsonObject> getAsOptionalJsonObject(JsonElement jElement, String memberName) {
-		try {
-			return Optional.of(getAsJsonObject(jElement, memberName));
-		} catch (OpenemsNamedException e) {
-			return Optional.empty();
-		}
-	}
-
-	public static Optional<Long> getAsOptionalLong(JsonElement jElement, String memberName) {
-		try {
-			return Optional.of(getAsLong(jElement, memberName));
-		} catch (OpenemsNamedException e) {
-			return Optional.empty();
-		}
-	}
-
-	public static Optional<String> getAsOptionalString(JsonElement jElement) {
-		try {
-			return Optional.of(getAsString(jElement));
-		} catch (OpenemsNamedException e) {
-			return Optional.empty();
-		}
-	}
-
-	public static Optional<String> getAsOptionalString(JsonElement jElement, String memberName) {
-		try {
-			return Optional.of(getAsString(jElement, memberName));
-		} catch (OpenemsNamedException e) {
-			return Optional.empty();
-		}
-	}
-
-	public static Optional<Inet4Address> getAsOptionalInet4Address(JsonElement jElement, String memberName) {
-		try {
-			return Optional.ofNullable((Inet4Address) Inet4Address.getByName(getAsString(jElement, memberName)));
-		} catch (OpenemsNamedException | UnknownHostException e) {
-			return Optional.empty();
-		}
-	}
-
-	public static Object getAsBestType(JsonElement j) throws OpenemsNamedException {
-		try {
-			if (j.isJsonArray()) {
-				JsonArray jA = (JsonArray) j;
-				if (jA.size() == 0) {
-					return new Object[0];
-				}
-				// identify the array type (boolean, int or String)
-				boolean isBoolean = true;
-				boolean isInt = true;
-				for (JsonElement jE : jA) {
-					if (jE.isJsonPrimitive()) {
-						JsonPrimitive jP = jE.getAsJsonPrimitive();
-						if (isBoolean && !jP.isBoolean()) {
-							isBoolean = false;
-						}
-						if (isInt && !jP.isNumber()) {
-							isInt = false;
-						}
-					} else {
-						isBoolean = false;
-						isInt = false;
-						break;
-					}
-				}
-				if (isBoolean) {
-					// convert to boolean array
-					boolean[] result = new boolean[jA.size()];
-					for (int i = 0; i < jA.size(); i++) {
-						result[i] = jA.get(i).getAsBoolean();
-					}
-					return result;
-				} else if (isInt) {
-					// convert to int array
-					int[] result = new int[jA.size()];
-					for (int i = 0; i < jA.size(); i++) {
-						result[i] = jA.get(i).getAsInt();
-					}
-					return result;
-				} else {
-					// convert to string array
-					String[] result = new String[jA.size()];
-					for (int i = 0; i < jA.size(); i++) {
-						JsonElement jE = jA.get(i);
-						if (!jE.isJsonPrimitive()) {
-							result[i] = jE.toString();
-						} else {
-							result[i] = jE.getAsString();
-						}
-					}
-					return result;
-				}
-			}
-			if (!j.isJsonPrimitive()) {
-				return j.toString();
-			}
-			JsonPrimitive jP = j.getAsJsonPrimitive();
-			if (jP.isBoolean()) {
-				return jP.getAsBoolean();
-			}
-			if (jP.isNumber()) {
-				Number n = jP.getAsNumber();
-				return n.intValue();
-			}
-			return j.getAsString();
-		} catch (Exception e) {
-			throw OpenemsError.JSON_PARSE_ELEMENT_FAILED.exception(j.toString().replaceAll("%", "%%"),
-					e.getClass().getSimpleName(), e.getMessage());
-		}
-	}
-
+	/**
+	 * Gets a {@link JsonElement} as the given type.
+	 * 
+	 * @param type the class of the type
+	 * @param j    the {@link JsonElement}
+	 * @return an Object of the given type
+	 */
 	public static Object getAsType(Class<?> type, JsonElement j) throws NotImplementedException {
 		try {
 			if (Integer.class.isAssignableFrom(type)) {
@@ -579,6 +1264,44 @@ public class JsonUtils {
 				"Converter for value [" + j + "] to class type [" + type + "] is not implemented.");
 	}
 
+	/**
+	 * Gets a {@link JsonElement} as the given {@link OpenemsType}.
+	 * 
+	 * @param type the {@link OpenemsType}
+	 * @param j    the {@link JsonElement}
+	 * @return an Object of the given type
+	 */
+	public static Object getAsType(OpenemsType type, JsonElement j) throws OpenemsNamedException {
+		if (j.isJsonNull()) {
+			return null;
+		}
+		switch (type) {
+		case BOOLEAN:
+			return JsonUtils.getAsBoolean(j);
+		case DOUBLE:
+			return JsonUtils.getAsDouble(j);
+		case FLOAT:
+			return JsonUtils.getAsFloat(j);
+		case INTEGER:
+			return JsonUtils.getAsInt(j);
+		case LONG:
+			return JsonUtils.getAsLong(j);
+		case SHORT:
+			return JsonUtils.getAsShort(j);
+		case STRING:
+			return JsonUtils.getAsString(j);
+		}
+		throw new NotImplementedException(
+				"Converter for value [" + j + "] to class type [" + type + "] is not implemented.");
+	}
+
+	/**
+	 * Gets a {@link JsonElement} as the given type.
+	 * 
+	 * @param typeOptional the class of the type
+	 * @param j            the {@link JsonElement}
+	 * @return an Object of the given type
+	 */
 	public static Object getAsType(Optional<Class<?>> typeOptional, JsonElement j) throws NotImplementedException {
 		if (!typeOptional.isPresent()) {
 			throw new NotImplementedException("Type of Channel was not set: " + j.getAsString());
@@ -587,59 +1310,14 @@ public class JsonUtils {
 		return getAsType(type, j);
 	}
 
-	public static JsonPrimitive getAsPrimitive(JsonElement jElement) throws OpenemsNamedException {
-		if (!jElement.isJsonPrimitive()) {
-			throw OpenemsError.JSON_NO_PRIMITIVE.exception(jElement.toString().replaceAll("%", "%%"));
-		}
-		return jElement.getAsJsonPrimitive();
-	}
-
-	public static JsonPrimitive getAsPrimitive(JsonElement jElement, String memberName) throws OpenemsNamedException {
-		JsonElement jSubElement = getSubElement(jElement, memberName);
-		return getAsPrimitive(jSubElement);
-	}
-
-	public static String getAsString(JsonElement jElement) throws OpenemsNamedException {
-		JsonPrimitive jPrimitive = getAsPrimitive(jElement);
-		if (!jPrimitive.isString()) {
-			throw OpenemsError.JSON_NO_STRING.exception(jPrimitive.toString().replaceAll("%", "%%"));
-		}
-		return jPrimitive.getAsString();
-	}
-
-	public static String getAsString(JsonElement jElement, String memberName) throws OpenemsNamedException {
-		JsonPrimitive jPrimitive = getAsPrimitive(jElement, memberName);
-		if (!jPrimitive.isString()) {
-			throw OpenemsError.JSON_NO_STRING_MEMBER.exception(memberName, jPrimitive.toString().replaceAll("%", "%%"));
-		}
-		return jPrimitive.getAsString();
-	}
-
-	public static UUID getAsUUID(JsonElement jElement, String memberName) throws OpenemsNamedException {
-		try {
-			return UUID.fromString(getAsString(jElement, memberName));
-		} catch (IllegalArgumentException e) {
-			throw new OpenemsException("Unable to parse UUID: " + e.getMessage());
-		}
-	}
-
-	public static Optional<UUID> getAsOptionalUUID(JsonElement jElement, String memberName) {
-		Optional<String> uuid = getAsOptionalString(jElement, memberName);
-		if (uuid.isPresent()) {
-			return Optional.ofNullable(UUID.fromString(uuid.get()));
-		} else {
-			return Optional.empty();
-		}
-	}
-
 	/**
-	 * Takes a JSON in the form 'YYYY-MM-DD' and converts it to a ZonedDateTime with
-	 * hour, minute and second set to zero.
+	 * Takes a JSON in the form 'YYYY-MM-DD' and converts it to a
+	 * {@link ZonedDateTime} with hour, minute and second set to zero.
 	 * 
-	 * @param element    the JsonElement
+	 * @param element    the {@link JsonElement}
 	 * @param memberName the name of the member of the JsonObject
-	 * @param timezone   the timezone
-	 * @return the ZonedDateTime
+	 * @param timezone   the timezone as {@link ZoneId}
+	 * @return the {@link ZonedDateTime}
 	 * @throws OpenemsNamedException on parse error
 	 */
 	public static ZonedDateTime getAsZonedDateTime(JsonElement element, String memberName, ZoneId timezone)
@@ -655,63 +1333,11 @@ public class JsonUtils {
 		}
 	}
 
-	public static Set<JsonElement> getMatchingElements(JsonElement j, String... paths) {
-		Set<JsonElement> result = new HashSet<JsonElement>();
-		if (paths.length == 0) {
-			// last path element
-			result.add(j);
-			return result;
-		}
-		String path = paths[0];
-		if (j.isJsonObject()) {
-			JsonObject jO = j.getAsJsonObject();
-			if (jO.has(path)) {
-				List<String> nextPathsList = new ArrayList<String>(Arrays.asList(paths));
-				nextPathsList.remove(0);
-				String[] nextPaths = nextPathsList.toArray(new String[0]);
-				result.addAll(getMatchingElements(jO.get(path), nextPaths));
-			}
-		} else if (j.isJsonArray()) {
-			for (JsonElement jE : j.getAsJsonArray()) {
-				result.addAll(getMatchingElements(jE, paths));
-			}
-		} else if (j.isJsonPrimitive()) {
-			JsonPrimitive jP = j.getAsJsonPrimitive();
-			if (jP.isString()) {
-				if (jP.getAsString().equals(path)) {
-					result.add(jP);
-				}
-			}
-		}
-		return result;
-	}
-
-	public static JsonElement getSubElement(JsonElement jElement, String memberName) throws OpenemsNamedException {
-		JsonObject jObject = getAsJsonObject(jElement);
-		if (!jObject.has(memberName)) {
-			throw OpenemsError.JSON_HAS_NO_MEMBER.exception(memberName,
-					StringUtils.toShortString(jElement, 100).replaceAll("%", "%%"));
-		}
-		return jObject.get(memberName);
-	}
-
-	public static Optional<JsonElement> getOptionalSubElement(JsonElement jElement, String memberName) {
-		try {
-			return Optional.of(getSubElement(jElement, memberName));
-		} catch (OpenemsNamedException e) {
-			return Optional.empty();
-		}
-	}
-
-	public static boolean hasElement(JsonElement j, String... paths) {
-		return getMatchingElements(j, paths).size() > 0;
-	}
-
 	/**
-	 * Parses a string to a JsonElement.
+	 * Parses a string to a {@link JsonElement}.
 	 * 
 	 * @param string to be parsed
-	 * @return the JsonElement
+	 * @return the {@link JsonElement}
 	 * @throws OpenemsNamedException on error
 	 */
 	public static JsonElement parse(String string) throws OpenemsNamedException {
@@ -724,195 +1350,24 @@ public class JsonUtils {
 	}
 
 	/**
-	 * Pretty print a JsonElement.
+	 * Parses a string to a {@link JsonObject}.
+	 * 
+	 * @param string the String
+	 * @return the {@link JsonObject}
+	 * @throws OpenemsNamedException on error
+	 */
+	public static JsonObject parseToJsonObject(String string) throws OpenemsNamedException {
+		return JsonUtils.getAsJsonObject(JsonUtils.parse(string));
+	}
+
+	/**
+	 * Pretty print a {@link JsonElement}.
 	 *
-	 * @param j the JsonElement
+	 * @param j the {@link JsonElement}
 	 */
 	public static void prettyPrint(JsonElement j) {
 		Gson gson = new GsonBuilder().setPrettyPrinting().create();
 		String json = gson.toJson(j);
 		System.out.println(json);
-	}
-
-	/**
-	 * A temporary builder class for JsonObjects.
-	 */
-	public static class JsonObjectBuilder {
-
-		private final JsonObject j;
-
-		protected JsonObjectBuilder() {
-			this(new JsonObject());
-		}
-
-		protected JsonObjectBuilder(JsonObject j) {
-			this.j = j;
-		}
-
-		public JsonObjectBuilder addProperty(String property, String value) {
-			j.addProperty(property, value);
-			return this;
-		}
-
-		public JsonObjectBuilder addProperty(String property, int value) {
-			j.addProperty(property, value);
-			return this;
-		}
-
-		public JsonObjectBuilder addProperty(String property, long value) {
-			j.addProperty(property, value);
-			return this;
-		}
-
-		public JsonObjectBuilder addProperty(String property, boolean value) {
-			j.addProperty(property, value);
-			return this;
-		}
-
-		public JsonObjectBuilder addProperty(String property, double value) {
-			j.addProperty(property, value);
-			return this;
-		}
-
-		public JsonObjectBuilder addPropertyIfNotNull(String property, String value) {
-			if (value != null) {
-				j.addProperty(property, value);
-			}
-			return this;
-		}
-
-		public JsonObjectBuilder addPropertyIfNotNull(String property, Integer value) {
-			if (value != null) {
-				j.addProperty(property, value);
-			}
-			return this;
-		}
-
-		public JsonObjectBuilder addPropertyIfNotNull(String property, Long value) {
-			if (value != null) {
-				j.addProperty(property, value);
-			}
-			return this;
-		}
-
-		public JsonObjectBuilder addPropertyIfNotNull(String property, Boolean value) {
-			if (value != null) {
-				j.addProperty(property, value);
-			}
-			return this;
-		}
-
-		public JsonObjectBuilder addPropertyIfNotNull(String property, Double value) {
-			if (value != null) {
-				j.addProperty(property, value);
-			}
-			return this;
-		}
-
-		public JsonObjectBuilder add(String property, JsonElement value) {
-			j.add(property, value);
-			return this;
-		}
-
-		public JsonObject build() {
-			return this.j;
-		}
-
-	}
-
-	/**
-	 * Creates a JsonObject using a Builder.
-	 * 
-	 * @return the Builder
-	 */
-	public static JsonObjectBuilder buildJsonObject() {
-		return new JsonObjectBuilder();
-	}
-
-	/**
-	 * Creates a JsonObject using a Builder. Initialized from an existing
-	 * JsonObject.
-	 * 
-	 * @param j the initial JsonObject
-	 * @return the Builder
-	 */
-	public static JsonObjectBuilder buildJsonObject(JsonObject j) {
-		return new JsonObjectBuilder(j);
-	}
-
-	/**
-	 * A temporary builder class for JsonArrays.
-	 */
-	public static class JsonArrayBuilder {
-
-		private final JsonArray j;
-
-		protected JsonArrayBuilder() {
-			this(new JsonArray());
-		}
-
-		protected JsonArrayBuilder(JsonArray j) {
-			this.j = j;
-		}
-
-		public JsonArrayBuilder add(String value) {
-			j.add(value);
-			return this;
-		}
-
-		public JsonArrayBuilder add(int value) {
-			j.add(value);
-			return this;
-		}
-
-		public JsonArrayBuilder add(long value) {
-			j.add(value);
-			return this;
-		}
-
-		public JsonArrayBuilder add(boolean value) {
-			j.add(value);
-			return this;
-		}
-
-		public JsonArrayBuilder add(JsonElement value) {
-			j.add(value);
-			return this;
-		}
-
-		public JsonArray build() {
-			return this.j;
-		}
-
-	}
-
-	/**
-	 * Creates a JsonArray using a Builder.
-	 * 
-	 * @return the Builder
-	 */
-	public static JsonArrayBuilder buildJsonArray() {
-		return new JsonArrayBuilder();
-	}
-
-	/**
-	 * Creates a JsonArray using a Builder. Initialized from an existing JsonArray.
-	 * 
-	 * @param j the initial JsonArray
-	 * @return the Builder
-	 */
-	public static JsonArrayBuilder buildJsonArray(JsonArray j) {
-		return new JsonArrayBuilder(j);
-	}
-
-	/**
-	 * Parses a string to a JsonObject.
-	 * 
-	 * @param string the String
-	 * @return the JsonObject
-	 * @throws OpenemsNamedException on error
-	 */
-	public static JsonObject parseToJsonObject(String string) throws OpenemsNamedException {
-		return JsonUtils.getAsJsonObject(JsonUtils.parse(string));
 	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/internal/AbstractDoc.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/internal/AbstractDoc.java
@@ -9,6 +9,7 @@ import io.openems.common.channel.PersistencePriority;
 import io.openems.common.channel.Unit;
 import io.openems.common.types.OpenemsType;
 import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.channel.ChannelId;
 import io.openems.edge.common.channel.Doc;
 import io.openems.edge.common.component.OpenemsComponent;
 
@@ -32,21 +33,22 @@ public abstract class AbstractDoc<T> implements Doc {
 
 	@Override
 	public OpenemsType getType() {
-		return type;
+		return this.type;
 	}
 
 	/**
-	 * Allowed Access-Mode for this Channel.
+	 * Allowed {@link AccessMode} for this Channel.
 	 */
 	private AccessMode accessMode = AccessMode.READ_ONLY;
 
 	/**
-	 * Sets the Access-Mode for the Channel.
+	 * Sets the {@link AccessMode} for the Channel.
 	 * 
 	 * <p>
 	 * This is validated on construction of the Channel by
 	 * {@link AbstractReadChannel}
 	 * 
+	 * @param accessMode the {@link AccessMode}
 	 * @return myself
 	 */
 	public AbstractDoc<T> accessMode(AccessMode accessMode) {
@@ -65,13 +67,15 @@ public abstract class AbstractDoc<T> implements Doc {
 	private PersistencePriority persistencePriority = PersistencePriority.VERY_LOW;
 
 	/**
-	 * Sets the Persistence Priority. Defaults to VERY_LOW.
+	 * Sets the {@link PersistencePriority}. Defaults to
+	 * {@link PersistencePriority#VERY_LOW}.
 	 * 
 	 * <p>
 	 * This parameter may be used by persistence services to decide, if the Channel
 	 * should be persisted to the hard disk.
 	 * 
 	 * @param persistencePriority the {@link PersistencePriority}
+	 * @return myself
 	 */
 	public AbstractDoc<T> persistencePriority(PersistencePriority persistencePriority) {
 		this.persistencePriority = persistencePriority;
@@ -91,7 +95,7 @@ public abstract class AbstractDoc<T> implements Doc {
 	/**
 	 * Initial-Value. Default: none
 	 * 
-	 * @param initialValue
+	 * @param initialValue the initial value
 	 * @return myself
 	 */
 	public AbstractDoc<T> initialValue(T initialValue) {
@@ -155,7 +159,7 @@ public abstract class AbstractDoc<T> implements Doc {
 	private final List<Consumer<Channel<T>>> onInitCallback = new CopyOnWriteArrayList<>();
 
 	/**
-	 * Provides a callback on initialization of the actual Channel
+	 * Provides a callback on initialization of the actual Channel.
 	 * 
 	 * @param callback the method to call on initialization
 	 * @return myself
@@ -171,14 +175,16 @@ public abstract class AbstractDoc<T> implements Doc {
 	 * @return a list of callbacks
 	 */
 	protected List<Consumer<Channel<T>>> getOnInitCallbacks() {
-		return onInitCallback;
+		return this.onInitCallback;
 	}
 
 	/**
 	 * Creates an instance of {@link Channel} for the given Channel-ID using its
 	 * Channel-{@link AbstractDoc}.
 	 * 
-	 * @param channelId the Channel-ID
+	 * @param <C>       the {@link Channel} type
+	 * @param component the {@link OpenemsComponent}
+	 * @param channelId the {@link ChannelId}
 	 * @return the Channel
 	 */
 	public abstract <C extends Channel<?>> C createChannelInstance(OpenemsComponent component,

--- a/io.openems.edge.common/src/io/openems/edge/common/component/AbstractOpenemsComponent.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/AbstractOpenemsComponent.java
@@ -178,7 +178,9 @@ public abstract class AbstractOpenemsComponent implements OpenemsComponent {
 	protected void deactivate() {
 		this.logMessage("Deactivate");
 		// disable the ServiceTracker
-		this.metaTypeServiceTracker.close();
+		if (this.metaTypeServiceTracker != null) {
+			this.metaTypeServiceTracker.close();
+		}
 
 		// deactivate all Channels
 		for (Channel<?> channel : this.channels.values()) {

--- a/io.openems.edge.common/src/io/openems/edge/common/component/AbstractOpenemsComponent.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/AbstractOpenemsComponent.java
@@ -122,7 +122,7 @@ public abstract class AbstractOpenemsComponent implements OpenemsComponent {
 		// Get the MetaTypeService via ServiceTracker
 		// If we wouldn't do this here, each inheriting Component would have to get an
 		// @Reference to MetaTypeService, which would be cumbersome.
-		if (context != null) {
+		if (context != null && context.getBundleContext() != null) {
 			this.metaTypeServiceTracker = new ServiceTracker<MetaTypeService, MetaTypeService>(
 					context.getBundleContext(), MetaTypeService.class, null) {
 

--- a/io.openems.edge.common/src/io/openems/edge/common/component/AbstractOpenemsComponent.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/AbstractOpenemsComponent.java
@@ -122,24 +122,27 @@ public abstract class AbstractOpenemsComponent implements OpenemsComponent {
 		// Get the MetaTypeService via ServiceTracker
 		// If we wouldn't do this here, each inheriting Component would have to get an
 		// @Reference to MetaTypeService, which would be cumbersome.
-		this.metaTypeServiceTracker = new ServiceTracker<MetaTypeService, MetaTypeService>(context.getBundleContext(),
-				MetaTypeService.class, null) {
+		if (context != null) {
+			this.metaTypeServiceTracker = new ServiceTracker<MetaTypeService, MetaTypeService>(
+					context.getBundleContext(), MetaTypeService.class, null) {
 
-			@Override
-			public MetaTypeService addingService(ServiceReference<MetaTypeService> serviceReference) {
-				MetaTypeService metaTypeService = super.addingService(serviceReference);
-				AbstractOpenemsComponent.this.metaTypeService.set(metaTypeService);
-				AbstractOpenemsComponent.this.addChannelsForProperties();
-				return metaTypeService;
-			}
+				@Override
+				public MetaTypeService addingService(ServiceReference<MetaTypeService> serviceReference) {
+					MetaTypeService metaTypeService = super.addingService(serviceReference);
+					AbstractOpenemsComponent.this.metaTypeService.set(metaTypeService);
+					AbstractOpenemsComponent.this.addChannelsForProperties();
+					return metaTypeService;
+				}
 
-			@Override
-			public void removedService(ServiceReference<MetaTypeService> serviceReference, MetaTypeService service) {
-				AbstractOpenemsComponent.this.metaTypeService.set(null);
-				super.removedService(serviceReference, service);
-			}
-		};
-		this.metaTypeServiceTracker.open(true);
+				@Override
+				public void removedService(ServiceReference<MetaTypeService> serviceReference,
+						MetaTypeService service) {
+					AbstractOpenemsComponent.this.metaTypeService.set(null);
+					super.removedService(serviceReference, service);
+				}
+			};
+			this.metaTypeServiceTracker.open(true);
+		}
 
 		this.updateContext(context, id, alias, enabled);
 


### PR DESCRIPTION
For each configuration property of an OpenEMS Component automatically a `_Property` Channel is created, e.g. `_PropertyEnabled` for the `enabled` configuration.

Currently the type of the Channel is guessed at runtime. This pull-request takes the information directly from `MetaTypeInformation` provided by the `MetaTypeService`. Additionally properties marked as password, will be not anymore published to Channels to avoid security issues.