### PR TITLE
Array-Properties: handle datatype properly

### DIFF
--- a/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
@@ -1,5 +1,6 @@
 package io.openems.edge.common.type;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -34,6 +35,15 @@ public class TypeUtils {
 		if (value instanceof Enum<?>) {
 			value = ((Enum<?>) value).ordinal();
 		}
+		// Extract value from Array
+		if (type != OpenemsType.STRING && value.getClass().isArray()) {
+			if (Array.getLength(value) == 1) {
+				return TypeUtils.getAsType(type, Array.get(value, 0));
+			} else {
+				return null;
+			}
+		}
+
 		switch (type) {
 		case BOOLEAN:
 			if (value == null) {


### PR DESCRIPTION
- Tries to extract 'one' value of the array
- Falls back to 'STRING' if there are more two or more values
- Handle 'IllegalArgumentException' instead of fail