### PR TITLE
Improvements for Time-Of-Use Tariffs

### DIFF
--- a/io.openems.edge.controller.ess.timeofusetariff.discharge/src/io/openems/edge/controller/ess/timeofusetariff/discharge/TimeOfUseTariffDischargeImpl.java
+++ b/io.openems.edge.controller.ess.timeofusetariff.discharge/src/io/openems/edge/controller/ess/timeofusetariff/discharge/TimeOfUseTariffDischargeImpl.java
@@ -96,8 +96,8 @@ public class TimeOfUseTariffDischargeImpl extends AbstractOpenemsComponent
 	private List<ZonedDateTime> targetPeriods = new ArrayList<>();
 	private final TreeMap<ZonedDateTime, Float> quarterlyPricesMap = new TreeMap<>();
 	private TreeMap<ZonedDateTime, Integer> socWithoutLogic = new TreeMap<>();
-	private ZonedDateTime lastAccessedTime = ZonedDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-	private ZonedDateTime lastUpdatePriceTime = ZonedDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+	private ZonedDateTime lastAccessedTime = null;
+	private ZonedDateTime lastUpdatePriceTime = null;
 
 	public TimeOfUseTariffDischargeImpl() {
 		super(//
@@ -161,10 +161,11 @@ public class TimeOfUseTariffDischargeImpl extends AbstractOpenemsComponent
 		 * Every day, Prices are updated in API at a certain hour. we update the
 		 * predictions and the prices during those hour.
 		 *
-		 * gets the prices and predictions when the controller is restarted or //
+		 * Gets the prices and predictions when the controller is restarted or //
 		 * re-enabled in any time.
 		 */
-		if (prices != null && this.lastUpdatePriceTime.isBefore(prices.getUpdateTime())) {
+		if (!prices.isEmpty()
+				&& (this.lastUpdatePriceTime == null || this.lastUpdatePriceTime.isBefore(prices.getUpdateTime()))) {
 			// gets the prices, predictions and calculates the boundary space.
 			this.getBoundarySpace(now, prices);
 
@@ -191,7 +192,7 @@ public class TimeOfUseTariffDischargeImpl extends AbstractOpenemsComponent
 		if (this.boundarySpace != null && this.boundarySpace.isWithinBoundary(now)) {
 
 			// Runs every 15 minutes.
-			if (now.isAfter(this.lastAccessedTime)) {
+			if (this.lastAccessedTime == null || now.isAfter(this.lastAccessedTime)) {
 
 				var availableEnergy = this.getAvailableEnergy(now);
 				var remainingEnergy = this.getRemainingCapacity(availableEnergy, this.productionMap,

--- a/io.openems.edge.timeofusetariff.api/src/io/openems/edge/timeofusetariff/api/TimeOfUsePrices.java
+++ b/io.openems.edge.timeofusetariff.api/src/io/openems/edge/timeofusetariff/api/TimeOfUsePrices.java
@@ -1,6 +1,7 @@
 package io.openems.edge.timeofusetariff.api;
 
 import java.time.ZonedDateTime;
+import java.util.stream.Stream;
 
 /**
  * Holds time of use prices for 24 h and the time when it is retrieved; //
@@ -12,6 +13,16 @@ import java.time.ZonedDateTime;
 public class TimeOfUsePrices {
 
 	public static final int NUMBER_OF_VALUES = 96;
+
+	/**
+	 * Factory method for an 'empty' {@link TimeOfUsePrices} object, i.e. all values
+	 * are 'null'.
+	 * 
+	 * @return an 'empty' {@link TimeOfUsePrices} object
+	 */
+	public static TimeOfUsePrices empty(ZonedDateTime updateTime) {
+		return new TimeOfUsePrices(updateTime);
+	}
 
 	private final ZonedDateTime updateTime;
 
@@ -53,4 +64,12 @@ public class TimeOfUsePrices {
 		return this.updateTime;
 	}
 
+	/**
+	 * Is this {@link TimeOfUsePrices} empty, i.e. every value is 'null'?.
+	 * 
+	 * @return true if all values are null; false otherwise
+	 */
+	public boolean isEmpty() {
+		return !Stream.of(this.values).anyMatch(v -> v != null);
+	}
 }

--- a/io.openems.edge.timeofusetariff.api/src/io/openems/edge/timeofusetariff/api/TimeOfUseTariff.java
+++ b/io.openems.edge.timeofusetariff.api/src/io/openems/edge/timeofusetariff/api/TimeOfUseTariff.java
@@ -17,7 +17,8 @@ public interface TimeOfUseTariff {
 	 * E.g. if called at 10:05, the first value stands for 10:00 to 10:15; second
 	 * value for 10:15 to 10:30.
 	 *
-	 * @return the prices, or null if no prices exist
+	 * @return the prices; {@link TimeOfUsePrices#empty(java.time.ZonedDateTime) if
+	 *         no prices are known
 	 */
 	public TimeOfUsePrices getPrices();
 

--- a/io.openems.edge.timeofusetariff.api/src/io/openems/edge/timeofusetariff/api/utils/TimeOfUseTariffUtils.java
+++ b/io.openems.edge.timeofusetariff.api/src/io/openems/edge/timeofusetariff/api/utils/TimeOfUseTariffUtils.java
@@ -2,7 +2,6 @@ package io.openems.edge.timeofusetariff.api.utils;
 
 import java.time.Clock;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 
 import com.google.common.collect.ImmutableSortedMap;
@@ -26,7 +25,7 @@ public class TimeOfUseTariffUtils {
 
 		// Returns the empty array if the map is empty.
 		if (priceMap.isEmpty()) {
-			return new TimeOfUsePrices(updateTimeStamp);
+			return TimeOfUsePrices.empty(updateTimeStamp);
 		}
 
 		var now = getNowRoundedDownToMinutes(clock, 15);
@@ -45,8 +44,18 @@ public class TimeOfUseTariffUtils {
 	 * @return the rounded result
 	 */
 	public static ZonedDateTime getNowRoundedDownToMinutes(Clock clock, int minutes) {
-		var d = ZonedDateTime.now(clock);
-		var minuteOfDay = d.get(ChronoField.MINUTE_OF_DAY);
-		return d.with(ChronoField.NANO_OF_DAY, 0).plus(minuteOfDay / minutes * minutes, ChronoUnit.MINUTES);
+		var now = ZonedDateTime.now(clock);
+		return getNowRoundedDownToMinutes(now, minutes);
+	}
+
+	/**
+	 * Gets 'now' from the Clock and rounds it down to required minutes.
+	 *
+	 * @param clock   the {@link Clock}
+	 * @param minutes the custom minutes to roundoff to.
+	 * @return the rounded result
+	 */
+	public static ZonedDateTime getNowRoundedDownToMinutes(ZonedDateTime now, int minutes) {
+		return now.withMinute(now.getMinute() - now.getMinute() % minutes).truncatedTo(ChronoUnit.MINUTES);
 	}
 }

--- a/io.openems.edge.timeofusetariff.api/src/io/openems/edge/timeofusetariff/test/DummyTimeOfUseTariffProvider.java
+++ b/io.openems.edge.timeofusetariff.api/src/io/openems/edge/timeofusetariff/test/DummyTimeOfUseTariffProvider.java
@@ -40,9 +40,9 @@ public class DummyTimeOfUseTariffProvider implements TimeOfUseTariff {
 
 	@Override
 	public TimeOfUsePrices getPrices() {
-		// return null if the dateTime is empty.
+		// return empty TimeOfUsePrice if the dateTime is empty.
 		if (this.prices.getUpdateTime() == null) {
-			return null;
+			return TimeOfUsePrices.empty(ZonedDateTime.now());
 		}
 		return this.prices;
 	}

--- a/io.openems.edge.timeofusetariff.awattar/test/io/openems/edge/timeofusetariff/awattar/AwattarProviderTest.java
+++ b/io.openems.edge.timeofusetariff.awattar/test/io/openems/edge/timeofusetariff/awattar/AwattarProviderTest.java
@@ -2,6 +2,7 @@ package io.openems.edge.timeofusetariff.awattar;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.time.ZonedDateTime;
 import java.util.SortedMap;
@@ -92,12 +93,15 @@ public class AwattarProviderTest {
 
 	@Test
 	public void emptyStringTest() throws OpenemsNamedException {
-		// Parsing with empty string
-		SortedMap<ZonedDateTime, Float> prices = AwattarImpl.parsePrices("");
+		try {
+			// Parsing with empty string
+			AwattarImpl.parsePrices("");
+		} catch (OpenemsNamedException e) {
+			// expected
+			return;
+		}
 
-		// To check if the map is empty.
-		assertTrue(prices.isEmpty());
-
+		fail("Expected Exception");
 	}
 
 }

--- a/io.openems.edge.timeofusetariff.corrently/test/io/openems/edge/timeofusetariff/corrently/CorrentlyProviderTest.java
+++ b/io.openems.edge.timeofusetariff.corrently/test/io/openems/edge/timeofusetariff/corrently/CorrentlyProviderTest.java
@@ -2,6 +2,7 @@ package io.openems.edge.timeofusetariff.corrently;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.time.ZonedDateTime;
 import java.util.SortedMap;
@@ -93,10 +94,14 @@ public class CorrentlyProviderTest {
 
 	@Test
 	public void emptyStringTest() throws OpenemsNamedException {
-		// Parsing with empty string
-		SortedMap<ZonedDateTime, Float> prices = CorrentlyImpl.parsePrices("");
+		try {
+			// Parsing with empty string
+			CorrentlyImpl.parsePrices("");
+		} catch (OpenemsNamedException e) {
+			// expected
+			return;
+		}
 
-		// To check if the map is empty.
-		assertTrue(prices.isEmpty());
+		fail("Expected Exception");
 	}
 }

--- a/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/TibberImpl.java
+++ b/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/TibberImpl.java
@@ -143,9 +143,9 @@ public class TibberImpl extends AbstractOpenemsComponent implements TimeOfUseTar
 
 	@Override
 	public TimeOfUsePrices getPrices() {
-		// return null if data is not yet available.
+		// return empty TimeOfUsePrices if data is not yet available.
 		if (this.updateTimeStamp == null) {
-			return null;
+			return TimeOfUsePrices.empty(ZonedDateTime.now());
 		}
 
 		return TimeOfUseTariffUtils.getNext24HourPrices(Clock.systemDefaultZone() /* can be mocked for testing */,
@@ -162,35 +162,32 @@ public class TibberImpl extends AbstractOpenemsComponent implements TimeOfUseTar
 	public static ImmutableSortedMap<ZonedDateTime, Float> parsePrices(String jsonData) throws OpenemsNamedException {
 		var result = new TreeMap<ZonedDateTime, Float>();
 
-		if (!jsonData.isEmpty()) {
+		var line = JsonUtils.parseToJsonObject(jsonData);
+		var homes = JsonUtils.getAsJsonObject(line, "data") //
+				.getAsJsonObject("viewer") //
+				.getAsJsonArray("homes");
 
-			var line = JsonUtils.parseToJsonObject(jsonData);
-			var homes = JsonUtils.getAsJsonObject(line, "data") //
-					.getAsJsonObject("viewer") //
-					.getAsJsonArray("homes");
+		for (JsonElement home : homes) {
 
-			for (JsonElement home : homes) {
+			var priceInfo = JsonUtils.getAsJsonObject(home, "currentSubscription") //
+					.getAsJsonObject("priceInfo");
 
-				var priceInfo = JsonUtils.getAsJsonObject(home, "currentSubscription") //
-						.getAsJsonObject("priceInfo");
+			// Price info for today and tomorrow.
+			var today = JsonUtils.getAsJsonArray(priceInfo, "today");
+			var tomorrow = JsonUtils.getAsJsonArray(priceInfo, "tomorrow");
 
-				// Price info for today and tomorrow.
-				var today = JsonUtils.getAsJsonArray(priceInfo, "today");
-				var tomorrow = JsonUtils.getAsJsonArray(priceInfo, "tomorrow");
+			// Adding to an array to avoid individual variables for individual for loops.
+			JsonArray[] days = { today, tomorrow };
 
-				// Adding to an array to avoid individual variables for individual for loops.
-				JsonArray[] days = { today, tomorrow };
-
-				// parse the arrays for price and time stamps.
-				for (JsonArray day : days) {
-					for (JsonElement element : day) {
-						var marketPrice = JsonUtils.getAsFloat(element, "total") * 1000;
-						var startTime = ZonedDateTime
-								.parse(JsonUtils.getAsString(element, "startsAt"), DateTimeFormatter.ISO_DATE_TIME)
-								.withZoneSameInstant(ZoneId.systemDefault());
-						// Adding the values in the Map.
-						result.put(startTime, marketPrice);
-					}
+			// parse the arrays for price and time stamps.
+			for (JsonArray day : days) {
+				for (JsonElement element : day) {
+					var marketPrice = JsonUtils.getAsFloat(element, "total") * 1000;
+					var startTime = ZonedDateTime
+							.parse(JsonUtils.getAsString(element, "startsAt"), DateTimeFormatter.ISO_DATE_TIME)
+							.withZoneSameInstant(ZoneId.systemDefault());
+					// Adding the values in the Map.
+					result.put(startTime, marketPrice);
 				}
 			}
 		}

--- a/io.openems.edge.timeofusetariff.tibber/test/io/openems/edge/timeofusetariff/tibber/TibberProviderTest.java
+++ b/io.openems.edge.timeofusetariff.tibber/test/io/openems/edge/timeofusetariff/tibber/TibberProviderTest.java
@@ -2,6 +2,7 @@ package io.openems.edge.timeofusetariff.tibber;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.time.ZonedDateTime;
 import java.util.SortedMap;
@@ -154,11 +155,15 @@ public class TibberProviderTest {
 	}
 
 	@Test
-	public void emptyStringTest() throws OpenemsNamedException {
-		// Parsing with empty string
-		SortedMap<ZonedDateTime, Float> prices = TibberImpl.parsePrices("");
+	public void emptyStringTest() {
+		try {
+			// Parsing with empty string
+			TibberImpl.parsePrices("");
+		} catch (OpenemsNamedException e) {
+			// expected
+			return;
+		}
 
-		// To check if the map is empty.
-		assertTrue(prices.isEmpty());
+		fail("Expected Exception");
 	}
 }


### PR DESCRIPTION
- Change TimeOfUseTariff to never return null
- Introduce TimeOfUsePrices.empty() instead
- Adjust Controller to handle the changed logic
- Awattar, Tibber, Corrently: throw Exception if HTTP GET result is empty
- Update JUnit tests to reflect new Exception handling