### PR TITLE
Switch to log4j2

### DIFF
--- a/cnf/pom.xml
+++ b/cnf/pom.xml
@@ -245,12 +245,12 @@
 		<dependency>
 			<groupId>org.ops4j.pax.logging</groupId>
 			<artifactId>pax-logging-api</artifactId>
-			<version>2.0.11</version>
+			<version>2.0.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ops4j.pax.logging</groupId>
-			<artifactId>pax-logging-log4j1</artifactId>
-			<version>2.0.11</version>
+			<artifactId>pax-logging-log4j2</artifactId>
+			<version>2.0.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>

--- a/io.openems.backend.application/BackendApp.bndrun
+++ b/io.openems.backend.application/BackendApp.bndrun
@@ -18,11 +18,11 @@
 
 -runbundles+: \
 	org.apache.felix.scr;startlevel=10,\
-    org.ops4j.pax.logging.pax-logging-log4j1;startlevel=12
+    org.ops4j.pax.logging.pax-logging-log4j2;startlevel=12
 
 -runrequires: \
 	bnd.identity;id='org.ops4j.pax.logging.pax-logging-api',\
-	bnd.identity;id='org.ops4j.pax.logging.pax-logging-log4j1',\
+	bnd.identity;id='org.ops4j.pax.logging.pax-logging-log4j2',\
 	bnd.identity;id='org.osgi.service.jdbc',\
 	bnd.identity;id='org.apache.felix.http.jetty',\
 	bnd.identity;id='org.apache.felix.webconsole',\
@@ -77,8 +77,8 @@
 	org.apache.felix.webconsole;version='[4.7.0,4.7.1)',\
 	org.apache.felix.webconsole.plugins.ds;version='[2.1.0,2.1.1)',\
 	org.jsr-305;version='[3.0.2,3.0.3)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.11,2.0.12)',\
-	org.ops4j.pax.logging.pax-logging-log4j1;version='[2.0.11,2.0.12)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.13,2.0.14)',\
+	org.ops4j.pax.logging.pax-logging-log4j2;version='[2.0.13,2.0.14)',\
 	org.osgi.service.jdbc;version='[1.0.1,1.0.2)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\

--- a/io.openems.backend.application/src/io/openems/backend/application/BackendApp.java
+++ b/io.openems.backend.application/src/io/openems/backend/application/BackendApp.java
@@ -37,20 +37,17 @@ public class BackendApp {
 		try {
 			config = cm.getConfiguration("org.ops4j.pax.logging", null);
 			Dictionary<String, Object> properties = config.getProperties();
-			if (properties != null && properties.isEmpty()) {
+			if (properties == null || properties.isEmpty() || properties.get("log4j2.rootLogger.level") == null) {
 				Hashtable<String, Object> log4j = new Hashtable<>();
-				log4j.put("log4j2.rootLogger", "INFO, CONSOLE, osgi:*");
-
 				log4j.put("log4j2.appender.console.type", "Console");
 				log4j.put("log4j2.appender.console.name", "console");
 				log4j.put("log4j2.appender.console.layout.type", "PatternLayout");
 				log4j.put("log4j2.appender.console.layout.pattern", "%d{ISO8601} [%-8.8t] %-5p [%-30.30c] %m%n");
 
-				log4j.put("log4j2.appender.osgi.type", "PaxOsgi");
-				log4j.put("log4j2.appender.osgi.name", "paxosgi");
+				log4j.put("log4j2.appender.paxosgi.type", "PaxOsgi");
+				log4j.put("log4j2.appender.paxosgi.name", "paxosgi");
 
-				log4j.put("log4j2.rootLogger.level", "info");
-				log4j.put("log4j2.rootLogger.appenderRefs", "console, osgi");
+				log4j.put("log4j2.rootLogger.level", "INFO");
 				log4j.put("log4j2.rootLogger.appenderRef.console.ref", "console");
 				log4j.put("log4j2.rootLogger.appenderRef.paxosgi.ref", "paxosgi");
 				config.update(log4j);

--- a/io.openems.backend.application/src/io/openems/backend/application/BackendApp.java
+++ b/io.openems.backend.application/src/io/openems/backend/application/BackendApp.java
@@ -39,12 +39,20 @@ public class BackendApp {
 			Dictionary<String, Object> properties = config.getProperties();
 			if (properties != null && properties.isEmpty()) {
 				Hashtable<String, Object> log4j = new Hashtable<>();
-				log4j.put("log4j.rootLogger", "INFO, CONSOLE, osgi:*");
-				log4j.put("log4j.appender.CONSOLE", "org.apache.log4j.ConsoleAppender");
-				log4j.put("log4j.appender.CONSOLE.layout", "org.apache.log4j.PatternLayout");
-				log4j.put("log4j.appender.CONSOLE.layout.ConversionPattern",
-						"%d{ISO8601} [%-8.8t] %-5p [%-30.30c] %m%n");
-				log4j.put("log4j.logger.org.eclipse.osgi", "WARN");
+				log4j.put("log4j2.rootLogger", "INFO, CONSOLE, osgi:*");
+
+				log4j.put("log4j2.appender.console.type", "Console");
+				log4j.put("log4j2.appender.console.name", "console");
+				log4j.put("log4j2.appender.console.layout.type", "PatternLayout");
+				log4j.put("log4j2.appender.console.layout.pattern", "%d{ISO8601} [%-8.8t] %-5p [%-30.30c] %m%n");
+
+				log4j.put("log4j2.appender.osgi.type", "PaxOsgi");
+				log4j.put("log4j2.appender.osgi.name", "paxosgi");
+
+				log4j.put("log4j2.rootLogger.level", "info");
+				log4j.put("log4j2.rootLogger.appenderRefs", "console, osgi");
+				log4j.put("log4j2.rootLogger.appenderRef.console.ref", "console");
+				log4j.put("log4j2.rootLogger.appenderRef.paxosgi.ref", "paxosgi");
 				config.update(log4j);
 			}
 		} catch (IOException | SecurityException e) {

--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -18,11 +18,11 @@
 -runbundles+: \
 	org.apache.felix.scr;startlevel=10,\
 	org.eclipse.equinox.event;startlevel=11,\
-    org.ops4j.pax.logging.pax-logging-log4j1;startlevel=12
+    org.ops4j.pax.logging.pax-logging-log4j2;startlevel=12
 
 -runrequires: \
 	bnd.identity;id='org.ops4j.pax.logging.pax-logging-api',\
-	bnd.identity;id='org.ops4j.pax.logging.pax-logging-log4j1',\
+	bnd.identity;id='org.ops4j.pax.logging.pax-logging-log4j2',\
 	bnd.identity;id='org.apache.felix.http.jetty',\
 	bnd.identity;id='org.apache.felix.webconsole',\
 	bnd.identity;id='org.apache.felix.webconsole.plugins.ds',\
@@ -323,8 +323,8 @@
 	org.jsr-305;version='[3.0.2,3.0.3)',\
 	org.openmuc.jmbus;version='[3.3.0,3.3.1)',\
 	org.openmuc.jrxtx;version='[1.0.1,1.0.2)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.11,2.0.12)',\
-	org.ops4j.pax.logging.pax-logging-log4j1;version='[2.0.11,2.0.12)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.13,2.0.14)',\
+	org.ops4j.pax.logging.pax-logging-log4j2;version='[2.0.13,2.0.14)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
 	rrd4j;version='[3.8.0,3.8.1)'

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
@@ -99,22 +99,19 @@ public class DefaultConfigurationWorker extends ComponentManagerWorker {
 		 * Create Default Logging configuration
 		 */
 		if (existingConfigs.stream().noneMatch(c -> //
-		"org.ops4j.pax.logging".equals(c.pid))) {
+		"org.ops4j.pax.logging".equals(c.pid) && c.properties.get("log4j2.rootLogger.level") != null)) {
 			// Adding Configuration manually, because this is not a OpenEMS Configuration
 			try {
 				Hashtable<String, Object> log4j = new Hashtable<>();
-				log4j.put("log4j2.rootLogger", "INFO, CONSOLE, osgi:*");
-
 				log4j.put("log4j2.appender.console.type", "Console");
 				log4j.put("log4j2.appender.console.name", "console");
 				log4j.put("log4j2.appender.console.layout.type", "PatternLayout");
 				log4j.put("log4j2.appender.console.layout.pattern", "%d{ISO8601} [%-8.8t] %-5p [%-30.30c] %m%n");
 
-				log4j.put("log4j2.appender.osgi.type", "PaxOsgi");
-				log4j.put("log4j2.appender.osgi.name", "paxosgi");
+				log4j.put("log4j2.appender.paxosgi.type", "PaxOsgi");
+				log4j.put("log4j2.appender.paxosgi.name", "paxosgi");
 
-				log4j.put("log4j2.rootLogger.level", "info");
-				log4j.put("log4j2.rootLogger.appenderRefs", "console, osgi");
+				log4j.put("log4j2.rootLogger.level", "INFO");
 				log4j.put("log4j2.rootLogger.appenderRef.console.ref", "console");
 				log4j.put("log4j2.rootLogger.appenderRef.paxosgi.ref", "paxosgi");
 				Configuration config = this.parent.cm.getConfiguration("org.ops4j.pax.logging", null);

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/DefaultConfigurationWorker.java
@@ -103,12 +103,20 @@ public class DefaultConfigurationWorker extends ComponentManagerWorker {
 			// Adding Configuration manually, because this is not a OpenEMS Configuration
 			try {
 				Hashtable<String, Object> log4j = new Hashtable<>();
-				log4j.put("log4j.rootLogger", "INFO, CONSOLE, osgi:*");
-				log4j.put("log4j.appender.CONSOLE", "org.apache.log4j.ConsoleAppender");
-				log4j.put("log4j.appender.CONSOLE.layout", "org.apache.log4j.PatternLayout");
-				log4j.put("log4j.appender.CONSOLE.layout.ConversionPattern",
-						"%d{ISO8601} [%-8.8t] %-5p [%-30.30c] %m%n");
-				log4j.put("log4j.logger.org.eclipse.osgi", "WARN");
+				log4j.put("log4j2.rootLogger", "INFO, CONSOLE, osgi:*");
+
+				log4j.put("log4j2.appender.console.type", "Console");
+				log4j.put("log4j2.appender.console.name", "console");
+				log4j.put("log4j2.appender.console.layout.type", "PatternLayout");
+				log4j.put("log4j2.appender.console.layout.pattern", "%d{ISO8601} [%-8.8t] %-5p [%-30.30c] %m%n");
+
+				log4j.put("log4j2.appender.osgi.type", "PaxOsgi");
+				log4j.put("log4j2.appender.osgi.name", "paxosgi");
+
+				log4j.put("log4j2.rootLogger.level", "info");
+				log4j.put("log4j2.rootLogger.appenderRefs", "console, osgi");
+				log4j.put("log4j2.rootLogger.appenderRef.console.ref", "console");
+				log4j.put("log4j2.rootLogger.appenderRef.paxosgi.ref", "paxosgi");
 				Configuration config = this.parent.cm.getConfiguration("org.ops4j.pax.logging", null);
 				config.update(log4j);
 			} catch (IOException e) {


### PR DESCRIPTION
Hi Stefan,

as discussed in the [community](https://community.openems.io/t/schwachstelle-in-log4j-und-openems/707/5), I have created a merge request regarding my Log4J2 changes.
The idea is to use a `PaxOsgi`appender, as described [here](https://ops4j1.jira.com/wiki/spaces/paxlogging/pages/499613746/Configuring+Log4J2).

I was able to test the changes successfully for the OpenEMS edge running on my local machine. However, the configuration file in 'pax/logging.config' is not updated when I start the backend locally.
Unfortunately, I was not able to find out why, but the problem already existed before applying my changes, so it might be an issue with the development branch.

Originally, I have developed these changes for a slightly older version of OpenEMS which still runs on Java 8. On this version, both OpenEMS Backend and Edge are working fine.

Regards,

Olaf