### PR TITLE
Add Time-Of-Use Tariff Tibber

### DIFF
--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -150,6 +150,7 @@
 	bnd.identity;id='io.openems.edge.timedata.rrd4j',\
 	bnd.identity;id='io.openems.edge.timeofusetariff.awattar',\
 	bnd.identity;id='io.openems.edge.timeofusetariff.corrently',\
+	bnd.identity;id='io.openems.edge.timeofusetariff.tibber',\
 
 -runbundles: \
 	Java-WebSocket;version='[1.5.2,1.5.3)',\
@@ -296,6 +297,7 @@
 	io.openems.edge.timeofusetariff.api;version=snapshot,\
 	io.openems.edge.timeofusetariff.awattar;version=snapshot,\
 	io.openems.edge.timeofusetariff.corrently;version=snapshot,\
+	io.openems.edge.timeofusetariff.tibber;version=snapshot,\
 	io.openems.shared.influxdb;version=snapshot,\
 	io.openems.wrapper.eu.chargetime.ocpp;version=snapshot,\
 	io.openems.wrapper.fastexcel;version=snapshot,\

--- a/io.openems.edge.timeofusetariff.corrently/readme.adoc
+++ b/io.openems.edge.timeofusetariff.corrently/readme.adoc
@@ -1,5 +1,5 @@
 = Time-Of-Use Tariff Corrently by STROMDAO
 
-Retrieves the hourly prices from the Corrently API and converts them into quarterly prices. Prices are updated every day at 14:00 and stored locally.
+Retrieves the quarterly prices from the Corrently API. Prices are updated every day at 14:00 and stored locally.
 
 https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.timeofusetariff.corrently[Source Code icon:github[]]

--- a/io.openems.edge.timeofusetariff.tibber/.classpath
+++ b/io.openems.edge.timeofusetariff.tibber/.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="src" output="bin_test" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/io.openems.edge.timeofusetariff.tibber/.gitignore
+++ b/io.openems.edge.timeofusetariff.tibber/.gitignore
@@ -1,0 +1,2 @@
+/bin_test/
+/generated/

--- a/io.openems.edge.timeofusetariff.tibber/.project
+++ b/io.openems.edge.timeofusetariff.tibber/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openems.edge.timeofusetariff.tibber</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/io.openems.edge.timeofusetariff.tibber/bnd.bnd
+++ b/io.openems.edge.timeofusetariff.tibber/bnd.bnd
@@ -1,0 +1,14 @@
+Bundle-Name: OpenEMS Edge Time-Of-Use Tariff Tibber
+Bundle-Vendor: FENECON GmbH
+Bundle-License: https://opensource.org/licenses/EPL-2.0
+Bundle-Version: 1.0.0.${tstamp}
+
+-buildpath: \
+	${buildpath},\
+	io.openems.common,\
+	io.openems.edge.common,\
+	io.openems.edge.timeofusetariff.api,\
+	io.openems.wrapper.okhttp,\
+
+-testpath: \
+	${testpath}

--- a/io.openems.edge.timeofusetariff.tibber/readme.adoc
+++ b/io.openems.edge.timeofusetariff.tibber/readme.adoc
@@ -1,0 +1,5 @@
+= Time-Of-Use Tariff Tibber
+
+Retrieves the hourly prices from the Tibber API and converts them into quarterly prices. Prices are updated every day at 14:00 and stored locally.
+
+https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.timeofusetariff.corrently[Source Code icon:github[]]

--- a/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/Config.java
+++ b/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/Config.java
@@ -1,0 +1,25 @@
+package io.openems.edge.timeofusetariff.tibber;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.AttributeType;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@ObjectClassDefinition(//
+		name = "Time-Of-Use Tariff Tibber", //
+		description = "Time-Of-Use Tariff implementation for Tibber.")
+@interface Config {
+
+	@AttributeDefinition(name = "Component-ID", description = "Unique ID of this Component")
+	String id() default "timeOfUseTariff0";
+
+	@AttributeDefinition(name = "Alias", description = "Human-readable name of this Component; defaults to Component-ID")
+	String alias() default "";
+
+	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
+	boolean enabled() default true;
+
+	@AttributeDefinition(name = "Access Token", description = "Access token for the Tibber API", type = AttributeType.PASSWORD)
+	String accessToken() default "";
+
+	String webconsole_configurationFactory_nameHint() default "Time-Of-Use Tariff Tibber [{id}]";
+}

--- a/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/Tibber.java
+++ b/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/Tibber.java
@@ -1,0 +1,26 @@
+package io.openems.edge.timeofusetariff.tibber;
+
+import io.openems.common.types.OpenemsType;
+import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.timeofusetariff.api.TimeOfUseTariff;
+
+public interface Tibber extends TimeOfUseTariff, OpenemsComponent {
+
+	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+		HTTP_STATUS_CODE(Doc.of(OpenemsType.INTEGER)//
+				.text("Displays the HTTP status code"))//
+		;
+
+		private final Doc doc;
+
+		private ChannelId(Doc doc) {
+			this.doc = doc;
+		}
+
+		@Override
+		public Doc doc() {
+			return this.doc;
+		}
+	}
+}

--- a/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/TibberImpl.java
+++ b/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/TibberImpl.java
@@ -1,0 +1,213 @@
+package io.openems.edge.timeofusetariff.tibber;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.TreeMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.metatype.annotations.Designate;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.utils.JsonUtils;
+import io.openems.common.utils.ThreadPoolUtils;
+import io.openems.edge.common.component.AbstractOpenemsComponent;
+import io.openems.edge.common.component.ComponentManager;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.timeofusetariff.api.TimeOfUsePrices;
+import io.openems.edge.timeofusetariff.api.TimeOfUseTariff;
+import io.openems.edge.timeofusetariff.api.utils.TimeOfUseTariffUtils;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+@Designate(ocd = Config.class, factory = true)
+@Component(//
+		name = "TimeOfUseTariff.Tibber", //
+		immediate = true, //
+		configurationPolicy = ConfigurationPolicy.REQUIRE //
+)
+public class TibberImpl extends AbstractOpenemsComponent implements TimeOfUseTariff, OpenemsComponent, Tibber {
+
+	private static final String TIBBER_API_URL = "https://api.tibber.com/v1-beta/gql";
+
+	private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+	private Config config = null;
+
+	private final AtomicReference<ImmutableSortedMap<ZonedDateTime, Float>> prices = new AtomicReference<ImmutableSortedMap<ZonedDateTime, Float>>(
+			ImmutableSortedMap.of());
+
+	private ZonedDateTime updateTimeStamp = null;
+
+	private final Runnable task = () -> {
+
+		/*
+		 * Update Map of prices
+		 */
+		OkHttpClient client = new OkHttpClient();
+		MediaType mediaType = MediaType.parse("application/json");
+		RequestBody body = RequestBody.create(mediaType, JsonUtils.buildJsonObject() //
+				.addProperty("query", //
+						"{\n"
+						+ "  viewer {\n"
+						+ "    homes {\n"
+						+ "      currentSubscription{\n"
+						+ "        priceInfo{\n"
+						+ "          today {\n"
+						+ "            total\n"
+						+ "            startsAt\n"
+						+ "          }\n"
+						+ "          tomorrow {\n"
+						+ "            total\n"
+						+ "            startsAt\n"
+						+ "          }\n"
+						+ "        }\n"
+						+ "      }\n"
+						+ "    }\n"
+						+ "  }\n"
+						+ "}" + "") //
+				.build().toString());
+		Request request = new Request.Builder() //
+				.url(TIBBER_API_URL) //
+				.header("Authorization", this.config.accessToken()).post(body) //
+				.build();
+		int httpStatusCode;
+		try (Response response = client.newCall(request).execute()) {
+			httpStatusCode = response.code();
+
+			if (!response.isSuccessful()) {
+				throw new IOException("Unexpected code " + response);
+			}
+
+			// Parse the response for the prices
+			this.prices.set(TibberImpl.parsePrices(response.body().string()));
+
+			// store the time stamp
+			this.updateTimeStamp = ZonedDateTime.now();
+
+		} catch (IOException | OpenemsNamedException e) {
+			e.printStackTrace();
+			httpStatusCode = 0;
+		}
+
+		this.channel(Tibber.ChannelId.HTTP_STATUS_CODE).setNextValue(httpStatusCode);
+
+		/*
+		 * Schedule next price update for 2 pm
+		 */
+		ZonedDateTime now = ZonedDateTime.now();
+		ZonedDateTime nextRun = now.withHour(14).truncatedTo(ChronoUnit.HOURS);
+		if (now.isAfter(nextRun)) {
+			nextRun = nextRun.plusDays(1);
+		}
+
+		Duration duration = Duration.between(now, nextRun);
+		long delay = duration.getSeconds();
+
+		this.executor.schedule(this.task, delay, TimeUnit.SECONDS);
+	};
+
+	@Reference
+	private ComponentManager componentManager;
+
+	public TibberImpl() {
+		super(//
+				OpenemsComponent.ChannelId.values(), //
+				Tibber.ChannelId.values() //
+		);
+	}
+
+	@Activate
+	void activate(ComponentContext context, Config config) {
+		super.activate(context, config.id(), config.alias(), config.enabled());
+
+		if (!config.enabled()) {
+			return;
+		}
+		this.config = config;
+		this.executor.schedule(this.task, 0, TimeUnit.SECONDS);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		super.deactivate();
+		ThreadPoolUtils.shutdownAndAwaitTermination(this.executor, 0);
+	}
+
+	@Override
+	public TimeOfUsePrices getPrices() {
+		// return null if data is not yet available.
+		if (this.updateTimeStamp == null) {
+			return null;
+		}
+
+		return TimeOfUseTariffUtils.getNext24HourPrices(Clock.systemDefaultZone() /* can be mocked for testing */,
+				this.prices.get(), this.updateTimeStamp);
+	}
+
+	/**
+	 * Parse the Tibber JSON to the Price Map.
+	 * 
+	 * @param jsonData the Tibber JSON
+	 * @return the Price Map
+	 * @throws OpenemsNamedException on error
+	 */
+	public static ImmutableSortedMap<ZonedDateTime, Float> parsePrices(String jsonData) throws OpenemsNamedException {
+		TreeMap<ZonedDateTime, Float> result = new TreeMap<>();
+
+		if (!jsonData.isEmpty()) {
+
+			JsonObject line = JsonUtils.parseToJsonObject(jsonData);
+			JsonArray homes = JsonUtils.getAsJsonObject(line, "data") //
+					.getAsJsonObject("viewer") //
+					.getAsJsonArray("homes");
+
+			for (JsonElement home : homes) {
+
+				JsonObject priceInfo = JsonUtils.getAsJsonObject(home, "currentSubscription") //
+						.getAsJsonObject("priceInfo");
+
+				// Price info for today and tomorrow.
+				JsonArray today = JsonUtils.getAsJsonArray(priceInfo, "today");
+				JsonArray tomorrow = JsonUtils.getAsJsonArray(priceInfo, "tomorrow");
+
+				// Adding to an array to avoid individual variables for individual for loops.
+				JsonArray[] days = { today, tomorrow };
+
+				// parse the arrays for price and time stamps.
+				for (JsonArray day : days) {
+					for (JsonElement element : day) {
+						float marketPrice = JsonUtils.getAsFloat(element, "total");
+						ZonedDateTime startTime = ZonedDateTime
+								.parse(JsonUtils.getAsString(element, "startsAt"), DateTimeFormatter.ISO_DATE_TIME)
+								.withZoneSameInstant(ZoneId.systemDefault());
+						// Adding the values in the Map.
+						result.put(startTime, marketPrice);
+					}
+				}
+			}
+		}
+		return ImmutableSortedMap.copyOf(result);
+	}
+}

--- a/io.openems.edge.timeofusetariff.tibber/test/io/openems/edge/timeofusetariff/tibber/MyConfig.java
+++ b/io.openems.edge.timeofusetariff.tibber/test/io/openems/edge/timeofusetariff/tibber/MyConfig.java
@@ -1,0 +1,51 @@
+package io.openems.edge.timeofusetariff.tibber;
+
+import io.openems.edge.common.test.AbstractComponentConfig;
+
+@SuppressWarnings("all")
+public class MyConfig extends AbstractComponentConfig implements Config {
+
+	public static class Builder {
+		private String id;
+		public String accessToken;
+
+		private Builder() {
+		}
+
+		public Builder setId(String id) {
+			this.id = id;
+			return this;
+		}
+
+		public Builder setAccessToken(String accessToken) {
+			this.accessToken = accessToken;
+			return this;
+		}
+
+		public MyConfig build() {
+			return new MyConfig(this);
+		}
+	}
+
+	/**
+	 * Create a Config builder.
+	 * 
+	 * @return a {@link Builder}
+	 */
+	public static Builder create() {
+		return new Builder();
+	}
+
+	private final Builder builder;
+
+	private MyConfig(Builder builder) {
+		super(Config.class, builder.id);
+		this.builder = builder;
+	}
+
+	@Override
+	public String accessToken() {
+		return this.builder.accessToken;
+	}
+
+}

--- a/io.openems.edge.timeofusetariff.tibber/test/io/openems/edge/timeofusetariff/tibber/TibberProviderTest.java
+++ b/io.openems.edge.timeofusetariff.tibber/test/io/openems/edge/timeofusetariff/tibber/TibberProviderTest.java
@@ -1,0 +1,165 @@
+package io.openems.edge.timeofusetariff.tibber;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.ZonedDateTime;
+import java.util.SortedMap;
+
+import org.junit.Test;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.edge.common.test.ComponentTest;
+
+public class TibberProviderTest {
+
+	private static final String CTRL_ID = "ctrl0";
+
+	@Test
+	public void test() throws Exception {
+		TibberImpl sut = new TibberImpl();
+		new ComponentTest(sut) //
+				.activate(MyConfig.create() //
+						.setId(CTRL_ID) //
+						.setAccessToken("dummy") //
+						.build()) //
+		;
+
+		 // Thread.sleep(5000);
+		 // System.out.println(sut.getPrices());
+	}
+
+	@Test
+	public void nonEmptyStringTest() throws OpenemsNamedException {
+		// Parsing with custom data
+		SortedMap<ZonedDateTime, Float> prices = TibberImpl.parsePrices("{\n"
+				+ "  \"data\": {\n"
+				+ "    \"viewer\": {\n"
+				+ "      \"homes\": [\n"
+				+ "        {\n"
+				+ "          \"currentSubscription\": {\n"
+				+ "            \"priceInfo\": {\n"
+				+ "              \"today\": [\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.187,\n"
+				+ "                  \"startsAt\": \"2021-11-15T00:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1841,\n"
+				+ "                  \"startsAt\": \"2021-11-15T01:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.18,\n"
+				+ "                  \"startsAt\": \"2021-11-15T02:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1747,\n"
+				+ "                  \"startsAt\": \"2021-11-15T03:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.179,\n"
+				+ "                  \"startsAt\": \"2021-11-15T04:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1809,\n"
+				+ "                  \"startsAt\": \"2021-11-15T05:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1795,\n"
+				+ "                  \"startsAt\": \"2021-11-15T06:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1848,\n"
+				+ "                  \"startsAt\": \"2021-11-15T07:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1868,\n"
+				+ "                  \"startsAt\": \"2021-11-15T08:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1876,\n"
+				+ "                  \"startsAt\": \"2021-11-15T09:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1874,\n"
+				+ "                  \"startsAt\": \"2021-11-15T10:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1874,\n"
+				+ "                  \"startsAt\": \"2021-11-15T11:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1875,\n"
+				+ "                  \"startsAt\": \"2021-11-15T12:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1878,\n"
+				+ "                  \"startsAt\": \"2021-11-15T13:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1868,\n"
+				+ "                  \"startsAt\": \"2021-11-15T14:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1853,\n"
+				+ "                  \"startsAt\": \"2021-11-15T15:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1848,\n"
+				+ "                  \"startsAt\": \"2021-11-15T16:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1829,\n"
+				+ "                  \"startsAt\": \"2021-11-15T17:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1835,\n"
+				+ "                  \"startsAt\": \"2021-11-15T18:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1846,\n"
+				+ "                  \"startsAt\": \"2021-11-15T19:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1851,\n"
+				+ "                  \"startsAt\": \"2021-11-15T20:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1854,\n"
+				+ "                  \"startsAt\": \"2021-11-15T21:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1853,\n"
+				+ "                  \"startsAt\": \"2021-11-15T22:00:00.000+01:00\"\n"
+				+ "                },\n"
+				+ "                {\n"
+				+ "                  \"total\": 0.1831,\n"
+				+ "                  \"startsAt\": \"2021-11-15T23:00:00.000+01:00\"\n"
+				+ "                }\n"
+				+ "              ],\n"
+				+ "              \"tomorrow\": []\n"
+				+ "            }\n"
+				+ "          }\n"
+				+ "        }\n"
+				+ "      ]\n"
+				+ "    }\n"
+				+ "  }\n"
+				+ "}"); //
+
+		// To check if the Map is not empty
+		assertFalse(prices.isEmpty());
+
+		// To check if the a value input from the string is present in map.
+		assertTrue(prices.containsValue(0.1853f));
+
+	}
+
+	@Test
+	public void emptyStringTest() throws OpenemsNamedException {
+		// Parsing with empty string
+		SortedMap<ZonedDateTime, Float> prices = TibberImpl.parsePrices("");
+
+		// To check if the map is empty.
+		assertTrue(prices.isEmpty());
+	}
+}


### PR DESCRIPTION
Implemented Tibber API to retrieve the prices for Time-Of-Use Tariff API service.
Coorent readme doc for corrently.

Co-authored-by: Stefan Feilmeier <stefan.feilmeier@fenecon.de>
Reviewed-by: Stefan Feilmeier <stefan.feilmeier@fenecon.de>
Co-authored-by: Sagar Venu <sagar.venu@fenecon.de>