### PR TITLE
Downgrade j2mod/jSerialComm

### DIFF
--- a/cnf/pom.xml
+++ b/cnf/pom.xml
@@ -14,12 +14,12 @@
 		<dependency>
 			<groupId>com.fazecast</groupId>
 			<artifactId>jSerialComm</artifactId>
-			<version>2.7.0</version>
+			<version>2.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ghgande</groupId>
 			<artifactId>j2mod</artifactId>
-			<version>3.0.0</version>
+			<version>2.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.rzymek</groupId>

--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -155,8 +155,8 @@
 
 -runbundles: \
 	Java-WebSocket;version='[1.5.2,1.5.3)',\
-	com.fazecast.jSerialComm;version='[2.7.0,2.7.1)',\
-	com.ghgande.j2mod;version='[3.0.0,3.0.1)',\
+	com.fazecast.jSerialComm;version='[2.5.1,2.5.2)',\
+	com.ghgande.j2mod;version='[2.5.5,2.5.6)',\
 	com.google.gson;version='[2.8.9,2.8.10)',\
 	com.google.guava;version='[31.0.1,31.0.2)',\
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/BridgeModbusSerialImpl.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/BridgeModbusSerialImpl.java
@@ -131,7 +131,6 @@ public class BridgeModbusSerialImpl extends AbstractModbusBridge
 			params.setStopbits(this.stopbits.getValue());
 			params.setParity(this.parity.getValue());
 			params.setEncoding(Modbus.SERIAL_ENCODING_RTU);
-			params.setRs485Mode(true);
 			params.setEcho(false);
 			SerialConnection connection = new SerialConnection(params);
 			this._connection = connection;


### PR DESCRIPTION
We have been trying a couple of times already to update j2mod and jSerialComm to there latest version, but it always fails, because jSerialComm somehow reconfigures the serial device and draws it unusable on our test systems. If anybody can help out, it will be much appreciated. Till then we will stay with the old version.