### PR TITLE
JUnit test framework for OpenEMS Backend

### DIFF
--- a/io.openems.backend.timedata.timescaledb/test/io/openems/backend/timedata/timescaledb/MyConfig.java
+++ b/io.openems.backend.timedata.timescaledb/test/io/openems/backend/timedata/timescaledb/MyConfig.java
@@ -1,0 +1,117 @@
+package io.openems.backend.timedata.timescaledb;
+
+import io.openems.common.test.AbstractComponentConfig;
+
+@SuppressWarnings("all")
+public class MyConfig extends AbstractComponentConfig implements Config {
+
+	protected static class Builder {
+		private String id = null;
+		public String host;
+		public int port;
+		public String user;
+		public String password;
+		public String database;
+		public boolean isReadOnly;
+		public WriteConfig betaWriteConfig;
+
+		private Builder() {
+		}
+
+		public Builder setId(String id) {
+			this.id = id;
+			return this;
+		}
+
+		public Builder setHost(String host) {
+			this.host = host;
+			return this;
+		}
+
+		public Builder setPort(int port) {
+			this.port = port;
+			return this;
+		}
+
+		public Builder setUser(String user) {
+			this.user = user;
+			return this;
+		}
+
+		public Builder setPassword(String password) {
+			this.password = password;
+			return this;
+		}
+
+		public Builder setDatabase(String database) {
+			this.database = database;
+			return this;
+		}
+
+		public Builder setReadOnly(boolean isReadOnly) {
+			this.isReadOnly = isReadOnly;
+			return this;
+		}
+
+		public Builder setBetaWriteConfig(WriteConfig betaWriteConfig) {
+			this.betaWriteConfig = betaWriteConfig;
+			return this;
+		}
+
+		public MyConfig build() {
+			return new MyConfig(this);
+		}
+	}
+
+	/**
+	 * Create a Config builder.
+	 *
+	 * @return a {@link Builder}
+	 */
+	public static Builder create() {
+		return new Builder();
+	}
+
+	private final Builder builder;
+
+	private MyConfig(Builder builder) {
+		super(Config.class, builder.id);
+		this.builder = builder;
+	}
+
+	@Override
+	public String host() {
+		return this.builder.host;
+	}
+
+	@Override
+	public int port() {
+		return this.builder.port;
+	}
+
+	@Override
+	public String user() {
+		return this.builder.user;
+	}
+
+	@Override
+	public String password() {
+		return this.builder.password;
+	}
+
+	@Override
+	public String database() {
+		return this.builder.database;
+	}
+
+	@Override
+	public boolean isReadOnly() {
+		return this.builder.isReadOnly;
+	}
+
+	@Override
+	public WriteConfig betaWriteConfig() {
+		return this.builder.betaWriteConfig;
+	}
+
+}

--- a/io.openems.common/src/io/openems/common/test/AbstractComponentConfig.java
+++ b/io.openems.common/src/io/openems/common/test/AbstractComponentConfig.java
@@ -1,4 +1,4 @@
-package io.openems.edge.common.test;
+package io.openems.common.test;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;

--- a/io.openems.common/src/io/openems/common/test/package-info.java
+++ b/io.openems.common/src/io/openems/common/test/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package io.openems.common.test;

--- a/io.openems.edge.battery.bmw/test/io/openems/edge/battery/bmw/MyConfig.java
+++ b/io.openems.edge.battery.bmw/test/io/openems/edge/battery/bmw/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.battery.bmw;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.battery.bmw.enums.BatteryState;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.battery.bydcommercial/test/io/openems/edge/battery/bydcommercial/MyConfig.java
+++ b/io.openems.edge.battery.bydcommercial/test/io/openems/edge/battery/bydcommercial/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.battery.bydcommercial;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.common.startstop.StartStopConfig;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.battery.fenecon.commercial/test/io/openems/edge/battery/fenecon/commercial/MyConfig.java
+++ b/io.openems.edge.battery.fenecon.commercial/test/io/openems/edge/battery/fenecon/commercial/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.battery.fenecon.commercial;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.common.startstop.StartStopConfig;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.battery.fenecon.home/test/io/openems/edge/battery/fenecon/home/MyConfig.java
+++ b/io.openems.edge.battery.fenecon.home/test/io/openems/edge/battery/fenecon/home/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.battery.fenecon.home;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.common.startstop.StartStopConfig;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.battery.soltaro/test/io/openems/edge/battery/soltaro/cluster/versionb/MyConfig.java
+++ b/io.openems.edge.battery.soltaro/test/io/openems/edge/battery/soltaro/cluster/versionb/MyConfig.java
@@ -1,9 +1,9 @@
 package io.openems.edge.battery.soltaro.cluster.versionb;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.battery.soltaro.common.enums.BatteryState;
 import io.openems.edge.battery.soltaro.common.enums.ModuleType;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.battery.soltaro/test/io/openems/edge/battery/soltaro/cluster/versionc/MyConfig.java
+++ b/io.openems.edge.battery.soltaro/test/io/openems/edge/battery/soltaro/cluster/versionc/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.battery.soltaro.cluster.versionc;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.common.startstop.StartStopConfig;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.battery.soltaro/test/io/openems/edge/battery/soltaro/single/versiona/MyConfig.java
+++ b/io.openems.edge.battery.soltaro/test/io/openems/edge/battery/soltaro/single/versiona/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.battery.soltaro.single.versiona;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.battery.soltaro.common.enums.BatteryState;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.battery.soltaro/test/io/openems/edge/battery/soltaro/single/versionb/MyConfig.java
+++ b/io.openems.edge.battery.soltaro/test/io/openems/edge/battery/soltaro/single/versionb/MyConfig.java
@@ -1,9 +1,9 @@
 package io.openems.edge.battery.soltaro.single.versionb;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.battery.soltaro.common.enums.ModuleType;
 import io.openems.edge.common.startstop.StartStopConfig;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.battery.soltaro/test/io/openems/edge/battery/soltaro/single/versionc/MyConfig.java
+++ b/io.openems.edge.battery.soltaro/test/io/openems/edge/battery/soltaro/single/versionc/MyConfig.java
@@ -1,9 +1,9 @@
 package io.openems.edge.battery.soltaro.single.versionc;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.battery.soltaro.common.enums.ModuleType;
 import io.openems.edge.common.startstop.StartStopConfig;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.batteryinverter.kaco.blueplanetgridsave/test/io/openems/edge/batteryinverter/kaco/blueplanetgridsave/MyConfig.java
+++ b/io.openems.edge.batteryinverter.kaco.blueplanetgridsave/test/io/openems/edge/batteryinverter/kaco/blueplanetgridsave/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.batteryinverter.kaco.blueplanetgridsave;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.common.startstop.StartStopConfig;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.batteryinverter.refu88k/test/io/openems/edge/batteryinverter/refu88k/MyConfig.java
+++ b/io.openems.edge.batteryinverter.refu88k/test/io/openems/edge/batteryinverter/refu88k/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.batteryinverter.refu88k;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.common.startstop.StartStopConfig;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.batteryinverter.sinexcel/test/io/openems/edge/batteryinverter/sinexcel/MyConfig.java
+++ b/io.openems.edge.batteryinverter.sinexcel/test/io/openems/edge/batteryinverter/sinexcel/MyConfig.java
@@ -1,10 +1,10 @@
 package io.openems.edge.batteryinverter.sinexcel;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.batteryinverter.sinexcel.enums.CountryCode;
 import io.openems.edge.batteryinverter.sinexcel.enums.EnableDisable;
 import io.openems.edge.common.startstop.StartStopConfig;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.bosch.bpts5hybrid/test/io/openems/edge/bosch/bpts5hybrid/core/MyConfig.java
+++ b/io.openems.edge.bosch.bpts5hybrid/test/io/openems/edge/bosch/bpts5hybrid/core/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.bosch.bpts5hybrid.core;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.bosch.bpts5hybrid/test/io/openems/edge/bosch/bpts5hybrid/ess/MyConfig.java
+++ b/io.openems.edge.bosch.bpts5hybrid/test/io/openems/edge/bosch/bpts5hybrid/ess/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.bosch.bpts5hybrid.ess;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.bosch.bpts5hybrid/test/io/openems/edge/bosch/bpts5hybrid/meter/MyConfig.java
+++ b/io.openems.edge.bosch.bpts5hybrid/test/io/openems/edge/bosch/bpts5hybrid/meter/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.bosch.bpts5hybrid.meter;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.bosch.bpts5hybrid/test/io/openems/edge/bosch/bpts5hybrid/pv/MyConfig.java
+++ b/io.openems.edge.bosch.bpts5hybrid/test/io/openems/edge/bosch/bpts5hybrid/pv/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.bosch.bpts5hybrid.pv;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/MyConfigSerial.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/MyConfigSerial.java
@@ -1,9 +1,9 @@
 package io.openems.edge.bridge.modbus;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.edge.bridge.modbus.api.LogVerbosity;
 import io.openems.edge.bridge.modbus.api.Parity;
 import io.openems.edge.bridge.modbus.api.Stopbit;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfigSerial extends AbstractComponentConfig implements ConfigSerial {

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/MyConfigTcp.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/MyConfigTcp.java
@@ -1,7 +1,7 @@
 package io.openems.edge.bridge.modbus;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.edge.bridge.modbus.api.LogVerbosity;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfigTcp extends AbstractComponentConfig implements ConfigTcp {

--- a/io.openems.edge.common/src/io/openems/edge/common/test/AbstractComponentTest.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/test/AbstractComponentTest.java
@@ -26,6 +26,7 @@ import org.osgi.service.event.EventHandler;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.function.ThrowingRunnable;
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.types.ChannelAddress;
 import io.openems.common.types.OpenemsType;
 import io.openems.edge.common.channel.Channel;

--- a/io.openems.edge.common/src/io/openems/edge/common/test/DummyComponentContext.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/test/DummyComponentContext.java
@@ -10,6 +10,8 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.ComponentInstance;
 
+import io.openems.common.test.AbstractComponentConfig;
+
 /**
  * Simulates a {@link ComponentContext} for the OpenEMS Component test
  * framework.

--- a/io.openems.edge.common/src/io/openems/edge/common/test/DummyConfigurationAdmin.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/test/DummyConfigurationAdmin.java
@@ -14,6 +14,8 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
+import io.openems.common.test.AbstractComponentConfig;
+
 /**
  * Simulates a ConfigurationAdmin for the OpenEMS Component test framework.
  */

--- a/io.openems.edge.controller.api.backend/test/io/openems/edge/controller/api/backend/MyConfig.java
+++ b/io.openems.edge.controller.api.backend/test/io/openems/edge/controller/api/backend/MyConfig.java
@@ -3,7 +3,7 @@ package io.openems.edge.controller.api.backend;
 import java.net.Proxy.Type;
 
 import io.openems.common.channel.PersistencePriority;
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.api.mqtt/test/io/openems/edge/controller/api/mqtt/MyConfig.java
+++ b/io.openems.edge.controller.api.mqtt/test/io/openems/edge/controller/api/mqtt/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.controller.api.mqtt;
 
 import io.openems.common.channel.PersistencePriority;
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readwrite/MyConfig.java
+++ b/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readwrite/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.api.rest.readwrite;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.asymmetric.peakshaving/test/io/openems/edge/controller/asymmetric/peakshaving/MyConfig.java
+++ b/io.openems.edge.controller.asymmetric.peakshaving/test/io/openems/edge/controller/asymmetric/peakshaving/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.asymmetric.peakshaving;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.chp.soc/test/io/openems/edge/controller/chp/soc/MyConfig.java
+++ b/io.openems.edge.controller.chp.soc/test/io/openems/edge/controller/chp/soc/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.chp.soc;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.debug.log/test/io/openems/edge/controller/debuglog/MyConfig.java
+++ b/io.openems.edge.controller.debug.log/test/io/openems/edge/controller/debuglog/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.debuglog;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.activepowervoltagecharacteristic/test/io/openems/edge/controller/ess/activepowervoltagecharacteristic/MyConfig.java
+++ b/io.openems.edge.controller.ess.activepowervoltagecharacteristic/test/io/openems/edge/controller/ess/activepowervoltagecharacteristic/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.controller.ess.activepowervoltagecharacteristic;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.cycle/test/io/openems/edge/controller/ess/cycle/MyConfig.java
+++ b/io.openems.edge.controller.ess.cycle/test/io/openems/edge/controller/ess/cycle/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.controller.ess.cycle;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.delaycharge/test/io/openems/edge/controller/ess/delaycharge/MyConfig.java
+++ b/io.openems.edge.controller.ess.delaycharge/test/io/openems/edge/controller/ess/delaycharge/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.ess.delaycharge;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.delayedselltogrid/test/io/openems/edge/controller/ess/delayedselltogrid/MyConfig.java
+++ b/io.openems.edge.controller.ess.delayedselltogrid/test/io/openems/edge/controller/ess/delayedselltogrid/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.ess.delayedselltogrid;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.emergencycapacityreserve/test/io/openems/edge/controller/ess/emergencycapacityreserve/MyConfig.java
+++ b/io.openems.edge.controller.ess.emergencycapacityreserve/test/io/openems/edge/controller/ess/emergencycapacityreserve/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.controller.ess.emergencycapacityreserve;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.fixactivepower/test/io/openems/edge/controller/ess/fixactivepower/MyConfig.java
+++ b/io.openems.edge.controller.ess.fixactivepower/test/io/openems/edge/controller/ess/fixactivepower/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.controller.ess.fixactivepower;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.gridoptimizedcharge/test/io/openems/edge/controller/ess/gridoptimizedcharge/MyConfig.java
+++ b/io.openems.edge.controller.ess.gridoptimizedcharge/test/io/openems/edge/controller/ess/gridoptimizedcharge/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.controller.ess.gridoptimizedcharge;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.hybrid.surplusfeedtogrid/test/io/openems/edge/controller/ess/hybrid/surplusfeedtogrid/MyConfig.java
+++ b/io.openems.edge.controller.ess.hybrid.surplusfeedtogrid/test/io/openems/edge/controller/ess/hybrid/surplusfeedtogrid/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.controller.ess.hybrid.surplusfeedtogrid;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.limittotaldischarge/test/io/openems/edge/controller/ess/limittotaldischarge/MyConfig.java
+++ b/io.openems.edge.controller.ess.limittotaldischarge/test/io/openems/edge/controller/ess/limittotaldischarge/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.ess.limittotaldischarge;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.linearpowerband/test/io/openems/edge/controller/ess/linearpowerband/MyConfig.java
+++ b/io.openems.edge.controller.ess.linearpowerband/test/io/openems/edge/controller/ess/linearpowerband/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.controller.ess.linearpowerband;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.reactivepowervoltagecharacteristic/test/io/openems/edge/controller/ess/reactivepowervoltagecharacteristic/MyConfig.java
+++ b/io.openems.edge.controller.ess.reactivepowervoltagecharacteristic/test/io/openems/edge/controller/ess/reactivepowervoltagecharacteristic/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.controller.ess.reactivepowervoltagecharacteristic;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.selltogridlimit/test/io/openems/edge/controller/symmetric/selltogridlimit/MyConfig.java
+++ b/io.openems.edge.controller.ess.selltogridlimit/test/io/openems/edge/controller/symmetric/selltogridlimit/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.controller.symmetric.selltogridlimit;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.standby/test/io/openems/edge/controller/ess/standby/MyConfig.java
+++ b/io.openems.edge.controller.ess.standby/test/io/openems/edge/controller/ess/standby/MyConfig.java
@@ -2,7 +2,7 @@ package io.openems.edge.controller.ess.standby;
 
 import java.time.DayOfWeek;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.ess.timeofusetariff.discharge/test/io/openems/edge/controller/ess/timeofusetariff/discharge/MyConfig.java
+++ b/io.openems.edge.controller.ess.timeofusetariff.discharge/test/io/openems/edge/controller/ess/timeofusetariff/discharge/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.controller.ess.timeofusetariff.discharge;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.evcs/test/io/openems/edge/controller/evcs/MyConfig.java
+++ b/io.openems.edge.controller.evcs/test/io/openems/edge/controller/evcs/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.evcs;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.generic.jsonlogic/test/io/openems/edge/controller/generic/jsonlogic/MyConfig.java
+++ b/io.openems.edge.controller.generic.jsonlogic/test/io/openems/edge/controller/generic/jsonlogic/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.controller.generic.jsonlogic;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.JsonUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.io.alarm/test/io/openems/edge/controller/io/alarm/MyConfig.java
+++ b/io.openems.edge.controller.io.alarm/test/io/openems/edge/controller/io/alarm/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.io.alarm;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.io.channelsinglethreshold/test/io/openems/edge/controller/io/channelsinglethreshold/MyConfig.java
+++ b/io.openems.edge.controller.io.channelsinglethreshold/test/io/openems/edge/controller/io/channelsinglethreshold/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.io.channelsinglethreshold;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.io.fixdigitaloutput/test/io/openems/edge/controller/io/fixdigitaloutput/MyConfig.java
+++ b/io.openems.edge.controller.io.fixdigitaloutput/test/io/openems/edge/controller/io/fixdigitaloutput/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.io.fixdigitaloutput;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.io.heatingelement/test/io/openems/edge/controller/io/heatingelement/MyConfig.java
+++ b/io.openems.edge.controller.io.heatingelement/test/io/openems/edge/controller/io/heatingelement/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.io.heatingelement;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.edge.controller.io.heatingelement.enums.Level;
 import io.openems.edge.controller.io.heatingelement.enums.Mode;
 import io.openems.edge.controller.io.heatingelement.enums.WorkMode;

--- a/io.openems.edge.controller.io.heatpump.sgready/test/io/openems/edge/controller/io/heatpump/sgready/MyConfig.java
+++ b/io.openems.edge.controller.io.heatpump.sgready/test/io/openems/edge/controller/io/heatpump/sgready/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.io.heatpump.sgready;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.symmetric.balancing/test/io/openems/edge/controller/symmetric/balancing/MyConfig.java
+++ b/io.openems.edge.controller.symmetric.balancing/test/io/openems/edge/controller/symmetric/balancing/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.symmetric.balancing;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.symmetric.balancingschedule/test/io/openems/edge/controller/symmetric/balancingschedule/MyConfig.java
+++ b/io.openems.edge.controller.symmetric.balancingschedule/test/io/openems/edge/controller/symmetric/balancingschedule/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.controller.symmetric.balancingschedule;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.symmetric.peakshaving/test/io/openems/edge/controller/symmetric/peakshaving/MyConfig.java
+++ b/io.openems.edge.controller.symmetric.peakshaving/test/io/openems/edge/controller/symmetric/peakshaving/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.symmetric.peakshaving;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.controller.symmetric.timeslotpeakshaving/test/io/openems/edge/controller/timeslotpeakshaving/MyConfig.java
+++ b/io.openems.edge.controller.symmetric.timeslotpeakshaving/test/io/openems/edge/controller/timeslotpeakshaving/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.controller.timeslotpeakshaving;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.core/test/io/openems/edge/core/appmanager/AppManagerImplTest.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/appmanager/AppManagerImplTest.java
@@ -8,9 +8,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.Map.Entry;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/io.openems.edge.core/test/io/openems/edge/core/appmanager/MyConfig.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/appmanager/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.core.appmanager;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.core/test/io/openems/edge/core/componentmanager/MyConfig.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/componentmanager/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.core.componentmanager;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.edge.common.component.ComponentManager;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.core/test/io/openems/edge/core/host/MyConfig.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/host/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.core.host;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.edge.common.host.Host;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.ess.adstec.storaxe/test/io/openems/edge/ess/adstec/storaxe/MyConfig.java
+++ b/io.openems.edge.ess.adstec.storaxe/test/io/openems/edge/ess/adstec/storaxe/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.ess.adstec.storaxe;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.ess.byd.container/test/io/openems/edge/ess/byd/container/MyConfig.java
+++ b/io.openems.edge.ess.byd.container/test/io/openems/edge/ess/byd/container/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.ess.byd.container;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.ess.byd.container/test/io/openems/edge/ess/byd/container/watchdog/MyEssConfig.java
+++ b/io.openems.edge.ess.byd.container/test/io/openems/edge/ess/byd/container/watchdog/MyEssConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.ess.byd.container.watchdog;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.ess.byd.container.Config;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.ess.byd.container/test/io/openems/edge/ess/byd/container/watchdog/MyWatchdogConfig.java
+++ b/io.openems.edge.ess.byd.container/test/io/openems/edge/ess/byd/container/watchdog/MyWatchdogConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.ess.byd.container.watchdog;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyWatchdogConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.ess.cluster/test/io/openems/edge/ess/cluster/MyConfig.java
+++ b/io.openems.edge.ess.cluster/test/io/openems/edge/ess/cluster/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.ess.cluster;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.ess.core/test/io/openems/edge/ess/core/power/MyConfig.java
+++ b/io.openems.edge.ess.core/test/io/openems/edge/ess/core/power/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.ess.core.power;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.edge.ess.power.api.SolverStrategy;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.ess.fenecon.commercial40/test/io/openems/edge/ess/fenecon/commercial40/MyConfig.java
+++ b/io.openems.edge.ess.fenecon.commercial40/test/io/openems/edge/ess/fenecon/commercial40/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.ess.fenecon.commercial40;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.ess.fenecon.commercial40/test/io/openems/edge/ess/fenecon/commercial40/charger/MyConfigPV1.java
+++ b/io.openems.edge.ess.fenecon.commercial40/test/io/openems/edge/ess/fenecon/commercial40/charger/MyConfigPV1.java
@@ -1,7 +1,7 @@
 package io.openems.edge.ess.fenecon.commercial40.charger;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfigPV1 extends AbstractComponentConfig implements ConfigPV1 {

--- a/io.openems.edge.ess.generic/test/io/openems/edge/ess/generic/offgrid/MyConfig.java
+++ b/io.openems.edge.ess.generic/test/io/openems/edge/ess/generic/offgrid/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.ess.generic.offgrid;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.common.startstop.StartStopConfig;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.ess.generic/test/io/openems/edge/ess/generic/symmetric/MyConfig.java
+++ b/io.openems.edge.ess.generic/test/io/openems/edge/ess/generic/symmetric/MyConfig.java
@@ -1,8 +1,8 @@
 package io.openems.edge.ess.generic.symmetric;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
 import io.openems.edge.common.startstop.StartStopConfig;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.ess.sma/test/io/openems/edge/sma/MyConfig.java
+++ b/io.openems.edge.ess.sma/test/io/openems/edge/sma/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.sma;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.ess.api.SinglePhase;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.evcs.cluster/test/io/openems/edge/evcs/cluster/MyConfigPeakShaving.java
+++ b/io.openems.edge.evcs.cluster/test/io/openems/edge/evcs/cluster/MyConfigPeakShaving.java
@@ -1,6 +1,6 @@
 package io.openems.edge.evcs.cluster;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfigPeakShaving extends AbstractComponentConfig implements ConfigPeakShaving {

--- a/io.openems.edge.evcs.hardybarth/test/io/openems/edge/evcs/hardybarth/MyConfig.java
+++ b/io.openems.edge.evcs.hardybarth/test/io/openems/edge/evcs/hardybarth/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.evcs.hardybarth;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.fenecon.dess/test/io/openems/edge/fenecon/dess/charger/MyChargerConfig.java
+++ b/io.openems.edge.fenecon.dess/test/io/openems/edge/fenecon/dess/charger/MyChargerConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.fenecon.dess.charger;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyChargerConfig extends AbstractComponentConfig implements Config1, Config2 {

--- a/io.openems.edge.fenecon.dess/test/io/openems/edge/fenecon/dess/ess/MyEssConfig.java
+++ b/io.openems.edge.fenecon.dess/test/io/openems/edge/fenecon/dess/ess/MyEssConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.fenecon.dess.ess;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyEssConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.fenecon.dess/test/io/openems/edge/fenecon/dess/gridmeter/MyConfig.java
+++ b/io.openems.edge.fenecon.dess/test/io/openems/edge/fenecon/dess/gridmeter/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.fenecon.dess.gridmeter;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.fenecon.dess/test/io/openems/edge/fenecon/dess/pvmeter/MyConfig.java
+++ b/io.openems.edge.fenecon.dess/test/io/openems/edge/fenecon/dess/pvmeter/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.fenecon.dess.pvmeter;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.fenecon.mini/test/io/openems/edge/fenecon/mini/ess/MyConfig.java
+++ b/io.openems.edge.fenecon.mini/test/io/openems/edge/fenecon/mini/ess/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.fenecon.mini.ess;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.ess.api.SinglePhase;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.fenecon.mini/test/io/openems/edge/fenecon/mini/gridmeter/MyConfig.java
+++ b/io.openems.edge.fenecon.mini/test/io/openems/edge/fenecon/mini/gridmeter/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.fenecon.mini.gridmeter;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.fenecon.mini/test/io/openems/edge/fenecon/mini/pvmeter/MyConfig.java
+++ b/io.openems.edge.fenecon.mini/test/io/openems/edge/fenecon/mini/pvmeter/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.fenecon.mini.pvmeter;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.fenecon.pro/test/io/openems/edge/fenecon/pro/ess/MyConfig.java
+++ b/io.openems.edge.fenecon.pro/test/io/openems/edge/fenecon/pro/ess/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.fenecon.pro.ess;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.fenecon.pro/test/io/openems/edge/fenecon/pro/pvmeter/MyConfig.java
+++ b/io.openems.edge.fenecon.pro/test/io/openems/edge/fenecon/pro/pvmeter/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.fenecon.pro.pvmeter;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.goodwe/test/io/openems/edge/goodwe/batteryinverter/MyConfig.java
+++ b/io.openems.edge.goodwe/test/io/openems/edge/goodwe/batteryinverter/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.goodwe.batteryinverter;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.goodwe.common.enums.ControlMode;
 import io.openems.edge.goodwe.common.enums.EnableDisable;
 import io.openems.edge.goodwe.common.enums.FeedInPowerSettings;

--- a/io.openems.edge.goodwe/test/io/openems/edge/goodwe/charger/MyConfig.java
+++ b/io.openems.edge.goodwe/test/io/openems/edge/goodwe/charger/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.goodwe.charger;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements ConfigPV1, ConfigPV2 {

--- a/io.openems.edge.goodwe/test/io/openems/edge/goodwe/emergencypowermeter/MyConfig.java
+++ b/io.openems.edge.goodwe/test/io/openems/edge/goodwe/emergencypowermeter/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.goodwe.emergencypowermeter;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.goodwe/test/io/openems/edge/goodwe/ess/MyConfig.java
+++ b/io.openems.edge.goodwe/test/io/openems/edge/goodwe/ess/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.goodwe.ess;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.goodwe.common.enums.ControlMode;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.goodwe/test/io/openems/edge/goodwe/gridmeter/MyConfig.java
+++ b/io.openems.edge.goodwe/test/io/openems/edge/goodwe/gridmeter/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.goodwe.gridmeter;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.io.kmtronic/test/io/openems/edge/io/kmtronic/eight/MyConfig.java
+++ b/io.openems.edge.io.kmtronic/test/io/openems/edge/io/kmtronic/eight/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.io.kmtronic.eight;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.io.kmtronic/test/io/openems/edge/io/kmtronic/four/MyConfig.java
+++ b/io.openems.edge.io.kmtronic/test/io/openems/edge/io/kmtronic/four/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.io.kmtronic.four;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.io.offgridswitch/test/io/openems/edge/iooffgridswitch/MyConfig.java
+++ b/io.openems.edge.io.offgridswitch/test/io/openems/edge/iooffgridswitch/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.iooffgridswitch;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.io.wago/test/io/openems/edge/wago/MyConfig.java
+++ b/io.openems.edge.io.wago/test/io/openems/edge/wago/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.wago;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.meter.artemes.am2/test/io/openems/edge/meter/artemes/am2/MyConfig.java
+++ b/io.openems.edge.meter.artemes.am2/test/io/openems/edge/meter/artemes/am2/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.artemes.am2;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.bcontrol.em300/test/io/openems/edge/meter/bcontrol/em300/MyConfig.java
+++ b/io.openems.edge.meter.bcontrol.em300/test/io/openems/edge/meter/bcontrol/em300/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.bcontrol.em300;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.carlo.gavazzi.em300/test/io/openems/edge/meter/carlo/gavazzi/em300/MyConfig.java
+++ b/io.openems.edge.meter.carlo.gavazzi.em300/test/io/openems/edge/meter/carlo/gavazzi/em300/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.carlo.gavazzi.em300;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.janitza/test/io/openems/edge/meter/janitza/umg511/MyConfig.java
+++ b/io.openems.edge.meter.janitza/test/io/openems/edge/meter/janitza/umg511/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.janitza.umg511;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.janitza/test/io/openems/edge/meter/janitza/umg604/MyConfig.java
+++ b/io.openems.edge.meter.janitza/test/io/openems/edge/meter/janitza/umg604/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.janitza.umg604;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.janitza/test/io/openems/edge/meter/janitza/umg96rme/MyConfig.java
+++ b/io.openems.edge.meter.janitza/test/io/openems/edge/meter/janitza/umg96rme/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.janitza.umg96rme;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.microcare.sdm630/test/io/openems/edge/meter/microcare/sdm630/MyConfig.java
+++ b/io.openems.edge.meter.microcare.sdm630/test/io/openems/edge/meter/microcare/sdm630/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.microcare.sdm630;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.pqplus/test/io/openems/edge/meter/pqplus/umd96/MyConfig.java
+++ b/io.openems.edge.meter.pqplus/test/io/openems/edge/meter/pqplus/umd96/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.pqplus.umd96;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.pqplus/test/io/openems/edge/meter/pqplus/umd97/MyConfig.java
+++ b/io.openems.edge.meter.pqplus/test/io/openems/edge/meter/pqplus/umd97/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.pqplus.umd97;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.schneider.acti9.smartlink/test/io/openems/edge/meter/schneider/acti9/smartlink/MyConfig.java
+++ b/io.openems.edge.meter.schneider.acti9.smartlink/test/io/openems/edge/meter/schneider/acti9/smartlink/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.schneider.acti9.smartlink;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.sma.shm20/test/io/openems/edge/meter/sma/shm20/MyConfig.java
+++ b/io.openems.edge.meter.sma.shm20/test/io/openems/edge/meter/sma/shm20/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.sma.shm20;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.socomec/test/io/openems/edge/meter/socomec/singlephase/MyConfig.java
+++ b/io.openems.edge.meter.socomec/test/io/openems/edge/meter/socomec/singlephase/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.socomec.singlephase;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 import io.openems.edge.meter.api.SinglePhase;
 

--- a/io.openems.edge.meter.socomec/test/io/openems/edge/meter/socomec/threephase/MyConfig.java
+++ b/io.openems.edge.meter.socomec/test/io/openems/edge/meter/socomec/threephase/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.socomec.threephase;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.virtual/test/io/openems/edge/meter/virtual/symmetric/subtract/MyConfig.java
+++ b/io.openems.edge.meter.virtual/test/io/openems/edge/meter/virtual/symmetric/subtract/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.virtual.symmetric.subtract;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.meter.weidmueller/test/io/openems/edge/meter/weidmueller/MyConfig.java
+++ b/io.openems.edge.meter.weidmueller/test/io/openems/edge/meter/weidmueller/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.meter.weidmueller;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 import io.openems.edge.meter.api.MeterType;
 
 @SuppressWarnings("all")

--- a/io.openems.edge.predictor.persistencemodel/test/io/openems/edge/predictor/persistencemodel/MyConfig.java
+++ b/io.openems.edge.predictor.persistencemodel/test/io/openems/edge/predictor/persistencemodel/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.predictor.persistencemodel;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.predictor.similardaymodel/test/io/openems/edge/predictor/similardaymodel/MyConfig.java
+++ b/io.openems.edge.predictor.similardaymodel/test/io/openems/edge/predictor/similardaymodel/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.predictor.similardaymodel;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.pvinverter.fronius/test/io/openems/edge/pvinverter/fronius/MyConfig.java
+++ b/io.openems.edge.pvinverter.fronius/test/io/openems/edge/pvinverter/fronius/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.pvinverter.fronius;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.pvinverter.kostal/test/io/openems/edge/pvinverter/kostal/MyConfig.java
+++ b/io.openems.edge.pvinverter.kostal/test/io/openems/edge/pvinverter/kostal/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.pvinverter.kostal;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.pvinverter.solarlog/test/io/openems/edge/pvinverter/solarlog/MyConfig.java
+++ b/io.openems.edge.pvinverter.solarlog/test/io/openems/edge/pvinverter/solarlog/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.pvinverter.solarlog;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.scheduler.allalphabetically/test/io/openems/edge/scheduler/allalphabetically/MyConfig.java
+++ b/io.openems.edge.scheduler.allalphabetically/test/io/openems/edge/scheduler/allalphabetically/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.scheduler.allalphabetically;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.scheduler.daily/test/io/openems/edge/scheduler/daily/MyConfig.java
+++ b/io.openems.edge.scheduler.daily/test/io/openems/edge/scheduler/daily/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.scheduler.daily;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.scheduler.fixedorder/test/io/openems/edge/scheduler/fixedorder/MyConfig.java
+++ b/io.openems.edge.scheduler.fixedorder/test/io/openems/edge/scheduler/fixedorder/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.scheduler.fixedorder;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.simulator/test/io/openems/edge/simulator/ess/symmetric/reacting/MyConfig.java
+++ b/io.openems.edge.simulator/test/io/openems/edge/simulator/ess/symmetric/reacting/MyConfig.java
@@ -1,7 +1,7 @@
 package io.openems.edge.simulator.ess.symmetric.reacting;
 
+import io.openems.common.test.AbstractComponentConfig;
 import io.openems.edge.common.sum.GridMode;
-import io.openems.edge.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.timeofusetariff.awattar/test/io/openems/edge/timeofusetariff/awattar/MyConfig.java
+++ b/io.openems.edge.timeofusetariff.awattar/test/io/openems/edge/timeofusetariff/awattar/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.timeofusetariff.awattar;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.timeofusetariff.corrently/test/io/openems/edge/timeofusetariff/corrently/MyConfig.java
+++ b/io.openems.edge.timeofusetariff.corrently/test/io/openems/edge/timeofusetariff/corrently/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.timeofusetariff.corrently;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {

--- a/io.openems.edge.timeofusetariff.tibber/test/io/openems/edge/timeofusetariff/tibber/MyConfig.java
+++ b/io.openems.edge.timeofusetariff.tibber/test/io/openems/edge/timeofusetariff/tibber/MyConfig.java
@@ -1,6 +1,6 @@
 package io.openems.edge.timeofusetariff.tibber;
 
-import io.openems.edge.common.test.AbstractComponentConfig;
+import io.openems.common.test.AbstractComponentConfig;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {


### PR DESCRIPTION
Move AbstractComponentConfig from `io.openems.edge.common` to `io.openems.common`. This is the first step to use the existing JUnit test framework also for OpenEMS Backend.