### PR TITLE
build dcdischarge sum out of hybridess channel instead of plain calculation

### DIFF
--- a/io.openems.edge.core/src/io/openems/edge/core/sum/SumImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/sum/SumImpl.java
@@ -135,7 +135,8 @@ public class SumImpl extends AbstractOpenemsComponent implements Sum, OpenemsCom
 		final var essDcChargeEnergy = new CalculateLongSum();
 		final var essDcDischargeEnergy = new CalculateLongSum();
 		final var essCapacity = new CalculateIntegerSum();
-
+		final var essDcDischargePower = new CalculateIntegerSum();
+		
 		// Grid
 		final var gridActivePower = new CalculateIntegerSum();
 		final var gridActivePowerL1 = new CalculateIntegerSum();
@@ -156,6 +157,7 @@ public class SumImpl extends AbstractOpenemsComponent implements Sum, OpenemsCom
 		final var productionMaxDcActualPower = new CalculateIntegerSum();
 		final var productionAcActiveEnergy = new CalculateLongSum();
 		final var productionDcActiveEnergy = new CalculateLongSum();
+		
 		// handling the corner-case of wrongly measured negative production, due to
 		// cabling errors, etc.
 		final var productionAcActiveEnergyNegative = new CalculateLongSum();
@@ -195,6 +197,7 @@ public class SumImpl extends AbstractOpenemsComponent implements Sum, OpenemsCom
 					var e = (HybridEss) ess;
 					essDcChargeEnergy.addValue(e.getDcChargeEnergyChannel());
 					essDcDischargeEnergy.addValue(e.getDcDischargeEnergyChannel());
+					essDcDischargePower.addValue(e.getDcDischargePowerChannel());
 				} else {
 					essDcChargeEnergy.addValue(ess.getActiveChargeEnergyChannel());
 					essDcDischargeEnergy.addValue(ess.getActiveDischargeEnergyChannel());
@@ -387,8 +390,9 @@ public class SumImpl extends AbstractOpenemsComponent implements Sum, OpenemsCom
 				Optional.ofNullable(enterTheSystem).orElse(0L) - Optional.ofNullable(leaveTheSystem).orElse(0L));
 
 		// Further calculated Channels
+		var essDischargePowerSum = essDcDischargePower.calculate();
 		this.getEssDischargePowerChannel()
-				.setNextValue(TypeUtils.subtract(essActivePowerSum, productionDcActualPowerSum));
+				.setNextValue(essDischargePowerSum);
 	}
 
 	/**


### PR DESCRIPTION
Hi @sfeilmeier 
I am implementing a HybridEss and realized that this channel is force calculated. I do have a managed battery that provides this information more precisely, so I would like to not have it calculated. IMO this is not an issue, since you do calculate it the same way here:
https://github.com/OpenEMS/openems/blob/f4b7c7e2aad1487acbdc59597f39bd9ef04ebdad/io.openems.edge.ess.fenecon.commercial40/src/io/openems/edge/ess/fenecon/commercial40/EssFeneconCommercial40Impl.java#L893

This PR is related to an HybridEss Nature Implementation of a Victron Ess (Multiplus 2GX and BlueSolar SolarCharger).
I will open-source the implementation once it works properly.