### PR TITLE
Update system update feature

### DIFF
--- a/ui/src/app/edge/settings/systemupdate/systemupdate.component.html
+++ b/ui/src/app/edge/settings/systemupdate/systemupdate.component.html
@@ -5,16 +5,29 @@
     <!--
       Is FEMS online?
     -->
-    <ion-row *ngIf="!edge.isOnline" class="ion-justify-content-center">
-      <ion-col size="12" size-sm="8">
-        <ion-card>
-          <ion-item lines="full" color="danger">
-            <ion-icon slot="start" name="alert-circle-outline" color="primary"></ion-icon>
-            <ion-label>{{ edge.id }} ist nicht online!</ion-label>
-          </ion-item>
-        </ion-card>
-      </ion-col>
-    </ion-row>
+    <ng-container *ngIf="!edge.isOnline">
+      <ion-row class="ion-justify-content-center">
+        <ion-col size="12" size-sm="8">
+          <ion-card>
+            <ion-item lines="full" color="danger">
+              <ion-icon slot="start" name="alert-circle-outline" color="primary"></ion-icon>
+              <ion-label>{{ edge.id }} ist nicht online!</ion-label>
+            </ion-item>
+
+            <!-- If Edge is Restarting after Update -->
+            <ion-card-content *ngIf="isEdgeRestarting">
+              <ion-row>
+                Das {{environment.edgeShortName}} wird neugestartet...
+              </ion-row>
+              <ion-row>
+                Dies kann bis zu 10 min dauern.
+              </ion-row>
+              <percentagebar [value]="100 - ((this.restartTime / ESTIMATED_REBOOT_TIME) * 100)"></percentagebar>
+            </ion-card-content>
+          </ion-card>
+        </ion-col>
+      </ion-row>
+    </ng-container>
 
     <!--
       System Update State
@@ -22,6 +35,7 @@
     <ion-row *ngIf="edge.isOnline" class="ion-justify-content-center">
       <ion-col size="12" size-sm="8">
         <ion-card>
+          <ngx-spinner [name]="spinnerId"></ngx-spinner>
           <ion-item lines="full" color="light">
             <ion-icon slot="start" name="cloud-download-outline" color="primary"></ion-icon>
             <ion-label>
@@ -30,7 +44,6 @@
             </ion-label>
           </ion-item>
 
-          <ngx-spinner [name]="spinnerId"></ngx-spinner>
           <ion-card-content *ngIf="systemUpdateState">
             <ion-grid>
               <ng-container *ngIf="systemUpdateState.unknown as state">
@@ -39,9 +52,6 @@
                 -->
                 <ion-row>
                   <ion-col>Update Status ist unbekannt</ion-col>
-                </ion-row>
-                <ion-row>
-                  <ion-col>{{ state | json }}</ion-col>
                 </ion-row>
               </ng-container>
               <ng-container *ngIf="systemUpdateState.updated as state">

--- a/ui/src/app/edge/settings/systemupdate/systemupdate.component.ts
+++ b/ui/src/app/edge/settings/systemupdate/systemupdate.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Subject, timer } from 'rxjs';
+import { Observable, Subject, timer } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ComponentJsonApiRequest } from 'src/app/shared/jsonrpc/request/componentJsonApiRequest';
 import { environment } from 'src/environments';
@@ -18,12 +18,16 @@ export class SystemUpdateComponent implements OnInit, OnDestroy {
   private static readonly SELECTOR = "systemUpdate";
 
   public readonly environment = environment;
-  public systemUpdateState: SystemUpdateState = null;
+  public systemUpdateState: SystemUpdateState = { unknown: {} };
   public readonly spinnerId: string = SystemUpdateComponent.SELECTOR;
   public showLog: boolean = false;
+  public readonly ESTIMATED_REBOOT_TIME = 600; // Seconds till the openems service is restarted after update
 
   public edge: Edge = null;
   private ngUnsubscribe = new Subject<void>();
+  public restartTime: number = this.ESTIMATED_REBOOT_TIME;
+  public isEdgeRestarting: boolean = false;
+  public lastResult: SystemUpdateState = { unknown: {} }
 
   constructor(
     private route: ActivatedRoute,
@@ -62,16 +66,36 @@ export class SystemUpdateComponent implements OnInit, OnDestroy {
         let result = (response as GetSystemUpdateStateResponse).result;
         this.systemUpdateState = result;
         this.service.stopSpinner(this.spinnerId);
-
         // Stop regular check if there is no Update available
         if (result.updated || result.running?.percentCompleted == 100) {
           this.stopRefreshSystemUpdateState();
         }
-
-      }).catch(reason => {
-        console.error(reason.error);
-        this.service.toast("Error while executing system update: " + reason.error.message, 'danger');
+        this.lastResult = result;
+      }).catch(error => {
+        if (this.lastResult.running?.percentCompleted >= 98) {
+          this.startTimer()
+          this.service.toast("Das " + environment.edgeShortName + " wird nun neugestartet", 'success');
+          return
+        }
+        console.error(error);
+        this.service.toast("Error while executing system update: " + error.message, 'danger');
       });
+  }
+  startTimer() {
+    this.isEdgeRestarting = true;
+    let timeLeft = this.ESTIMATED_REBOOT_TIME;
+    let interval = setInterval(() => {
+      if (timeLeft >= 0) {
+        if (this.edge.isOnline) {
+          timeLeft = 0
+          this.restartTime = timeLeft;
+        } else {
+          this.restartTime = timeLeft--;
+        }
+      } else {
+        clearInterval(interval)
+      }
+    }, 1000)
   }
 
   public executeSystemUpdate() {
@@ -89,6 +113,9 @@ export class SystemUpdateComponent implements OnInit, OnDestroy {
 
       }).catch(reason => {
         console.error(reason.error);
+        if (this.lastResult.running?.percentCompleted >= 98) {
+          return
+        }
         this.service.toast("Error while executing system update: " + reason.error.message, 'danger');
       });
   }


### PR DESCRIPTION
This is an improvement to the current system update feature. Future required tasks include (in German):

- Umbenennen "Update Status ist unbekannt" zu "Suche nach Updates..." (oder ähnlich)
- Nach Klick auf "Update installieren" sollte sofort die Prozentanzeige mit "Update wird ausgeführt" erscheinen
-  Am Anfang springt die Prozentanzeige hin und her
- Die Prüfung auf >= 98 % ist so nicht sinnvoll, da brauchen wir eine andere Logik.
- Im Log für ngx-spinner bekomme ich die folgende Fehlermeldung (auch für andere spinner, z. B. im Live): [ngx-spinner]: Property "type" is missed. Please, provide animation type to <ngx-spinner> component and ensure css is added to angular.json file
    "Das System ist auf dem aktuellen Softwarestand" sollten wir deutlicher hervorheben/fett drucken
- Die Prozentanzeige beim Neustart macht keinen Sinn; evtl. die Prozent ausblenden?
- Übersetzungen fehlen noch