### PR TITLE
Fix OCPP dependencies for Java 11

### DIFF
--- a/cnf/pom.xml
+++ b/cnf/pom.xml
@@ -1,6 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>local</groupId>
@@ -76,6 +74,12 @@
 			<groupId>com.squareup.retrofit2</groupId>
 			<artifactId>retrofit</artifactId>
 			<version>2.9.0</version>
+		</dependency>
+		<dependency>
+			<!-- JavaBeans Activation Framework -->
+			<groupId>com.sun.activation</groupId>
+			<artifactId>javax.activation</artifactId>
+			<version>1.2.0</version>
 		</dependency>
 		<dependency>
 			<!-- HikariCP A solid, high-performance, JDBC connection pool at last. -->

--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -304,10 +304,12 @@
 	io.openems.wrapper.eu.chargetime.ocpp;version=snapshot,\
 	io.openems.wrapper.fastexcel;version=snapshot,\
 	io.openems.wrapper.influxdb-java;version=snapshot,\
+	io.openems.wrapper.javax.activation;version=snapshot,\
 	io.openems.wrapper.okhttp;version=snapshot,\
 	io.openems.wrapper.opczip;version=snapshot,\
 	io.openems.wrapper.paho-mqttv5;version=snapshot,\
 	io.openems.wrapper.sdnotify;version=snapshot,\
+	javax.xml.soap-api;version='[1.4.0,1.4.1)',\
 	org.apache.commons.commons-fileupload;version='[1.4.0,1.4.1)',\
 	org.apache.commons.commons-io;version='[2.8.0,2.8.1)',\
 	org.apache.commons.math3;version='[3.6.1,3.6.2)',\

--- a/io.openems.wrapper/bnd.bnd
+++ b/io.openems.wrapper/bnd.bnd
@@ -10,6 +10,7 @@ Bundle-Description: This wraps external java libraries that do not have OSGi hea
 	com.squareup.okio:okio;version='1.17.2',\
 	com.squareup.retrofit2:converter-moshi;version='2.9.0',\
 	com.squareup.retrofit2:retrofit;version='2.9.0',\
+	com.sun.activation.javax.activation;version='1.2.0',\
 	eu.chargetime.ocpp:OCPP-J;version='1.0.1',\
 	eu.chargetime.ocpp:common;version='1.0',\
 	eu.chargetime.ocpp:v1_6;version='1.0.1',\

--- a/io.openems.wrapper/eu.chargetime.ocpp.bnd
+++ b/io.openems.wrapper/eu.chargetime.ocpp.bnd
@@ -1,8 +1,8 @@
-Bundle-Name: SDNotify
-Bundle-Description:  SDNotify implements the systemd notification protocol in Java.
-Bundle-DocURL: https://github.com/faljse/SDNotify
-Bundle-License: https://opensource.org/licenses/LGPL-2.1
-Bundle-Version: 1.0
+Bundle-Name: Java-OCA-OCPP
+Bundle-Description: A client and server library of Open Charge-Point Protocol from openchargealliance.org
+Bundle-DocURL: https://github.com/ChargeTimeEU/Java-OCA-OCPP
+Bundle-License: https://opensource.org/licenses/MIT
+Bundle-Version: 1.0.1
 
 Include-Resource: \
 	@v1_6-1.0.1.jar, \
@@ -14,8 +14,8 @@ Include-Resource: \
 -metatypeannotations: *
 
 Import-Package: \
-    com.sun.activation.registries;resolution:=optional,\
-    javax.xml.soap;resolution:=optional,\
+    com.sun.activation.registries,\
+    javax.xml.soap,\
     com.google.gson,\
     javax.xml.transform,\
     org.java_websocket,\

--- a/io.openems.wrapper/javax.activation.bnd
+++ b/io.openems.wrapper/javax.activation.bnd
@@ -1,0 +1,19 @@
+Bundle-Name: JavaBeans Activation Framework
+Bundle-License: https://opensource.org/licenses/CDDL-1.0
+Bundle-Version: 1.2.0
+
+Include-Resource: \
+	@javax.activation-1.2.0.jar
+
+-dsannotations: *
+
+-metatypeannotations: *
+
+Import-Package: \
+
+Export-Package: \
+    com.sun.activation.registries,\
+    com.sun.activation.viewers,\
+	javax.activation,\
+	
+-sources: false

--- a/io.openems.wrapper/sdnotify.bnd
+++ b/io.openems.wrapper/sdnotify.bnd
@@ -1,5 +1,5 @@
 Bundle-Name: SDNotify
-Bundle-Description:  SDNotify implements the systemd notification protocol in Java.
+Bundle-Description: SDNotify implements the systemd notification protocol in Java.
 Bundle-DocURL: https://github.com/faljse/SDNotify
 Bundle-License: https://opensource.org/licenses/LGPL-2.1
 Bundle-Version: 1.3


### PR DESCRIPTION
With Java 11 `javax.activation` was dropped from the JRE. This adds the library as an explicit dependency.