### PR TITLE
Fix and refactor Channel Meta-Info

### DIFF
--- a/io.openems.edge.battery.api/src/io/openems/edge/battery/protection/BatteryProtection.java
+++ b/io.openems.edge.battery.api/src/io/openems/edge/battery/protection/BatteryProtection.java
@@ -301,8 +301,8 @@ public class BatteryProtection {
 		this.chargeMaxCurrentHandler = chargeMaxCurrentHandler;
 		this.dischargeMaxCurrentHandler = dischargeMaxCurrentHandler;
 
-		this.battery.getChargeMaxCurrentChannel().setReadSource("Battery-Protection");
-		this.battery.getDischargeMaxCurrentChannel().setReadSource("Battery-Protection");
+		this.battery.getChargeMaxCurrentChannel().setMetaInfo("Battery-Protection");
+		this.battery.getDischargeMaxCurrentChannel().setMetaInfo("Battery-Protection");
 	}
 
 	/**

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/AbstractOpenemsModbusComponent.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/AbstractOpenemsModbusComponent.java
@@ -265,12 +265,22 @@ public abstract class AbstractOpenemsModbusComponent extends AbstractOpenemsComp
 		 */
 		public ChannelMapper<T> m(io.openems.edge.common.channel.ChannelId channelId,
 				ElementToChannelConverter converter) {
+			return this.m(channelId, converter, new ChannelMetaInfo(element.getStartAddress()));
+		}
+
+		/**
+		 * Maps the given element 1-to-1 to the Channel identified by channelId.
+		 * 
+		 * @param channelId       the Channel-ID
+		 * @param converter       the {@link ElementToChannelConverter}
+		 * @param channelMetaInfo an object that holds meta information about the
+		 *                        Channel
+		 * @return the element parameter
+		 */
+		public ChannelMapper<T> m(io.openems.edge.common.channel.ChannelId channelId,
+				ElementToChannelConverter converter, ChannelMetaInfo channelMetaInfo) {
 			Channel<?> channel = channel(channelId);
-			if (channel instanceof WriteChannel<?>) {
-				((WriteChannel<?>) channel).setWriteTarget(new ModbusChannelMetaInfo(element.getStartAddress()));
-			} else {
-				channel.setReadSource(new ModbusChannelMetaInfo(element.getStartAddress()));
-			}
+			channel.setMetaInfo(channelMetaInfo);
 			this.channelMaps.put(channel, converter);
 			return this;
 		}
@@ -400,6 +410,21 @@ public abstract class AbstractOpenemsModbusComponent extends AbstractOpenemsComp
 	}
 
 	/**
+	 * Maps the given element 1-to-1 to the Channel identified by channelId.
+	 * 
+	 * @param <T>             the type of the {@link AbstractModbusElement}d
+	 * @param channelId       the Channel-ID
+	 * @param element         the ModbusElement
+	 * @param channelMetaInfo an object that holds meta information about the
+	 *                        Channel
+	 * @return the element parameter
+	 */
+	protected final <T extends AbstractModbusElement<?>> T m(io.openems.edge.common.channel.ChannelId channelId,
+			T element, ChannelMetaInfo channelMetaInfo) {
+		return this.m(channelId, element, ElementToChannelConverter.DIRECT_1_TO_1, channelMetaInfo);
+	}
+
+	/**
 	 * Maps the given element to the Channel identified by channelId, applying the
 	 * given @link{ElementToChannelConverter}.
 	 * 
@@ -413,6 +438,25 @@ public abstract class AbstractOpenemsModbusComponent extends AbstractOpenemsComp
 			T element, ElementToChannelConverter converter) {
 		return new ChannelMapper<T>(element) //
 				.m(channelId, converter) //
+				.build();
+	}
+
+	/**
+	 * Maps the given element to the Channel identified by channelId, applying the
+	 * given @link{ElementToChannelConverter}.
+	 * 
+	 * @param <T>             the type of the {@link AbstractModbusElement}d
+	 * @param channelId       the Channel-ID
+	 * @param element         the ModbusElement
+	 * @param converter       the ElementToChannelConverter
+	 * @param channelMetaInfo an object that holds meta information about the
+	 *                        Channel
+	 * @return the element parameter
+	 */
+	protected final <T extends AbstractModbusElement<?>> T m(io.openems.edge.common.channel.ChannelId channelId,
+			T element, ElementToChannelConverter converter, ChannelMetaInfo channelMetaInfo) {
+		return new ChannelMapper<T>(element) //
+				.m(channelId, converter, channelMetaInfo) //
 				.build();
 	}
 

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/ChannelMetaInfo.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/ChannelMetaInfo.java
@@ -1,0 +1,47 @@
+package io.openems.edge.bridge.modbus.api;
+
+import java.util.Objects;
+
+/**
+ * Describes a Channel that has a read- or read-and-write-mapping to one Modbus
+ * Register.
+ */
+public class ChannelMetaInfo {
+
+	/**
+	 * Holds the Address for Modbus Read Register.
+	 */
+	protected final int address;
+
+	public ChannelMetaInfo(int address) {
+		this.address = address;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder b = new StringBuilder();
+		b.append("0x").append(Integer.toHexString(this.address));
+		return b.toString();
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.address);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		ChannelMetaInfo other = (ChannelMetaInfo) obj;
+		return this.address == other.address;
+	}
+
+}

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/ChannelMetaInfoBit.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/ChannelMetaInfoBit.java
@@ -2,25 +2,18 @@ package io.openems.edge.bridge.modbus.api;
 
 import java.util.Objects;
 
-public class ModbusChannelMetaInfo {
-
-	/**
-	 * Holds the Start-Address of the Modbus Register.
-	 */
-	private final int address;
+/**
+ * Describes a Channel that has a read-mapping to a Modbus Coil.
+ */
+public class ChannelMetaInfoBit extends ChannelMetaInfo {
 
 	/**
 	 * Holds the index of the bit inside the Register if applicable.
 	 */
 	private final int bit;
 
-	public ModbusChannelMetaInfo(int address) {
-		this.address = address;
-		this.bit = -1;
-	}
-
-	public ModbusChannelMetaInfo(int address, int bit) {
-		this.address = address;
+	public ChannelMetaInfoBit(int address, int bit) {
+		super(address);
 		this.bit = bit;
 	}
 
@@ -50,7 +43,7 @@ public class ModbusChannelMetaInfo {
 		if (getClass() != obj.getClass()) {
 			return false;
 		}
-		ModbusChannelMetaInfo other = (ModbusChannelMetaInfo) obj;
+		ChannelMetaInfoBit other = (ChannelMetaInfoBit) obj;
 		return this.address == other.address && this.bit == other.bit;
 	}
 

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/ChannelMetaInfoReadAndWrite.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/ChannelMetaInfoReadAndWrite.java
@@ -1,0 +1,49 @@
+package io.openems.edge.bridge.modbus.api;
+
+import java.util.Objects;
+
+/**
+ * Describes a Channel that has a read-and-write-mapping to two Modbus
+ * Registers.
+ */
+public class ChannelMetaInfoReadAndWrite extends ChannelMetaInfo {
+
+	/**
+	 * Holds the Address for Modbus Write Register.
+	 */
+	private final int writeAddress;
+
+	public ChannelMetaInfoReadAndWrite(int readAddress, int writeAaddress) {
+		super(readAddress);
+		this.writeAddress = writeAaddress;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder b = new StringBuilder();
+		b.append("READ:0x").append(Integer.toHexString(this.address));
+		b.append(" | WRITE:0x").append(Integer.toHexString(this.writeAddress));
+		return b.toString();
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.address, this.writeAddress);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		ChannelMetaInfoReadAndWrite other = (ChannelMetaInfoReadAndWrite) obj;
+		return this.address == other.address && this.writeAddress == other.writeAddress;
+	}
+
+}

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/ChannelToElementConverter.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/ChannelToElementConverter.java
@@ -1,0 +1,260 @@
+package io.openems.edge.bridge.modbus.api;
+
+import java.util.function.Function;
+
+/**
+ * Provides Functions to convert from Element to Channel and back. Also has some
+ * static convenience functions to facilitate conversion.
+ */
+public class ChannelToElementConverter implements Function<Object, Object> {
+
+	/**
+	 * Converts directly 1-to-1 between Channel and Element.
+	 */
+	public static final ChannelToElementConverter DIRECT_1_TO_1 = new ChannelToElementConverter(value -> value);
+
+	private final Function<Object, Object> function;
+
+	public ChannelToElementConverter(Function<Object, Object> function) {
+		this.function = function;
+	}
+
+	@Override
+	public Object apply(Object t) {
+		return this.function.apply(t);
+	}
+//	/**
+//	 * Applies a scale factor of -1. Converts value [1] to [0.1].
+//	 * 
+//	 * @see ElementToChannelScaleFactorConverter
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_MINUS_1 = new ElementToChannelScaleFactorConverter(-1);
+//
+//	/**
+//	 * Applies a scale factor of -2. Converts value [1] to [0.01].
+//	 * 
+//	 * @see ElementToChannelScaleFactorConverter
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_MINUS_2 = new ElementToChannelScaleFactorConverter(-2);
+//
+//	/**
+//	 * Applies a scale factor of -3. Converts value [1] to [0.001].
+//	 * 
+//	 * @see ElementToChannelScaleFactorConverter
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_MINUS_3 = new ElementToChannelScaleFactorConverter(-3);
+//
+//	/**
+//	 * Applies a scale factor of 1. Converts value [1] to [10].
+//	 * 
+//	 * @see ElementToChannelScaleFactorConverter
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_1 = new ElementToChannelScaleFactorConverter(1);
+//
+//	/**
+//	 * Applies a scale factor of 2. Converts value [1] to [100].
+//	 * 
+//	 * @see ElementToChannelScaleFactorConverter
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_2 = new ElementToChannelScaleFactorConverter(2);
+//
+//	/**
+//	 * Applies a scale factor of 3. Converts value [1] to [1000].
+//	 * 
+//	 * @see ElementToChannelScaleFactorConverter
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_3 = new ElementToChannelScaleFactorConverter(3);
+//
+//	/**
+//	 * Converts only positive values from Element to Channel.
+//	 */
+//	public static final ChannelToElementConverter KEEP_POSITIVE = new ChannelToElementConverter(//
+//			// element -> channel
+//			value -> StaticConverters.KEEP_POSITIVE, //
+//			// channel -> element
+//			value -> value);
+//
+//	/**
+//	 * Inverts the value from Element to Channel.
+//	 */
+//	public static final ChannelToElementConverter INVERT = new ChannelToElementConverter(//
+//			// element -> channel
+//			StaticConverters.INVERT, //
+//			// channel -> element
+//			StaticConverters.INVERT);
+//
+//	/**
+//	 * Sets the value to 'zero' if parameter is true; otherwise
+//	 * {@link #DIRECT_1_TO_1}.
+//	 * 
+//	 * <ul>
+//	 * <li>true: set zero
+//	 * <li>false: apply {@link #DIRECT_1_TO_1}
+//	 * </ul>
+//	 * 
+//	 * @param setZero true to set to null
+//	 * @return the {@link ChannelToElementConverter}
+//	 */
+//	// CHECKSTYLE:OFF
+//	public static ChannelToElementConverter SET_ZERO_IF_TRUE(boolean setZero) {
+//		// CHECKSTYLE:ON
+//		if (setZero) {
+//			return new ChannelToElementConverter(//
+//					// element -> channel
+//					value -> 0, //
+//					// channel -> element
+//					value -> 0);
+//		} else {
+//			return DIRECT_1_TO_1;
+//		}
+//	}
+//
+//	/**
+//	 * Converts depending on the given parameter.
+//	 * 
+//	 * <ul>
+//	 * <li>true: invert value
+//	 * <li>false: keep value (1-to-1)
+//	 * </ul>
+//	 * 
+//	 * @param invert true if Converter should invert
+//	 * @return the {@link ChannelToElementConverter}
+//	 */
+//	// CHECKSTYLE:OFF
+//	public static ChannelToElementConverter INVERT_IF_TRUE(boolean invert) {
+//		// CHECKSTYLE:ON
+//		if (invert) {
+//			return INVERT;
+//		} else {
+//			return DIRECT_1_TO_1;
+//		}
+//	}
+//
+//	/**
+//	 * Converts only negative values from Element to Channel and inverts them (makes
+//	 * the value positive).
+//	 */
+//	public static final ChannelToElementConverter KEEP_NEGATIVE_AND_INVERT = new ElementToChannelConverterChain(INVERT,
+//			KEEP_POSITIVE);
+//
+//	/**
+//	 * Applies {@link ChannelToElementConverter#SCALE_FACTOR_1} and
+//	 * CONVERT_POSITIVE.
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_1_AND_KEEP_POSITIVE = new ElementToChannelConverterChain(
+//			SCALE_FACTOR_1, KEEP_POSITIVE);
+//
+//	/**
+//	 * Applies {@link ChannelToElementConverter#SCALE_FACTOR_2} and INVERT.
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_2_AND_INVERT = new ElementToChannelConverterChain(
+//			SCALE_FACTOR_2, INVERT);
+//
+//	/**
+//	 * Applies {@link ChannelToElementConverter#SCALE_FACTOR_1} and
+//	 * CONVERT_NEGATIVE_AND_INVERT.
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_1_AND_KEEP_NEGATIVE_AND_INVERT = new ElementToChannelConverterChain(
+//			SCALE_FACTOR_1, KEEP_NEGATIVE_AND_INVERT);
+//
+//	/**
+//	 * Applies {@link ChannelToElementConverter#SCALE_FACTOR_2} and
+//	 * CONVERT_POSITIVE.
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_2_AND_KEEP_POSITIVE = new ElementToChannelConverterChain(
+//			SCALE_FACTOR_2, KEEP_POSITIVE);
+//
+//	/**
+//	 * Applies {@link ChannelToElementConverter#SCALE_FACTOR_2} and @see
+//	 * {@link ChannelToElementConverter#KEEP_NEGATIVE_AND_INVERT}.
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_2_AND_KEEP_NEGATIVE_AND_INVERT = new ElementToChannelConverterChain(
+//			SCALE_FACTOR_2, KEEP_NEGATIVE_AND_INVERT);
+//
+//	/**
+//	 * Applies {@link ChannelToElementConverter#SCALE_FACTOR_2_AND_KEEP_NEGATIVE}
+//	 * and @see {@link ChannelToElementConverter#INVERT}.
+//	 */
+//	public static ChannelToElementConverter SCALE_FACTOR_2_AND_KEEP_NEGATIVE = new ElementToChannelConverterChain(
+//			SCALE_FACTOR_2_AND_KEEP_NEGATIVE_AND_INVERT, INVERT);
+//
+//	/**
+//	 * Applies {@link ChannelToElementConverter#SCALE_FACTOR_1} and INVERT_IF_TRUE.
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_1_AND_INVERT_IF_TRUE(boolean invert) {
+//		return new ElementToChannelConverterChain(SCALE_FACTOR_1, INVERT_IF_TRUE(invert));
+//	}
+//
+//	/**
+//	 * Applies {@link ChannelToElementConverter#SCALE_FACTOR_2} and INVERT_IF_TRUE.
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_2_AND_INVERT_IF_TRUE(boolean invert) {
+//		return new ElementToChannelConverterChain(SCALE_FACTOR_2, INVERT_IF_TRUE(invert));
+//	}
+//
+//	/**
+//	 * Applies {@link ChannelToElementConverter#SCALE_FACTOR_3} and INVERT_IF_TRUE.
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_3_AND_INVERT_IF_TRUE(boolean invert) {
+//		return new ElementToChannelConverterChain(SCALE_FACTOR_3, INVERT_IF_TRUE(invert));
+//	}
+//
+//	/**
+//	 * Applies {@link ChannelToElementConverter#SCALE_FACTOR_MINUS_1} and
+//	 * INVERT_IF_TRUE.
+//	 */
+//	public static final ChannelToElementConverter SCALE_FACTOR_MINUS_1_AND_INVERT_IF_TRUE(boolean invert) {
+//		return new ElementToChannelConverterChain(SCALE_FACTOR_MINUS_1, INVERT_IF_TRUE(invert));
+//	}
+//
+//	private final Function<Object, Object> elementToChannel;
+//	private final Function<Object, Object> channelToElement;
+//
+//	/**
+//	 * This constructs and back-and-forth converter from Element to Channel and
+//	 * back.
+//	 * 
+//	 * @param elementToChannel from Element to Channel
+//	 * @param channelToElement from Channel to Element
+//	 */
+//	public ChannelToElementConverter(Function<Object, Object> elementToChannel,
+//			Function<Object, Object> channelToElement) {
+//		this.elementToChannel = elementToChannel;
+//		this.channelToElement = channelToElement;
+//	}
+//
+//	/**
+//	 * This constructs a forward-only converter from Element to Channel.
+//	 * Back-conversion throws an Exception.
+//	 * 
+//	 * @param elementToChannel Element to Channel
+//	 */
+//	public ChannelToElementConverter(Function<Object, Object> elementToChannel) {
+//		this.elementToChannel = elementToChannel;
+//		this.channelToElement = (value) -> {
+//			throw new IllegalArgumentException("Backwards-Conversion for [" + value + "] is not implemented.");
+//		};
+//	}
+//
+//	/**
+//	 * Convert an Element value to a Channel value. If the value can or should not
+//	 * be converted, this method returns null.
+//	 * 
+//	 * @param value the Element value
+//	 * @return the converted value or null
+//	 */
+//	public Object elementToChannel(Object value) {
+//		return this.elementToChannel.apply(value);
+//	}
+//
+//	/**
+//	 * Convert a Channel value to an Element value. If the value can or should not
+//	 * be converted, this method returns null.
+//	 * 
+//	 * @param value the Channel value
+//	 * @return the converted value or null
+//	 */
+//	public Object channelToElement(Object value) {
+//		return this.channelToElement.apply(value);
+//	}
+}

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/BitsWordElement.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/BitsWordElement.java
@@ -19,7 +19,7 @@ import io.openems.common.types.ChannelAddress;
 import io.openems.common.types.OpenemsType;
 import io.openems.edge.bridge.modbus.api.AbstractOpenemsModbusComponent;
 import io.openems.edge.bridge.modbus.api.AbstractOpenemsModbusComponent.BitConverter;
-import io.openems.edge.bridge.modbus.api.ModbusChannelMetaInfo;
+import io.openems.edge.bridge.modbus.api.ChannelMetaInfoBit;
 import io.openems.edge.common.channel.Channel;
 import io.openems.edge.common.channel.ChannelId;
 import io.openems.edge.common.channel.WriteChannel;
@@ -71,6 +71,9 @@ public class BitsWordElement extends UnsignedWordElement {
 
 		ChannelWrapper channelWrapper = new ChannelWrapper(booleanChannel, converter);
 
+		// Set Channel-Source
+		channel.setMetaInfo(new ChannelMetaInfoBit(this.getStartAddress(), bitIndex));
+
 		// Add Modbus Address and Bit-Index to Channel Source
 		if (channel instanceof WriteChannel<?>) {
 			// Handle Writes to Bit-Channels
@@ -79,9 +82,6 @@ public class BitsWordElement extends UnsignedWordElement {
 				// Listen on Writes to the BooleanChannel and store the value
 				channelWrapper.setWriteValue(value);
 			});
-			booleanWriteChannel.setWriteTarget(new ModbusChannelMetaInfo(this.getStartAddress(), bitIndex));
-		} else {
-			channel.setReadSource(new ModbusChannelMetaInfo(this.getStartAddress(), bitIndex));
 		}
 
 		this.channels[bitIndex] = channelWrapper;

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/ModbusReadElement.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/ModbusReadElement.java
@@ -1,0 +1,9 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import java.util.function.Consumer;
+
+public interface ModbusReadElement<T> extends ModbusElement<T> {
+
+	public AbstractModbusElement<T> onUpdateCallback(Consumer<T> onUpdateCallback);
+
+}

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/ModbusWriteElement.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/element/ModbusWriteElement.java
@@ -1,0 +1,5 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+public interface ModbusWriteElement<T> extends ModbusElement<T> {
+
+}

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/BooleanWriteChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/BooleanWriteChannel.java
@@ -74,21 +74,4 @@ public class BooleanWriteChannel extends BooleanReadChannel implements WriteChan
 	public void onSetNextWrite(ThrowingConsumer<Boolean, OpenemsNamedException> callback) {
 		this.getOnSetNextWrites().add(callback);
 	}
-
-	/**
-	 * An object that holds information about the write target of this Channel, i.e.
-	 * a Modbus Register or REST-Api endpoint address. Defaults to null.
-	 */
-	private Object writeTarget = null;
-
-	@Override
-	public <WRITE_TARGET> void setWriteTarget(WRITE_TARGET writeTarget) throws IllegalArgumentException {
-		this.writeTarget = WriteChannel.checkWriteTarget(this, writeTarget, writeTarget);
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <WRITE_TARGET> WRITE_TARGET getWriteTarget() {
-		return (WRITE_TARGET) this.writeTarget;
-	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/Channel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/Channel.java
@@ -208,22 +208,23 @@ public interface Channel<T> {
 	public void deactivate();
 
 	/**
-	 * Sets an object that holds information about the read source of this Channel,
-	 * i.e. a Modbus Register or REST-Api endpoint address. Defaults to null.
+	 * Sets an object that holds meta information about the Channel, e.g. a read
+	 * source or write target of this Channel, like a Modbus Register or REST-Api
+	 * endpoint address. Defaults to null.
 	 * 
-	 * @param <SOURCE> the type of the source attachment
-	 * @param source   the source object
-	 * @throws IllegalArgumentException if there is already a source registered with
-	 *                                  the Channel
+	 * @param <META_INFO> the type of the meta info
+	 * @param metaInfo    the meta info object
+	 * @throws IllegalArgumentException if there is already a different meta-info
+	 *                                  registered with the Channel
 	 */
-	public <SOURCE> void setReadSource(SOURCE source) throws IllegalArgumentException;
+	public <META_INFO> void setMetaInfo(META_INFO metaInfo) throws IllegalArgumentException;
 
 	/**
-	 * Gets the read source information object. Defaults to empty String.
+	 * Gets the meta information object. Defaults to null.
 	 * 
-	 * @param <SOURCE> the type of the source attachment
-	 * @return the source information object
+	 * @param <META_INFO> the type of the meta info attachment
+	 * @return the meta info object
 	 */
-	public <SOURCE> SOURCE getReadSource();
+	public <META_INFO> META_INFO getMetaInfo();
 
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/DoubleWriteChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/DoubleWriteChannel.java
@@ -43,21 +43,4 @@ public class DoubleWriteChannel extends DoubleReadChannel implements WriteChanne
 	public void onSetNextWrite(ThrowingConsumer<Double, OpenemsNamedException> callback) {
 		this.getOnSetNextWrites().add(callback);
 	}
-
-	/**
-	 * An object that holds information about the write target of this Channel, i.e.
-	 * a Modbus Register or REST-Api endpoint address. Defaults to null.
-	 */
-	private Object writeTarget = null;
-
-	@Override
-	public <WRITE_TARGET> void setWriteTarget(WRITE_TARGET writeTarget) throws IllegalArgumentException {
-		this.writeTarget = WriteChannel.checkWriteTarget(this, writeTarget, writeTarget);
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <WRITE_TARGET> WRITE_TARGET getWriteTarget() {
-		return (WRITE_TARGET) this.writeTarget;
-	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/EnumWriteChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/EnumWriteChannel.java
@@ -100,21 +100,4 @@ public class EnumWriteChannel extends EnumReadChannel implements WriteChannel<In
 	public void onSetNextWrite(ThrowingConsumer<Integer, OpenemsNamedException> callback) {
 		this.getOnSetNextWrites().add(callback);
 	}
-
-	/**
-	 * An object that holds information about the write target of this Channel, i.e.
-	 * a Modbus Register or REST-Api endpoint address. Defaults to null.
-	 */
-	private Object writeTarget = null;
-
-	@Override
-	public <WRITE_TARGET> void setWriteTarget(WRITE_TARGET writeTarget) throws IllegalArgumentException {
-		this.writeTarget = WriteChannel.checkWriteTarget(this, writeTarget, writeTarget);
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <WRITE_TARGET> WRITE_TARGET getWriteTarget() {
-		return (WRITE_TARGET) this.writeTarget;
-	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/FloatWriteChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/FloatWriteChannel.java
@@ -72,21 +72,4 @@ public class FloatWriteChannel extends FloatReadChannel implements WriteChannel<
 	public void onSetNextWrite(ThrowingConsumer<Float, OpenemsNamedException> callback) {
 		this.getOnSetNextWrites().add(callback);
 	}
-
-	/**
-	 * An object that holds information about the write target of this Channel, i.e.
-	 * a Modbus Register or REST-Api endpoint address. Defaults to null.
-	 */
-	private Object writeTarget = null;
-
-	@Override
-	public <WRITE_TARGET> void setWriteTarget(WRITE_TARGET writeTarget) throws IllegalArgumentException {
-		this.writeTarget = WriteChannel.checkWriteTarget(this, writeTarget, writeTarget);
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <WRITE_TARGET> WRITE_TARGET getWriteTarget() {
-		return (WRITE_TARGET) this.writeTarget;
-	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/IntegerWriteChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/IntegerWriteChannel.java
@@ -72,21 +72,4 @@ public class IntegerWriteChannel extends IntegerReadChannel implements WriteChan
 	public void onSetNextWrite(ThrowingConsumer<Integer, OpenemsNamedException> callback) {
 		this.getOnSetNextWrites().add(callback);
 	}
-
-	/**
-	 * An object that holds information about the write target of this Channel, i.e.
-	 * a Modbus Register or REST-Api endpoint address. Defaults to null.
-	 */
-	private Object writeTarget = null;
-
-	@Override
-	public <WRITE_TARGET> void setWriteTarget(WRITE_TARGET writeTarget) throws IllegalArgumentException {
-		this.writeTarget = WriteChannel.checkWriteTarget(this, writeTarget, writeTarget);
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <WRITE_TARGET> WRITE_TARGET getWriteTarget() {
-		return (WRITE_TARGET) this.writeTarget;
-	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/LongWriteChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/LongWriteChannel.java
@@ -72,21 +72,4 @@ public class LongWriteChannel extends LongReadChannel implements WriteChannel<Lo
 	public void onSetNextWrite(ThrowingConsumer<Long, OpenemsNamedException> callback) {
 		this.getOnSetNextWrites().add(callback);
 	}
-
-	/**
-	 * An object that holds information about the write target of this Channel, i.e.
-	 * a Modbus Register or REST-Api endpoint address. Defaults to null.
-	 */
-	private Object writeTarget = null;
-
-	@Override
-	public <WRITE_TARGET> void setWriteTarget(WRITE_TARGET writeTarget) throws IllegalArgumentException {
-		this.writeTarget = WriteChannel.checkWriteTarget(this, writeTarget, writeTarget);
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <WRITE_TARGET> WRITE_TARGET getWriteTarget() {
-		return (WRITE_TARGET) this.writeTarget;
-	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/ShortWriteChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/ShortWriteChannel.java
@@ -72,21 +72,4 @@ public class ShortWriteChannel extends ShortReadChannel implements WriteChannel<
 	public void onSetNextWrite(ThrowingConsumer<Short, OpenemsNamedException> callback) {
 		this.getOnSetNextWrites().add(callback);
 	}
-
-	/**
-	 * An object that holds information about the write target of this Channel, i.e.
-	 * a Modbus Register or REST-Api endpoint address. Defaults to null.
-	 */
-	private Object writeTarget = null;
-
-	@Override
-	public <WRITE_TARGET> void setWriteTarget(WRITE_TARGET writeTarget) throws IllegalArgumentException {
-		this.writeTarget = WriteChannel.checkWriteTarget(this, writeTarget, writeTarget);
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <WRITE_TARGET> WRITE_TARGET getWriteTarget() {
-		return (WRITE_TARGET) this.writeTarget;
-	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/StringWriteChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/StringWriteChannel.java
@@ -72,21 +72,4 @@ public class StringWriteChannel extends StringReadChannel implements WriteChanne
 	public void onSetNextWrite(ThrowingConsumer<String, OpenemsNamedException> callback) {
 		this.getOnSetNextWrites().add(callback);
 	}
-
-	/**
-	 * An object that holds information about the write target of this Channel, i.e.
-	 * a Modbus Register or REST-Api endpoint address. Defaults to null.
-	 */
-	private Object writeTarget = null;
-
-	@Override
-	public <WRITE_TARGET> void setWriteTarget(WRITE_TARGET writeTarget) throws IllegalArgumentException {
-		this.writeTarget = WriteChannel.checkWriteTarget(this, writeTarget, writeTarget);
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <WRITE_TARGET> WRITE_TARGET getWriteTarget() {
-		return (WRITE_TARGET) this.writeTarget;
-	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/WriteChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/WriteChannel.java
@@ -1,7 +1,6 @@
 package io.openems.edge.common.channel;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -94,44 +93,4 @@ public interface WriteChannel<T> extends Channel<T> {
 
 	public List<ThrowingConsumer<T, OpenemsNamedException>> getOnSetNextWrites();
 
-	/**
-	 * Sets an object that holds information about the write target of this Channel,
-	 * i.e. a Modbus Register or REST-Api endpoint address. Defaults to null.
-	 * 
-	 * @param <WRITE_TARGET> the type of the target attachment
-	 * @param target         the target object
-	 * @return myself
-	 * @throws IllegalArgumentException if there is already a target registered with
-	 *                                  the Channel
-	 */
-	public <WRITE_TARGET> void setWriteTarget(WRITE_TARGET target) throws IllegalArgumentException;
-
-	/**
-	 * Gets the write target information object. Defaults to empty String.
-	 * 
-	 * @param <WRITE_TARGET> the type of the target attachment
-	 * @return the target information object
-	 */
-	public <WRITE_TARGET> WRITE_TARGET getWriteTarget();
-
-	/**
-	 * Static helper method to be used within {@link #setWriteTarget(Object)}.
-	 * 
-	 * @param <WRITE_TARGET> the type of the target attachment
-	 * @param channel        the {@link WriteChannel}
-	 * @param existingValue  the existing value, or null
-	 * @param newValue       the new value
-	 * @return the new value
-	 * @throws IllegalArgumentException if the Channel already has a different
-	 *                                  Write-Target set
-	 */
-	public static <WRITE_TARGET> WRITE_TARGET checkWriteTarget(WriteChannel<?> channel, WRITE_TARGET existingValue,
-			WRITE_TARGET newValue) throws IllegalArgumentException {
-		if (existingValue != null && newValue != null && !Objects.equals(existingValue, newValue)) {
-			throw new IllegalArgumentException("Unable to set write target [" + newValue.toString() + "]." //
-					+ " Channel [" + channel.address() + "] already has a write target [" + existingValue.toString()
-					+ "]");
-		}
-		return newValue;
-	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/internal/AbstractReadChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/internal/AbstractReadChannel.java
@@ -264,21 +264,22 @@ public abstract class AbstractReadChannel<D extends AbstractDoc<T>, T> implement
 	 * An object that holds information about the source of this Channel, i.e. a
 	 * Modbus Register or REST-Api endpoint address. Defaults to null.
 	 */
-	private Object readSource = null;
+	private Object source = null;
 
 	@Override
-	public <READ_SOURCE> void setReadSource(READ_SOURCE readSource) throws IllegalArgumentException {
-		if (this.readSource != null && readSource != null && !Objects.equals(this.readSource, readSource)) {
-			throw new IllegalArgumentException("Unable to set read source [" + readSource.toString() + "]." //
-					+ " Channel [" + this.address() + "] already has a read source [" + this.readSource.toString()
-					+ "]");
+	public <SOURCE> void setMetaInfo(SOURCE source) throws IllegalArgumentException {
+		if (this.source != null && source != null && !Objects.equals(this.source, source)) {
+			throw new IllegalArgumentException("Unable to set meta info [" + source.toString() + "]." //
+					+ " Channel [" + this.address() + "] already has one [" + this.source.toString() + "]. " //
+					+ "Hint: Possibly you are trying to map a single Channel to multiple Modbus Registers. " //
+					+ "If this is on purpose, you can manually provide a `ChannelMetaInfoReadAndWrite` object.");
 		}
-		this.readSource = readSource;
+		this.source = source;
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <READ_SOURCE> READ_SOURCE getReadSource() {
-		return (READ_SOURCE) this.readSource;
+	public <SOURCE> SOURCE getMetaInfo() {
+		return (SOURCE) this.source;
 	}
 }

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/jsonrpc/ChannelExportXlsxResponse.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/jsonrpc/ChannelExportXlsxResponse.java
@@ -24,7 +24,6 @@ import io.openems.common.jsonrpc.response.Base64PayloadResponse;
 import io.openems.edge.common.channel.Channel;
 import io.openems.edge.common.channel.EnumReadChannel;
 import io.openems.edge.common.channel.StateChannel;
-import io.openems.edge.common.channel.WriteChannel;
 import io.openems.edge.common.channel.internal.StateCollectorChannel;
 import io.openems.edge.common.component.OpenemsComponent;
 
@@ -51,9 +50,8 @@ public class ChannelExportXlsxResponse extends Base64PayloadResponse {
 	private static final int COL_VALUE = 1;
 	private static final int COL_UNIT = 2;
 	private static final int COL_DESCRIPTION = 3;
-	private static final int COL_READ_SOURCE = 4;
-	private static final int COL_WRITE_TARGET = 5;
-	private static final int COL_ACCESS = 6;
+	private static final int COL_SOURCE = 4;
+	private static final int COL_ACCESS = 5;
 
 	public ChannelExportXlsxResponse(UUID id, OpenemsComponent component) throws OpenemsException {
 		super(id, generatePayload(component));
@@ -121,25 +119,10 @@ public class ChannelExportXlsxResponse extends Base64PayloadResponse {
 						ws.value(row, COL_DESCRIPTION, description);
 						ws.value(row, COL_ACCESS, channel.channelDoc().getAccessMode().getAbbreviation());
 
-						// Read Source
-						{
-							final Object readSource = channel.getReadSource();
-							if (readSource != null) {
-								ws.value(row, COL_READ_SOURCE, readSource.toString());
-							}
-						}
-
-						// Write Target
-						{
-							final Object writeTarget;
-							if (channel instanceof WriteChannel<?>) {
-								writeTarget = ((WriteChannel<?>) channel).getWriteTarget();
-							} else {
-								writeTarget = null;
-							}
-							if (writeTarget != null) {
-								ws.value(row, COL_WRITE_TARGET, writeTarget.toString());
-							}
+						// Source
+						final Object readSource = channel.getMetaInfo();
+						if (readSource != null) {
+							ws.value(row, COL_SOURCE, readSource.toString());
 						}
 
 						row++;
@@ -191,8 +174,7 @@ public class ChannelExportXlsxResponse extends Base64PayloadResponse {
 		addTableHeader(wb, ws, row, COL_VALUE, "Value", 35);
 		addTableHeader(wb, ws, row, COL_UNIT, "Unit", 20);
 		addTableHeader(wb, ws, row, COL_DESCRIPTION, "Description", 25);
-		addTableHeader(wb, ws, row, COL_READ_SOURCE, "Read Source", 20);
-		addTableHeader(wb, ws, row, COL_WRITE_TARGET, "Write Target", 20);
+		addTableHeader(wb, ws, row, COL_SOURCE, "Read Source", 20);
 		addTableHeader(wb, ws, row, COL_ACCESS, "Access", 10);
 
 		return ++row;

--- a/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/FeneconMiniEssImpl.java
+++ b/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/FeneconMiniEssImpl.java
@@ -25,6 +25,7 @@ import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.types.OpenemsType;
 import io.openems.edge.bridge.modbus.api.AbstractOpenemsModbusComponent;
 import io.openems.edge.bridge.modbus.api.BridgeModbus;
+import io.openems.edge.bridge.modbus.api.ChannelMetaInfoReadAndWrite;
 import io.openems.edge.bridge.modbus.api.ElementToChannelConverter;
 import io.openems.edge.bridge.modbus.api.ElementToChannelOffsetConverter;
 import io.openems.edge.bridge.modbus.api.ModbusProtocol;
@@ -455,22 +456,30 @@ public class FeneconMiniEssImpl extends AbstractOpenemsModbusComponent
 						m(FeneconMiniEss.ChannelId.RTC_SECOND, new UnsignedWordElement(9019))), //
 				new FC16WriteRegistersTask(30526, //
 						m(FeneconMiniEss.ChannelId.GRID_MAX_CHARGE_CURRENT, new UnsignedWordElement(30526),
-								ElementToChannelConverter.SCALE_FACTOR_2), //
+								ElementToChannelConverter.SCALE_FACTOR_2,
+								new ChannelMetaInfoReadAndWrite(30126, 30526)), //
 						m(FeneconMiniEss.ChannelId.GRID_MAX_DISCHARGE_CURRENT, new UnsignedWordElement(30527),
-								ElementToChannelConverter.SCALE_FACTOR_2)), //
+								ElementToChannelConverter.SCALE_FACTOR_2,
+								new ChannelMetaInfoReadAndWrite(30127, 30527))), //
 				new FC16WriteRegistersTask(30558, //
-						m(FeneconMiniEss.ChannelId.SETUP_MODE, new UnsignedWordElement(30558))), //
+						m(FeneconMiniEss.ChannelId.SETUP_MODE, new UnsignedWordElement(30558),
+								new ChannelMetaInfoReadAndWrite(30157, 30558))), //
 				new FC16WriteRegistersTask(30559, //
-						m(FeneconMiniEss.ChannelId.PCS_MODE, new UnsignedWordElement(30559))), //
+						m(FeneconMiniEss.ChannelId.PCS_MODE, new UnsignedWordElement(30559),
+								new ChannelMetaInfoReadAndWrite(30158, 30559))), //
 
 				new FC3ReadRegistersTask(30126, Priority.LOW, //
 						m(FeneconMiniEss.ChannelId.GRID_MAX_CHARGE_CURRENT, new UnsignedWordElement(30126),
-								ElementToChannelConverter.SCALE_FACTOR_2), //
+								ElementToChannelConverter.SCALE_FACTOR_2,
+								new ChannelMetaInfoReadAndWrite(30126, 30526)), //
 						m(FeneconMiniEss.ChannelId.GRID_MAX_DISCHARGE_CURRENT, new UnsignedWordElement(30127),
-								ElementToChannelConverter.SCALE_FACTOR_2), //
+								ElementToChannelConverter.SCALE_FACTOR_2,
+								new ChannelMetaInfoReadAndWrite(30127, 30527)), //
 						new DummyRegisterElement(30128, 30156), //
-						m(FeneconMiniEss.ChannelId.SETUP_MODE, new UnsignedWordElement(30157)), //
-						m(FeneconMiniEss.ChannelId.PCS_MODE, new UnsignedWordElement(30158)), //
+						m(FeneconMiniEss.ChannelId.SETUP_MODE, new UnsignedWordElement(30157),
+								new ChannelMetaInfoReadAndWrite(30157, 30558)), //
+						m(FeneconMiniEss.ChannelId.PCS_MODE, new UnsignedWordElement(30158),
+								new ChannelMetaInfoReadAndWrite(30158, 30559)), //
 						new DummyRegisterElement(30159, 30165), //
 						m(SymmetricEss.ChannelId.GRID_MODE, new UnsignedWordElement(30166),
 								new ElementToChannelConverter(

--- a/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/FeneconProEss.java
+++ b/io.openems.edge.fenecon.pro/src/io/openems/edge/fenecon/pro/ess/FeneconProEss.java
@@ -22,6 +22,7 @@ import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.edge.bridge.modbus.api.AbstractOpenemsModbusComponent;
 import io.openems.edge.bridge.modbus.api.BridgeModbus;
+import io.openems.edge.bridge.modbus.api.ChannelMetaInfoReadAndWrite;
 import io.openems.edge.bridge.modbus.api.ElementToChannelConverter;
 import io.openems.edge.bridge.modbus.api.ModbusProtocol;
 import io.openems.edge.bridge.modbus.api.element.BitsWordElement;
@@ -438,12 +439,16 @@ public class FeneconProEss extends AbstractOpenemsModbusComponent implements Sym
 						m(ProChannelId.RTC_MINUTE, new UnsignedWordElement(9018)), //
 						m(ProChannelId.RTC_SECOND, new UnsignedWordElement(9019))), //
 				new FC16WriteRegistersTask(30558, //
-						m(ProChannelId.SETUP_MODE, new UnsignedWordElement(30558))), //
+						m(ProChannelId.SETUP_MODE, new UnsignedWordElement(30558),
+								new ChannelMetaInfoReadAndWrite(30157, 30558))), //
 				new FC16WriteRegistersTask(30559, //
-						m(ProChannelId.PCS_MODE, new UnsignedWordElement(30559))), //
+						m(ProChannelId.PCS_MODE, new UnsignedWordElement(30559),
+								new ChannelMetaInfoReadAndWrite(30158, 30559))), //
 				new FC3ReadRegistersTask(30157, Priority.LOW, //
-						m(ProChannelId.SETUP_MODE, new UnsignedWordElement(30157)), //
-						m(ProChannelId.PCS_MODE, new UnsignedWordElement(30158)))//
+						m(ProChannelId.SETUP_MODE, new UnsignedWordElement(30157),
+								new ChannelMetaInfoReadAndWrite(30157, 30558)), //
+						m(ProChannelId.PCS_MODE, new UnsignedWordElement(30158),
+								new ChannelMetaInfoReadAndWrite(30158, 30559)))//
 
 		);
 	}

--- a/io.openems.edge.pvinverter.solarlog/src/io/openems/edge/pvinverter/solarlog/SolarLogImpl.java
+++ b/io.openems.edge.pvinverter.solarlog/src/io/openems/edge/pvinverter/solarlog/SolarLogImpl.java
@@ -20,6 +20,7 @@ import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.edge.bridge.modbus.api.AbstractOpenemsModbusComponent;
 import io.openems.edge.bridge.modbus.api.BridgeModbus;
+import io.openems.edge.bridge.modbus.api.ChannelMetaInfoReadAndWrite;
 import io.openems.edge.bridge.modbus.api.ElementToChannelConverter;
 import io.openems.edge.bridge.modbus.api.ModbusProtocol;
 import io.openems.edge.bridge.modbus.api.element.SignedDoublewordElement;
@@ -130,14 +131,16 @@ public class SolarLogImpl extends AbstractOpenemsModbusComponent
 
 				new FC16WriteRegistersTask(10400, //
 						m(SolarLog.ChannelId.P_LIMIT_TYPE, new UnsignedWordElement(10400)),
-						m(SolarLog.ChannelId.P_LIMIT_PERC, new UnsignedWordElement(10401))),
+						m(SolarLog.ChannelId.P_LIMIT_PERC, new UnsignedWordElement(10401),
+								new ChannelMetaInfoReadAndWrite(10901, 10401))),
 				new FC16WriteRegistersTask(10404,
 						m(SolarLog.ChannelId.WATCH_DOG_TAG,
 								new UnsignedDoublewordElement(10404).wordOrder(WordOrder.LSWMSW))),
 
 				new FC4ReadInputRegistersTask(10900, Priority.LOW, //
 						m(SolarLog.ChannelId.STATUS, new SignedWordElement(10900)), //
-						m(SolarLog.ChannelId.P_LIMIT_PERC, new SignedWordElement(10901)),
+						m(SolarLog.ChannelId.P_LIMIT_PERC, new SignedWordElement(10901),
+								new ChannelMetaInfoReadAndWrite(10901, 10401)),
 						m(SolarLog.ChannelId.P_LIMIT, new SignedWordElement(10902))));
 	}
 

--- a/io.openems.wrapper.eu.chargetime.ocpp/generated/buildfiles
+++ b/io.openems.wrapper.eu.chargetime.ocpp/generated/buildfiles
@@ -1,0 +1,1 @@
+/mnt/c/Users/stefan.feilmeier/fems/develop2/io.openems.wrapper.eu.chargetime.ocpp/generated/io.openems.wrapper.eu.chargetime.ocpp.jar


### PR DESCRIPTION
The Channel Source and Target information introduced in #1595 was not working, because Read-Write-Channel information would always be considered a 'target' information. This Pull-Request refactors the information to a generic MetaInfo and allows explicit definition of different read- and write-registers for one Channel  