### PR TITLE
Updated the MQTT component to optionally filter its messages by topic paths

### DIFF
--- a/io.openems.edge.controller.api.mqtt/src/io/openems/edge/controller/api/mqtt/Config.java
+++ b/io.openems.edge.controller.api.mqtt/src/io/openems/edge/controller/api/mqtt/Config.java
@@ -38,5 +38,8 @@ import io.openems.common.channel.PersistencePriority;
 	@AttributeDefinition(name = "Debug Mode", description = "Activates the debug mode")
 	boolean debugMode() default false;
 
+	@AttributeDefinition(name = "Filter Spec", description = "A list of valid topic paths. Follows the MQTT topic subscription rules for globbing.")
+	String filterSpec();
+
 	String webconsole_configurationFactory_nameHint() default "Controller Api MQTT [{id}]";
 }


### PR DESCRIPTION
The current implementation of MQTT can turn in to a bit of a fire hose of data for situations where you only want some of the fields possible. This patch adds a filter function which inhibits certain topics from actually sending to the broker, instead they silently complete, doing nothing.

A single new configuration string has been added, into which a semicolon-delimited set of topic filters can be written allowing only topics which match these specifications to pass.

The topic filters use the same syntax as normal MQTT client subscriptions, so can use the `+` and `#` specifiers to indicate single, or multi-level paths.

An example path might be `edge/fems33/channel/meter+/+` which would pull all metrics in meter0, meter1, etc. paths, but exclude any other topics.

THIS NEEDS TESTING - Please can someone with an otherwise working setup please check that this works, as I'm currently unable to, as I don't have access to our test hardware.