### PR TITLE
Consider inverter losses for HybridEss

### DIFF
--- a/io.openems.edge.controller.ess.gridoptimizedcharge/src/io/openems/edge/controller/ess/gridoptimizedcharge/GridOptimizedChargeImpl.java
+++ b/io.openems.edge.controller.ess.gridoptimizedcharge/src/io/openems/edge/controller/ess/gridoptimizedcharge/GridOptimizedChargeImpl.java
@@ -299,9 +299,19 @@ public class GridOptimizedChargeImpl extends AbstractOpenemsComponent
 	 */
 	private int calculateDelayChargeAcLimit(int delayChargeMaxChargePower) {
 
-		// Calculate AC-Setpoint depending on the DC production
+		int essDischargePower = this.sum.getEssDischargePower().orElse(0);
 		int productionDcPower = this.sum.getProductionDcActualPower().orElse(0);
-		return productionDcPower - delayChargeMaxChargePower;
+		int essActivePower = this.sum.getEssActivePower().orElse(0);
+		
+		int inverterLosses = productionDcPower + essDischargePower - essActivePower;
+
+		// in case of missing data assume there are no losses.
+		if (inverterLosses < 0) {
+			inverterLosses = 0;
+		}
+		
+		// Calculate AC-Setpoint depending on the DC production & Inverter Losses
+		return productionDcPower - delayChargeMaxChargePower - inverterLosses;
 	}
 
 	/**


### PR DESCRIPTION
Hi @sfeilmeier. This PR is related to https://github.com/OpenEMS/openems/pull/1800
I noticed that the AC Limit calculation neglects any losses on the inverter. 
This has a high impact on the actual charge rate of the battery (for me this was about 50% off).
This change will consider the losses on the inverter and provides a more precise AC limit.
In case of a calculated EssDischargePower from an unmanaged battery the losses would be 0 and not make any difference.