### PR TITLE
Controller IO HeatingElement: add cumulated active time

### DIFF
--- a/io.openems.edge.controller.io.heatingelement/bnd.bnd
+++ b/io.openems.edge.controller.io.heatingelement/bnd.bnd
@@ -10,6 +10,7 @@ Bundle-Version:	1.0.0.${tstamp}
 	io.openems.edge.controller.api,\
 	io.openems.edge.ess.api,\
 	io.openems.edge.io.api,\
+	io.openems.edge.timedata.api,\
 
 -testpath: \
 	${testpath}

--- a/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/Config.java
+++ b/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/Config.java
@@ -3,6 +3,10 @@ package io.openems.edge.controller.io.heatingelement;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
+import io.openems.edge.controller.io.heatingelement.enums.Level;
+import io.openems.edge.controller.io.heatingelement.enums.Mode;
+import io.openems.edge.controller.io.heatingelement.enums.WorkMode;
+
 @ObjectClassDefinition(//
 		name = "Controller IO Heating Element", //
 		description = "Controls a three-phase heating element via Relays, according to grid active power")

--- a/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/ControllerHeatingElement.java
+++ b/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/ControllerHeatingElement.java
@@ -1,31 +1,53 @@
 package io.openems.edge.controller.io.heatingelement;
 
-import io.openems.common.channel.Unit;
-import io.openems.common.types.OpenemsType;
+import static io.openems.common.channel.PersistencePriority.HIGH;
+import static io.openems.common.channel.Unit.CUMULATED_SECONDS;
+import static io.openems.common.channel.Unit.SECONDS;
+import static io.openems.common.types.OpenemsType.INTEGER;
+import static io.openems.common.types.OpenemsType.LONG;
+
 import io.openems.edge.common.channel.Doc;
+import io.openems.edge.controller.io.heatingelement.enums.Level;
 
 public interface ControllerHeatingElement {
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
 		LEVEL(Doc.of(Level.values()) //
 				.text("Current Level")),
-		AWAITING_HYSTERESIS(Doc.of(OpenemsType.INTEGER)), //
-		PHASE1_TIME(Doc.of(OpenemsType.INTEGER)//
-				.unit(Unit.SECONDS)), //
-		PHASE2_TIME(Doc.of(OpenemsType.INTEGER)//
-				.unit(Unit.SECONDS)), //
-		PHASE3_TIME(Doc.of(OpenemsType.INTEGER)//
-				.unit(Unit.SECONDS)), //
-		LEVEL1_TIME(Doc.of(OpenemsType.INTEGER)//
-				.unit(Unit.SECONDS)), //
-		LEVEL2_TIME(Doc.of(OpenemsType.INTEGER)//
-				.unit(Unit.SECONDS)), //
-		LEVEL3_TIME(Doc.of(OpenemsType.INTEGER)//
-				.unit(Unit.SECONDS)), //
-		TOTAL_PHASE_TIME(Doc.of(OpenemsType.INTEGER)//
-				.unit(Unit.SECONDS)), //
-		FORCE_START_AT_SECONDS_OF_DAY(Doc.of(OpenemsType.INTEGER)//
-				.unit(Unit.SECONDS)); //
+		AWAITING_HYSTERESIS(Doc.of(INTEGER)), //
+		PHASE1_TIME(Doc.of(INTEGER)//
+				.unit(SECONDS)), //
+		PHASE2_TIME(Doc.of(INTEGER)//
+				.unit(SECONDS)), //
+		PHASE3_TIME(Doc.of(INTEGER)//
+				.unit(SECONDS)), //
+		/*
+		 * LEVELx_TIME was used for old history view. It is left for the analysis of the
+		 * forced duration on a day.
+		 */
+		LEVEL1_TIME(Doc.of(INTEGER)//
+				.unit(SECONDS)), //
+		LEVEL2_TIME(Doc.of(INTEGER)//
+				.unit(SECONDS)), //
+		LEVEL3_TIME(Doc.of(INTEGER)//
+				.unit(SECONDS)), //
+
+		/*
+		 * Total active Time of each Level.
+		 */
+		LEVEL1_CUMULATED_TIME(Doc.of(LONG)//
+				.unit(CUMULATED_SECONDS) //
+				.persistencePriority(HIGH)), //
+		LEVEL2_CUMULATED_TIME(Doc.of(LONG)//
+				.unit(CUMULATED_SECONDS) //
+				.persistencePriority(HIGH)), //
+		LEVEL3_CUMULATED_TIME(Doc.of(LONG)//
+				.unit(CUMULATED_SECONDS) //
+				.persistencePriority(HIGH)), //
+		TOTAL_PHASE_TIME(Doc.of(INTEGER)//
+				.unit(SECONDS)), //
+		FORCE_START_AT_SECONDS_OF_DAY(Doc.of(INTEGER)//
+				.unit(SECONDS)); //
 
 		private final Doc doc;
 

--- a/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/Mode.java
+++ b/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/Mode.java
@@ -1,5 +1,0 @@
-package io.openems.edge.controller.io.heatingelement;
-
-public enum Mode {
-	MANUAL_ON, MANUAL_OFF, AUTOMATIC;
-}

--- a/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/Phase.java
+++ b/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/Phase.java
@@ -1,5 +1,0 @@
-package io.openems.edge.controller.io.heatingelement;
-
-public enum Phase {
-	L1, L2, L3
-}

--- a/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/PhaseDef.java
+++ b/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/PhaseDef.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.edge.controller.io.heatingelement.enums.Phase;
 
 /**
  * PhaseDef represents one Phase of the Heating Element.
@@ -23,7 +24,7 @@ public class PhaseDef {
 	 * keeps the total summed up Duration of the current day; it is updated on
 	 * switchOff() and reset after midnight by getTotalDuration().
 	 */
-	private Duration duration = Duration.ZERO;
+	private Duration dailyDuration = Duration.ZERO;
 
 	/**
 	 * Keeps the current day to detect changes in day.
@@ -43,8 +44,6 @@ public class PhaseDef {
 	/**
 	 * Switch the output ON.
 	 *
-	 * @param outputChannelAddress address of the channel which must set to ON
-	 *
 	 * @throws OpenemsNamedException    on error.
 	 * @throws IllegalArgumentException on error.
 	 */
@@ -59,14 +58,12 @@ public class PhaseDef {
 	/**
 	 * Switch the output OFF.
 	 *
-	 * @param outputChannelAddress address of the channel which must set to OFF.
-	 *
 	 * @throws OpenemsNamedException    on error.
 	 * @throws IllegalArgumentException on error.
 	 */
 	protected void switchOff() throws IllegalArgumentException, OpenemsNamedException {
 		if (this.lastSwitchOn != null) {
-			this.duration = this.getTotalDuration();
+			this.dailyDuration = this.getTotalDuration();
 			this.lastSwitchOn = null;
 		}
 
@@ -85,7 +82,7 @@ public class PhaseDef {
 		if (!this.currentDay.equals(today)) {
 			// Always reset Duration
 			this.currentDay = today;
-			this.duration = Duration.ZERO;
+			this.dailyDuration = Duration.ZERO;
 			if (this.lastSwitchOn != null) {
 				this.lastSwitchOn = LocalTime.MIN;
 			}
@@ -94,8 +91,8 @@ public class PhaseDef {
 		// Calculate and return the Duration
 		if (this.lastSwitchOn != null) {
 			var now = LocalTime.now(this.parent.componentManager.getClock());
-			return this.duration.plus(Duration.between(this.lastSwitchOn, now));
+			return this.dailyDuration.plus(Duration.between(this.lastSwitchOn, now));
 		}
-		return this.duration;
+		return this.dailyDuration;
 	}
 }

--- a/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/enums/Level.java
+++ b/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/enums/Level.java
@@ -1,4 +1,4 @@
-package io.openems.edge.controller.io.heatingelement;
+package io.openems.edge.controller.io.heatingelement.enums;
 
 import io.openems.common.types.OptionsEnum;
 

--- a/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/enums/Mode.java
+++ b/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/enums/Mode.java
@@ -1,0 +1,5 @@
+package io.openems.edge.controller.io.heatingelement.enums;
+
+public enum Mode {
+	MANUAL_ON, MANUAL_OFF, AUTOMATIC;
+}

--- a/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/enums/Phase.java
+++ b/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/enums/Phase.java
@@ -1,0 +1,5 @@
+package io.openems.edge.controller.io.heatingelement.enums;
+
+public enum Phase {
+	L1, L2, L3
+}

--- a/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/enums/WorkMode.java
+++ b/io.openems.edge.controller.io.heatingelement/src/io/openems/edge/controller/io/heatingelement/enums/WorkMode.java
@@ -1,5 +1,4 @@
-
-package io.openems.edge.controller.io.heatingelement;
+package io.openems.edge.controller.io.heatingelement.enums;
 
 public enum WorkMode {
 	/**

--- a/io.openems.edge.controller.io.heatingelement/test/io/openems/edge/controller/io/heatingelement/HeatingElementTest.java
+++ b/io.openems.edge.controller.io.heatingelement/test/io/openems/edge/controller/io/heatingelement/HeatingElementTest.java
@@ -11,23 +11,26 @@ import io.openems.edge.common.sum.DummySum;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
 import io.openems.edge.common.test.DummyComponentManager;
 import io.openems.edge.common.test.TimeLeapClock;
+import io.openems.edge.controller.io.heatingelement.enums.Level;
+import io.openems.edge.controller.io.heatingelement.enums.Mode;
+import io.openems.edge.controller.io.heatingelement.enums.WorkMode;
 import io.openems.edge.controller.test.ControllerTest;
 import io.openems.edge.io.test.DummyInputOutput;
 
 public class HeatingElementTest {
 
-	private final static String CTRL_ID = "ctrl0";
-	private final static String IO_ID = "io0";
+	private static final String CTRL_ID = "ctrl0";
+	private static final String IO_ID = "io0";
 
-	private final static ChannelAddress SUM_GRID_ACTIVE_POWER = new ChannelAddress("_sum", "GridActivePower");
+	private static final ChannelAddress SUM_GRID_ACTIVE_POWER = new ChannelAddress("_sum", "GridActivePower");
 
-	private final static ChannelAddress IO_OUTPUT1 = new ChannelAddress(IO_ID, "InputOutput1");
-	private final static ChannelAddress IO_OUTPUT2 = new ChannelAddress(IO_ID, "InputOutput2");
-	private final static ChannelAddress IO_OUTPUT3 = new ChannelAddress(IO_ID, "InputOutput3");
+	private static final ChannelAddress IO_OUTPUT1 = new ChannelAddress(IO_ID, "InputOutput1");
+	private static final ChannelAddress IO_OUTPUT2 = new ChannelAddress(IO_ID, "InputOutput2");
+	private static final ChannelAddress IO_OUTPUT3 = new ChannelAddress(IO_ID, "InputOutput3");
 
-	private final static ChannelAddress CTRL_PHASE1TIME = new ChannelAddress(CTRL_ID, "Phase1Time");
-	private final static ChannelAddress CTRL_PHASE2TIME = new ChannelAddress(CTRL_ID, "Phase2Time");
-	private final static ChannelAddress CTRL_PHASE3TIME = new ChannelAddress(CTRL_ID, "Phase3Time");
+	private static final ChannelAddress CTRL_PHASE1TIME = new ChannelAddress(CTRL_ID, "Phase1Time");
+	private static final ChannelAddress CTRL_PHASE2TIME = new ChannelAddress(CTRL_ID, "Phase2Time");
+	private static final ChannelAddress CTRL_PHASE3TIME = new ChannelAddress(CTRL_ID, "Phase3Time");
 
 	@Test
 	public void test() throws Exception {
@@ -51,7 +54,7 @@ public class HeatingElementTest {
 						.setMinimumSwitchingTime(60) //
 						.build()) //
 				.next(new TestCase() //
-										// Grid active power : 0, Excess power : 0,
+						// Grid active power : 0, Excess power : 0,
 						// from -> UNDEFINED --to--> LEVEL_0, no of relais = 0
 						.input(SUM_GRID_ACTIVE_POWER, 0) //
 						.output(IO_OUTPUT1, false) //

--- a/io.openems.edge.controller.io.heatingelement/test/io/openems/edge/controller/io/heatingelement/HeatingElementTest2.java
+++ b/io.openems.edge.controller.io.heatingelement/test/io/openems/edge/controller/io/heatingelement/HeatingElementTest2.java
@@ -11,23 +11,26 @@ import io.openems.edge.common.sum.DummySum;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
 import io.openems.edge.common.test.DummyComponentManager;
 import io.openems.edge.common.test.TimeLeapClock;
+import io.openems.edge.controller.io.heatingelement.enums.Level;
+import io.openems.edge.controller.io.heatingelement.enums.Mode;
+import io.openems.edge.controller.io.heatingelement.enums.WorkMode;
 import io.openems.edge.controller.test.ControllerTest;
 import io.openems.edge.io.test.DummyInputOutput;
 
 public class HeatingElementTest2 {
 
-	private final static String CTRL_ID = "ctrl0";
-	private final static String IO_ID = "io0";
+	private static final String CTRL_ID = "ctrl0";
+	private static final String IO_ID = "io0";
 
-	private final static ChannelAddress SUM_GRID_ACTIVE_POWER = new ChannelAddress("_sum", "GridActivePower");
+	private static final ChannelAddress SUM_GRID_ACTIVE_POWER = new ChannelAddress("_sum", "GridActivePower");
 
-	private final static ChannelAddress IO_OUTPUT1 = new ChannelAddress(IO_ID, "InputOutput1");
-	private final static ChannelAddress IO_OUTPUT2 = new ChannelAddress(IO_ID, "InputOutput2");
-	private final static ChannelAddress IO_OUTPUT3 = new ChannelAddress(IO_ID, "InputOutput3");
+	private static final ChannelAddress IO_OUTPUT1 = new ChannelAddress(IO_ID, "InputOutput1");
+	private static final ChannelAddress IO_OUTPUT2 = new ChannelAddress(IO_ID, "InputOutput2");
+	private static final ChannelAddress IO_OUTPUT3 = new ChannelAddress(IO_ID, "InputOutput3");
 
-	private final static ChannelAddress CTRL_FORCE_START_AT_SECONDS_OF_DAY = new ChannelAddress(CTRL_ID,
+	private static final ChannelAddress CTRL_FORCE_START_AT_SECONDS_OF_DAY = new ChannelAddress(CTRL_ID,
 			"ForceStartAtSecondsOfDay");
-	private final static ChannelAddress CTRL_TOTAL_PHASE_TIME = new ChannelAddress(CTRL_ID, "TotalPhaseTime");
+	private static final ChannelAddress CTRL_TOTAL_PHASE_TIME = new ChannelAddress(CTRL_ID, "TotalPhaseTime");
 
 	@Test
 	public void test() throws Exception {

--- a/io.openems.edge.controller.io.heatingelement/test/io/openems/edge/controller/io/heatingelement/HeatingElementTestManual.java
+++ b/io.openems.edge.controller.io.heatingelement/test/io/openems/edge/controller/io/heatingelement/HeatingElementTestManual.java
@@ -11,17 +11,20 @@ import io.openems.edge.common.sum.DummySum;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
 import io.openems.edge.common.test.DummyComponentManager;
 import io.openems.edge.common.test.TimeLeapClock;
+import io.openems.edge.controller.io.heatingelement.enums.Level;
+import io.openems.edge.controller.io.heatingelement.enums.Mode;
+import io.openems.edge.controller.io.heatingelement.enums.WorkMode;
 import io.openems.edge.controller.test.ControllerTest;
 import io.openems.edge.io.test.DummyInputOutput;
 
 public class HeatingElementTestManual {
 
-	private final static String CTRL_ID = "ctrl0";
-	private final static String IO_ID = "io0";
+	private static final String CTRL_ID = "ctrl0";
+	private static final String IO_ID = "io0";
 
-	private final static ChannelAddress IO_OUTPUT1 = new ChannelAddress(IO_ID, "InputOutput1");
-	private final static ChannelAddress IO_OUTPUT2 = new ChannelAddress(IO_ID, "InputOutput2");
-	private final static ChannelAddress IO_OUTPUT3 = new ChannelAddress(IO_ID, "InputOutput3");
+	private static final ChannelAddress IO_OUTPUT1 = new ChannelAddress(IO_ID, "InputOutput1");
+	private static final ChannelAddress IO_OUTPUT2 = new ChannelAddress(IO_ID, "InputOutput2");
+	private static final ChannelAddress IO_OUTPUT3 = new ChannelAddress(IO_ID, "InputOutput3");
 
 	private static ControllerTest prepareTest(Mode mode, Level level) throws OpenemsNamedException, Exception {
 		return new ControllerTest(new ControllerHeatingElementImpl()) //

--- a/io.openems.edge.controller.io.heatingelement/test/io/openems/edge/controller/io/heatingelement/MyConfig.java
+++ b/io.openems.edge.controller.io.heatingelement/test/io/openems/edge/controller/io/heatingelement/MyConfig.java
@@ -1,6 +1,9 @@
 package io.openems.edge.controller.io.heatingelement;
 
 import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.edge.controller.io.heatingelement.enums.Level;
+import io.openems.edge.controller.io.heatingelement.enums.Mode;
+import io.openems.edge.controller.io.heatingelement.enums.WorkMode;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {
@@ -82,6 +85,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 		}
 	}
 
+	/**
+	 * Create a Config builder.
+	 *
+	 * @return a {@link Builder}
+	 */
 	public static Builder create() {
 		return new Builder();
 	}


### PR DESCRIPTION
Add cummulated time channels & update them depending on the current level.
Use this channels in the UI history.

Co-authored-by: Sebastian Asen <sebastian.asen@fenecon.de>
Co-authored-by: Lukas Rieger <lukas.rieger@fenecon.de>
Co-authored-by: Maximilian Lang <maximilian.lang@fenecon.de>
Co-authored-by: Stefan Feilmeier <stefan.feilmeier@fenecon.de>