### PR TITLE
fixed filter for influxdbv2 query to use edge instead of fems keyword

### DIFF
--- a/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnector.java
+++ b/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnector.java
@@ -279,7 +279,7 @@ public class InfluxConnector {
 				.append("|> filter(fn: (r) => r._measurement == \"").append(MEASUREMENT).append("\")");
 
 		if (influxEdgeId.isPresent()) {
-			builder.append("|> filter(fn: (r) => r.fems == \"" + influxEdgeId.get() + "\")");
+			builder.append("|> filter(fn: (r) => r.edge == \"" + influxEdgeId.get() + "\")");
 		}
 
 		builder //


### PR DESCRIPTION
Tested with OpenEMS backend.
This filter does not work, since edges by default use the influxdb field "edge" instead of "fems"