### PR TITLE
Fix compatibility with Apache WebConsole 4.7.0

### DIFF
--- a/io.openems.common/src/io/openems/common/OpenemsConstants.java
+++ b/io.openems.common/src/io/openems/common/OpenemsConstants.java
@@ -84,17 +84,6 @@ public class OpenemsConstants {
 	 */
 	public final static String MANUFACTURER_EMS_SERIAL_NUMBER = "";
 
-	/*
-	 * Static OpenEMS Component-IDs
-	 */
-	public final static String CYCLE_ID = "_cycle";
-	public final static String COMPONENT_MANAGER_ID = "_componentManager";
-	public final static String PREDICTOR_MANAGER_ID = "_predictorManager";
-	public final static String META_ID = "_meta";
-	public final static String SUM_ID = "_sum";
-	public final static String HOST_ID = "_host";
-	public final static String SIMULATOR_ID = "_simulator";
-
 	public final static String POWER_DOC_TEXT = "Negative values for Consumption; positive for Production";
 
 	/*

--- a/io.openems.common/src/io/openems/common/types/EdgeConfig.java
+++ b/io.openems.common/src/io/openems/common/types/EdgeConfig.java
@@ -940,6 +940,19 @@ public class EdgeConfig {
 		}
 
 		/**
+		 * Gets the default value of a property.
+		 * 
+		 * @param propertyId the Property ID
+		 */
+		public JsonElement getPropertyDefaultValue(String propertyId) {
+			Optional<Property> property = this.getProperty(propertyId);
+			if (!property.isPresent()) {
+				return JsonNull.INSTANCE;
+			}
+			return property.get().getDefaultValue();
+		}
+
+		/**
 		 * Gets the Nature-IDs of the {@link Factory}.
 		 * 
 		 * @return the Nature-IDs

--- a/io.openems.common/src/io/openems/common/websocket/AbstractWebsocketServer.java
+++ b/io.openems.common/src/io/openems/common/websocket/AbstractWebsocketServer.java
@@ -201,7 +201,9 @@ public abstract class AbstractWebsocketServer<T extends WsData> extends Abstract
 	 */
 	@Override
 	protected void execute(Runnable command) {
-		this.executor.execute(command);
+		if (!this.executor.isShutdown()) {
+			this.executor.execute(command);
+		}
 	}
 
 	/**

--- a/io.openems.edge.common/src/io/openems/edge/common/component/ComponentManager.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/ComponentManager.java
@@ -3,7 +3,6 @@ package io.openems.edge.common.component;
 import java.time.Clock;
 import java.util.List;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.channel.Level;
 import io.openems.common.exceptions.OpenemsError;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -19,6 +18,9 @@ import io.openems.edge.common.jsonapi.JsonApi;
  * A Service that provides access to OpenEMS-Components.
  */
 public interface ComponentManager extends OpenemsComponent, JsonApi, ClockProvider {
+
+	public final static String SINGLETON_SERVICE_PID = "Core.ComponentManager";
+	public final static String SINGLETON_COMPONENT_ID = "_componentManager";
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
 		CONFIG_NOT_ACTIVATED(Doc.of(Level.FAULT) //
@@ -201,7 +203,7 @@ public interface ComponentManager extends OpenemsComponent, JsonApi, ClockProvid
 	 */
 	@SuppressWarnings("unchecked")
 	public default <T extends OpenemsComponent> T getComponent(String componentId) throws OpenemsNamedException {
-		if (componentId.equals(OpenemsConstants.COMPONENT_MANAGER_ID)) {
+		if (SINGLETON_COMPONENT_ID.equals(componentId)) {
 			return (T) this;
 		}
 		List<OpenemsComponent> components = this.getEnabledComponents();
@@ -226,7 +228,7 @@ public interface ComponentManager extends OpenemsComponent, JsonApi, ClockProvid
 	@SuppressWarnings("unchecked")
 	public default <T extends OpenemsComponent> T getPossiblyDisabledComponent(String componentId)
 			throws OpenemsNamedException {
-		if (componentId == OpenemsConstants.COMPONENT_MANAGER_ID) {
+		if (SINGLETON_COMPONENT_ID.equals(componentId)) {
 			return (T) this;
 		}
 		List<OpenemsComponent> components = this.getAllComponents();

--- a/io.openems.edge.common/src/io/openems/edge/common/cycle/Cycle.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/cycle/Cycle.java
@@ -11,6 +11,9 @@ import io.openems.edge.common.component.OpenemsComponent;
 
 public interface Cycle extends OpenemsComponent {
 
+	public final static String SINGLETON_SERVICE_PID = "Core.Cycle";
+	public final static String SINGLETON_COMPONENT_ID = "_cycle";
+
 	public static final int DEFAULT_CYCLE_TIME = 1000; // in [ms]
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {

--- a/io.openems.edge.common/src/io/openems/edge/common/host/Host.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/host/Host.java
@@ -11,6 +11,9 @@ import io.openems.edge.common.jsonapi.JsonApi;
 
 public interface Host extends OpenemsComponent, JsonApi {
 
+	public final static String SINGLETON_SERVICE_PID = "Core.Host";
+	public final static String SINGLETON_COMPONENT_ID = "_host";
+
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
 		DISK_IS_FULL(Doc.of(Level.INFO) //
 				.text("Disk is full")), //

--- a/io.openems.edge.common/src/io/openems/edge/common/meta/Meta.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/meta/Meta.java
@@ -10,6 +10,9 @@ import io.openems.edge.common.modbusslave.ModbusSlaveTable;
 
 public interface Meta extends ModbusSlave {
 
+	public final static String SINGLETON_SERVICE_PID = "Core.Meta";
+	public final static String SINGLETON_COMPONENT_ID = "_meta";
+
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
 		/**
 		 * OpenEMS Version

--- a/io.openems.edge.common/src/io/openems/edge/common/sum/DummySum.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/sum/DummySum.java
@@ -1,6 +1,5 @@
 package io.openems.edge.common.sum;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.edge.common.channel.Channel;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
 import io.openems.edge.common.component.OpenemsComponent;
@@ -21,7 +20,7 @@ public class DummySum extends AbstractOpenemsComponent implements Sum, OpenemsCo
 		for (Channel<?> channel : this.channels()) {
 			channel.nextProcessImage();
 		}
-		super.activate(null, OpenemsConstants.SUM_ID, "", true);
+		super.activate(null, Sum.SINGLETON_COMPONENT_ID, Sum.SINGLETON_SERVICE_PID, true);
 	}
 
 	@Override

--- a/io.openems.edge.common/src/io/openems/edge/common/sum/Sum.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/sum/Sum.java
@@ -19,6 +19,9 @@ import io.openems.edge.common.modbusslave.ModbusType;
  */
 public interface Sum extends OpenemsComponent {
 
+	public final static String SINGLETON_SERVICE_PID = "Core.Sum";
+	public final static String SINGLETON_COMPONENT_ID = "_sum";
+
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
 		/**
 		 * Ess: Average State of Charge.

--- a/io.openems.edge.common/src/io/openems/edge/common/test/DummyComponentManager.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/test/DummyComponentManager.java
@@ -9,7 +9,6 @@ import java.util.concurrent.CompletableFuture;
 
 import org.osgi.service.component.ComponentContext;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.exceptions.NotImplementedException;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
@@ -77,12 +76,12 @@ public class DummyComponentManager implements ComponentManager {
 
 	@Override
 	public String id() {
-		return OpenemsConstants.COMPONENT_MANAGER_ID;
+		return ComponentManager.SINGLETON_COMPONENT_ID;
 	}
 
 	@Override
 	public String alias() {
-		return OpenemsConstants.COMPONENT_MANAGER_ID;
+		return ComponentManager.SINGLETON_COMPONENT_ID;
 	}
 
 	@Override

--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/OnRequest.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/OnRequest.java
@@ -6,7 +6,6 @@ import org.java_websocket.WebSocket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.exceptions.NotImplementedException;
 import io.openems.common.exceptions.OpenemsError;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -25,6 +24,7 @@ import io.openems.common.jsonrpc.request.UpdateComponentConfigRequest;
 import io.openems.common.jsonrpc.request.UpdateUserLanguageRequest;
 import io.openems.common.jsonrpc.response.AuthenticatedRpcResponse;
 import io.openems.common.session.Role;
+import io.openems.edge.common.component.ComponentManager;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.jsonapi.JsonApi;
 import io.openems.edge.common.user.User;
@@ -127,7 +127,7 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 	private CompletableFuture<GenericJsonrpcResponseSuccess> handleGetEdgeConfigRequest(User user,
 			GetEdgeConfigRequest getEdgeConfigRequest) throws OpenemsNamedException {
 		// wrap original request inside ComponentJsonApiRequest
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(OpenemsConstants.COMPONENT_MANAGER_ID,
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(ComponentManager.SINGLETON_COMPONENT_ID,
 				getEdgeConfigRequest);
 
 		return this.handleComponentJsonApiRequest(user, request);
@@ -146,8 +146,8 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 		user.assertRoleIsAtLeast(DeleteComponentConfigRequest.METHOD, Role.INSTALLER);
 
 		// wrap original request inside ComponentJsonApiRequest
-		String componentId = OpenemsConstants.COMPONENT_MANAGER_ID;
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(componentId, createComponentConfigRequest);
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(ComponentManager.SINGLETON_COMPONENT_ID,
+				createComponentConfigRequest);
 
 		return this.handleComponentJsonApiRequest(user, request);
 	}
@@ -165,8 +165,8 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 		user.assertRoleIsAtLeast(DeleteComponentConfigRequest.METHOD, Role.OWNER);
 
 		// wrap original request inside ComponentJsonApiRequest
-		String componentId = OpenemsConstants.COMPONENT_MANAGER_ID;
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(componentId, updateComponentConfigRequest);
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(ComponentManager.SINGLETON_COMPONENT_ID,
+				updateComponentConfigRequest);
 
 		return this.handleComponentJsonApiRequest(user, request);
 	}
@@ -184,8 +184,8 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 		user.assertRoleIsAtLeast(DeleteComponentConfigRequest.METHOD, Role.INSTALLER);
 
 		// wrap original request inside ComponentJsonApiRequest
-		String componentId = OpenemsConstants.COMPONENT_MANAGER_ID;
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(componentId, deleteComponentConfigRequest);
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(ComponentManager.SINGLETON_COMPONENT_ID,
+				deleteComponentConfigRequest);
 
 		return this.handleComponentJsonApiRequest(user, request);
 	}

--- a/io.openems.edge.controller.api.backend/test/io/openems/edge/controller/api/backend/BackendApiImplTest.java
+++ b/io.openems.edge.controller.api.backend/test/io/openems/edge/controller/api/backend/BackendApiImplTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 
 import com.google.gson.JsonObject;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.channel.PersistencePriority;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
@@ -32,8 +31,8 @@ import io.openems.edge.common.test.TimeLeapClock;
 public class BackendApiImplTest {
 
 	private static final String CTRL_ID = "ctrl0";
+	private static final String SUM_ID = "_sum";
 
-	private static final String SUM_ID = OpenemsConstants.SUM_ID;
 	private static final ChannelAddress SUM_GRID_ACTIVE_POWER = new ChannelAddress(SUM_ID,
 			Sum.ChannelId.GRID_ACTIVE_POWER.id());
 	private static final ChannelAddress SUM_PRODUCTION_ACTIVE_POWER = new ChannelAddress(SUM_ID,

--- a/io.openems.edge.controller.api.backend/test/io/openems/edge/controller/api/backend/BackendApiImplTest.java
+++ b/io.openems.edge.controller.api.backend/test/io/openems/edge/controller/api/backend/BackendApiImplTest.java
@@ -31,7 +31,7 @@ import io.openems.edge.common.test.TimeLeapClock;
 public class BackendApiImplTest {
 
 	private static final String CTRL_ID = "ctrl0";
-	private static final String SUM_ID = "_sum";
+	private static final String SUM_ID = Sum.SINGLETON_COMPONENT_ID;
 
 	private static final ChannelAddress SUM_GRID_ACTIVE_POWER = new ChannelAddress(SUM_ID,
 			Sum.ChannelId.GRID_ACTIVE_POWER.id());

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/RestHandler.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/RestHandler.java
@@ -34,7 +34,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.exceptions.OpenemsError;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
@@ -59,6 +58,7 @@ import io.openems.common.utils.JsonUtils;
 import io.openems.common.utils.StringUtils;
 import io.openems.common.utils.UuidUtils;
 import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.component.ComponentManager;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.jsonapi.JsonApi;
 import io.openems.edge.common.user.User;
@@ -554,7 +554,7 @@ public class RestHandler extends AbstractHandler {
 	private CompletableFuture<JsonrpcResponseSuccess> handleGetEdgeConfigRequest(User user,
 			GetEdgeConfigRequest getEdgeConfigRequest) throws OpenemsNamedException {
 		// wrap original request inside ComponentJsonApiRequest
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(OpenemsConstants.COMPONENT_MANAGER_ID,
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(ComponentManager.SINGLETON_COMPONENT_ID,
 				getEdgeConfigRequest);
 
 		return this.handleComponentJsonApiRequest(user, request);
@@ -571,8 +571,8 @@ public class RestHandler extends AbstractHandler {
 	private CompletableFuture<JsonrpcResponseSuccess> handleCreateComponentConfigRequest(User user,
 			CreateComponentConfigRequest createComponentConfigRequest) throws OpenemsNamedException {
 		// wrap original request inside ComponentJsonApiRequest
-		String componentId = OpenemsConstants.COMPONENT_MANAGER_ID;
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(componentId, createComponentConfigRequest);
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(ComponentManager.SINGLETON_COMPONENT_ID,
+				createComponentConfigRequest);
 
 		return this.handleComponentJsonApiRequest(user, request);
 	}
@@ -588,8 +588,8 @@ public class RestHandler extends AbstractHandler {
 	private CompletableFuture<JsonrpcResponseSuccess> handleUpdateComponentConfigRequest(User user,
 			UpdateComponentConfigRequest updateComponentConfigRequest) throws OpenemsNamedException {
 		// wrap original request inside ComponentJsonApiRequest
-		String componentId = OpenemsConstants.COMPONENT_MANAGER_ID;
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(componentId, updateComponentConfigRequest);
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(ComponentManager.SINGLETON_COMPONENT_ID,
+				updateComponentConfigRequest);
 
 		return this.handleComponentJsonApiRequest(user, request);
 	}
@@ -605,8 +605,8 @@ public class RestHandler extends AbstractHandler {
 	private CompletableFuture<JsonrpcResponseSuccess> handleDeleteComponentConfigRequest(User user,
 			DeleteComponentConfigRequest deleteComponentConfigRequest) throws OpenemsNamedException {
 		// wrap original request inside ComponentJsonApiRequest
-		String componentId = OpenemsConstants.COMPONENT_MANAGER_ID;
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(componentId, deleteComponentConfigRequest);
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(ComponentManager.SINGLETON_COMPONENT_ID,
+				deleteComponentConfigRequest);
 
 		return this.handleComponentJsonApiRequest(user, request);
 	}

--- a/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/OnRequest.java
+++ b/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/OnRequest.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.JsonElement;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.exceptions.OpenemsError;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
@@ -42,6 +41,7 @@ import io.openems.common.jsonrpc.response.QueryHistoricTimeseriesEnergyResponse;
 import io.openems.common.session.Role;
 import io.openems.common.types.ChannelAddress;
 import io.openems.common.websocket.SubscribedChannelsWorker;
+import io.openems.edge.common.component.ComponentManager;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.jsonapi.JsonApi;
 import io.openems.edge.common.user.User;
@@ -322,8 +322,8 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 	private CompletableFuture<JsonrpcResponseSuccess> handleCreateComponentConfigRequest(User user,
 			CreateComponentConfigRequest createComponentConfigRequest) throws OpenemsNamedException {
 		// wrap original request inside ComponentJsonApiRequest
-		String componentId = OpenemsConstants.COMPONENT_MANAGER_ID;
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(componentId, createComponentConfigRequest);
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(ComponentManager.SINGLETON_COMPONENT_ID,
+				createComponentConfigRequest);
 
 		return this.handleComponentJsonApiRequest(user, request);
 	}
@@ -339,8 +339,8 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 	private CompletableFuture<JsonrpcResponseSuccess> handleUpdateComponentConfigRequest(User user,
 			UpdateComponentConfigRequest updateComponentConfigRequest) throws OpenemsNamedException {
 		// wrap original request inside ComponentJsonApiRequest
-		String componentId = OpenemsConstants.COMPONENT_MANAGER_ID;
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(componentId, updateComponentConfigRequest);
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(ComponentManager.SINGLETON_COMPONENT_ID,
+				updateComponentConfigRequest);
 
 		return this.handleComponentJsonApiRequest(user, request);
 	}
@@ -356,8 +356,8 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 	private CompletableFuture<JsonrpcResponseSuccess> handleDeleteComponentConfigRequest(User user,
 			DeleteComponentConfigRequest deleteComponentConfigRequest) throws OpenemsNamedException {
 		// wrap original request inside ComponentJsonApiRequest
-		String componentId = OpenemsConstants.COMPONENT_MANAGER_ID;
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(componentId, deleteComponentConfigRequest);
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(ComponentManager.SINGLETON_COMPONENT_ID,
+				deleteComponentConfigRequest);
 
 		return this.handleComponentJsonApiRequest(user, request);
 	}
@@ -373,7 +373,7 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 	private CompletableFuture<JsonrpcResponseSuccess> handleGetEdgeConfigRequest(User user,
 			GetEdgeConfigRequest getEdgeConfigRequest) throws OpenemsNamedException {
 		// wrap original request inside ComponentJsonApiRequest
-		ComponentJsonApiRequest request = new ComponentJsonApiRequest(OpenemsConstants.COMPONENT_MANAGER_ID,
+		ComponentJsonApiRequest request = new ComponentJsonApiRequest(ComponentManager.SINGLETON_COMPONENT_ID,
 				getEdgeConfigRequest);
 
 		return this.handleComponentJsonApiRequest(user, request);

--- a/io.openems.edge.controller.generic.jsonlogic/test/io/openems/edge/controller/generic/jsonlogic/JsonLogicControllerTest.java
+++ b/io.openems.edge.controller.generic.jsonlogic/test/io/openems/edge/controller/generic/jsonlogic/JsonLogicControllerTest.java
@@ -2,7 +2,6 @@ package io.openems.edge.controller.generic.jsonlogic;
 
 import org.junit.Test;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.types.ChannelAddress;
 import io.openems.edge.common.sum.DummySum;
 import io.openems.edge.common.sum.Sum;
@@ -13,7 +12,7 @@ import io.openems.edge.ess.test.DummyManagedSymmetricEss;
 
 public class JsonLogicControllerTest {
 
-	private final static ChannelAddress ESS_SOC = new ChannelAddress(OpenemsConstants.SUM_ID,
+	private final static ChannelAddress ESS_SOC = new ChannelAddress(Sum.SINGLETON_COMPONENT_ID,
 			Sum.ChannelId.ESS_SOC.id());
 
 	private final static String ESS_ID = "ess0";

--- a/io.openems.edge.controller.generic.jsonlogic/test/io/openems/edge/controller/generic/jsonlogic/JsonLogicControllerTest2.java
+++ b/io.openems.edge.controller.generic.jsonlogic/test/io/openems/edge/controller/generic/jsonlogic/JsonLogicControllerTest2.java
@@ -2,7 +2,6 @@ package io.openems.edge.controller.generic.jsonlogic;
 
 import org.junit.Test;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.types.ChannelAddress;
 import io.openems.edge.common.sum.DummySum;
 import io.openems.edge.common.sum.Sum;
@@ -13,9 +12,9 @@ import io.openems.edge.io.test.DummyInputOutput;
 
 public class JsonLogicControllerTest2 {
 
-	private final static ChannelAddress SUM_PRODUCTION_POWER = new ChannelAddress(OpenemsConstants.SUM_ID,
+	private final static ChannelAddress SUM_PRODUCTION_POWER = new ChannelAddress(Sum.SINGLETON_COMPONENT_ID,
 			Sum.ChannelId.PRODUCTION_ACTIVE_POWER.id());
-	private final static ChannelAddress SUM_SOC = new ChannelAddress(OpenemsConstants.SUM_ID,
+	private final static ChannelAddress SUM_SOC = new ChannelAddress(Sum.SINGLETON_COMPONENT_ID,
 			Sum.ChannelId.ESS_SOC.id());
 
 	private final static String IO_ID = "io0";

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/ComponentManagerImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/ComponentManagerImpl.java
@@ -65,10 +65,9 @@ import io.openems.edge.core.componentmanager.jsonrpc.ChannelExportXlsxResponse;
 
 @Designate(ocd = Config.class, factory = false)
 @Component(//
-		name = "Core.ComponentManager", //
+		name = ComponentManager.SINGLETON_SERVICE_PID, //
 		immediate = true, //
 		property = { //
-				"id=" + OpenemsConstants.COMPONENT_MANAGER_ID, //
 				"enabled=true" //
 		})
 public class ComponentManagerImpl extends AbstractOpenemsComponent
@@ -119,9 +118,12 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 
 	@Activate
 	void activate(ComponentContext componentContext, BundleContext bundleContext) throws OpenemsException {
-		super.activate(componentContext, OpenemsConstants.COMPONENT_MANAGER_ID, "Component-Manager", true);
-
+		super.activate(componentContext, SINGLETON_COMPONENT_ID, SINGLETON_SERVICE_PID, true);
 		this.bundleContext = bundleContext;
+
+		if (OpenemsComponent.validateSingleton(this.cm, SINGLETON_SERVICE_PID, SINGLETON_COMPONENT_ID)) {
+			return;
+		}
 
 		for (ComponentManagerWorker worker : this.workers) {
 			worker.activate(this.id());

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/ComponentManagerImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/ComponentManagerImpl.java
@@ -10,6 +10,7 @@ import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -51,6 +52,7 @@ import io.openems.common.jsonrpc.request.UpdateComponentConfigRequest.Property;
 import io.openems.common.jsonrpc.response.GetEdgeConfigResponse;
 import io.openems.common.session.Role;
 import io.openems.common.types.EdgeConfig;
+import io.openems.common.types.EdgeConfig.Factory;
 import io.openems.common.utils.JsonUtils;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
 import io.openems.edge.common.component.ClockProvider;
@@ -252,14 +254,14 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 		if (componentId != null) {
 			// Normal OpenEMS Component with ID.
 			// Check that there is currently no Component with the same ID.
-			Configuration[] configs;
+			List<Configuration> configs;
 			try {
-				configs = this.cm.listConfigurations("(id=" + componentId + ")");
+				configs = this.listConfigurations(componentId);
 			} catch (IOException | InvalidSyntaxException e) {
 				throw OpenemsError.GENERIC.exception("Unable to list configurations for ID [" + componentId + "]. "
 						+ e.getClass().getSimpleName() + ": " + e.getMessage());
 			}
-			if (configs != null && configs.length > 0) {
+			if (!configs.isEmpty()) {
 				throw new OpenemsException("A Component with id [" + componentId + "] is already existing!");
 			}
 			try {
@@ -434,16 +436,16 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 	 * @throws OpenemsNamedException on error
 	 */
 	protected Configuration getExistingConfigForId(String componentId) throws OpenemsNamedException {
-		Configuration[] configs;
+		List<Configuration> configs;
 		try {
-			configs = this.cm.listConfigurations("(id=" + componentId + ")");
+			configs = this.listConfigurations(componentId);
 		} catch (IOException | InvalidSyntaxException e) {
 			e.printStackTrace();
 			throw OpenemsError.GENERIC.exception("Unable to list configurations for ID [" + componentId + "]. "
 					+ e.getClass().getSimpleName() + ": " + e.getMessage());
 		}
 
-		if (configs == null) {
+		if (configs.isEmpty()) {
 			// Maybe this is a Singleton?
 			String factoryPid = this.getComponent(componentId).serviceFactoryPid();
 			try {
@@ -457,12 +459,58 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 		}
 
 		// Make sure we only have one config
-		if (configs == null || configs.length == 0) {
-			throw OpenemsError.EDGE_NO_COMPONENT_WITH_ID.exception(componentId);
-		} else if (configs.length > 1) {
+		if (configs.size() > 1) {
 			throw OpenemsError.EDGE_MULTIPLE_COMPONENTS_WITH_ID.exception(componentId);
 		}
-		return configs[0];
+		return configs.get(0);
+	}
+
+	/**
+	 * Extends the ConfigurationAdmin 'listConfigurations' method by additionally
+	 * searching through Factory default values.
+	 * 
+	 * @param componentId the Component-ID
+	 * @return an array of Configurations
+	 * @throws InvalidSyntaxException on error
+	 * @throws IOException            on error
+	 */
+	private List<Configuration> listConfigurations(String componentId) throws IOException, InvalidSyntaxException {
+		List<Configuration> result = new ArrayList<>();
+		Configuration[] configs = this.cm.listConfigurations(null);
+		if (configs == null) {
+			return result;
+		}
+
+		for (Configuration config : configs) {
+			Object id = config.getProperties().get("id");
+			if (id != null) {
+				// Configuration has an 'id' property
+				if (id instanceof String && componentId.equals((String) id)) {
+					// 'id' property matches
+					result.add(config);
+				}
+
+			} else {
+				// compare default value for property 'id'
+				String factoryPid = config.getFactoryPid();
+				if (factoryPid == null) {
+					// Singleton?
+					factoryPid = config.getPid();
+					if (factoryPid == null) {
+						continue;
+					}
+				}
+				Factory factory = this.getEdgeConfig().getFactories().get(factoryPid);
+				if (factory == null) {
+					continue;
+				}
+				Optional<String> defaultValue = JsonUtils.getAsOptionalString(factory.getPropertyDefaultValue("id"));
+				if (defaultValue.isPresent() && componentId.equals(defaultValue.get())) {
+					result.add(config);
+				}
+			}
+		}
+		return result;
 	}
 
 	@Override

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/EdgeConfigWorker.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/EdgeConfigWorker.java
@@ -49,7 +49,6 @@ import io.openems.common.types.EdgeConfig.Component.Channel.ChannelDetail;
 import io.openems.common.types.EdgeConfig.Component.Channel.ChannelDetailOpenemsType;
 import io.openems.common.types.EdgeConfig.Component.Channel.ChannelDetailState;
 import io.openems.common.types.EdgeConfig.Factory;
-import io.openems.common.types.EdgeConfig.Factory.Property;
 import io.openems.common.types.OptionsEnum;
 import io.openems.common.utils.JsonUtils;
 import io.openems.edge.common.channel.Channel;
@@ -299,7 +298,7 @@ public class EdgeConfigWorker extends ComponentManagerWorker {
 					Factory factory = result.getFactories().get(factoryPid);
 					if (factory != null) {
 						Optional<String> defaultValue = JsonUtils
-								.getAsOptionalString(getPropertyDefaultValue(factory, "id"));
+								.getAsOptionalString(factory.getPropertyDefaultValue("id"));
 						if (defaultValue.isPresent()) {
 							componentId = defaultValue.get();
 						}
@@ -356,21 +355,6 @@ public class EdgeConfigWorker extends ComponentManagerWorker {
 			}
 		}
 		return true;
-	}
-
-	/**
-	 * Gets the default value of a property.
-	 * 
-	 * @param edgeConfig the {@link EdgeConfig}
-	 * @param factoryPid the Factory-PID
-	 * @param propertyId the Property ID
-	 */
-	private static JsonElement getPropertyDefaultValue(Factory factory, String propertyId) {
-		Optional<Property> property = factory.getProperty(propertyId);
-		if (!property.isPresent()) {
-			return JsonNull.INSTANCE;
-		}
-		return property.get().getDefaultValue();
 	}
 
 	/**
@@ -623,7 +607,7 @@ public class EdgeConfigWorker extends ComponentManagerWorker {
 
 				if (value == null || value.isJsonNull()) {
 					// get default value
-					value = getPropertyDefaultValue(factory, key);
+					value = factory.getPropertyDefaultValue(key);
 				}
 			}
 

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/EdgeConfigWorker.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/EdgeConfigWorker.java
@@ -588,35 +588,37 @@ public class EdgeConfigWorker extends ComponentManagerWorker {
 		/*
 		 * Read Factory Properties
 		 */
-		for (EdgeConfig.Factory.Property property : factory.getProperties()) {
-			String key = property.getId();
+		if (factory != null) {
+			for (EdgeConfig.Factory.Property property : factory.getProperties()) {
+				String key = property.getId();
 
-			if (EdgeConfig.ignorePropertyKey(key)) {
-				// Ignore this Property
-				continue;
-			}
-
-			JsonElement value = null;
-			if (property.isPassword()) {
-				// hide Password fields
-				value = new JsonPrimitive("xxx");
-
-			} else {
-				// get configured value
-				value = getPropertyAsJsonElement(properties, key);
-
-				if (value == null || value.isJsonNull()) {
-					// get default value
-					value = factory.getPropertyDefaultValue(key);
+				if (EdgeConfig.ignorePropertyKey(key)) {
+					// Ignore this Property
+					continue;
 				}
-			}
 
-			if (value == null) {
-				// fallback to JsonNull
-				value = JsonNull.INSTANCE;
-			}
+				JsonElement value = null;
+				if (property.isPassword()) {
+					// hide Password fields
+					value = new JsonPrimitive("xxx");
 
-			result.put(key, value);
+				} else {
+					// get configured value
+					value = getPropertyAsJsonElement(properties, key);
+
+					if (value == null || value.isJsonNull()) {
+						// get default value
+						value = factory.getPropertyDefaultValue(key);
+					}
+				}
+
+				if (value == null) {
+					// fallback to JsonNull
+					value = JsonNull.INSTANCE;
+				}
+
+				result.put(key, value);
+			}
 		}
 
 		/*

--- a/io.openems.edge.core/src/io/openems/edge/core/cycle/CycleImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/cycle/CycleImpl.java
@@ -3,6 +3,7 @@ package io.openems.edge.core.cycle;
 import java.util.Comparator;
 import java.util.TreeSet;
 
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -17,8 +18,8 @@ import org.osgi.service.event.EventAdmin;
 import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
 import io.openems.edge.common.component.ComponentManager;
 import io.openems.edge.common.component.OpenemsComponent;
@@ -28,16 +29,18 @@ import io.openems.edge.scheduler.api.Scheduler;
 
 @Designate(ocd = Config.class, factory = false)
 @Component(//
-		name = "Core.Cycle", //
+		name = Cycle.SINGLETON_SERVICE_PID, //
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.OPTIONAL, //
 		property = { //
-				"id=" + OpenemsConstants.CYCLE_ID, //
 				"enabled=true" //
 		})
 public class CycleImpl extends AbstractOpenemsComponent implements OpenemsComponent, Cycle {
 
 	private final CycleWorker worker = new CycleWorker(this);
+
+	@Reference
+	ConfigurationAdmin cm;
 
 	@Reference
 	protected EventAdmin eventAdmin;
@@ -81,9 +84,12 @@ public class CycleImpl extends AbstractOpenemsComponent implements OpenemsCompon
 	}
 
 	@Activate
-	void activate(ComponentContext context, Config config) {
-		super.activate(context, OpenemsConstants.CYCLE_ID, "Core.Cycle", true);
+	private void activate(ComponentContext context, Config config) throws OpenemsException {
+		super.activate(context, SINGLETON_COMPONENT_ID, SINGLETON_SERVICE_PID, true);
 		this.config = config;
+		if (OpenemsComponent.validateSingleton(this.cm, SINGLETON_SERVICE_PID, SINGLETON_COMPONENT_ID)) {
+			return;
+		}
 		this.worker.activate("Core.Cycle");
 	}
 
@@ -95,9 +101,12 @@ public class CycleImpl extends AbstractOpenemsComponent implements OpenemsCompon
 
 	@Modified
 	void modified(ComponentContext context, Config config) throws OpenemsNamedException {
-		super.modified(context, OpenemsConstants.CYCLE_ID, "Core.Cycle", true);
+		super.modified(context, SINGLETON_COMPONENT_ID, "Core.Cycle", true);
 		Config oldConfig = this.config;
 		this.config = config;
+		if (OpenemsComponent.validateSingleton(this.cm, this.serviceFactoryPid(), SINGLETON_COMPONENT_ID)) {
+			return;
+		}
 		// make sure the worker starts if it had been stopped
 		if (oldConfig.cycleTime() <= 0 && oldConfig.cycleTime() != config.cycleTime()) {
 			this.worker.triggerNextRun();

--- a/io.openems.edge.core/src/io/openems/edge/core/cycle/CycleImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/cycle/CycleImpl.java
@@ -90,7 +90,7 @@ public class CycleImpl extends AbstractOpenemsComponent implements OpenemsCompon
 		if (OpenemsComponent.validateSingleton(this.cm, SINGLETON_SERVICE_PID, SINGLETON_COMPONENT_ID)) {
 			return;
 		}
-		this.worker.activate("Core.Cycle");
+		this.worker.activate(SINGLETON_SERVICE_PID);
 	}
 
 	@Deactivate
@@ -101,10 +101,10 @@ public class CycleImpl extends AbstractOpenemsComponent implements OpenemsCompon
 
 	@Modified
 	void modified(ComponentContext context, Config config) throws OpenemsNamedException {
-		super.modified(context, SINGLETON_COMPONENT_ID, "Core.Cycle", true);
+		super.modified(context, SINGLETON_COMPONENT_ID, SINGLETON_SERVICE_PID, true);
 		Config oldConfig = this.config;
 		this.config = config;
-		if (OpenemsComponent.validateSingleton(this.cm, this.serviceFactoryPid(), SINGLETON_COMPONENT_ID)) {
+		if (OpenemsComponent.validateSingleton(this.cm, SINGLETON_SERVICE_PID, SINGLETON_COMPONENT_ID)) {
 			return;
 		}
 		// make sure the worker starts if it had been stopped

--- a/io.openems.edge.core/src/io/openems/edge/core/meta/MetaImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/meta/MetaImpl.java
@@ -1,9 +1,11 @@
 package io.openems.edge.core.meta;
 
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.metatype.annotations.Designate;
 
 import io.openems.common.OpenemsConstants;
@@ -14,13 +16,15 @@ import io.openems.edge.common.modbusslave.ModbusSlave;
 
 @Designate(ocd = Config.class, factory = false)
 @Component(//
-		name = "Core.Meta", //
+		name = Meta.SINGLETON_SERVICE_PID, //
 		immediate = true, //
 		property = { //
-				"id=" + OpenemsConstants.META_ID, //
 				"enabled=true" //
 		})
 public class MetaImpl extends AbstractOpenemsComponent implements Meta, OpenemsComponent, ModbusSlave {
+
+	@Reference
+	private ConfigurationAdmin cm;
 
 	public MetaImpl() {
 		super(//
@@ -32,7 +36,10 @@ public class MetaImpl extends AbstractOpenemsComponent implements Meta, OpenemsC
 
 	@Activate
 	void activate(ComponentContext context) {
-		super.activate(context, OpenemsConstants.META_ID, "Core.Meta", true);
+		super.activate(context, SINGLETON_COMPONENT_ID, Meta.SINGLETON_SERVICE_PID, true);
+		if (OpenemsComponent.validateSingleton(this.cm, Meta.SINGLETON_SERVICE_PID, SINGLETON_COMPONENT_ID)) {
+			return;
+		}
 	}
 
 	@Deactivate

--- a/io.openems.edge.core/src/io/openems/edge/core/predictormanager/PredictorManagerImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/predictormanager/PredictorManagerImpl.java
@@ -36,7 +36,7 @@ import io.openems.edge.predictor.api.oneday.Predictor24Hours;
 
 @Designate(ocd = Config.class, factory = false)
 @Component(//
-		name = "Core.PredictorManager", //
+		name = PredictorManager.SINGLETON_SERVICE_PID, //
 		immediate = true, //
 		property = { //
 				"enabled=true" //
@@ -65,8 +65,8 @@ public class PredictorManagerImpl extends AbstractOpenemsComponent
 
 	@Activate
 	void activate(ComponentContext context) {
-		super.activate(context, PredictorManager.SINGLETON_COMPONENT_ID, "Core.PredictorManager", true);
-		if (OpenemsComponent.validateSingleton(this.cm, this.serviceFactoryPid(), SINGLETON_COMPONENT_ID)) {
+		super.activate(context, PredictorManager.SINGLETON_COMPONENT_ID, SINGLETON_SERVICE_PID, true);
+		if (OpenemsComponent.validateSingleton(this.cm, SINGLETON_SERVICE_PID, SINGLETON_COMPONENT_ID)) {
 			return;
 		}
 	}

--- a/io.openems.edge.core/src/io/openems/edge/core/sum/SumImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/sum/SumImpl.java
@@ -2,6 +2,7 @@ package io.openems.edge.core.sum;
 
 import java.util.Optional;
 
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -12,7 +13,6 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.metatype.annotations.Designate;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.channel.AccessMode;
 import io.openems.common.channel.Level;
 import io.openems.edge.common.channel.calculate.CalculateAverage;
@@ -39,13 +39,15 @@ import io.openems.edge.timedata.api.Timedata;
 
 @Designate(ocd = Config.class, factory = false)
 @Component(//
-		name = "Core.Sum", //
+		name = Sum.SINGLETON_SERVICE_PID, //
 		immediate = true, //
 		property = { //
-				"id=" + OpenemsConstants.SUM_ID, //
 				"enabled=true" //
 		})
 public class SumImpl extends AbstractOpenemsComponent implements Sum, OpenemsComponent, ModbusSlave {
+
+	@Reference
+	private ConfigurationAdmin cm;
 
 	@Reference(policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.OPTIONAL)
 	protected volatile Timedata timedata = null;
@@ -72,7 +74,10 @@ public class SumImpl extends AbstractOpenemsComponent implements Sum, OpenemsCom
 
 	@Activate
 	void activate(ComponentContext context) {
-		super.activate(context, OpenemsConstants.SUM_ID, "Sum", true);
+		super.activate(context, SINGLETON_COMPONENT_ID, SINGLETON_SERVICE_PID, true);
+		if (OpenemsComponent.validateSingleton(this.cm, SINGLETON_SERVICE_PID, SINGLETON_COMPONENT_ID)) {
+			return;
+		}
 		this.energyValuesHandler.activate();
 	}
 

--- a/io.openems.edge.predictor.api/src/io/openems/edge/predictor/api/manager/PredictorManager.java
+++ b/io.openems.edge.predictor.api/src/io/openems/edge/predictor/api/manager/PredictorManager.java
@@ -8,6 +8,8 @@ import io.openems.edge.predictor.api.oneday.Predictor24Hours;
 
 public interface PredictorManager extends OpenemsComponent {
 
+	public final static String SINGLETON_COMPONENT_ID = "_predictorManager";
+
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
 		;
 		private final Doc doc;

--- a/io.openems.edge.predictor.api/src/io/openems/edge/predictor/api/manager/PredictorManager.java
+++ b/io.openems.edge.predictor.api/src/io/openems/edge/predictor/api/manager/PredictorManager.java
@@ -8,6 +8,7 @@ import io.openems.edge.predictor.api.oneday.Predictor24Hours;
 
 public interface PredictorManager extends OpenemsComponent {
 
+	public final static String SINGLETON_SERVICE_PID = "Core.PredictorManager";
 	public final static String SINGLETON_COMPONENT_ID = "_predictorManager";
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {

--- a/io.openems.edge.predictor.api/src/io/openems/edge/predictor/api/test/DummyPredictorManager.java
+++ b/io.openems.edge.predictor.api/src/io/openems/edge/predictor/api/test/DummyPredictorManager.java
@@ -26,7 +26,7 @@ public class DummyPredictorManager extends AbstractOpenemsComponent implements P
 		for (Predictor24Hours predictor : predictors) {
 			this.predictors.add(predictor);
 		}
-		super.activate(null, PredictorManager.SINGLETON_COMPONENT_ID, "", true);
+		super.activate(null, PredictorManager.SINGLETON_COMPONENT_ID, PredictorManager.SINGLETON_SERVICE_PID, true);
 	}
 
 	public void addPredictor(Predictor24Hours predictor) {

--- a/io.openems.edge.predictor.api/src/io/openems/edge/predictor/api/test/DummyPredictorManager.java
+++ b/io.openems.edge.predictor.api/src/io/openems/edge/predictor/api/test/DummyPredictorManager.java
@@ -3,7 +3,6 @@ package io.openems.edge.predictor.api.test;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.types.ChannelAddress;
 import io.openems.edge.common.channel.Channel;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
@@ -27,7 +26,7 @@ public class DummyPredictorManager extends AbstractOpenemsComponent implements P
 		for (Predictor24Hours predictor : predictors) {
 			this.predictors.add(predictor);
 		}
-		super.activate(null, OpenemsConstants.PREDICTOR_MANAGER_ID, "", true);
+		super.activate(null, PredictorManager.SINGLETON_COMPONENT_ID, "", true);
 	}
 
 	public void addPredictor(Predictor24Hours predictor) {

--- a/io.openems.edge.predictor.persistencemodel/src/io/openems/edge/predictor/deprecatedpersistencemodel/consumption/ConsumptionPredictor.java
+++ b/io.openems.edge.predictor.persistencemodel/src/io/openems/edge/predictor/deprecatedpersistencemodel/consumption/ConsumptionPredictor.java
@@ -10,7 +10,6 @@ import org.osgi.service.event.EventConstants;
 import org.osgi.service.event.EventHandler;
 import org.osgi.service.metatype.annotations.Designate;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.edge.common.component.ComponentManager;
 import io.openems.edge.common.component.OpenemsComponent;
@@ -32,7 +31,7 @@ public class ConsumptionPredictor extends AbstractPersistenceModelPredictor
 	protected ComponentManager componentManager;
 
 	public ConsumptionPredictor() {
-		super(OpenemsConstants.SUM_ID, Sum.ChannelId.CONSUMPTION_ACTIVE_ENERGY);
+		super(Sum.SINGLETON_COMPONENT_ID, Sum.ChannelId.CONSUMPTION_ACTIVE_ENERGY);
 	}
 
 	@Activate

--- a/io.openems.edge.predictor.persistencemodel/src/io/openems/edge/predictor/deprecatedpersistencemodel/prediction/ProductionPredictor.java
+++ b/io.openems.edge.predictor.persistencemodel/src/io/openems/edge/predictor/deprecatedpersistencemodel/prediction/ProductionPredictor.java
@@ -10,7 +10,6 @@ import org.osgi.service.event.EventConstants;
 import org.osgi.service.event.EventHandler;
 import org.osgi.service.metatype.annotations.Designate;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.edge.common.component.ComponentManager;
 import io.openems.edge.common.component.OpenemsComponent;
@@ -32,7 +31,7 @@ public class ProductionPredictor extends AbstractPersistenceModelPredictor
 	protected ComponentManager componentManager;
 
 	public ProductionPredictor() {
-		super(OpenemsConstants.SUM_ID, Sum.ChannelId.PRODUCTION_ACTIVE_ENERGY);
+		super(Sum.SINGLETON_COMPONENT_ID, Sum.ChannelId.PRODUCTION_ACTIVE_ENERGY);
 	}
 
 	@Activate

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/app/SimulatorApp.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/app/SimulatorApp.java
@@ -39,7 +39,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonPrimitive;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.exceptions.NotImplementedException;
 import io.openems.common.exceptions.OpenemsError;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -72,20 +71,25 @@ import io.openems.edge.timedata.api.Timedata;
 
 @Designate(ocd = Config.class, factory = false)
 @Component(//
-		name = "Simulator.App", //
+		name = SimulatorApp.SINGLETON_SERVICE_PID, //
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE, //
 		property = { //
-				"id=" + OpenemsConstants.SIMULATOR_ID, //
 				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE, //
 				EventConstants.EVENT_TOPIC + "=" + EdgeEventConstants.TOPIC_CYCLE_AFTER_WRITE //
 		})
 public class SimulatorApp extends AbstractOpenemsComponent
 		implements SimulatorDatasource, ClockProvider, OpenemsComponent, JsonApi, EventHandler, Timedata {
 
+	public final static String SINGLETON_SERVICE_PID = "Simulator.App";
+	public final static String SINGLETON_COMPONENT_ID = "_simulator";
+
 	private static final long MILLISECONDS_BETWEEN_LOGS = 5_000;
 
 	private final Logger log = LoggerFactory.getLogger(SimulatorApp.class);
+
+	@Reference
+	private ConfigurationAdmin cm;
 
 	@Reference
 	private ConfigurationAdmin configurationAdmin;
@@ -144,7 +148,10 @@ public class SimulatorApp extends AbstractOpenemsComponent
 
 	@Activate
 	void activate(ComponentContext componentContext, Config config) throws OpenemsException {
-		super.activate(componentContext, OpenemsConstants.SIMULATOR_ID, "Simulator", config.enabled());
+		super.activate(componentContext, SINGLETON_COMPONENT_ID, SINGLETON_SERVICE_PID, config.enabled());
+		if (OpenemsComponent.validateSingleton(this.cm, SINGLETON_SERVICE_PID, SINGLETON_COMPONENT_ID)) {
+			return;
+		}
 	}
 
 	@Deactivate

--- a/io.openems.edge.timedata.api/src/io/openems/edge/timedata/api/utils/CalculateActiveTime.java
+++ b/io.openems.edge.timedata.api/src/io/openems/edge/timedata/api/utils/CalculateActiveTime.java
@@ -1,6 +1,5 @@
 package io.openems.edge.timedata.api.utils;
 
-import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 


### PR DESCRIPTION
Latest version of Apache WebConsole does not explicitely store unchanged default configuration properties. This has certain implications on the way OpenEMS uses properties, e.g. it means that a Component that is created via Apache WebConsole with default 'id' does not have the 'id' stored as property.

See this issue for details:
https://issues.apache.org/jira/browse/FELIX-6436?focusedCommentId=17412472&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17412472