### PR TITLE
Modbus/TCP: Add GridMode to Sum (#204)

### DIFF
--- a/io.openems.common/src/io/openems/common/OpenemsConstants.java
+++ b/io.openems.common/src/io/openems/common/OpenemsConstants.java
@@ -98,8 +98,6 @@ public class OpenemsConstants {
 	 */
 	public static final String MANUFACTURER_EMS_SERIAL_NUMBER = "";
 
-	public static final String POWER_DOC_TEXT = "Negative values for Consumption; positive for Production";
-
 	/*
 	 * Constants for Component properties
 	 */

--- a/io.openems.common/src/io/openems/common/types/OptionsEnum.java
+++ b/io.openems.common/src/io/openems/common/types/OptionsEnum.java
@@ -9,21 +9,21 @@ public interface OptionsEnum {
 	 *
 	 * @return the int representation
 	 */
-	int getValue();
+	public int getValue();
 
 	/**
 	 * Gets this enums String representation.
 	 *
 	 * @return the String representation
 	 */
-	String getName();
+	public String getName();
 
 	/**
 	 * Gets the enum that is used for 'UNDEFINED' values.
 	 *
 	 * @return the UNDEFINED enum
 	 */
-	OptionsEnum getUndefined();
+	public OptionsEnum getUndefined();
 
 	/**
 	 * Gets the name in CamelCase format.

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/EnumDoc.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/EnumDoc.java
@@ -1,6 +1,8 @@
 package io.openems.edge.common.channel;
 
 import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.openems.common.channel.ChannelCategory;
 import io.openems.common.exceptions.OpenemsError;
@@ -142,5 +144,22 @@ public class EnumDoc extends AbstractDoc<Integer> {
 			return Value.UNDEFINED_VALUE_STRING;
 		}
 		return option.getName();
+	}
+
+	@Override
+	public String getText() {
+		// If Doc has a Text, return it
+		var docText = super.getText();
+		if (!docText.isBlank()) {
+			return docText;
+		}
+		// Otherwise generate Text from options without UNDEFINED option in the form
+		// "<value>:<name>, <value>:<name>".
+		return Stream.of(this.options) //
+				.filter(option -> !option.isUndefined()) //
+				.map(option -> { //
+					return option.getValue() + ":" + option.getName(); //
+				}) //
+				.collect(Collectors.joining(", "));
 	}
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/component/OpenemsComponent.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/OpenemsComponent.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.osgi.framework.Constants;
 import org.osgi.service.cm.Configuration;
@@ -187,6 +189,12 @@ public interface OpenemsComponent {
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
 		// Running State of the component. Keep values in sync with 'Level' enum!
 		STATE(new StateCollectorChannelDoc() //
+				// Set Text to "0:Ok, 1:Info, 2:Warning, 3:Fault"
+				.text(Stream.of(Level.values()) //
+						.map(option -> { //
+							return option.getValue() + ":" + option.getName(); //
+						}) //
+						.collect(Collectors.joining(", "))) //
 				.persistencePriority(PersistencePriority.VERY_HIGH));
 
 		private final Doc doc;
@@ -210,7 +218,7 @@ public interface OpenemsComponent {
 	 */
 	public static ModbusSlaveNatureTable getModbusSlaveNatureTable(AccessMode accessMode) {
 		return ModbusSlaveNatureTable.of(OpenemsComponent.class, accessMode, 80) //
-				.channel(0, ChannelId.STATE, ModbusType.UINT16) //
+				.channel(0, ChannelId.STATE, ModbusType.ENUM16) //
 				.build();
 	}
 

--- a/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordChannel.java
@@ -1,9 +1,7 @@
 package io.openems.edge.common.modbusslave;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,8 +11,6 @@ import io.openems.common.channel.Unit;
 import io.openems.common.types.ChannelAddress;
 import io.openems.edge.common.channel.Channel;
 import io.openems.edge.common.channel.ChannelId;
-import io.openems.edge.common.channel.Doc;
-import io.openems.edge.common.channel.EnumDoc;
 import io.openems.edge.common.component.OpenemsComponent;
 
 public class ModbusRecordChannel extends ModbusRecord {
@@ -49,6 +45,7 @@ public class ModbusRecordChannel extends ModbusRecord {
 		case STRING16:
 			byteLength = ModbusRecordString16.BYTE_LENGTH;
 			break;
+		case ENUM16:
 		case UINT16:
 			byteLength = ModbusRecordUint16.BYTE_LENGTH;
 			break;
@@ -141,6 +138,7 @@ public class ModbusRecordChannel extends ModbusRecord {
 			case WRITE_ONLY:
 				return ModbusRecordString16Reserved.UNDEFINED_VALUE;
 			}
+		case ENUM16:
 		case UINT16:
 			switch (this.accessMode) {
 			case READ_ONLY:
@@ -211,6 +209,8 @@ public class ModbusRecordChannel extends ModbusRecord {
 		case STRING16:
 			value = ""; // TODO implement String conversion
 			break;
+
+		case ENUM16:
 		case UINT16:
 			value = buff.getShort();
 			break;
@@ -239,18 +239,7 @@ public class ModbusRecordChannel extends ModbusRecord {
 
 	@Override
 	public String getValueDescription() {
-		Doc doc = this.channelId.doc();
-		if (doc instanceof EnumDoc) {
-			// List possible Options for this Enum
-			EnumDoc d = (EnumDoc) doc;
-			return Arrays.stream(d.getOptions()) //
-					.map(option -> {
-						return option.getValue() + ":" + option.getName();
-					}) //
-					.collect(Collectors.joining(", "));
-		}
-
-		return ""; // TODO get some meaningful text from Doc(), like 'between 0 and 100 %'
+		return this.channelId.doc().getText();
 	}
 
 	@Override

--- a/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordFloat32.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordFloat32.java
@@ -37,7 +37,7 @@ public class ModbusRecordFloat32 extends ModbusRecordConstant {
 
 	@Override
 	public String getValueDescription() {
-		return this.value != null ? this.value.toString() : "";
+		return this.value != null ? "\"" + this.value.toString() + "\"" : "";
 	}
 
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordFloat64.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordFloat64.java
@@ -38,7 +38,7 @@ public class ModbusRecordFloat64 extends ModbusRecordConstant {
 
 	@Override
 	public String getValueDescription() {
-		return this.value != null ? this.value.toString() : "";
+		return this.value != null ? "\"" + this.value.toString() + "\"" : "";
 	}
 
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordString16.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordString16.java
@@ -40,7 +40,7 @@ public class ModbusRecordString16 extends ModbusRecordConstant {
 
 	@Override
 	public String getValueDescription() {
-		return this.value != null ? this.value : "";
+		return this.value != null ? "\"" + this.value.toString() + "\"" : "";
 	}
 
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordUint16.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordUint16.java
@@ -38,7 +38,7 @@ public class ModbusRecordUint16 extends ModbusRecordConstant {
 
 	@Override
 	public String getValueDescription() {
-		return this.value != null ? Short.toString(this.value) : "";
+		return this.value != null ? "\"" + Short.toString(this.value) + "\"" : "";
 	}
 
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordUint16Hash.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordUint16Hash.java
@@ -17,7 +17,7 @@ public class ModbusRecordUint16Hash extends ModbusRecordUint16 {
 
 	@Override
 	public String getValueDescription() {
-		return "0x" + Integer.toHexString(this.value & 0xffff);
+		return "\"0x" + Integer.toHexString(this.value & 0xffff) + "\"";
 	}
 
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordUint32.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordUint32.java
@@ -38,7 +38,7 @@ public class ModbusRecordUint32 extends ModbusRecordConstant {
 
 	@Override
 	public String getValueDescription() {
-		return this.value != null ? Integer.toString(this.value) : "";
+		return this.value != null ? "\"" + Integer.toString(this.value) + "\"" : "";
 	}
 
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusSlaveNatureTable.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusSlaveNatureTable.java
@@ -48,6 +48,7 @@ public final class ModbusSlaveNatureTable {
 				case STRING16:
 					this.string16Reserved(offset);
 					break;
+				case ENUM16:
 				case UINT16:
 					this.uint16Reserved(offset);
 					break;

--- a/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusType.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusType.java
@@ -1,6 +1,7 @@
 package io.openems.edge.common.modbusslave;
 
 public enum ModbusType {
+	ENUM16(1, "enum16"), //
 	UINT16(1, "uint16"), //
 	UINT32(2, "uint32"), //
 	FLOAT32(2, "float32"), //

--- a/io.openems.edge.common/src/io/openems/edge/common/sum/Sum.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/sum/Sum.java
@@ -1,6 +1,5 @@
 package io.openems.edge.common.sum;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.channel.AccessMode;
 import io.openems.common.channel.Level;
 import io.openems.common.channel.PersistencePriority;
@@ -37,7 +36,8 @@ public interface Sum extends OpenemsComponent {
 		 */
 		ESS_SOC(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.PERCENT) //
-				.persistencePriority(PersistencePriority.VERY_HIGH)),
+				.persistencePriority(PersistencePriority.VERY_HIGH) //
+				.text("Range 0..100")), //
 		/**
 		 * Ess: Active Power.
 		 * 
@@ -51,7 +51,9 @@ public interface Sum extends OpenemsComponent {
 		ESS_ACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.VERY_HIGH) //
-				.text(OpenemsConstants.POWER_DOC_TEXT)),
+				.text("AC-side power of Energy Storage System. " //
+						+ "Includes excess DC-PV production for hybrid inverters. " //
+						+ "Negative values for charge; positive for discharge")),
 		/**
 		 * Reactive Power.
 		 * 
@@ -59,14 +61,11 @@ public interface Sum extends OpenemsComponent {
 		 * <li>Interface: Ess Symmetric
 		 * <li>Type: Integer
 		 * <li>Unit: var
-		 * <li>Range: negative values for Charge; positive for Discharge
 		 * </ul>
 		 */
 		ESS_REACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.VOLT_AMPERE_REACTIVE) //
-				.persistencePriority(PersistencePriority.VERY_HIGH) //
-				.text(OpenemsConstants.POWER_DOC_TEXT) //
-		),
+				.persistencePriority(PersistencePriority.VERY_HIGH)), //
 		/**
 		 * Ess: Active Power L1.
 		 * 
@@ -80,7 +79,9 @@ public interface Sum extends OpenemsComponent {
 		ESS_ACTIVE_POWER_L1(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.VERY_HIGH) //
-				.text(OpenemsConstants.POWER_DOC_TEXT)),
+				.text("AC-side power of Energy Storage System on phase L1. " //
+						+ "Includes excess DC-PV production for hybrid inverters. " //
+						+ "Negative values for charge; positive for discharge")),
 		/**
 		 * Ess: Active Power L2.
 		 * 
@@ -94,7 +95,9 @@ public interface Sum extends OpenemsComponent {
 		ESS_ACTIVE_POWER_L2(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.VERY_HIGH) //
-				.text(OpenemsConstants.POWER_DOC_TEXT)),
+				.text("AC-side power of Energy Storage System on phase L2. " //
+						+ "Includes excess DC-PV production for hybrid inverters. " //
+						+ "Negative values for charge; positive for discharge")),
 		/**
 		 * Ess: Active Power L3.
 		 * 
@@ -108,7 +111,9 @@ public interface Sum extends OpenemsComponent {
 		ESS_ACTIVE_POWER_L3(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.VERY_HIGH) //
-				.text(OpenemsConstants.POWER_DOC_TEXT)),
+				.text("AC-side power of Energy Storage System on phase L3. " //
+						+ "Includes excess DC-PV production for hybrid inverters. " //
+						+ "Negative values for charge; positive for discharge")),
 		/**
 		 * Ess: Discharge Power.
 		 * 
@@ -127,7 +132,8 @@ public interface Sum extends OpenemsComponent {
 		ESS_DISCHARGE_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.VERY_HIGH) //
-				.text(OpenemsConstants.POWER_DOC_TEXT)),
+				.text("Actual AC-side battery discharge power of Energy Storage System. " //
+						+ "Negative values for charge; positive for discharge")),
 		/**
 		 * Ess: Capacity.
 		 * 
@@ -157,7 +163,8 @@ public interface Sum extends OpenemsComponent {
 		GRID_ACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.VERY_HIGH) //
-				.text(OpenemsConstants.POWER_DOC_TEXT)),
+				.text("Grid exchange power. " //
+						+ "Negative values for sell-to-grid; positive for buy-from-grid")),
 		/**
 		 * Grid: Active Power L1.
 		 * 
@@ -173,7 +180,8 @@ public interface Sum extends OpenemsComponent {
 		GRID_ACTIVE_POWER_L1(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.VERY_HIGH) //
-				.text(OpenemsConstants.POWER_DOC_TEXT)),
+				.text("Grid exchange power on phase L1. " //
+						+ "Negative values for sell-to-grid; positive for buy-from-grid")),
 		/**
 		 * Grid: Active Power L2.
 		 * 
@@ -189,7 +197,8 @@ public interface Sum extends OpenemsComponent {
 		GRID_ACTIVE_POWER_L2(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.VERY_HIGH) //
-				.text(OpenemsConstants.POWER_DOC_TEXT)),
+				.text("Grid exchange power on phase L2. " //
+						+ "Negative values for sell-to-grid; positive for buy-from-grid")),
 		/**
 		 * Grid: Active Power L3.
 		 * 
@@ -205,7 +214,8 @@ public interface Sum extends OpenemsComponent {
 		GRID_ACTIVE_POWER_L3(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.VERY_HIGH) //
-				.text(OpenemsConstants.POWER_DOC_TEXT)),
+				.text("Grid exchange power on phase L3. " //
+						+ "Negative values for sell-to-grid; positive for buy-from-grid")),
 		/**
 		 * Grid: Minimum Ever Active Power.
 		 * 
@@ -244,7 +254,8 @@ public interface Sum extends OpenemsComponent {
 		 */
 		PRODUCTION_ACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
-				.persistencePriority(PersistencePriority.VERY_HIGH)), //
+				.persistencePriority(PersistencePriority.VERY_HIGH) //
+				.text("Total production; always positive")),
 		/**
 		 * Production: AC Active Power.
 		 * 
@@ -257,7 +268,8 @@ public interface Sum extends OpenemsComponent {
 		 */
 		PRODUCTION_AC_ACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
-				.persistencePriority(PersistencePriority.VERY_HIGH)), //
+				.persistencePriority(PersistencePriority.VERY_HIGH) //
+				.text("Production from AC source")),
 		/**
 		 * Production: AC Active Power L1.
 		 * 
@@ -270,7 +282,8 @@ public interface Sum extends OpenemsComponent {
 		 */
 		PRODUCTION_AC_ACTIVE_POWER_L1(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
-				.persistencePriority(PersistencePriority.VERY_HIGH)), //
+				.persistencePriority(PersistencePriority.VERY_HIGH) //
+				.text("Production from AC source on phase L1")),
 		/**
 		 * Production: AC Active Power L2.
 		 * 
@@ -283,7 +296,8 @@ public interface Sum extends OpenemsComponent {
 		 */
 		PRODUCTION_AC_ACTIVE_POWER_L2(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
-				.persistencePriority(PersistencePriority.VERY_HIGH)), //
+				.persistencePriority(PersistencePriority.VERY_HIGH) //
+				.text("Production from AC source on phase L2")),
 		/**
 		 * Production: AC Active Power L3.
 		 * 
@@ -296,7 +310,8 @@ public interface Sum extends OpenemsComponent {
 		 */
 		PRODUCTION_AC_ACTIVE_POWER_L3(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
-				.persistencePriority(PersistencePriority.VERY_HIGH)), //
+				.persistencePriority(PersistencePriority.VERY_HIGH) //
+				.text("Production from AC source on phase L3")),
 		/**
 		 * Production: DC Actual Power.
 		 * 
@@ -309,7 +324,8 @@ public interface Sum extends OpenemsComponent {
 		 */
 		PRODUCTION_DC_ACTUAL_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
-				.persistencePriority(PersistencePriority.VERY_HIGH)), //
+				.persistencePriority(PersistencePriority.VERY_HIGH) //
+				.text("Production from DC source")),
 		/**
 		 * Production: Maximum Ever Active Power.
 		 * 
@@ -428,7 +444,7 @@ public interface Sum extends OpenemsComponent {
 		 * <ul>
 		 * <li>Interface: Sum (origin: SymmetricEss))
 		 * <li>Type: Integer
-		 * <li>Values: '0' = UNDEFINED, '1' = ON GRID, '2' = OFF GRID
+		 * <li>Values: '-1' = UNDEFINED, '1' = On-Grid, '2' = Off-Grid
 		 * </ul>
 		 */
 		GRID_MODE(Doc.of(GridMode.values()) //
@@ -550,7 +566,6 @@ public interface Sum extends OpenemsComponent {
 		 * <li>Unit: Wh
 		 * </ul>
 		 */
-		// TODO rename to Actual_Energy
 		PRODUCTION_DC_ACTIVE_ENERGY(Doc.of(OpenemsType.LONG) //
 				.unit(Unit.WATT_HOURS) //
 				.persistencePriority(PersistencePriority.VERY_HIGH)), //
@@ -643,6 +658,7 @@ public interface Sum extends OpenemsComponent {
 				.channel(109, ChannelId.CONSUMPTION_ACTIVE_POWER_L2, ModbusType.FLOAT32) //
 				.channel(111, ChannelId.CONSUMPTION_ACTIVE_POWER_L3, ModbusType.FLOAT32) //
 				.channel(113, ChannelId.ESS_DISCHARGE_POWER, ModbusType.FLOAT32) //
+				.channel(115, ChannelId.GRID_MODE, ModbusType.ENUM16) //
 				.build();
 	}
 

--- a/io.openems.edge.controller.api.modbus/src/io/openems/edge/controller/api/modbus/jsonrpc/GetModbusProtocolExportXlsxResponse.java
+++ b/io.openems.edge.controller.api.modbus/src/io/openems/edge/controller/api/modbus/jsonrpc/GetModbusProtocolExportXlsxResponse.java
@@ -44,9 +44,9 @@ public class GetModbusProtocolExportXlsxResponse extends Base64PayloadResponse {
 	}
 
 	private static final int COL_ADDRESS = 0;
-	private static final int COL_DESCRIPTION = 1;
+	private static final int COL_NAME = 1;
 	private static final int COL_TYPE = 2;
-	private static final int COL_VALUE = 3;
+	private static final int COL_VALUE_DESCRIPTION = 3;
 	private static final int COL_UNIT = 4;
 	private static final int COL_ACCESS = 5;
 
@@ -62,9 +62,9 @@ public class GetModbusProtocolExportXlsxResponse extends Base64PayloadResponse {
 					ws = wb.newWorksheet("Modbus-Table");
 
 					ws.width(COL_ADDRESS, 10);
-					ws.width(COL_DESCRIPTION, 25);
+					ws.width(COL_NAME, 25);
 					ws.width(COL_TYPE, 10);
-					ws.width(COL_VALUE, 35);
+					ws.width(COL_VALUE_DESCRIPTION, 150);
 					ws.width(COL_UNIT, 20);
 					ws.width(COL_ACCESS, 10);
 					// Add headers
@@ -115,9 +115,9 @@ public class GetModbusProtocolExportXlsxResponse extends Base64PayloadResponse {
 
 	private static void addSheetHeader(Workbook workbook, Worksheet sheet) {
 		sheet.value(0, COL_ADDRESS, "Address");
-		sheet.value(0, COL_DESCRIPTION, "Description");
+		sheet.value(0, COL_NAME, "Name");
 		sheet.value(0, COL_TYPE, "Type");
-		sheet.value(0, COL_VALUE, "Value/Range");
+		sheet.value(0, COL_VALUE_DESCRIPTION, "Value/Description");
 		sheet.value(0, COL_UNIT, "Unit");
 		sheet.value(0, COL_ACCESS, "Access");
 		sheet.style(0, 0).bold().fillColor(Color.GRAY5).borderStyle("thin");
@@ -130,9 +130,9 @@ public class GetModbusProtocolExportXlsxResponse extends Base64PayloadResponse {
 
 	private static void addRecord(Worksheet sheet, int address, ModbusRecord record, int rowCount) {
 		sheet.value(rowCount, COL_ADDRESS, address);
-		sheet.value(rowCount, COL_DESCRIPTION, record.getName());
+		sheet.value(rowCount, COL_NAME, record.getName());
 		sheet.value(rowCount, COL_TYPE, record.getType().toString());
-		sheet.value(rowCount, COL_VALUE, record.getValueDescription());
+		sheet.value(rowCount, COL_VALUE_DESCRIPTION, record.getValueDescription());
 		Unit unit = record.getUnit();
 		if (unit != Unit.NONE) {
 			sheet.value(rowCount, COL_UNIT, unit.toString());
@@ -165,6 +165,7 @@ public class GetModbusProtocolExportXlsxResponse extends Base64PayloadResponse {
 			case STRING16:
 				value = ModbusRecordString16.UNDEFINED_VALUE;
 				break;
+			case ENUM16:
 			case UINT16:
 				value = ModbusRecordUint16.UNDEFINED_VALUE;
 				break;

--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/api/AsymmetricEss.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/api/AsymmetricEss.java
@@ -32,8 +32,9 @@ public interface AsymmetricEss extends SymmetricEss {
 		ACTIVE_POWER_L1(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.HIGH) //
-				.text(POWER_DOC_TEXT) //
-		),
+				.text("AC-side power of Energy Storage System on phase L1. " //
+						+ "Includes excess DC-PV production for hybrid inverters. " //
+						+ "Negative values for charge; positive for discharge")),
 		/**
 		 * Active Power L2
 		 * 
@@ -47,8 +48,9 @@ public interface AsymmetricEss extends SymmetricEss {
 		ACTIVE_POWER_L2(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.HIGH) //
-				.text(POWER_DOC_TEXT) //
-		),
+				.text("AC-side power of Energy Storage System on phase L2. " //
+						+ "Includes excess DC-PV production for hybrid inverters. " //
+						+ "Negative values for charge; positive for discharge")),
 		/**
 		 * Active Power L3
 		 * 
@@ -62,8 +64,9 @@ public interface AsymmetricEss extends SymmetricEss {
 		ACTIVE_POWER_L3(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.HIGH) //
-				.text(POWER_DOC_TEXT) //
-		),
+				.text("AC-side power of Energy Storage System on phase L3. " //
+						+ "Includes excess DC-PV production for hybrid inverters. " //
+						+ "Negative values for charge; positive for discharge")),
 		/**
 		 * Reactive Power L1
 		 * 
@@ -76,9 +79,7 @@ public interface AsymmetricEss extends SymmetricEss {
 		 */
 		REACTIVE_POWER_L1(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.VOLT_AMPERE_REACTIVE) //
-				.persistencePriority(PersistencePriority.HIGH) //
-				.text(POWER_DOC_TEXT) //
-		),
+				.persistencePriority(PersistencePriority.HIGH)), //
 		/**
 		 * Reactive Power L2
 		 * 
@@ -91,9 +92,7 @@ public interface AsymmetricEss extends SymmetricEss {
 		 */
 		REACTIVE_POWER_L2(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.VOLT_AMPERE_REACTIVE) //
-				.persistencePriority(PersistencePriority.HIGH) //
-				.text(POWER_DOC_TEXT) //
-		),
+				.persistencePriority(PersistencePriority.HIGH)), //
 		/**
 		 * Reactive Power L3
 		 * 
@@ -106,9 +105,8 @@ public interface AsymmetricEss extends SymmetricEss {
 		 */
 		REACTIVE_POWER_L3(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.VOLT_AMPERE_REACTIVE) //
-				.persistencePriority(PersistencePriority.HIGH) //
-				.text(POWER_DOC_TEXT) //
-		);
+				.persistencePriority(PersistencePriority.HIGH)) //
+		;
 
 		private final Doc doc;
 

--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/api/CalculateGridMode.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/api/CalculateGridMode.java
@@ -29,6 +29,10 @@ public class CalculateGridMode {
 	 * @return
 	 */
 	public GridMode calculate() {
+		if(this.values.isEmpty()) {
+			return GridMode.UNDEFINED;
+		}
+		
 		int onGrids = 0;
 		int offGrids = 0;
 		for (GridMode gridMode : this.values) {

--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/api/HybridEss.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/api/HybridEss.java
@@ -36,8 +36,8 @@ public interface HybridEss extends SymmetricEss {
 		DC_DISCHARGE_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.HIGH) //
-				.text(POWER_DOC_TEXT) //
-		),
+				.text("Actual AC-side battery discharge power of Energy Storage System. " //
+						+ "Negative values for charge; positive for discharge")),
 		/**
 		 * DC Charge Energy.
 		 * 

--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/api/SymmetricEss.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/api/SymmetricEss.java
@@ -19,8 +19,6 @@ import io.openems.edge.common.sum.GridMode;
 @ProviderType
 public interface SymmetricEss extends OpenemsComponent {
 
-	public static final String POWER_DOC_TEXT = "Negative values for Charge; positive for Discharge";
-
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
 		/**
 		 * State of Charge.
@@ -73,7 +71,7 @@ public interface SymmetricEss extends OpenemsComponent {
 		ACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.HIGH) //
-				.text(POWER_DOC_TEXT) //
+				.text("Negative values for Charge; positive for Discharge") //
 		),
 		/**
 		 * Reactive Power.
@@ -82,13 +80,11 @@ public interface SymmetricEss extends OpenemsComponent {
 		 * <li>Interface: Ess Symmetric
 		 * <li>Type: Integer
 		 * <li>Unit: var
-		 * <li>Range: negative values for Charge; positive for Discharge
 		 * </ul>
 		 */
 		REACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.VOLT_AMPERE_REACTIVE) //
 				.persistencePriority(PersistencePriority.HIGH) //
-				.text(POWER_DOC_TEXT) //
 		),
 		/**
 		 * Holds the currently maximum possible apparent power. This value is commonly

--- a/io.openems.edge.meter.api/src/io/openems/edge/meter/api/SymmetricMeter.java
+++ b/io.openems.edge.meter.api/src/io/openems/edge/meter/api/SymmetricMeter.java
@@ -1,6 +1,5 @@
 package io.openems.edge.meter.api;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.channel.AccessMode;
 import io.openems.common.channel.PersistencePriority;
 import io.openems.common.channel.Unit;
@@ -87,7 +86,6 @@ public interface SymmetricMeter extends OpenemsComponent {
 		ACTIVE_POWER(new IntegerDoc() //
 				.unit(Unit.WATT) //
 				.persistencePriority(PersistencePriority.HIGH) //
-				.text(OpenemsConstants.POWER_DOC_TEXT) //
 				.onInit(channel -> {
 					channel.onSetNextValue(value -> {
 						/*
@@ -135,8 +133,7 @@ public interface SymmetricMeter extends OpenemsComponent {
 		 */
 		REACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.VOLT_AMPERE_REACTIVE) //
-				.persistencePriority(PersistencePriority.HIGH) //
-				.text(OpenemsConstants.POWER_DOC_TEXT)), //
+				.persistencePriority(PersistencePriority.HIGH)), //
 		/**
 		 * Active Production Energy.
 		 * 

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/evcs/AsymmetricMeterEvcs.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/evcs/AsymmetricMeterEvcs.java
@@ -1,6 +1,5 @@
 package io.openems.edge.simulator.evcs;
 
-import io.openems.common.OpenemsConstants;
 import io.openems.common.channel.PersistencePriority;
 import io.openems.common.channel.Unit;
 import io.openems.common.types.OpenemsType;
@@ -17,473 +16,469 @@ import io.openems.edge.meter.api.MeterType;
 
 public interface AsymmetricMeterEvcs extends OpenemsComponent {
 
-
-		public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
-			/**
-			 * Frequency.
-			 * 
-			 * <ul>
-			 * <li>Interface: Meter Symmetric
-			 * <li>Type: Integer
-			 * <li>Unit: mHz
-			 * <li>Range: only positive values
-			 * </ul>
-			 */
-			FREQUENCY(Doc.of(OpenemsType.INTEGER) //
-					.unit(Unit.MILLIHERTZ) //
-					.persistencePriority(PersistencePriority.HIGH)),
-			/**
-			 * Minimum Ever Active Power.
-			 * 
-			 * <ul>
-			 * <li>Interface: Meter Symmetric
-			 * <li>Type: Integer
-			 * <li>Unit: W
-			 * <li>Range: negative or '0'
-			 * <li>Implementation Note: value is automatically derived from ACTIVE_POWER
-			 * </ul>
-			 */
-			MIN_ACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
-					.unit(Unit.WATT) //
-					.persistencePriority(PersistencePriority.HIGH)),
-			/**
-			 * Maximum Ever Active Power.
-			 * 
-			 * <ul>
-			 * <li>Interface: Meter Symmetric
-			 * <li>Type: Integer
-			 * <li>Unit: W
-			 * <li>Range: positive or '0'
-			 * <li>Implementation Note: value is automatically derived from ACTIVE_POWER
-			 * </ul>
-			 */
-			MAX_ACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
-					.unit(Unit.WATT) //
-					.persistencePriority(PersistencePriority.HIGH)),
-			/**
-			 * Active Power.
-			 * 
-			 * <ul>
-			 * <li>Interface: Meter Symmetric
-			 * <li>Type: Integer
-			 * <li>Unit: W
-			 * <li>Range: negative values for Consumption (power that is 'leaving the
-			 * system', e.g. feed-to-grid); positive for Production (power that is 'entering
-			 * the system')
-			 * </ul>
-			 */
-			ACTIVE_POWER(new IntegerDoc() //
-					.unit(Unit.WATT) //
-					.persistencePriority(PersistencePriority.HIGH) //
-					.text(OpenemsConstants.POWER_DOC_TEXT) //
-					.onInit(channel -> {
-						channel.onSetNextValue(value -> {
-							/*
-							 * Fill Min/Max Active Power channels
-							 */
-							if (value.isDefined()) {
-								int newValue = value.get();
-								{
-									Channel<Integer> minActivePowerChannel = channel.getComponent()
-											.channel(ChannelId.MIN_ACTIVE_POWER);
-									int minActivePower = minActivePowerChannel.value().orElse(0);
-									int minNextActivePower = minActivePowerChannel.getNextValue().orElse(0);
-									if (newValue < Math.min(minActivePower, minNextActivePower)) {
-										// avoid getting called too often -> round to 100
-										newValue = IntUtils.roundToPrecision(newValue, Round.TOWARDS_ZERO, 100);
-										minActivePowerChannel.setNextValue(newValue);
-									}
-								}
-								{
-									Channel<Integer> maxActivePowerChannel = channel.getComponent()
-											.channel(ChannelId.MAX_ACTIVE_POWER);
-									int maxActivePower = maxActivePowerChannel.value().orElse(0);
-									int maxNextActivePower = maxActivePowerChannel.getNextValue().orElse(0);
-									if (newValue > Math.max(maxActivePower, maxNextActivePower)) {
-										// avoid getting called too often -> round to 100
-										newValue = IntUtils.roundToPrecision(newValue, Round.AWAY_FROM_ZERO, 100);
-										maxActivePowerChannel.setNextValue(newValue);
-									}
+	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+		/**
+		 * Frequency.
+		 * 
+		 * <ul>
+		 * <li>Interface: Meter Symmetric
+		 * <li>Type: Integer
+		 * <li>Unit: mHz
+		 * <li>Range: only positive values
+		 * </ul>
+		 */
+		FREQUENCY(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.MILLIHERTZ) //
+				.persistencePriority(PersistencePriority.HIGH)),
+		/**
+		 * Minimum Ever Active Power.
+		 * 
+		 * <ul>
+		 * <li>Interface: Meter Symmetric
+		 * <li>Type: Integer
+		 * <li>Unit: W
+		 * <li>Range: negative or '0'
+		 * <li>Implementation Note: value is automatically derived from ACTIVE_POWER
+		 * </ul>
+		 */
+		MIN_ACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.WATT) //
+				.persistencePriority(PersistencePriority.HIGH)),
+		/**
+		 * Maximum Ever Active Power.
+		 * 
+		 * <ul>
+		 * <li>Interface: Meter Symmetric
+		 * <li>Type: Integer
+		 * <li>Unit: W
+		 * <li>Range: positive or '0'
+		 * <li>Implementation Note: value is automatically derived from ACTIVE_POWER
+		 * </ul>
+		 */
+		MAX_ACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.WATT) //
+				.persistencePriority(PersistencePriority.HIGH)),
+		/**
+		 * Active Power.
+		 * 
+		 * <ul>
+		 * <li>Interface: Meter Symmetric
+		 * <li>Type: Integer
+		 * <li>Unit: W
+		 * <li>Range: negative values for Consumption (power that is 'leaving the
+		 * system', e.g. feed-to-grid); positive for Production (power that is 'entering
+		 * the system')
+		 * </ul>
+		 */
+		ACTIVE_POWER(new IntegerDoc() //
+				.unit(Unit.WATT) //
+				.persistencePriority(PersistencePriority.HIGH) //
+				.onInit(channel -> {
+					channel.onSetNextValue(value -> {
+						/*
+						 * Fill Min/Max Active Power channels
+						 */
+						if (value.isDefined()) {
+							int newValue = value.get();
+							{
+								Channel<Integer> minActivePowerChannel = channel.getComponent()
+										.channel(ChannelId.MIN_ACTIVE_POWER);
+								int minActivePower = minActivePowerChannel.value().orElse(0);
+								int minNextActivePower = minActivePowerChannel.getNextValue().orElse(0);
+								if (newValue < Math.min(minActivePower, minNextActivePower)) {
+									// avoid getting called too often -> round to 100
+									newValue = IntUtils.roundToPrecision(newValue, Round.TOWARDS_ZERO, 100);
+									minActivePowerChannel.setNextValue(newValue);
 								}
 							}
-						});
-					})), //
-
-			/**
-			 * Reactive Power.
-			 * 
-			 * <ul>
-			 * <li>Interface: Meter Symmetric
-			 * <li>Type: Integer
-			 * <li>Unit: var
-			 * <li>Range: negative values for Consumption (power that is 'leaving the
-			 * system', e.g. feed-to-grid); positive for Production (power that is 'entering
-			 * the system')
-			 * </ul>
-			 */
-			REACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
-					.unit(Unit.VOLT_AMPERE_REACTIVE) //
-					.persistencePriority(PersistencePriority.HIGH) //
-					.text(OpenemsConstants.POWER_DOC_TEXT)), //
-			/**
-			 * Active Production Energy.
-			 * 
-			 * <ul>
-			 * <li>Interface: Meter Symmetric
-			 * <li>Type: Integer
-			 * <li>Unit: Wh
-			 * </ul>
-			 */
-			ACTIVE_PRODUCTION_ENERGY(Doc.of(OpenemsType.LONG) //
-					.unit(Unit.WATT_HOURS) //
-					.persistencePriority(PersistencePriority.HIGH)),
-			/**
-			 * Voltage.
-			 * 
-			 * <ul>
-			 * <li>Interface: Meter Symmetric
-			 * <li>Type: Integer
-			 * <li>Unit: mV
-			 * </ul>
-			 */
-			VOLTAGE(Doc.of(OpenemsType.INTEGER) //
-					.unit(Unit.MILLIVOLT) //
-					.persistencePriority(PersistencePriority.HIGH)),
-			/**
-			 * Current.
-			 * 
-			 * <ul>
-			 * <li>Interface: Meter Symmetric
-			 * <li>Type: Integer
-			 * <li>Unit: mA
-			 * </ul>
-			 */
-			CURRENT(Doc.of(OpenemsType.INTEGER) //
-					.unit(Unit.MILLIAMPERE) //
-					.persistencePriority(PersistencePriority.HIGH));
-
-			private final Doc doc;
-
-			private ChannelId(Doc doc) {
-				this.doc = doc;
-			}
-
-			public Doc doc() {
-				return this.doc;
-			}
-		}
+							{
+								Channel<Integer> maxActivePowerChannel = channel.getComponent()
+										.channel(ChannelId.MAX_ACTIVE_POWER);
+								int maxActivePower = maxActivePowerChannel.value().orElse(0);
+								int maxNextActivePower = maxActivePowerChannel.getNextValue().orElse(0);
+								if (newValue > Math.max(maxActivePower, maxNextActivePower)) {
+									// avoid getting called too often -> round to 100
+									newValue = IntUtils.roundToPrecision(newValue, Round.AWAY_FROM_ZERO, 100);
+									maxActivePowerChannel.setNextValue(newValue);
+								}
+							}
+						}
+					});
+				})), //
 
 		/**
-		 * Gets the type of this Meter.
+		 * Reactive Power.
 		 * 
-		 * @return the MeterType
+		 * <ul>
+		 * <li>Interface: Meter Symmetric
+		 * <li>Type: Integer
+		 * <li>Unit: var
+		 * <li>Range: negative values for Consumption (power that is 'leaving the
+		 * system', e.g. feed-to-grid); positive for Production (power that is 'entering
+		 * the system')
+		 * </ul>
 		 */
-		MeterType getMeterType();
-
+		REACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.VOLT_AMPERE_REACTIVE) //
+				.persistencePriority(PersistencePriority.HIGH)), //
 		/**
-		 * Gets the Channel for {@link ChannelId#FREQUENCY}.
-		 *
-		 * @return the Channel
-		 */
-		public default IntegerReadChannel getFrequencyChannel() {
-			return this.channel(ChannelId.FREQUENCY);
-		}
-
-		/**
-		 * Gets the Frequency in [mHz]. See {@link ChannelId#FREQUENCY}.
-		 *
-		 * @return the Channel {@link Value}
-		 */
-		public default Value<Integer> getFrequency() {
-			return this.getFrequencyChannel().value();
-		}
-
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#FREQUENCY}
-		 * Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setFrequency(Integer value) {
-			this.getFrequencyChannel().setNextValue(value);
-		}
-
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#FREQUENCY}
-		 * Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setFrequency(int value) {
-			this.getFrequencyChannel().setNextValue(value);
-		}
-
-		/**
-		 * Gets the Channel for {@link ChannelId#MIN_ACTIVE_POWER}.
-		 *
-		 * @return the Channel
-		 */
-		public default IntegerReadChannel getMinActivePowerChannel() {
-			return this.channel(ChannelId.MIN_ACTIVE_POWER);
-		}
-
-		/**
-		 * Gets the Minimum Ever Active Power in [W]. See
-		 * {@link ChannelId#MIN_ACTIVE_POWER}.
-		 *
-		 * @return the Channel {@link Value}
-		 */
-		public default Value<Integer> getMinActivePower() {
-			return this.getMinActivePowerChannel().value();
-		}
-
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#MIN_ACTIVE_POWER}
-		 * Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setMinActivePower(Integer value) {
-			this.getMinActivePowerChannel().setNextValue(value);
-		}
-
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#MIN_ACTIVE_POWER}
-		 * Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setMinActivePower(int value) {
-			this.getMinActivePowerChannel().setNextValue(value);
-		}
-
-		/**
-		 * Gets the Channel for {@link ChannelId#MAX_ACTIVE_POWER}.
-		 *
-		 * @return the Channel
-		 */
-		public default IntegerReadChannel getMaxActivePowerChannel() {
-			return this.channel(ChannelId.MAX_ACTIVE_POWER);
-		}
-
-		/**
-		 * Gets the Maximum Ever Active Power in [W]. See
-		 * {@link ChannelId#MAX_ACTIVE_POWER}.
-		 *
-		 * @return the Channel {@link Value}
-		 */
-		public default Value<Integer> getMaxActivePower() {
-			return this.getMaxActivePowerChannel().value();
-		}
-
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#MAX_ACTIVE_POWER}
-		 * Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setMaxActivePower(Integer value) {
-			this.getMaxActivePowerChannel().setNextValue(value);
-		}
-
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#MAX_ACTIVE_POWER}
-		 * Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setMaxActivePower(int value) {
-			this.getMaxActivePowerChannel().setNextValue(value);
-		}
-
-		/**
-		 * Gets the Channel for {@link ChannelId#ACTIVE_POWER}.
-		 *
-		 * @return the Channel
-		 */
-		public default IntegerReadChannel getActivePowerChannel() {
-			return this.channel(ChannelId.ACTIVE_POWER);
-		}
-
-		/**
-		 * Gets the Active Power in [W]. Negative values for Consumption (power that is
-		 * 'leaving the system', e.g. feed-to-grid); positive for Production (power that
-		 * is 'entering the system'). See {@link ChannelId#ACTIVE_POWER}.
+		 * Active Production Energy.
 		 * 
-		 * @return the Channel {@link Value}
+		 * <ul>
+		 * <li>Interface: Meter Symmetric
+		 * <li>Type: Integer
+		 * <li>Unit: Wh
+		 * </ul>
 		 */
-		public default Value<Integer> getActivePower() {
-			return this.getActivePowerChannel().value();
+		ACTIVE_PRODUCTION_ENERGY(Doc.of(OpenemsType.LONG) //
+				.unit(Unit.WATT_HOURS) //
+				.persistencePriority(PersistencePriority.HIGH)),
+		/**
+		 * Voltage.
+		 * 
+		 * <ul>
+		 * <li>Interface: Meter Symmetric
+		 * <li>Type: Integer
+		 * <li>Unit: mV
+		 * </ul>
+		 */
+		VOLTAGE(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.MILLIVOLT) //
+				.persistencePriority(PersistencePriority.HIGH)),
+		/**
+		 * Current.
+		 * 
+		 * <ul>
+		 * <li>Interface: Meter Symmetric
+		 * <li>Type: Integer
+		 * <li>Unit: mA
+		 * </ul>
+		 */
+		CURRENT(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.MILLIAMPERE) //
+				.persistencePriority(PersistencePriority.HIGH));
+
+		private final Doc doc;
+
+		private ChannelId(Doc doc) {
+			this.doc = doc;
 		}
 
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#ACTIVE_POWER}
-		 * Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setActivePower(Integer value) {
-			this.getActivePowerChannel().setNextValue(value);
+		public Doc doc() {
+			return this.doc;
 		}
+	}
 
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#ACTIVE_POWER}
-		 * Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setActivePower(int value) {
-			this.getActivePowerChannel().setNextValue(value);
-		}
+	/**
+	 * Gets the type of this Meter.
+	 * 
+	 * @return the MeterType
+	 */
+	MeterType getMeterType();
 
-		/**
-		 * Gets the Channel for {@link ChannelId#REACTIVE_POWER}.
-		 *
-		 * @return the Channel
-		 */
-		public default IntegerReadChannel getReactivePowerChannel() {
-			return this.channel(ChannelId.REACTIVE_POWER);
-		}
+	/**
+	 * Gets the Channel for {@link ChannelId#FREQUENCY}.
+	 *
+	 * @return the Channel
+	 */
+	public default IntegerReadChannel getFrequencyChannel() {
+		return this.channel(ChannelId.FREQUENCY);
+	}
 
-		/**
-		 * Gets the Reactive Power in [var]. See {@link ChannelId#REACTIVE_POWER}.
-		 *
-		 * @return the Channel {@link Value}
-		 */
-		public default Value<Integer> getReactivePower() {
-			return this.getReactivePowerChannel().value();
-		}
+	/**
+	 * Gets the Frequency in [mHz]. See {@link ChannelId#FREQUENCY}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Integer> getFrequency() {
+		return this.getFrequencyChannel().value();
+	}
 
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#REACTIVE_POWER}
-		 * Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setReactivePower(Integer value) {
-			this.getReactivePowerChannel().setNextValue(value);
-		}
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#FREQUENCY}
+	 * Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setFrequency(Integer value) {
+		this.getFrequencyChannel().setNextValue(value);
+	}
 
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#REACTIVE_POWER}
-		 * Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setReactivePower(int value) {
-			this.getReactivePowerChannel().setNextValue(value);
-		}
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#FREQUENCY}
+	 * Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setFrequency(int value) {
+		this.getFrequencyChannel().setNextValue(value);
+	}
 
-		/**
-		 * Gets the Channel for {@link ChannelId#ACTIVE_PRODUCTION_ENERGY}.
-		 *
-		 * @return the Channel
-		 */
-		public default LongReadChannel getActiveProductionEnergyChannel() {
-			return this.channel(ChannelId.ACTIVE_PRODUCTION_ENERGY);
-		}
+	/**
+	 * Gets the Channel for {@link ChannelId#MIN_ACTIVE_POWER}.
+	 *
+	 * @return the Channel
+	 */
+	public default IntegerReadChannel getMinActivePowerChannel() {
+		return this.channel(ChannelId.MIN_ACTIVE_POWER);
+	}
 
-		/**
-		 * Gets the Active Production Energy in [Wh]. This relates to positive
-		 * ACTIVE_POWER. See {@link ChannelId#ACTIVE_PRODUCTION_ENERGY}.
-		 *
-		 * @return the Channel {@link Value}
-		 */
-		public default Value<Long> getActiveProductionEnergy() {
-			return this.getActiveProductionEnergyChannel().value();
-		}
+	/**
+	 * Gets the Minimum Ever Active Power in [W]. See
+	 * {@link ChannelId#MIN_ACTIVE_POWER}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Integer> getMinActivePower() {
+		return this.getMinActivePowerChannel().value();
+	}
 
-		/**
-		 * Internal method to set the 'nextValue' on
-		 * {@link ChannelId#ACTIVE_PRODUCTION_ENERGY} Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setActiveProductionEnergy(Long value) {
-			this.getActiveProductionEnergyChannel().setNextValue(value);
-		}
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#MIN_ACTIVE_POWER}
+	 * Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setMinActivePower(Integer value) {
+		this.getMinActivePowerChannel().setNextValue(value);
+	}
 
-		/**
-		 * Internal method to set the 'nextValue' on
-		 * {@link ChannelId#ACTIVE_PRODUCTION_ENERGY} Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setActiveProductionEnergy(long value) {
-			this.getActiveProductionEnergyChannel().setNextValue(value);
-		}
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#MIN_ACTIVE_POWER}
+	 * Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setMinActivePower(int value) {
+		this.getMinActivePowerChannel().setNextValue(value);
+	}
 
-		/**
-		 * Gets the Channel for {@link ChannelId#VOLTAGE}.
-		 *
-		 * @return the Channel
-		 */
-		public default IntegerReadChannel getVoltageChannel() {
-			return this.channel(ChannelId.VOLTAGE);
-		}
+	/**
+	 * Gets the Channel for {@link ChannelId#MAX_ACTIVE_POWER}.
+	 *
+	 * @return the Channel
+	 */
+	public default IntegerReadChannel getMaxActivePowerChannel() {
+		return this.channel(ChannelId.MAX_ACTIVE_POWER);
+	}
 
-		/**
-		 * Gets the Voltage in [mV]. See {@link ChannelId#VOLTAGE}.
-		 *
-		 * @return the Channel {@link Value}
-		 */
-		public default Value<Integer> getVoltage() {
-			return this.getVoltageChannel().value();
-		}
+	/**
+	 * Gets the Maximum Ever Active Power in [W]. See
+	 * {@link ChannelId#MAX_ACTIVE_POWER}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Integer> getMaxActivePower() {
+		return this.getMaxActivePowerChannel().value();
+	}
 
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#VOLTAGE} Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setVoltage(Integer value) {
-			this.getVoltageChannel().setNextValue(value);
-		}
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#MAX_ACTIVE_POWER}
+	 * Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setMaxActivePower(Integer value) {
+		this.getMaxActivePowerChannel().setNextValue(value);
+	}
 
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#VOLTAGE} Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setVoltage(int value) {
-			this.getVoltageChannel().setNextValue(value);
-		}
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#MAX_ACTIVE_POWER}
+	 * Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setMaxActivePower(int value) {
+		this.getMaxActivePowerChannel().setNextValue(value);
+	}
 
-		/**
-		 * Gets the Channel for {@link ChannelId#CURRENT}.
-		 *
-		 * @return the Channel
-		 */
-		public default IntegerReadChannel getCurrentChannel() {
-			return this.channel(ChannelId.CURRENT);
-		}
+	/**
+	 * Gets the Channel for {@link ChannelId#ACTIVE_POWER}.
+	 *
+	 * @return the Channel
+	 */
+	public default IntegerReadChannel getActivePowerChannel() {
+		return this.channel(ChannelId.ACTIVE_POWER);
+	}
 
-		/**
-		 * Gets the Current in [mA]. See {@link ChannelId#CURRENT}.
-		 *
-		 * @return the Channel {@link Value}
-		 */
-		public default Value<Integer> getCurrent() {
-			return this.getCurrentChannel().value();
-		}
+	/**
+	 * Gets the Active Power in [W]. Negative values for Consumption (power that is
+	 * 'leaving the system', e.g. feed-to-grid); positive for Production (power that
+	 * is 'entering the system'). See {@link ChannelId#ACTIVE_POWER}.
+	 * 
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Integer> getActivePower() {
+		return this.getActivePowerChannel().value();
+	}
 
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#CURRENT} Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setCurrent(Integer value) {
-			this.getCurrentChannel().setNextValue(value);
-		}
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#ACTIVE_POWER}
+	 * Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setActivePower(Integer value) {
+		this.getActivePowerChannel().setNextValue(value);
+	}
 
-		/**
-		 * Internal method to set the 'nextValue' on {@link ChannelId#CURRENT} Channel.
-		 *
-		 * @param value the next value
-		 */
-		public default void _setCurrent(int value) {
-			this.getCurrentChannel().setNextValue(value);
-		}
-	
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#ACTIVE_POWER}
+	 * Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setActivePower(int value) {
+		this.getActivePowerChannel().setNextValue(value);
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#REACTIVE_POWER}.
+	 *
+	 * @return the Channel
+	 */
+	public default IntegerReadChannel getReactivePowerChannel() {
+		return this.channel(ChannelId.REACTIVE_POWER);
+	}
+
+	/**
+	 * Gets the Reactive Power in [var]. See {@link ChannelId#REACTIVE_POWER}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Integer> getReactivePower() {
+		return this.getReactivePowerChannel().value();
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#REACTIVE_POWER}
+	 * Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setReactivePower(Integer value) {
+		this.getReactivePowerChannel().setNextValue(value);
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#REACTIVE_POWER}
+	 * Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setReactivePower(int value) {
+		this.getReactivePowerChannel().setNextValue(value);
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#ACTIVE_PRODUCTION_ENERGY}.
+	 *
+	 * @return the Channel
+	 */
+	public default LongReadChannel getActiveProductionEnergyChannel() {
+		return this.channel(ChannelId.ACTIVE_PRODUCTION_ENERGY);
+	}
+
+	/**
+	 * Gets the Active Production Energy in [Wh]. This relates to positive
+	 * ACTIVE_POWER. See {@link ChannelId#ACTIVE_PRODUCTION_ENERGY}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Long> getActiveProductionEnergy() {
+		return this.getActiveProductionEnergyChannel().value();
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#ACTIVE_PRODUCTION_ENERGY} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setActiveProductionEnergy(Long value) {
+		this.getActiveProductionEnergyChannel().setNextValue(value);
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#ACTIVE_PRODUCTION_ENERGY} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setActiveProductionEnergy(long value) {
+		this.getActiveProductionEnergyChannel().setNextValue(value);
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#VOLTAGE}.
+	 *
+	 * @return the Channel
+	 */
+	public default IntegerReadChannel getVoltageChannel() {
+		return this.channel(ChannelId.VOLTAGE);
+	}
+
+	/**
+	 * Gets the Voltage in [mV]. See {@link ChannelId#VOLTAGE}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Integer> getVoltage() {
+		return this.getVoltageChannel().value();
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#VOLTAGE} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setVoltage(Integer value) {
+		this.getVoltageChannel().setNextValue(value);
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#VOLTAGE} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setVoltage(int value) {
+		this.getVoltageChannel().setNextValue(value);
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#CURRENT}.
+	 *
+	 * @return the Channel
+	 */
+	public default IntegerReadChannel getCurrentChannel() {
+		return this.channel(ChannelId.CURRENT);
+	}
+
+	/**
+	 * Gets the Current in [mA]. See {@link ChannelId#CURRENT}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Integer> getCurrent() {
+		return this.getCurrentChannel().value();
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#CURRENT} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setCurrent(Integer value) {
+		this.getCurrentChannel().setNextValue(value);
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#CURRENT} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setCurrent(int value) {
+		this.getCurrentChannel().setNextValue(value);
+	}
 
 }


### PR DESCRIPTION
GridMode can now be read via Modbus Address `417`.

Additionally:
- Add new type `enum16`
- Show `text` of Channels in Description
- Improve texts for Channels
- Fix calculation of GridMode when there is no ESS.

Co-authored-by: Michael Grill <michael.grill@fenecon.de>
Co-authored-by: Stefan Feilmeier <stefan.feilmeier@fenecon.de>
Reviewed-by: Stefan Feilmeier <stefan.feilmeier@fenecon.de>
Reviewed-by: Jan Seidemann <jan.seidemann@fenecon.de>