### PR TITLE
Set explicit UTF-8 encoding for Java projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ tmp/
 *.swp
 *~.nib
 local.properties
-.settings/
 .loadpath
 .recommenders
 

--- a/cnf/.settings/org.eclipse.core.resources.prefs
+++ b/cnf/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.alerting/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.alerting/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.application/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.application/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.b2brest/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.b2brest/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.b2bwebsocket/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.b2bwebsocket/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.common/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.common/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.core/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.edgewebsocket/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.edgewebsocket/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.metadata.dummy/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.metadata.dummy/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.metadata.file/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.metadata.file/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.metadata.odoo/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.metadata.odoo/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.timedata.dummy/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.timedata.dummy/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.timedata.influx/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.timedata.influx/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.backend.uiwebsocket/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.backend.uiwebsocket/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.common/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.common/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.application/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.application/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -32,11 +32,11 @@
 	bnd.identity;id='io.openems.edge.battery.bydcommercial',\
 	bnd.identity;id='io.openems.edge.battery.fenecon.commercial',\
 	bnd.identity;id='io.openems.edge.battery.fenecon.home',\
-	bnd.identity;id='io.openems.edge.battery.soltaro',\
 	bnd.identity;id='io.openems.edge.batteryinverter.kaco.blueplanetgridsave',\
 	bnd.identity;id='io.openems.edge.batteryinverter.refu88k',\
 	bnd.identity;id='io.openems.edge.batteryinverter.sinexcel',\
 	bnd.identity;id='io.openems.edge.batteryinverter.sunspec',\
+	bnd.identity;id='io.openems.edge.battery.soltaro',\
 	bnd.identity;id='io.openems.edge.bosch.bpts5hybrid',\
 	bnd.identity;id='io.openems.edge.bridge.mbus',\
 	bnd.identity;id='io.openems.edge.bridge.modbus',\

--- a/io.openems.edge.battery.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.battery.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.battery.bmw/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.battery.bmw/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.battery.bydcommercial/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.battery.bydcommercial/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.battery.fenecon.commercial/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.battery.fenecon.commercial/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.battery.fenecon.home/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.battery.fenecon.home/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.battery.soltaro/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.battery.soltaro/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.batteryinverter.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.batteryinverter.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.batteryinverter.kaco.blueplanetgridsave/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.batteryinverter.kaco.blueplanetgridsave/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.batteryinverter.refu88k/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.batteryinverter.refu88k/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.batteryinverter.sinexcel/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.batteryinverter.sinexcel/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.batteryinverter.sunspec/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.batteryinverter.sunspec/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.bosch.bpts5hybrid/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.bosch.bpts5hybrid/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.bridge.mbus/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.bridge.mbus/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.bridge.modbus/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.bridge.modbus/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.bridge.onewire/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.bridge.onewire/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.common/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.common/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.api.backend/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.api.backend/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.api.common/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.api.common/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.api.modbus/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.api.modbus/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.api.mqtt/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.api.mqtt/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.api.rest/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.api.rest/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.api.websocket/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.api.websocket/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.asymmetric.balancingcosphi/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.asymmetric.balancingcosphi/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.asymmetric.fixactivepower/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.asymmetric.fixactivepower/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.asymmetric.fixreactivepower/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.asymmetric.fixreactivepower/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.asymmetric.peakshaving/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.asymmetric.peakshaving/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.asymmetric.phaserectification/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.asymmetric.phaserectification/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.channelthreshold/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.channelthreshold/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.chp.soc/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.chp.soc/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.debug.detailedlog/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.debug.detailedlog/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.debug.log/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.debug.log/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.acisland/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.acisland/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.activepowervoltagecharacteristic/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.activepowervoltagecharacteristic/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.cycle/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.cycle/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.delaycharge/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.delaycharge/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.delayedselltogrid/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.delayedselltogrid/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.emergencycapacityreserve/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.emergencycapacityreserve/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.fixactivepower/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.fixactivepower/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.gridoptimizedcharge/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.gridoptimizedcharge/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.hybrid.surplusfeedtogrid/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.hybrid.surplusfeedtogrid/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.limittotaldischarge/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.limittotaldischarge/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.linearpowerband/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.linearpowerband/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.mindischargeperiod/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.mindischargeperiod/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.reactivepowervoltagecharacteristic/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.reactivepowervoltagecharacteristic/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.selltogridlimit/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.selltogridlimit/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.standby/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.standby/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.ess.timeofusetariff.discharge/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.ess.timeofusetariff.discharge/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.evcs.fixactivepower/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.evcs.fixactivepower/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.evcs/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.evcs/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.generic.jsonlogic/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.generic.jsonlogic/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.highloadtimeslot/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.highloadtimeslot/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.io.alarm/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.io.alarm/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.io.channelsinglethreshold/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.io.channelsinglethreshold/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.io.fixdigitaloutput/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.io.fixdigitaloutput/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.io.heatingelement/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.io.heatingelement/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.io.heatpump.sgready/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.io.heatpump.sgready/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.pvinverter.fixpowerlimit/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.pvinverter.fixpowerlimit/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.pvinverter.selltogridlimit/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.pvinverter.selltogridlimit/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.symmetric.balancing/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.symmetric.balancing/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.symmetric.balancingschedule/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.symmetric.balancingschedule/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.symmetric.fixreactivepower/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.symmetric.fixreactivepower/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.symmetric.limitactivepower/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.symmetric.limitactivepower/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.symmetric.peakshaving/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.symmetric.peakshaving/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.symmetric.randompower/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.symmetric.randompower/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.controller.symmetric.timeslotpeakshaving/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.controller.symmetric.timeslotpeakshaving/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.core/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.ess.adstec.storaxe/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.ess.adstec.storaxe/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.ess.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.ess.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.ess.byd.container/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.ess.byd.container/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.ess.cluster/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.ess.cluster/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.ess.core/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.ess.core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.ess.fenecon.commercial40/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.ess.fenecon.commercial40/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.ess.generic/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.ess.generic/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.ess.mr.gridcon/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.ess.mr.gridcon/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.ess.sma/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.ess.sma/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.evcs.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.evcs.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.evcs.cluster/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.evcs.cluster/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.evcs.core/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.evcs.core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.evcs.goe.chargerhome/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.evcs.goe.chargerhome/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.evcs.hardybarth/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.evcs.hardybarth/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.evcs.keba.kecontact/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.evcs.keba.kecontact/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.evcs.ocpp.abl/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.evcs.ocpp.abl/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.evcs.ocpp.common/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.evcs.ocpp.common/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.evcs.ocpp.ies.keywatt.singleccs/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.evcs.ocpp.ies.keywatt.singleccs/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.evcs.ocpp.server/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.evcs.ocpp.server/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.fenecon.dess/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.fenecon.dess/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.fenecon.mini/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.fenecon.mini/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.fenecon.pro/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.fenecon.pro/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.goodwe/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.goodwe/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.io.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.io.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.io.kmtronic/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.io.kmtronic/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.io.offgridswitch/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.io.offgridswitch/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.io.revpi/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.io.revpi/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.io.shelly/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.io.shelly/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.io.wago/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.io.wago/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.kostal.piko/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.kostal.piko/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.abb/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.abb/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.artemes.am2/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.artemes.am2/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.bcontrol.em300/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.bcontrol.em300/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.carlo.gavazzi.em300/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.carlo.gavazzi.em300/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.discovergy/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.discovergy/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.janitza/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.janitza/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.microcare.sdm630/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.microcare.sdm630/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.pqplus/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.pqplus/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.schneider.acti9.smartlink/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.schneider.acti9.smartlink/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.siemens/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.siemens/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.sma.shm20/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.sma.shm20/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.socomec/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.socomec/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.sunspec/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.sunspec/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.virtual/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.virtual/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.weidmueller/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.weidmueller/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.onewire.thermometer/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.onewire.thermometer/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.predictor.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.predictor.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.predictor.persistencemodel/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.predictor.persistencemodel/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.predictor.similardaymodel/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.predictor.similardaymodel/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.pvinverter.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.pvinverter.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.pvinverter.cluster/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.pvinverter.cluster/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.pvinverter.fronius/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.pvinverter.fronius/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.pvinverter.kaco.blueplanet/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.pvinverter.kaco.blueplanet/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.pvinverter.kostal/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.pvinverter.kostal/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.pvinverter.sma/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.pvinverter.sma/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.pvinverter.solarlog/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.pvinverter.solarlog/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.pvinverter.sunspec/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.pvinverter.sunspec/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.scheduler.allalphabetically/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.scheduler.allalphabetically/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.scheduler.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.scheduler.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.scheduler.daily/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.scheduler.daily/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.scheduler.fixedorder/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.scheduler.fixedorder/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.simulator/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.simulator/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.solaredge/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.solaredge/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.tesla.powerwall2/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.tesla.powerwall2/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.thermometer.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.thermometer.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.timedata.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.timedata.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.timedata.influxdb/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.timedata.influxdb/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.timedata.rrd4j/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.timedata.rrd4j/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.timeofusetariff.api/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.timeofusetariff.api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.timeofusetariff.awattar/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.timeofusetariff.awattar/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.timeofusetariff.corrently/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.timeofusetariff.corrently/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.timeofusetariff.tibber/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.timeofusetariff.tibber/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.shared.influxdb/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.shared.influxdb/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.wrapper/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.wrapper/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tools/prepare-commit.sh
+++ b/tools/prepare-commit.sh
@@ -63,6 +63,16 @@ for D in *; do
 					touch ${D}/test/.gitignore
 				fi
 
+				# verify explicit encoding for Eclipse IDE; avoids 'Project has no explicit encoding set' warnings
+				if [ ! -f "./${D}/.settings/org.eclipse.core.resources.prefs" ]; then
+					echo "${D}/.settings/org.eclipse.core.resources.prefs -> missing"
+					mkdir "${D}/.settings"
+					cat <<EOT > "${D}/.settings/org.eclipse.core.resources.prefs"
+eclipse.preferences.version=1
+encoding/<project>=UTF-8
+EOT
+				fi
+
 				# Set default .classpath file
 				if [ -f "${D}/.classpath" ]; then
 					cat <<EOT > "${D}/.classpath"
@@ -79,11 +89,6 @@ for D in *; do
 	<classpathentry kind="output" path="bin"/>
 </classpath>
 EOT
-				fi
-
-				# Remove .settings directory
-				if [ -d "${D}/.settings" ]; then
-					rm -R "${D}/.settings"
 				fi
 
 				# Verify bnd.bnd file


### PR DESCRIPTION
Starting with Eclipse IDE 2022-06, the IDE shows a warning if no explicit encoding is set. The warning message is _"Project has no explicit encoding set"_.

This pull-request adds the explicit configuration for every project directory and adds an automatic check/creation in `tools/prepare-commit.sh` script.