### PR TITLE
UI bugfix `isProducer()` method

### DIFF
--- a/ui/src/app/shared/edge/edgeconfig.ts
+++ b/ui/src/app/shared/edge/edgeconfig.ts
@@ -1,4 +1,3 @@
-import { is } from 'date-fns/locale';
 import { ChannelAddress } from '../type/channeladdress';
 import { Widgets } from '../type/widget';
 import { Edge } from './edge';
@@ -262,9 +261,8 @@ export class EdgeConfig {
         }
         // Do we have a Meter with type PRODUCTION?
         for (let component of this.getComponentsImplementingNature("io.openems.edge.meter.api.SymmetricMeter")) {
-            if (component.isEnabled) {
-
-                return this.isProducer(component);
+            if (component.isEnabled && this.isProducer(component)) {
+                return true;
             }
         }
         return false;


### PR DESCRIPTION
Fixes a bug that had been introduced by #1749

Under certain circumstances this bug would cause Production meters to be not displayed.

Thanks danielco for pointing it out in the OpenEMS Community forum: https://community.openems.io/t/trying-to-simulate-pv-production/838