### PR TITLE
App Manager

### DIFF
--- a/io.openems.edge.common/src/io/openems/edge/common/test/DummyComponentManager.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/test/DummyComponentManager.java
@@ -190,6 +190,18 @@ public class DummyComponentManager implements ComponentManager {
 		}
 	}
 
+	/**
+	 * Handles a {@link CreateComponentConfigRequest}.
+	 * 
+	 * <p>
+	 * Only creates the Configuration with the given Properties. Does not actually
+	 * add the component the the dummy component list.
+	 * 
+	 * @param user    the executing user
+	 * @param request the {@link CreateComponentConfigRequest}
+	 * @return the Future JSON-RPC Response
+	 * @throws OpenemsNamedException on error
+	 */
 	private CompletableFuture<JsonrpcResponseSuccess> handleCreateComponentConfigRequest(User user,
 			CreateComponentConfigRequest request) throws OpenemsNamedException {
 		if (this.configurationAdmin == null) {

--- a/io.openems.edge.core/src/io/openems/edge/app/api/ModbusTcpApiReadOnly.java
+++ b/io.openems.edge.core/src/io/openems/edge/app/api/ModbusTcpApiReadOnly.java
@@ -2,7 +2,6 @@ package io.openems.edge.app.api;
 
 import java.util.EnumMap;
 import java.util.List;
-import java.util.TreeMap;
 
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
@@ -29,8 +28,6 @@ import io.openems.edge.core.appmanager.ConfigurationTarget;
 import io.openems.edge.core.appmanager.OpenemsApp;
 import io.openems.edge.core.appmanager.OpenemsAppCardinality;
 import io.openems.edge.core.appmanager.OpenemsAppCategory;
-import io.openems.edge.core.appmanager.validator.CheckAppsNotInstalled;
-import io.openems.edge.core.appmanager.validator.ValidatorConfig;
 
 /**
  * Describes a App for ReadOnly Modbus/TCP Api.
@@ -106,16 +103,6 @@ public class ModbusTcpApiReadOnly extends AbstractOpenemsApp<Property> implement
 
 			return new AppConfiguration(components);
 		};
-	}
-
-	@Override
-	protected io.openems.edge.core.appmanager.validator.ValidatorConfig.Builder getValidateBuilder() {
-		return ValidatorConfig.create() //
-				.setInstallableCheckableConfigs(
-						Lists.newArrayList(new ValidatorConfig.CheckableConfig(CheckAppsNotInstalled.COMPONENT_NAME,
-								new ValidatorConfig.MapBuilder<>(new TreeMap<String, Object>()) //
-										.put("appIds", new String[] { "App.Api.ModbusTcp.ReadWrite" }) //
-										.build())));
 	}
 
 	@Override

--- a/io.openems.edge.core/src/io/openems/edge/app/heat/CombinedHeatAndPower.java
+++ b/io.openems.edge.core/src/io/openems/edge/app/heat/CombinedHeatAndPower.java
@@ -113,7 +113,7 @@ public class CombinedHeatAndPower extends AbstractOpenemsApp<Property> implement
 			var componentIdOfRelay = outputChannelAddress.substring(0, outputChannelAddress.indexOf('/'));
 
 			var appIdOfRelay = DependencyUtil.getInstanceIdOfAppWhichHasComponent(this.componentManager,
-					componentIdOfRelay, this.getAppId());
+					componentIdOfRelay);
 
 			if (appIdOfRelay == null) {
 				// relay may be created but not as a app

--- a/io.openems.edge.core/src/io/openems/edge/app/heat/HeatPump.java
+++ b/io.openems.edge.core/src/io/openems/edge/app/heat/HeatPump.java
@@ -95,7 +95,7 @@ public class HeatPump extends AbstractOpenemsApp<Property> implements OpenemsApp
 
 			var componentIdOfRelay = outputChannel1.substring(0, outputChannel1.indexOf('/'));
 			var appIdOfRelay = DependencyUtil.getInstanceIdOfAppWhichHasComponent(this.componentManager,
-					componentIdOfRelay, this.getAppId());
+					componentIdOfRelay);
 
 			if (appIdOfRelay == null) {
 				// relay may be created but not as a app

--- a/io.openems.edge.core/src/io/openems/edge/app/heat/HeatingElement.java
+++ b/io.openems.edge.core/src/io/openems/edge/app/heat/HeatingElement.java
@@ -118,7 +118,7 @@ public class HeatingElement extends AbstractOpenemsApp<Property> implements Open
 
 			var componentIdOfRelay = outputChannelPhaseL1.substring(0, outputChannelPhaseL1.indexOf('/'));
 			var appIdOfRelay = DependencyUtil.getInstanceIdOfAppWhichHasComponent(this.componentManager,
-					componentIdOfRelay, this.getAppId());
+					componentIdOfRelay);
 
 			if (appIdOfRelay == null) {
 				// relay may be created but not as a app

--- a/io.openems.edge.core/src/io/openems/edge/app/integratedsystem/FeneconHome.java
+++ b/io.openems.edge.core/src/io/openems/edge/app/integratedsystem/FeneconHome.java
@@ -416,7 +416,12 @@ public class FeneconHome extends AbstractOpenemsApp<Property> implements Openems
 								.setDescription(TranslationUtil.getTranslation(bundle,
 										this.getAppId() + ".rippleControlReceiver.description"))
 								.setDefaultValue(false) //
-								.build())
+								.onlyIf(batteryInverter.isPresent(), t -> {
+									var defaultValue = batteryInverter.get().getProperty("feedPowerEnable")
+											.map(j -> JsonUtils.getAsOptionalString(j).get()).orElse("ENABLE")
+											.equals("DISABLE");
+									t.setDefaultValue(defaultValue);
+								}).build())
 						.add(JsonFormlyUtil.buildInput(Property.MAX_FEED_IN_POWER) //
 								.setLabel(
 										TranslationUtil.getTranslation(bundle, this.getAppId() + ".feedInLimit.label")) //

--- a/io.openems.edge.core/src/io/openems/edge/app/meter/CarloGavazziMeter.java
+++ b/io.openems.edge.core/src/io/openems/edge/app/meter/CarloGavazziMeter.java
@@ -137,7 +137,7 @@ public class CarloGavazziMeter extends AbstractMeterApp<Property> implements Ope
 
 	@Override
 	public OpenemsAppCardinality getCardinality() {
-		return OpenemsAppCardinality.SINGLE_IN_CATEGORY;
+		return OpenemsAppCardinality.MULTIPLE;
 	}
 
 }

--- a/io.openems.edge.core/src/io/openems/edge/app/meter/JanitzaMeter.java
+++ b/io.openems.edge.core/src/io/openems/edge/app/meter/JanitzaMeter.java
@@ -164,7 +164,7 @@ public class JanitzaMeter extends AbstractMeterApp<Property> implements OpenemsA
 
 	@Override
 	public OpenemsAppCardinality getCardinality() {
-		return OpenemsAppCardinality.SINGLE_IN_CATEGORY;
+		return OpenemsAppCardinality.MULTIPLE;
 	}
 
 	protected final Set<Entry<String, String>> buildFactorieIdOptions() {

--- a/io.openems.edge.core/src/io/openems/edge/app/meter/SocomecMeter.java
+++ b/io.openems.edge.core/src/io/openems/edge/app/meter/SocomecMeter.java
@@ -138,7 +138,7 @@ public class SocomecMeter extends AbstractMeterApp<Property> implements OpenemsA
 
 	@Override
 	public OpenemsAppCardinality getCardinality() {
-		return OpenemsAppCardinality.SINGLE_IN_CATEGORY;
+		return OpenemsAppCardinality.MULTIPLE;
 	}
 
 }

--- a/io.openems.edge.core/src/io/openems/edge/app/pvselfconsumption/GridOptimizedCharge.java
+++ b/io.openems.edge.core/src/io/openems/edge/app/pvselfconsumption/GridOptimizedCharge.java
@@ -98,8 +98,8 @@ public class GridOptimizedCharge extends AbstractOpenemsApp<Property> implements
 									j -> j.addProperty("ess.id", "ess0") //
 											.addProperty("meter.id", "meter0"))
 							.addProperty("sellToGridLimitEnabled", sellToGridLimitEnabled) //
-							.onlyIf(sellToGridLimitEnabled,
-									o -> o.addProperty("maximumSellToGridPower", maximumSellToGridPower)) //
+							// always set the maximumSellToGridPower value
+							.addProperty("maximumSellToGridPower", maximumSellToGridPower) //
 							.build()));//
 
 			var schedulerExecutionOrder = Lists.newArrayList("ctrlGridOptimizedCharge0", "ctrlEssSurplusFeedToGrid0");

--- a/io.openems.edge.core/src/io/openems/edge/core/appmanager/AppManagerUtil.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/appmanager/AppManagerUtil.java
@@ -1,0 +1,93 @@
+package io.openems.edge.core.appmanager;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import com.google.gson.JsonObject;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.session.Language;
+
+public interface AppManagerUtil {
+
+	/**
+	 * Gets the {@link OpenemsApp} for the given appId.
+	 *
+	 * @param appId the appId of the {@link OpenemsApp}
+	 * @return the {@link OpenemsApp}
+	 * @throws NoSuchElementException if there is no {@link OpenemsApp} with the
+	 *                                given appId
+	 */
+	public OpenemsApp getAppById(String appId) throws NoSuchElementException;
+
+	/**
+	 * Gets the {@link OpenemsAppInstance} for the given instanceId.
+	 *
+	 * @param instanceId the instanceId of the {@link OpenemsAppInstance}
+	 * @return the {@link OpenemsAppInstance}
+	 * @throws NoSuchElementException if there is not {@link OpenemsAppInstance}
+	 *                                with the given instanceId
+	 */
+	public OpenemsAppInstance getInstanceById(UUID instanceId) throws NoSuchElementException;
+
+	/**
+	 * Gets the {@link AppConfiguration} with the given parameter.
+	 *
+	 * @param target     the {@link ConfigurationTarget} of the configuration
+	 * @param app        the {@link OpenemsApp}
+	 * @param alias      the alias of the instance
+	 * @param properties the {@link JsonObject} properties of the instance
+	 * @param language   the {@link Language} of the configuration
+	 * @return the {@link AppConfiguration}
+	 * @throws OpenemsException on error
+	 */
+	public AppConfiguration getAppConfiguration(ConfigurationTarget target, OpenemsApp app, String alias,
+			JsonObject properties, Language language) throws OpenemsNamedException;
+
+	/**
+	 * Gets the {@link AppConfiguration} with the given parameter.
+	 * 
+	 * @param target     the {@link ConfigurationTarget} of the configuration
+	 * @param appId      the {@link OpenemsApp#getAppId()} of the {@link OpenemsApp}
+	 * @param alias      the alias of the instance
+	 * @param properties the {@link JsonObject} properties of the instance
+	 * @param language   the {@link Language} of the configuration
+	 * @return the {@link AppConfiguration}
+	 * @throws OpenemsException on error
+	 */
+	public default AppConfiguration getAppConfiguration(ConfigurationTarget target, String appId, String alias,
+			JsonObject properties, Language language) throws OpenemsNamedException {
+		return this.getAppConfiguration(target, this.getAppById(appId), alias, properties, language);
+	}
+
+	/**
+	 * Gets the {@link AppConfiguration} with the given parameter.
+	 * 
+	 * @param target   the {@link ConfigurationTarget} of the configuration
+	 * @param app      the {@link OpenemsApp#getAppId()} of the {@link OpenemsApp}
+	 * @param instance the {@link OpenemsAppInstance}
+	 * @param language the {@link Language} of the configuration
+	 * @return the {@link AppConfiguration}
+	 * @throws OpenemsException on error
+	 */
+	public default AppConfiguration getAppConfiguration(ConfigurationTarget target, OpenemsApp app,
+			OpenemsAppInstance instance, Language language) throws OpenemsNamedException {
+		return this.getAppConfiguration(target, app, instance.alias, instance.properties, language);
+	}
+
+	/**
+	 * Gets the {@link AppConfiguration} with the given parameter.
+	 * 
+	 * @param target   the {@link ConfigurationTarget} of the configuration
+	 * @param instance the {@link OpenemsAppInstance}
+	 * @param language the {@link Language} of the configuration
+	 * @return the {@link AppConfiguration}
+	 * @throws OpenemsException on error
+	 */
+	public default AppConfiguration getAppConfiguration(ConfigurationTarget target, OpenemsAppInstance instance,
+			Language language) throws OpenemsNamedException {
+		return this.getAppConfiguration(target, this.getAppById(instance.appId), instance, language);
+	}
+
+}

--- a/io.openems.edge.core/src/io/openems/edge/core/appmanager/AppManagerUtilImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/appmanager/AppManagerUtilImpl.java
@@ -1,0 +1,64 @@
+package io.openems.edge.core.appmanager;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import com.google.gson.JsonObject;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.session.Language;
+
+@Component
+public class AppManagerUtilImpl implements AppManagerUtil {
+
+	@Reference(policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.OPTIONAL)
+	private volatile AppManager appManager;
+
+	@Activate
+	public AppManagerUtilImpl() {
+	}
+
+	@Override
+	public OpenemsApp getAppById(String appId) throws NoSuchElementException {
+		return this.getAppManagerImpl().findAppById(appId);
+	}
+
+	@Override
+	public OpenemsAppInstance getInstanceById(UUID instanceId) throws NoSuchElementException {
+		return this.getAppManagerImpl().findInstanceById(instanceId);
+	}
+
+	@Override
+	public AppConfiguration getAppConfiguration(ConfigurationTarget target, OpenemsApp app, String alias,
+			JsonObject properties, Language language) throws OpenemsNamedException {
+		if (alias != null) {
+			properties.addProperty("ALIAS", alias);
+		}
+		AppConfiguration config = null;
+		OpenemsNamedException error = null;
+		try {
+			config = app.getAppConfiguration(target, properties, language);
+		} catch (OpenemsNamedException e) {
+			error = e;
+		}
+		if (alias != null) {
+			properties.remove("ALIAS");
+		}
+		if (error != null) {
+			throw error;
+		}
+		return config;
+	}
+
+	private final AppManagerImpl getAppManagerImpl() {
+		return (AppManagerImpl) this.appManager;
+	}
+
+}

--- a/io.openems.edge.core/src/io/openems/edge/core/appmanager/ComponentUtilImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/appmanager/ComponentUtilImpl.java
@@ -596,9 +596,9 @@ public class ComponentUtilImpl implements ComponentUtil {
 	}
 
 	private void setSchedulerComponentIds(User user, List<String> componentIds) throws OpenemsNamedException {
-
 		try {
 			var scheduler = this.getScheduler();
+			// null is necessary otherwise a new configuration gets created
 			var config = this.cm.getConfiguration(scheduler.getPid(), null);
 
 			var properties = config.getProperties();

--- a/io.openems.edge.core/src/io/openems/edge/core/appmanager/dependency/AppManagerAppHelperImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/appmanager/dependency/AppManagerAppHelperImpl.java
@@ -959,7 +959,7 @@ public class AppManagerAppHelperImpl implements AppManagerAppHelper {
 	 * <p>
 	 * Order bottom -> top.
 	 *
-	 * @param errors					the errors that occur during the call
+	 * @param errors                    the errors that occur during the call
 	 * @param app                       the app to be installed
 	 * @param appConfig                 the {@link AppDependencyConfig} of the
 	 *                                  current app
@@ -1270,6 +1270,7 @@ public class AppManagerAppHelperImpl implements AppManagerAppHelper {
 			EdgeConfig.Component foundComponent = null;
 
 			// try to find a component with the necessary settings
+			// has to be at first place to make sure no unnecessary components are created
 			if (canBeReplaced) {
 				// TODO include currently creating components
 				foundComponent = this.componentUtil.getComponentByConfig(comp);
@@ -1277,8 +1278,11 @@ public class AppManagerAppHelperImpl implements AppManagerAppHelper {
 					id = foundComponent.getId();
 				}
 			}
-			if (foundComponent == null && oldAppInstance != null && oldAppInstance.properties.has(id.toUpperCase())) {
-				id = oldAppInstance.properties.get(id.toUpperCase()).getAsString();
+
+			// use component based on the last configuration
+			if (foundComponent == null && oldAppInstance != null && canBeReplaced
+					&& oldAppInstance.properties.has(replacableIds.get(id))) {
+				id = oldAppInstance.properties.get(replacableIds.get(id)).getAsString();
 				foundComponent = this.componentManager.getEdgeConfig().getComponent(id).orElse(null);
 				final var tempId = id;
 				// other app uses the same component because they had the same configuration
@@ -1289,6 +1293,7 @@ public class AppManagerAppHelperImpl implements AppManagerAppHelper {
 					foundComponent = null;
 				}
 			}
+
 			isNewComponent = isNewComponent && foundComponent == null;
 			if (isNewComponent) {
 				// if the id is not already set and there is no component with the default id

--- a/io.openems.edge.core/src/io/openems/edge/core/appmanager/dependency/ComponentAggregateTaskImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/appmanager/dependency/ComponentAggregateTaskImpl.java
@@ -48,6 +48,9 @@ public class ComponentAggregateTaskImpl implements AggregateTask, AggregateTask.
 	@Override
 	public void aggregate(AppConfiguration config, AppConfiguration oldConfig) {
 		if (config != null) {
+			// remove duplicated components
+			// TODO maybe error
+			this.components.removeIf(t -> config.components.stream().anyMatch(o -> t.getId().equals(o.getId())));
 			this.components.addAll(config.components);
 		}
 		if (oldConfig != null) {
@@ -174,9 +177,13 @@ public class ComponentAggregateTaskImpl implements AggregateTask, AggregateTask.
 		properties.add(new Property("id", comp.getId()));
 		properties.add(new Property("alias", comp.getAlias()));
 
+		var request = new CreateComponentConfigRequest(comp.getFactoryId(), properties);
+		if (user != null) {
+			this.componentManager.handleJsonrpcRequest(user, request);
+			return;
+		}
 		// user can be null using internal method
-		((ComponentManagerImpl) this.componentManager).handleCreateComponentConfigRequest(user,
-				new CreateComponentConfigRequest(comp.getFactoryId(), properties));
+		((ComponentManagerImpl) this.componentManager).handleCreateComponentConfigRequest(user, request);
 	}
 
 	/**
@@ -200,6 +207,11 @@ public class ComponentAggregateTaskImpl implements AggregateTask, AggregateTask.
 				.collect(Collectors.toList());
 		properties.add(new Property("alias", myComp.getAlias()));
 		var updateRequest = new UpdateComponentConfigRequest(actualComp.getId(), properties);
+
+		if (user != null) {
+			this.componentManager.handleJsonrpcRequest(user, updateRequest);
+			return;
+		}
 		// user can be null using internal method
 		((ComponentManagerImpl) this.componentManager).handleUpdateComponentConfigRequest(user, updateRequest);
 	}

--- a/io.openems.edge.core/src/io/openems/edge/core/appmanager/dependency/DependencyUtil.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/appmanager/dependency/DependencyUtil.java
@@ -1,6 +1,12 @@
 package io.openems.edge.core.appmanager.dependency;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+
+import org.osgi.framework.FrameworkUtil;
 
 import io.openems.edge.common.component.ComponentManager;
 import io.openems.edge.core.appmanager.AppConfiguration;
@@ -9,10 +15,52 @@ import io.openems.edge.core.appmanager.AppManagerImpl;
 
 public class DependencyUtil {
 
+	// instance per thread so the installation of an app is separated
+	// from the validate worker
+	private static final Map<Thread, DependencyUtil> THREAD_2_INSTANCE = new HashMap<>();
+
+	// only for testing
+	private static AppManagerAppHelper appHelper;
+
+	// only create one instance per thread and remove the instance after the first
+	// caller of the method finishes
+	private static final <T> T using(Function<DependencyUtil, T> consumer) {
+		var createdInstance = false;
+		var currentThread = Thread.currentThread();
+		var util = THREAD_2_INSTANCE.get(currentThread);
+		if (util == null) {
+			util = new DependencyUtil();
+			THREAD_2_INSTANCE.put(currentThread, util);
+			createdInstance = true;
+		}
+		var value = consumer.apply(util);
+		if (createdInstance) {
+			THREAD_2_INSTANCE.remove(currentThread);
+		}
+		return value;
+	}
+
 	/**
 	 * Temporary field to avoid endless loop.
 	 */
-	private static boolean isCurrentlyRunning = false;
+	private boolean isCurrentlyRunning = false;
+	private final Object getInstanceIdLock = new Object();
+
+	private DependencyUtil() {
+		// no instance needed
+	}
+
+	/**
+	 * Gets the instanceId of the app which has the given Component.
+	 * 
+	 * @param componentManager the {@link ComponentManager}
+	 * @param componentId      the ComponentId
+	 * @return the Id or null if no app has this component
+	 */
+	public static final UUID getInstanceIdOfAppWhichHasComponent(ComponentManager componentManager,
+			String componentId) {
+		return using(t -> t.getInstanceIdOfAppWhichHasComponentInternal(componentManager, componentId));
+	}
 
 	/**
 	 * Gets the instanceId of the first found app that has the given componentId in
@@ -24,36 +72,59 @@ public class DependencyUtil {
 	 *
 	 * @param componentManager    a componentManager to get the appManager
 	 * @param componentId         the component id that the app should have
-	 * @param currentlyCallingApp the app that is currently calling this methode
 	 * @return the found instanceId or null if no app has this component
 	 */
-	public static final UUID getInstanceIdOfAppWhichHasComponent(ComponentManager componentManager, String componentId,
-			String currentlyCallingApp) {
-		if (isCurrentlyRunning) {
-			return null;
+	public final UUID getInstanceIdOfAppWhichHasComponentInternal(ComponentManager componentManager,
+			String componentId) {
+		synchronized (this.getInstanceIdLock) {
+			if (this.isCurrentlyRunning) {
+				return null;
+			}
+			this.isCurrentlyRunning = true;
 		}
-		isCurrentlyRunning = true;
 		var appManagerImpl = DependencyUtil.getAppManagerImpl(componentManager);
 		if (appManagerImpl == null) {
-			isCurrentlyRunning = false;
+			this.setCurrentlyRunning(false);
 			return null;
 		}
-		for (var entry : appManagerImpl.appConfigs()) {
+		var instances = new ArrayList<>(appManagerImpl.getInstantiatedApps());
+		var appHelper = getAppManagerAppHelper();
+		if (appHelper.getTemporaryApps() != null) {
+			instances.addAll(appHelper.getTemporaryApps().currentlyCreatingApps);
+		}
+		for (var entry : appManagerImpl.appConfigs(instances, null)) {
 			if (entry.getValue().components.stream().anyMatch(c -> c.getId().equals(componentId))) {
-				isCurrentlyRunning = false;
+				this.setCurrentlyRunning(false);
 				return entry.getKey().instanceId;
 			}
 		}
-		isCurrentlyRunning = false;
+		this.setCurrentlyRunning(false);
 		return null;
+	}
+
+	private void setCurrentlyRunning(boolean isCurrentlyRunning) {
+		synchronized (this.getInstanceIdLock) {
+			this.isCurrentlyRunning = isCurrentlyRunning;
+		}
 	}
 
 	private static final AppManagerImpl getAppManagerImpl(ComponentManager componentManager) {
 		var appManager = componentManager.getEnabledComponentsOfType(AppManager.class);
-		if (appManager.size() != 1 || !(appManager.get(0) instanceof AppManagerImpl)) {
+		if (appManager.size() == 0 || !(appManager.get(0) instanceof AppManagerImpl)) {
 			return null;
 		}
 		return (AppManagerImpl) appManager.get(0);
+	}
+
+	private static final AppManagerAppHelper getAppManagerAppHelper() {
+		if (appHelper != null) {
+			return appHelper;
+		}
+		var context = FrameworkUtil.getBundle(AppManagerAppHelper.class).getBundleContext();
+		var serviceReference = context.getServiceReference(AppManagerAppHelper.class);
+		var appHelper = context.getService(serviceReference);
+		context.ungetService(serviceReference);
+		return appHelper;
 	}
 
 }

--- a/io.openems.edge.core/src/io/openems/edge/core/appmanager/dependency/DependencyUtil.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/appmanager/dependency/DependencyUtil.java
@@ -44,6 +44,7 @@ public class DependencyUtil {
 	 * Temporary field to avoid endless loop.
 	 */
 	private boolean isCurrentlyRunning = false;
+	// can not use synchronized for primitive types
 	private final Object getInstanceIdLock = new Object();
 
 	private DependencyUtil() {

--- a/io.openems.edge.core/src/io/openems/edge/core/appmanager/validator/CheckCardinality.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/appmanager/validator/CheckCardinality.java
@@ -12,6 +12,7 @@ import org.osgi.service.component.annotations.Reference;
 import io.openems.common.session.Language;
 import io.openems.edge.core.appmanager.AppManager;
 import io.openems.edge.core.appmanager.AppManagerImpl;
+import io.openems.edge.core.appmanager.AppManagerUtil;
 import io.openems.edge.core.appmanager.OpenemsApp;
 import io.openems.edge.core.appmanager.OpenemsAppCardinality;
 import io.openems.edge.core.appmanager.OpenemsAppCategory;
@@ -23,6 +24,7 @@ public class CheckCardinality extends AbstractCheckable implements Checkable {
 	public static final String COMPONENT_NAME = "Validator.Checkable.CheckCardinality";
 
 	private final AppManager appManager;
+	private final AppManagerUtil appManagerUtil;
 	private OpenemsApp openemsApp;
 
 	private ErrorType errorType = ErrorType.NONE;
@@ -38,9 +40,11 @@ public class CheckCardinality extends AbstractCheckable implements Checkable {
 	}
 
 	@Activate
-	public CheckCardinality(@Reference AppManager appManager, ComponentContext componentContext) {
+	public CheckCardinality(@Reference AppManager appManager, @Reference AppManagerUtil appManagerUtil,
+			ComponentContext componentContext) {
 		super(componentContext);
 		this.appManager = appManager;
+		this.appManagerUtil = appManagerUtil;
 	}
 
 	@Override
@@ -73,7 +77,7 @@ public class CheckCardinality extends AbstractCheckable implements Checkable {
 			}
 			break;
 		case SINGLE_IN_CATEGORY:
-			var matchedCategorie = this.getMatchingCategorie(appManagerImpl, instantiatedApps);
+			var matchedCategorie = this.getMatchingCategorie(this.appManagerUtil, instantiatedApps);
 			if (matchedCategorie != null) {
 				// only create one instance with the same category of this app
 				this.matchingCategory = matchedCategorie;
@@ -88,11 +92,11 @@ public class CheckCardinality extends AbstractCheckable implements Checkable {
 		return this.errorType == ErrorType.NONE;
 	}
 
-	private OpenemsAppCategory getMatchingCategorie(AppManagerImpl appManager,
+	private OpenemsAppCategory getMatchingCategorie(AppManagerUtil appManagerUtil,
 			List<OpenemsAppInstance> instantiatedApps) {
 		for (var openemsAppInstance : instantiatedApps) {
 			try {
-				var app = appManager.findAppById(openemsAppInstance.appId);
+				var app = appManagerUtil.getAppById(openemsAppInstance.appId);
 				if (app.getCardinality() != OpenemsAppCardinality.SINGLE_IN_CATEGORY) {
 					continue;
 				}

--- a/io.openems.edge.core/test/io/openems/edge/app/TestC.java
+++ b/io.openems.edge.core/test/io/openems/edge/app/TestC.java
@@ -65,9 +65,7 @@ public class TestC extends AbstractOpenemsApp<Property> implements OpenemsApp {
 
 	@Override
 	protected ThrowingTriFunction<ConfigurationTarget, EnumMap<Property, JsonElement>, Language, AppConfiguration, OpenemsNamedException> appConfigurationFactory() {
-		return (t, u, s) -> {
-			return new AppConfiguration();
-		};
+		return (t, u, s) -> new AppConfiguration();
 	}
 
 	@Override

--- a/io.openems.edge.core/test/io/openems/edge/app/api/TestModbusTcpApiReadWrite.java
+++ b/io.openems.edge.core/test/io/openems/edge/app/api/TestModbusTcpApiReadWrite.java
@@ -1,0 +1,91 @@
+package io.openems.edge.app.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import io.openems.common.session.Language;
+import io.openems.common.session.Role;
+import io.openems.common.utils.JsonUtils;
+import io.openems.edge.common.test.DummyUser;
+import io.openems.edge.common.user.User;
+import io.openems.edge.core.appmanager.AppManagerTestBundle;
+import io.openems.edge.core.appmanager.jsonrpc.AddAppInstance;
+import io.openems.edge.core.appmanager.jsonrpc.DeleteAppInstance;
+
+public class TestModbusTcpApiReadWrite {
+
+	private final User user = new DummyUser("1", "password", Language.DEFAULT, Role.ADMIN);
+
+	private AppManagerTestBundle appManagerTestBundle;
+
+	private ModbusTcpApiReadOnly modbusTcpApiReadOnly;
+	private ModbusTcpApiReadWrite modbusTcpApiReadWrite;
+
+	@Before
+	public void beforeEach() throws Exception {
+		this.appManagerTestBundle = new AppManagerTestBundle(null, null, t -> {
+			this.modbusTcpApiReadOnly = new ModbusTcpApiReadOnly(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.Api.ModbusTcp.ReadOnly"), t.cm, t.componentUtil);
+			this.modbusTcpApiReadWrite = new ModbusTcpApiReadWrite(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.Api.ModbusTcp.ReadWrite"), t.cm, t.componentUtil);
+
+			return ImmutableList.of(this.modbusTcpApiReadOnly, this.modbusTcpApiReadWrite);
+		});
+	}
+
+	@Test
+	public void testDeactivateReadOnly() throws Exception {
+		// create ReadOnly app
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(user, new AddAppInstance.Request(
+				modbusTcpApiReadOnly.getAppId(), "alias", JsonUtils.buildJsonObject().build()));
+
+		assertEquals(1, this.appManagerTestBundle.sut.getInstantiatedApps().size());
+
+		// ACTIVE not set or true
+		var readOnlyApp = this.appManagerTestBundle.sut.getInstantiatedApps().get(0);
+
+		if (readOnlyApp.properties.has("ACTIVE")) {
+			var isActiv = readOnlyApp.properties.get("ACTIVE").getAsBoolean();
+			assertTrue(isActiv);
+		}
+
+		// create ReadWrite app
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(user,
+				new AddAppInstance.Request(modbusTcpApiReadWrite.getAppId(), "alias", JsonUtils.buildJsonObject() //
+						.addProperty("API_TIMEOUT", 60) //
+						.add("COMPONENT_IDS", JsonUtils.buildJsonArray() //
+								.add("_sum") //
+								.build()) //
+						.build()));
+
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
+
+		var readWriteApp = this.appManagerTestBundle.sut.getInstantiatedApps().get(0);
+
+		// ACTIVE not set or true
+		readOnlyApp = this.appManagerTestBundle.sut.getInstantiatedApps().get(0);
+
+		assertTrue(readOnlyApp.properties.has("ACTIVE"));
+		var isActiv = readOnlyApp.properties.get("ACTIVE").getAsBoolean();
+		assertFalse(isActiv);
+
+		// remove ReadWrite to see if the ReadOnly gets activated
+		this.appManagerTestBundle.sut.handleDeleteAppInstanceRequest(user,
+				new DeleteAppInstance.Request(readWriteApp.instanceId));
+
+		// ACTIVE not set or true
+		readOnlyApp = this.appManagerTestBundle.sut.getInstantiatedApps().get(0);
+
+		if (readOnlyApp.properties.has("ACTIVE")) {
+			isActiv = readOnlyApp.properties.get("ACTIVE").getAsBoolean();
+			assertTrue(isActiv);
+		}
+	}
+
+}

--- a/io.openems.edge.core/test/io/openems/edge/app/api/TestModbusTcpApiReadWrite.java
+++ b/io.openems.edge.core/test/io/openems/edge/app/api/TestModbusTcpApiReadWrite.java
@@ -42,8 +42,8 @@ public class TestModbusTcpApiReadWrite {
 	@Test
 	public void testDeactivateReadOnly() throws Exception {
 		// create ReadOnly app
-		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(user, new AddAppInstance.Request(
-				modbusTcpApiReadOnly.getAppId(), "alias", JsonUtils.buildJsonObject().build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(
+				this.modbusTcpApiReadOnly.getAppId(), "alias", JsonUtils.buildJsonObject().build()));
 
 		assertEquals(1, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
@@ -56,8 +56,8 @@ public class TestModbusTcpApiReadWrite {
 		}
 
 		// create ReadWrite app
-		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(user,
-				new AddAppInstance.Request(modbusTcpApiReadWrite.getAppId(), "alias", JsonUtils.buildJsonObject() //
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.modbusTcpApiReadWrite.getAppId(), "alias", JsonUtils.buildJsonObject() //
 						.addProperty("API_TIMEOUT", 60) //
 						.add("COMPONENT_IDS", JsonUtils.buildJsonArray() //
 								.add("_sum") //
@@ -66,7 +66,7 @@ public class TestModbusTcpApiReadWrite {
 
 		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		var readWriteApp = this.appManagerTestBundle.sut.getInstantiatedApps().get(0);
+		final var readWriteApp = this.appManagerTestBundle.sut.getInstantiatedApps().get(0);
 
 		// ACTIVE set and false
 		readOnlyApp = this.appManagerTestBundle.sut.getInstantiatedApps().get(0);
@@ -76,7 +76,7 @@ public class TestModbusTcpApiReadWrite {
 		assertFalse(isActiv);
 
 		// remove ReadWrite to see if the ReadOnly gets activated
-		this.appManagerTestBundle.sut.handleDeleteAppInstanceRequest(user,
+		this.appManagerTestBundle.sut.handleDeleteAppInstanceRequest(this.user,
 				new DeleteAppInstance.Request(readWriteApp.instanceId));
 
 		// ACTIVE not set or true

--- a/io.openems.edge.core/test/io/openems/edge/app/api/TestModbusTcpApiReadWrite.java
+++ b/io.openems.edge.core/test/io/openems/edge/app/api/TestModbusTcpApiReadWrite.java
@@ -68,7 +68,7 @@ public class TestModbusTcpApiReadWrite {
 
 		var readWriteApp = this.appManagerTestBundle.sut.getInstantiatedApps().get(0);
 
-		// ACTIVE not set or true
+		// ACTIVE set and false
 		readOnlyApp = this.appManagerTestBundle.sut.getInstantiatedApps().get(0);
 
 		assertTrue(readOnlyApp.properties.has("ACTIVE"));

--- a/io.openems.edge.core/test/io/openems/edge/app/integratedsystem/TestFeneconHome.java
+++ b/io.openems.edge.core/test/io/openems/edge/app/integratedsystem/TestFeneconHome.java
@@ -1,0 +1,206 @@
+package io.openems.edge.app.integratedsystem;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import io.openems.common.session.Language;
+import io.openems.common.session.Role;
+import io.openems.common.utils.JsonUtils;
+import io.openems.edge.app.meter.SocomecMeter;
+import io.openems.edge.app.pvselfconsumption.GridOptimizedCharge;
+import io.openems.edge.app.pvselfconsumption.SelfConsumptionOptimization;
+import io.openems.edge.common.test.DummyUser;
+import io.openems.edge.common.user.User;
+import io.openems.edge.core.appmanager.AppManagerTestBundle;
+import io.openems.edge.core.appmanager.OpenemsAppInstance;
+import io.openems.edge.core.appmanager.jsonrpc.AddAppInstance;
+import io.openems.edge.core.appmanager.jsonrpc.UpdateAppInstance;
+
+public class TestFeneconHome {
+
+	private final User user = new DummyUser("1", "password", Language.DEFAULT, Role.ADMIN);
+
+	private AppManagerTestBundle appManagerTestBundle;
+
+	private FeneconHome homeApp;
+	private GridOptimizedCharge gridOptimizedCharge;
+	private SelfConsumptionOptimization selfConsumptionOptimization;
+	private SocomecMeter socomecMeter;
+
+	@Before
+	public void beforeEach() throws Exception {
+		this.appManagerTestBundle = new AppManagerTestBundle(null, null, t -> {
+			this.homeApp = new FeneconHome(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.FENECON.Home"), t.cm, t.componentUtil);
+			this.gridOptimizedCharge = new GridOptimizedCharge(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.PvSelfConsumption.GridOptimizedCharge"), t.cm,
+					t.componentUtil);
+			this.selfConsumptionOptimization = new SelfConsumptionOptimization(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.PvSelfConsumption.SelfConsumptionOptimization"), t.cm,
+					t.componentUtil);
+			this.socomecMeter = new SocomecMeter(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.Meter.Socomec"), t.cm, t.componentUtil);
+			return ImmutableList.of(this.homeApp, this.gridOptimizedCharge, this.selfConsumptionOptimization,
+					this.socomecMeter);
+		});
+	}
+
+	@Test
+	public void testCreateHomeFullSettings() throws Exception {
+		this.createFullHome();
+	}
+
+	@Test
+	public void testCreateAndUpdateHomeFullSettings() throws Exception {
+		var fullConfig = JsonUtils.buildJsonObject() //
+				.addProperty("SAFETY_COUNTRY", "GERMANY") //
+				.addProperty("RIPPLE_CONTROL_RECEIVER_ACTIV", false) //
+				.addProperty("MAX_FEED_IN_POWER", 1000) //
+				.addProperty("FEED_IN_SETTING", "LAGGING_0_95") //
+				.addProperty("HAS_AC_METER", true) //
+				.addProperty("HAS_DC_PV1", true) //
+				.addProperty("DC_PV1_ALIAS", "alias pv 1") //
+				.addProperty("HAS_DC_PV2", true) //
+				.addProperty("DC_PV2_ALIAS", "alias pv 2") //
+				.addProperty("HAS_EMERGENCY_RESERVE", true) //
+				.addProperty("EMERGENCY_RESERVE_ENABLED", true) //
+				.addProperty("EMERGENCY_RESERVE_SOC", 15) //
+				.addProperty("SHADOW_MANAGEMENT_DISABLED", false) //
+				.build();
+
+		var homeInstance = this.createFullHome();
+
+		this.appManagerTestBundle.sut.handleJsonrpcRequest(this.user,
+				new UpdateAppInstance.Request(homeInstance.instanceId, "aliasrename", fullConfig));
+		// expect the same as before
+		// make sure every dependency got installed
+		assertEquals(this.appManagerTestBundle.sut.getInstantiatedApps().size(), 4);
+
+		// check properties of created apps
+		for (var instance : this.appManagerTestBundle.sut.getInstantiatedApps()) {
+			int expectedDependencies;
+			switch (instance.appId) {
+			case "App.FENECON.Home":
+				expectedDependencies = 3;
+				break;
+			case "App.PvSelfConsumption.GridOptimizedCharge":
+				expectedDependencies = 0;
+				break;
+			case "App.PvSelfConsumption.SelfConsumptionOptimization":
+				expectedDependencies = 0;
+				break;
+			case "App.Meter.Socomec":
+				expectedDependencies = 0;
+				break;
+			default:
+				throw new Exception("App with ID[" + instance.appId + "] should not have been created!");
+			}
+			assertEquals(expectedDependencies, instance.dependencies.size());
+		}
+	}
+
+	@Test
+	public void testRemoveAcMeter() throws Exception {
+		var homeInstance = this.createFullHome();
+
+		var configNoMeter = JsonUtils.buildJsonObject() //
+				.addProperty("SAFETY_COUNTRY", "GERMANY") //
+				.addProperty("RIPPLE_CONTROL_RECEIVER_ACTIV", false) //
+				.addProperty("MAX_FEED_IN_POWER", 1000) //
+				.addProperty("FEED_IN_SETTING", "LAGGING_0_95") //
+				.addProperty("HAS_AC_METER", false) //
+				.addProperty("HAS_DC_PV1", true) //
+				.addProperty("DC_PV1_ALIAS", "alias pv 1") //
+				.addProperty("HAS_DC_PV2", true) //
+				.addProperty("DC_PV2_ALIAS", "alias pv 2") //
+				.addProperty("HAS_EMERGENCY_RESERVE", true) //
+				.addProperty("EMERGENCY_RESERVE_ENABLED", true) //
+				.addProperty("EMERGENCY_RESERVE_SOC", 15) //
+				.addProperty("SHADOW_MANAGEMENT_DISABLED", false) //
+				.build();
+
+		this.appManagerTestBundle.sut.handleJsonrpcRequest(this.user,
+				new UpdateAppInstance.Request(homeInstance.instanceId, "aliasrename", configNoMeter));
+		// expect the same as before
+		// make sure every dependency got installed
+		assertEquals(this.appManagerTestBundle.sut.getInstantiatedApps().size(), 3);
+
+		// check properties of created apps
+		for (var instance : this.appManagerTestBundle.sut.getInstantiatedApps()) {
+			int expectedDependencies;
+			switch (instance.appId) {
+			case "App.FENECON.Home":
+				expectedDependencies = 2;
+				break;
+			case "App.PvSelfConsumption.GridOptimizedCharge":
+				expectedDependencies = 0;
+				break;
+			case "App.PvSelfConsumption.SelfConsumptionOptimization":
+				expectedDependencies = 0;
+				break;
+			default:
+				throw new Exception("App with ID[" + instance.appId + "] should not have been created!");
+			}
+			assertEquals(expectedDependencies, instance.dependencies.size());
+		}
+
+	}
+
+	private final OpenemsAppInstance createFullHome() throws Exception {
+		var fullConfig = JsonUtils.buildJsonObject() //
+				.addProperty("SAFETY_COUNTRY", "GERMANY") //
+				.addProperty("RIPPLE_CONTROL_RECEIVER_ACTIV", false) //
+				.addProperty("MAX_FEED_IN_POWER", 1000) //
+				.addProperty("FEED_IN_SETTING", "LAGGING_0_95") //
+				.addProperty("HAS_AC_METER", true) //
+				.addProperty("HAS_DC_PV1", true) //
+				.addProperty("DC_PV1_ALIAS", "alias pv 1") //
+				.addProperty("HAS_DC_PV2", true) //
+				.addProperty("DC_PV2_ALIAS", "alias pv 2") //
+				.addProperty("HAS_EMERGENCY_RESERVE", true) //
+				.addProperty("EMERGENCY_RESERVE_ENABLED", true) //
+				.addProperty("EMERGENCY_RESERVE_SOC", 15) //
+				.addProperty("SHADOW_MANAGEMENT_DISABLED", false) //
+				.build();
+
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request("App.FENECON.Home", "alias", fullConfig));
+
+		// make sure every dependency got installed
+		assertEquals(this.appManagerTestBundle.sut.getInstantiatedApps().size(), 4);
+
+		// check properties of created apps
+		for (var instance : this.appManagerTestBundle.sut.getInstantiatedApps()) {
+			int expectedDependencies;
+			switch (instance.appId) {
+			case "App.FENECON.Home":
+				expectedDependencies = 3;
+				break;
+			case "App.PvSelfConsumption.GridOptimizedCharge":
+				expectedDependencies = 0;
+				break;
+			case "App.PvSelfConsumption.SelfConsumptionOptimization":
+				expectedDependencies = 0;
+				break;
+			case "App.Meter.Socomec":
+				expectedDependencies = 0;
+				break;
+			default:
+				throw new Exception("App with ID[" + instance.appId + "] should not have been created!");
+			}
+			assertEquals(expectedDependencies, instance.dependencies.size());
+		}
+
+		var homeInstance = this.appManagerTestBundle.sut.getInstantiatedApps().stream()
+				.filter(t -> t.appId.equals("App.FENECON.Home")).findAny().orElse(null);
+
+		assertNotNull(homeInstance);
+		return homeInstance;
+	}
+
+}

--- a/io.openems.edge.core/test/io/openems/edge/core/appmanager/AppManagerAppHelperImplTest.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/appmanager/AppManagerAppHelperImplTest.java
@@ -3,23 +3,17 @@ package io.openems.edge.core.appmanager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Dictionary;
-import java.util.Hashtable;
 import java.util.concurrent.ExecutionException;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.osgi.service.component.ComponentConstants;
-import org.osgi.service.component.ComponentContext;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.session.Language;
 import io.openems.common.session.Role;
 import io.openems.common.utils.JsonUtils;
-import io.openems.common.utils.ReflectionUtils;
 import io.openems.edge.app.TestADependencyToC;
 import io.openems.edge.app.TestBDependencyToC;
 import io.openems.edge.app.TestC;
@@ -27,31 +21,18 @@ import io.openems.edge.app.evcs.KebaEvcs;
 import io.openems.edge.app.integratedsystem.FeneconHome;
 import io.openems.edge.app.timeofusetariff.AwattarHourly;
 import io.openems.edge.app.timeofusetariff.StromdaoCorrently;
-import io.openems.edge.common.test.ComponentTest;
-import io.openems.edge.common.test.DummyComponentContext;
-import io.openems.edge.common.test.DummyComponentManager;
-import io.openems.edge.common.test.DummyConfigurationAdmin;
 import io.openems.edge.common.test.DummyUser;
 import io.openems.edge.common.user.User;
-import io.openems.edge.core.appmanager.dependency.AppManagerAppHelperImpl;
-import io.openems.edge.core.appmanager.dependency.ComponentAggregateTaskImpl;
 import io.openems.edge.core.appmanager.dependency.DependencyDeclaration;
-import io.openems.edge.core.appmanager.dependency.SchedulerAggregateTaskImpl;
-import io.openems.edge.core.appmanager.dependency.StaticIpAggregateTaskImpl;
 import io.openems.edge.core.appmanager.jsonrpc.AddAppInstance;
 import io.openems.edge.core.appmanager.jsonrpc.DeleteAppInstance;
 import io.openems.edge.core.appmanager.jsonrpc.UpdateAppInstance;
-import io.openems.edge.core.appmanager.validator.CheckCardinality;
-import io.openems.edge.core.appmanager.validator.Validator;
 
 public class AppManagerAppHelperImplTest {
 
 	private final User user = new DummyUser("1", "password", Language.DEFAULT, Role.ADMIN);
 
-	private DummyConfigurationAdmin cm;
-	private DummyComponentManager componentManger;
-	private ComponentUtil componentUtil;
-	private Validator validator;
+	private AppManagerTestBundle appManagerTestBundle;
 
 	private FeneconHome homeApp;
 	private KebaEvcs kebaEvcsApp;
@@ -62,154 +43,108 @@ public class AppManagerAppHelperImplTest {
 	private TestBDependencyToC testBApp;
 	private TestC testCApp;
 
-	private AppManagerImpl sut;
-
 	@Before
 	public void beforeEach() throws Exception {
+		this.appManagerTestBundle = new AppManagerTestBundle(null, null, t -> {
+			this.homeApp = new FeneconHome(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.FENECON.Home"), t.cm, t.componentUtil);
+			this.kebaEvcsApp = new KebaEvcs(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.Evcs.Keba"), t.cm, t.componentUtil);
+			this.awattarApp = new AwattarHourly(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.TimeVariablePrice.Awattar"), t.cm, t.componentUtil);
+			this.stromdao = new StromdaoCorrently(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.TimeVariablePrice.Stromdao"), t.cm, t.componentUtil);
 
-		this.cm = new DummyConfigurationAdmin();
-		this.cm.getOrCreateEmptyConfiguration(AppManager.SINGLETON_SERVICE_PID);
+			this.testAApp = new TestADependencyToC(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.Test.TestADependencyToC"), t.cm, t.componentUtil);
+			this.testBApp = new TestBDependencyToC(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.Test.TestBDependencyToC"), t.cm, t.componentUtil);
+			this.testCApp = new TestC(t.componentManger, AppManagerTestBundle.getComponentContext("App.Test.TestC"),
+					t.cm, t.componentUtil);
 
-		this.componentManger = new DummyComponentManager();
-		this.componentManger.setConfigJson(JsonUtils.buildJsonObject() //
-				.add("components", JsonUtils.buildJsonObject() //
-						.add("scheduler0", JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "Scheduler.AllAlphabetically") //
-								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.add("controllers.ids", JsonUtils.buildJsonArray() //
-												.add("ctrlGridOptimizedCharge0") //
-												.add("ctrlEssSurplusFeedToGrid0") //
-												.add("ctrlBalancing0") //
-												.build()) //
-										.build()) //
-								.build()) //
-						.build()) //
-				.add("factories", JsonUtils.buildJsonObject() //
-						.build()) //
-				.build() //
-		);
-		this.componentUtil = new ComponentUtilImpl(this.componentManger, this.cm);
-
-		this.homeApp = new FeneconHome(this.componentManger, getComponentContext("App.FENECON.Home"), this.cm,
-				this.componentUtil);
-		this.kebaEvcsApp = new KebaEvcs(this.componentManger, getComponentContext("App.Evcs.Keba"), this.cm,
-				this.componentUtil);
-		this.awattarApp = new AwattarHourly(this.componentManger, getComponentContext("App.TimeVariablePrice.Awattar"),
-				this.cm, this.componentUtil);
-		this.stromdao = new StromdaoCorrently(this.componentManger,
-				getComponentContext("App.TimeVariablePrice.Stromdao"), this.cm, this.componentUtil);
-
-		this.testAApp = new TestADependencyToC(this.componentManger, getComponentContext("App.Test.TestADependencyToC"),
-				this.cm, this.componentUtil);
-
-		this.testBApp = new TestBDependencyToC(this.componentManger, getComponentContext("App.Test.TestBDependencyToC"),
-				this.cm, this.componentUtil);
-
-		this.testCApp = new TestC(this.componentManger, getComponentContext("App.Test.TestC"), this.cm,
-				this.componentUtil);
-
-		final var componentTask = new ComponentAggregateTaskImpl(this.componentManger);
-		final var schedulerTask = new SchedulerAggregateTaskImpl(componentTask, this.componentUtil);
-		final var staticIpTask = new StaticIpAggregateTaskImpl(this.componentUtil);
-
-		this.sut = new AppManagerImpl();
-		this.componentManger.addComponent(this.sut);
-		this.componentManger.setConfigurationAdmin(this.cm);
-
-		var dummyValidator = new DummyValidator();
-		dummyValidator.setCheckables(Lists
-				.newArrayList(new CheckCardinality(this.sut, getComponentContext(CheckCardinality.COMPONENT_NAME))));
-		this.validator = dummyValidator;
-
-		var appManagerAppHelper = new AppManagerAppHelperImpl(this.componentManger, this.componentUtil, this.validator,
-				componentTask, schedulerTask, staticIpTask);
-
-		// use this so the appManagerAppHelper does not has to be a OpenemsComponent and
-		// the attribute can still be private
-		ReflectionUtils.setAttribute(appManagerAppHelper.getClass(), appManagerAppHelper, "appManager", this.sut);
-
-		new ComponentTest(this.sut) //
-				.addReference("cm", this.cm) //
-				.addReference("componentManager", this.componentManger) //
-				.addReference("appHelper", appManagerAppHelper) //
-				.addReference("validator", this.validator) //
-				.addReference("availableApps",
-						ImmutableList.of(this.homeApp, this.kebaEvcsApp, this.awattarApp, this.stromdao, this.testAApp,
-								this.testBApp, this.testCApp)) //
-				.activate(MyConfig.create() //
-						.setApps(JsonUtils.buildJsonArray() //
-								.build().toString()) //
-						.build());
+			return ImmutableList.of(this.homeApp, this.kebaEvcsApp, this.awattarApp, this.stromdao, this.testAApp,
+					this.testBApp, this.testCApp);
+		});
 
 	}
 
 	@Test
 	public void testCreatePolicyIfNotExisting() throws OpenemsNamedException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("CREATE_POLICY", DependencyDeclaration.CreatePolicy.IF_NOT_EXISTING.name())
-						.build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("CREATE_POLICY", DependencyDeclaration.CreatePolicy.IF_NOT_EXISTING.name())
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testBApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("CREATE_POLICY", DependencyDeclaration.CreatePolicy.IF_NOT_EXISTING.name())
-						.build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testBApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("CREATE_POLICY", DependencyDeclaration.CreatePolicy.IF_NOT_EXISTING.name())
+								.build()));
 
-		assertEquals(3, this.sut.getInstantiatedApps().size());
+		assertEquals(3, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 	}
 
 	@Test
 	public void testCreatePolicyAlways() throws OpenemsNamedException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("CREATE_POLICY", DependencyDeclaration.CreatePolicy.ALWAYS.name()).build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("CREATE_POLICY", DependencyDeclaration.CreatePolicy.ALWAYS.name())
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testBApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("CREATE_POLICY", DependencyDeclaration.CreatePolicy.ALWAYS.name()).build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testBApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("CREATE_POLICY", DependencyDeclaration.CreatePolicy.ALWAYS.name())
+								.build()));
 
-		assertEquals(4, this.sut.getInstantiatedApps().size());
+		assertEquals(4, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 	}
 
 	@Test
 	public void testCreatePolicyNever() throws OpenemsNamedException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("CREATE_POLICY", DependencyDeclaration.CreatePolicy.NEVER.name()).build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("CREATE_POLICY", DependencyDeclaration.CreatePolicy.NEVER.name())
+								.build()));
 
-		assertEquals(1, this.sut.getInstantiatedApps().size());
+		assertEquals(1, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testBApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("CREATE_POLICY", DependencyDeclaration.CreatePolicy.NEVER.name()).build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testBApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("CREATE_POLICY", DependencyDeclaration.CreatePolicy.NEVER.name())
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 	}
 
 	@Test
 	public void testUpdatePolicyNever() throws OpenemsNamedException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("UPDATE_POLICY", DependencyDeclaration.UpdatePolicy.NEVER.name()) //
-						.addProperty("NUMBER", 1) //
-						.build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("UPDATE_POLICY", DependencyDeclaration.UpdatePolicy.NEVER.name()) //
+								.addProperty("NUMBER", 1) //
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleJsonrpcRequest(this.user,
+		this.appManagerTestBundle.sut.handleJsonrpcRequest(this.user,
 				new UpdateAppInstance.Request(this.getAppByAppId(this.testAApp.getAppId()).instanceId, "",
 						JsonUtils.buildJsonObject() //
 								.addProperty("UPDATE_POLICY", DependencyDeclaration.UpdatePolicy.NEVER.name()) //
@@ -222,22 +157,24 @@ public class AppManagerAppHelperImplTest {
 
 	@Test
 	public void testUpdatePolicyAlways() throws OpenemsNamedException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("UPDATE_POLICY", DependencyDeclaration.UpdatePolicy.ALWAYS.name()) //
-						.addProperty("NUMBER", 1) //
-						.build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("UPDATE_POLICY", DependencyDeclaration.UpdatePolicy.ALWAYS.name()) //
+								.addProperty("NUMBER", 1) //
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testBApp.getAppId(), "", //
-				JsonUtils.buildJsonObject().build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testBApp.getAppId(), "", //
+						JsonUtils.buildJsonObject().build()));
 
-		assertEquals(3, this.sut.getInstantiatedApps().size());
+		assertEquals(3, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleJsonrpcRequest(this.user,
+		this.appManagerTestBundle.sut.handleJsonrpcRequest(this.user,
 				new UpdateAppInstance.Request(this.getAppByAppId(this.testAApp.getAppId()).instanceId, "",
 						JsonUtils.buildJsonObject() //
 								.addProperty("UPDATE_POLICY", DependencyDeclaration.UpdatePolicy.ALWAYS.name()) //
@@ -250,17 +187,18 @@ public class AppManagerAppHelperImplTest {
 
 	@Test
 	public void testUpdatePolicyIfMine() throws OpenemsNamedException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("UPDATE_POLICY", DependencyDeclaration.UpdatePolicy.IF_MINE.name()) //
-						.addProperty("NUMBER", 1) //
-						.build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("UPDATE_POLICY", DependencyDeclaration.UpdatePolicy.IF_MINE.name()) //
+								.addProperty("NUMBER", 1) //
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleJsonrpcRequest(this.user,
+		this.appManagerTestBundle.sut.handleJsonrpcRequest(this.user,
 				new UpdateAppInstance.Request(this.getAppByAppId(this.testAApp.getAppId()).instanceId, "",
 						JsonUtils.buildJsonObject() //
 								.addProperty("UPDATE_POLICY", DependencyDeclaration.UpdatePolicy.IF_MINE.name()) //
@@ -270,12 +208,13 @@ public class AppManagerAppHelperImplTest {
 		var instance = this.getAppByAppId(this.testCApp.getAppId());
 		assertEquals(2, instance.properties.get(TestC.Property.NUMBER.name()).getAsInt());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testBApp.getAppId(), "", //
-				JsonUtils.buildJsonObject().build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testBApp.getAppId(), "", //
+						JsonUtils.buildJsonObject().build()));
 
-		assertEquals(3, this.sut.getInstantiatedApps().size());
+		assertEquals(3, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleJsonrpcRequest(this.user,
+		this.appManagerTestBundle.sut.handleJsonrpcRequest(this.user,
 				new UpdateAppInstance.Request(this.getAppByAppId(this.testAApp.getAppId()).instanceId, "",
 						JsonUtils.buildJsonObject() //
 								.addProperty("UPDATE_POLICY", DependencyDeclaration.UpdatePolicy.IF_MINE.name()) //
@@ -288,122 +227,135 @@ public class AppManagerAppHelperImplTest {
 
 	@Test
 	public void testDeletePolicyNever() throws OpenemsNamedException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("DELETE_POLICY", DependencyDeclaration.DeletePolicy.NEVER.name()) //
-						.build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("DELETE_POLICY", DependencyDeclaration.DeletePolicy.NEVER.name()) //
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
 		var instance = this.getAppByAppId(this.testAApp.getAppId());
-		this.sut.handleDeleteAppInstanceRequest(this.user, new DeleteAppInstance.Request(instance.instanceId));
+		this.appManagerTestBundle.sut.handleDeleteAppInstanceRequest(this.user,
+				new DeleteAppInstance.Request(instance.instanceId));
 
-		assertEquals(1, this.sut.getInstantiatedApps().size());
+		assertEquals(1, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 	}
 
 	@Test
 	public void testDeletePolicyAlways() throws OpenemsNamedException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("DELETE_POLICY", DependencyDeclaration.DeletePolicy.ALWAYS.name()) //
-						.build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("DELETE_POLICY", DependencyDeclaration.DeletePolicy.ALWAYS.name()) //
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testBApp.getAppId(), "", //
-				JsonUtils.buildJsonObject().build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testBApp.getAppId(), "", //
+						JsonUtils.buildJsonObject().build()));
 
-		assertEquals(3, this.sut.getInstantiatedApps().size());
+		assertEquals(3, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
 		var instance = this.getAppByAppId(this.testAApp.getAppId());
-		this.sut.handleDeleteAppInstanceRequest(this.user, new DeleteAppInstance.Request(instance.instanceId));
+		this.appManagerTestBundle.sut.handleDeleteAppInstanceRequest(this.user,
+				new DeleteAppInstance.Request(instance.instanceId));
 
-		assertEquals(1, this.sut.getInstantiatedApps().size());
+		assertEquals(1, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 	}
 
 	@Test
 	public void testDeletePolicyIfMine() throws OpenemsNamedException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("DELETE_POLICY", DependencyDeclaration.DeletePolicy.IF_MINE.name()) //
-						.build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("DELETE_POLICY", DependencyDeclaration.DeletePolicy.IF_MINE.name()) //
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testBApp.getAppId(), "", //
-				JsonUtils.buildJsonObject().build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testBApp.getAppId(), "", //
+						JsonUtils.buildJsonObject().build()));
 
-		assertEquals(3, this.sut.getInstantiatedApps().size());
+		assertEquals(3, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
 		var instance = this.getAppByAppId(this.testAApp.getAppId());
-		this.sut.handleDeleteAppInstanceRequest(this.user, new DeleteAppInstance.Request(instance.instanceId));
+		this.appManagerTestBundle.sut.handleDeleteAppInstanceRequest(this.user,
+				new DeleteAppInstance.Request(instance.instanceId));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 	}
 
 	@Test
 	public void testDependencyDeletePolicyAllowed() throws OpenemsNamedException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("DEPENDENCY_DELETE_POLICY",
-								DependencyDeclaration.DependencyDeletePolicy.ALLOWED.name()) //
-						.build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("DEPENDENCY_DELETE_POLICY",
+										DependencyDeclaration.DependencyDeletePolicy.ALLOWED.name()) //
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
 		var instance = this.getAppByAppId(this.testCApp.getAppId());
-		this.sut.handleDeleteAppInstanceRequest(this.user, new DeleteAppInstance.Request(instance.instanceId));
+		this.appManagerTestBundle.sut.handleDeleteAppInstanceRequest(this.user,
+				new DeleteAppInstance.Request(instance.instanceId));
 
-		assertEquals(1, this.sut.getInstantiatedApps().size());
+		assertEquals(1, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 	}
 
 	@Test(expected = OpenemsNamedException.class)
 	public void testDependencyDeletePolicyNotAllowed() throws OpenemsNamedException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("DEPENDENCY_DELETE_POLICY",
-								DependencyDeclaration.DependencyDeletePolicy.NOT_ALLOWED.name()) //
-						.build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("DEPENDENCY_DELETE_POLICY",
+										DependencyDeclaration.DependencyDeletePolicy.NOT_ALLOWED.name()) //
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
 		var instance = this.getAppByAppId(this.testCApp.getAppId());
-		this.sut.handleDeleteAppInstanceRequest(this.user, new DeleteAppInstance.Request(instance.instanceId));
+		this.appManagerTestBundle.sut.handleDeleteAppInstanceRequest(this.user,
+				new DeleteAppInstance.Request(instance.instanceId));
 	}
 
 	@Test
 	public void testDependencyUpdatePolicyAllowAll()
 			throws OpenemsNamedException, InterruptedException, ExecutionException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("DEPENDENCY_UPDATE_POLICY",
-								DependencyDeclaration.DependencyUpdatePolicy.ALLOW_ALL.name()) //
-						.addProperty("NUMBER", 1) //
-						.build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("DEPENDENCY_UPDATE_POLICY",
+										DependencyDeclaration.DependencyUpdatePolicy.ALLOW_ALL.name()) //
+								.addProperty("NUMBER", 1) //
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
 		var newAlias = "newAppAlias";
-		var completable = this.sut.handleJsonrpcRequest(this.user,
+		var completable = this.appManagerTestBundle.sut.handleJsonrpcRequest(this.user,
 				new UpdateAppInstance.Request(this.getAppByAppId(this.testCApp.getAppId()).instanceId, newAlias,
 						JsonUtils.buildJsonObject() //
 								.addProperty("NUMBER", 2) //
 								.build()));
 
 		var result = completable.get().getResult();
-		assertTrue(!result.has("warnings") || (result.get("warnings").getAsJsonArray().size() == 0));
+		assertTrue(!result.has("warnings") || result.get("warnings").getAsJsonArray().size() == 0);
 
 		var instance = this.getAppByAppId(this.testCApp.getAppId());
 		assertEquals(newAlias, instance.alias);
@@ -413,19 +365,20 @@ public class AppManagerAppHelperImplTest {
 	@Test(expected = OpenemsNamedException.class)
 	public void testDependencyUpdatePolicyAllowNone()
 			throws OpenemsNamedException, InterruptedException, ExecutionException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
-				JsonUtils.buildJsonObject() //
-						.addProperty("DEPENDENCY_UPDATE_POLICY",
-								DependencyDeclaration.DependencyUpdatePolicy.ALLOW_NONE.name()) //
-						.addProperty("NUMBER", 1) //
-						.build()));
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user,
+				new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+						JsonUtils.buildJsonObject() //
+								.addProperty("DEPENDENCY_UPDATE_POLICY",
+										DependencyDeclaration.DependencyUpdatePolicy.ALLOW_NONE.name()) //
+								.addProperty("NUMBER", 1) //
+								.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
 		var newAlias = "newAppAlias";
-		this.sut.handleJsonrpcRequest(this.user,
+		this.appManagerTestBundle.sut.handleJsonrpcRequest(this.user,
 				new UpdateAppInstance.Request(this.getAppByAppId(this.testCApp.getAppId()).instanceId, newAlias,
 						JsonUtils.buildJsonObject() //
 								.addProperty("NUMBER", 2) //
@@ -435,19 +388,20 @@ public class AppManagerAppHelperImplTest {
 	@Test
 	public void testDependencyUpdatePolicyAllowOnlyUnconfiguredProperties()
 			throws OpenemsNamedException, InterruptedException, ExecutionException {
-		assertEquals(0, this.sut.getInstantiatedApps().size());
+		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
-		this.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(this.testAApp.getAppId(), "", //
+		this.appManagerTestBundle.sut.handleAddAppInstanceRequest(this.user, new AddAppInstance.Request(
+				this.testAApp.getAppId(), "", //
 				JsonUtils.buildJsonObject() //
 						.addProperty("DEPENDENCY_UPDATE_POLICY",
 								DependencyDeclaration.DependencyUpdatePolicy.ALLOW_ONLY_UNCONFIGURED_PROPERTIES.name()) //
 						.addProperty("NUMBER", 1) //
 						.build()));
 
-		assertEquals(2, this.sut.getInstantiatedApps().size());
+		assertEquals(2, this.appManagerTestBundle.sut.getInstantiatedApps().size());
 
 		var newAlias = "newAppAlias";
-		var completable = this.sut.handleJsonrpcRequest(this.user,
+		var completable = this.appManagerTestBundle.sut.handleJsonrpcRequest(this.user,
 				new UpdateAppInstance.Request(this.getAppByAppId(this.testCApp.getAppId()).instanceId, newAlias,
 						JsonUtils.buildJsonObject() //
 								.addProperty("NUMBER", 2) //
@@ -464,13 +418,8 @@ public class AppManagerAppHelperImplTest {
 	}
 
 	private OpenemsAppInstance getAppByAppId(String appId) {
-		return this.sut.getInstantiatedApps().stream().filter(i -> i.appId.equals(appId)).findAny().get();
-	}
-
-	private static ComponentContext getComponentContext(String appId) {
-		Dictionary<String, Object> properties = new Hashtable<>();
-		properties.put(ComponentConstants.COMPONENT_NAME, appId);
-		return new DummyComponentContext(properties);
+		return this.appManagerTestBundle.sut.getInstantiatedApps().stream().filter(i -> i.appId.equals(appId)).findAny()
+				.get();
 	}
 
 }

--- a/io.openems.edge.core/test/io/openems/edge/core/appmanager/AppManagerImplTest.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/appmanager/AppManagerImplTest.java
@@ -6,16 +6,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.UUID;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.osgi.service.component.ComponentConstants;
-import org.osgi.service.component.ComponentContext;
 
 import com.google.common.collect.ImmutableList;
 
@@ -29,26 +24,11 @@ import io.openems.edge.app.pvselfconsumption.SelfConsumptionOptimization;
 import io.openems.edge.app.timeofusetariff.AwattarHourly;
 import io.openems.edge.app.timeofusetariff.StromdaoCorrently;
 import io.openems.edge.common.host.Host;
-import io.openems.edge.common.test.ComponentTest;
-import io.openems.edge.common.test.DummyComponentContext;
-import io.openems.edge.common.test.DummyComponentManager;
-import io.openems.edge.common.test.DummyConfigurationAdmin;
-import io.openems.edge.core.appmanager.dependency.AggregateTask;
-import io.openems.edge.core.appmanager.dependency.AppManagerAppHelperImpl;
-import io.openems.edge.core.appmanager.dependency.ComponentAggregateTaskImpl;
-import io.openems.edge.core.appmanager.dependency.SchedulerAggregateTaskImpl;
-import io.openems.edge.core.appmanager.dependency.StaticIpAggregateTaskImpl;
-import io.openems.edge.core.appmanager.validator.CheckCardinality;
-import io.openems.edge.core.appmanager.validator.Validator;
 import io.openems.edge.core.appmanager.validator.ValidatorConfig;
 
 public class AppManagerImplTest {
 
-	private DummyConfigurationAdmin cm;
-	private DummyComponentManager componentManger;
-	private ComponentUtil componentUtil;
-
-	private Validator validator = new DummyValidator();
+	private AppManagerTestBundle appManagerTestBundle;
 
 	private FeneconHome homeApp;
 	private GridOptimizedCharge gridOptimizedCharge;
@@ -57,8 +37,6 @@ public class AppManagerImplTest {
 	private KebaEvcs kebaEvcsApp;
 	private AwattarHourly awattarApp;
 	private StromdaoCorrently stromdao;
-
-	private AppManagerImpl sut;
 
 	@Before
 	public void beforeEach() throws Exception {
@@ -70,7 +48,7 @@ public class AppManagerImplTest {
 		final var meterId = "meter0";
 
 		final var emergencyReserveEnabled = false;
-		
+
 		final var shadowManagmentDisabled = false;
 
 		// Battery-Inverter Settings
@@ -78,272 +56,247 @@ public class AppManagerImplTest {
 		final var maxFeedInPower = 10000;
 		final var feedInSetting = "LAGGING_0_95";
 
-		this.cm = new DummyConfigurationAdmin();
-		this.cm.getOrCreateEmptyConfiguration(AppManager.SINGLETON_SERVICE_PID);
+		var componentConfig = JsonUtils.buildJsonObject() //
+				.add(modbusIdInternal, JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", "Bridge.Modbus.Serial") //
+						.addProperty("alias", "Kommunikation mit der Batterie") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("enabled", true) //
+								.addProperty("portName", "/dev/busUSB1") //
+								.addProperty("baudRate", 19200) //
+								.addProperty("databits", 8) //
+								.addProperty("stopbits", "ONE") //
+								.addProperty("parity", "NONE") //
+								.addProperty("logVerbosity", "NONE") //
+								.addProperty("invalidateElementsAfterReadErrors", 1) //
+								.build()) //
+						.build()) //
+				.add(modbusIdExternal, JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", "Bridge.Modbus.Serial") //
+						.addProperty("alias", "Kommunikation mit dem Batterie-Wechselrichter") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("enabled", true) //
+								.addProperty("portName", "/dev/busUSB2") //
+								.addProperty("baudRate", 9600) //
+								.addProperty("databits", 8) //
+								.addProperty("stopbits", "ONE") //
+								.addProperty("parity", "NONE") //
+								.addProperty("logVerbosity", "NONE") //
+								.addProperty("invalidateElementsAfterReadErrors", 1) //
+								.build()) //
+						.build()) //
+				.add(meterId, JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", "GoodWe.Grid-Meter") //
+						.addProperty("alias", "Netzzähler") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("enabled", true) //
+								.addProperty("modbus.id", modbusIdExternal) //
+								.addProperty("modbusUnitId", 247) //
+								.build()) //
+						.build()) //
+				.add("io0", JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", "IO.KMtronic.4Port") //
+						.addProperty("alias", "Relaisboard") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("enabled", true) //
+								.addProperty("modbus.id", modbusIdInternal) //
+								.addProperty("modbusUnitId", 2) //
+								.build()) //
+						.build()) //
+				.add("battery0", JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", "Battery.Fenecon.Home") //
+						.addProperty("alias", "Batterie") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("enabled", true) //
+								.addProperty("startStop", "AUTO") //
+								.addProperty("modbus.id", modbusIdInternal) //
+								.addProperty("modbusUnitId", 1) //
+								.addProperty("batteryStartUpRelay", "io0/Relay4") //
+								.build()) //
+						.build()) //
+				.add(essId, JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", "Ess.Generic.ManagedSymmetric") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("enabled", true) //
+								.addProperty("startStop", "START") //
+								.addProperty("batteryInverter.id", "batteryInverter0") //
+								.addProperty("battery.id", "battery0") //
+								.build()) //
+						.build()) //
+				.add("batteryInverter0", JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", "GoodWe.BatteryInverter") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("enabled", true) //
+								.addProperty("modbus.id", modbusIdExternal) //
+								.addProperty("modbusUnitId", 247) //
+								.addProperty("safetyCountry", safetyCountry) //
+								.addProperty("backupEnable", "DISABLE") //
+								.addProperty("feedPowerEnable", "ENABLE") //
+								.addProperty("feedPowerPara", 10000) //
+								.addProperty("setfeedInPowerSettings", "LAGGING_0_95") //
+								.addProperty("mpptForShadowEnable", shadowManagmentDisabled ? "DISABLE" : "ENABLE") //
+								.build()) //
+						.build()) //
+				.add("predictor0", JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", "Predictor.PersistenceModel") //
+						.addProperty("alias", "Prognose") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("enabled", true) //
+								.add("channelAddresses", JsonUtils.buildJsonArray() //
+										.add("_sum/ProductionActivePower") //
+										.add("_sum/ConsumptionActivePower") //
+										.build()) //
+								.build()) //
+						.build()) //
+				.add("ctrlGridOptimizedCharge0", JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", "Controller.Ess.GridOptimizedCharge") //
+						.addProperty("alias", "Netzdienliche Beladung") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("enabled", true) //
+								.addProperty("ess.id", essId) //
+								.addProperty("meter.id", "meter0") //
+								.addProperty("sellToGridLimitEnabled", true) //
+								.addProperty("maximumSellToGridPower", maxFeedInPower) //
+								.build()) //
+						.build()) //
+				.add("ctrlEssSurplusFeedToGrid0", JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", "Controller.Ess.Hybrid.Surplus-Feed-To-Grid") //
+						.addProperty("alias", "Überschusseinspeisung") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("enabled", true) //
+								.addProperty("ess.id", essId) //
+								.build()) //
+						.build()) //
+				.add("ctrlBalancing0", JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", "Controller.Symmetric.Balancing") //
+						.addProperty("alias", "Eigenverbrauchsoptimierung") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("enabled", true) //
+								.addProperty("ess.id", essId) //
+								.addProperty("meter.id", "meter0") //
+								.addProperty("targetGridSetpoint", 0) //
+								.build()) //
+						.build()) //
+				.add("scheduler0", JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", "Scheduler.AllAlphabetically") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("enabled", true) //
+								.add("controllers.ids", JsonUtils.buildJsonArray() //
+										.add("ctrlGridOptimizedCharge0") //
+										.add("ctrlEssSurplusFeedToGrid0") //
+										.add("ctrlBalancing0") //
+										.build()) //
+								.build()) //
+						.build()) //
+				.add(Host.SINGLETON_COMPONENT_ID, JsonUtils.buildJsonObject() //
+						.addProperty("factoryId", Host.SINGLETON_SERVICE_PID) //
+						.addProperty("alias", "") //
+						.add("properties", JsonUtils.buildJsonObject() //
+								.addProperty("networkConfiguration", //
+										"{\n" //
+												+ "  \"interfaces\": {\n" //
+												+ "    \"enx*\": {\n" //
+												+ "      \"dhcp\": false,\n" //
+												+ "      \"addresses\": [\n" //
+												+ "        \"10.4.0.1/16\",\n" //
+												+ "        \"192.168.1.9/29\"\n" //
+												+ "      ]\n" //
+												+ "    },\n" //
+												+ "    \"eth0\": {\n" //
+												+ "      \"dhcp\": true,\n" //
+												+ "      \"linkLocalAddressing\": true,\n" //
+												+ "      \"addresses\": [\n" //
+												+ "        \"192.168.100.100/24\"\n" //
+												+ "      ]\n" //
+												+ "    }\n" //
+												+ "  }\n" //
+												+ "}") //
+								.build()) //
+						.build()) //
+				.build();
 
-		this.componentManger = new DummyComponentManager();
-		this.componentManger.setConfigJson(JsonUtils.buildJsonObject() //
-				.add("components", JsonUtils.buildJsonObject() //
-						.add(modbusIdInternal, JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "Bridge.Modbus.Serial") //
-								.addProperty("alias", "Kommunikation mit der Batterie") //
+		var initialConfig = MyConfig.create() //
+				.setApps(JsonUtils.buildJsonArray() //
+						.add(JsonUtils.buildJsonObject() //
+								.addProperty("appId", "App.FENECON.Home") //
+								.addProperty("alias", "FENECON Home") //
+								.addProperty("instanceId", UUID.randomUUID().toString()) //
 								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.addProperty("portName", "/dev/busUSB1") //
-										.addProperty("baudRate", 19200) //
-										.addProperty("databits", 8) //
-										.addProperty("stopbits", "ONE") //
-										.addProperty("parity", "NONE") //
-										.addProperty("logVerbosity", "NONE") //
-										.addProperty("invalidateElementsAfterReadErrors", 1) //
+										.addProperty("SAFETY_COUNTRY", safetyCountry) //
+										.addProperty("MAX_FEED_IN_POWER", maxFeedInPower) //
+										.addProperty("FEED_IN_SETTING", feedInSetting) //
+										.addProperty("HAS_AC_METER", false) //
+										.addProperty("HAS_DC_PV1", false) //
+										.addProperty("HAS_DC_PV2", false) //
+										.addProperty("EMERGENCY_RESERVE_ENABLED", emergencyReserveEnabled) //
+										.addProperty("SHADOW_MANAGEMENT_DISABLED", shadowManagmentDisabled) //
 										.build()) //
 								.build()) //
-						.add(modbusIdExternal, JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "Bridge.Modbus.Serial") //
-								.addProperty("alias", "Kommunikation mit dem Batterie-Wechselrichter") //
-								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.addProperty("portName", "/dev/busUSB2") //
-										.addProperty("baudRate", 9600) //
-										.addProperty("databits", 8) //
-										.addProperty("stopbits", "ONE") //
-										.addProperty("parity", "NONE") //
-										.addProperty("logVerbosity", "NONE") //
-										.addProperty("invalidateElementsAfterReadErrors", 1) //
-										.build()) //
-								.build()) //
-						.add(meterId, JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "GoodWe.Grid-Meter") //
-								.addProperty("alias", "Netzzähler") //
-								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.addProperty("modbus.id", modbusIdExternal) //
-										.addProperty("modbusUnitId", 247) //
-										.build()) //
-								.build()) //
-						.add("io0", JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "IO.KMtronic.4Port") //
-								.addProperty("alias", "Relaisboard") //
-								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.addProperty("modbus.id", modbusIdInternal) //
-										.addProperty("modbusUnitId", 2) //
-										.build()) //
-								.build()) //
-						.add("battery0", JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "Battery.Fenecon.Home") //
-								.addProperty("alias", "Batterie") //
-								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.addProperty("startStop", "AUTO") //
-										.addProperty("modbus.id", modbusIdInternal) //
-										.addProperty("modbusUnitId", 1) //
-										.addProperty("batteryStartUpRelay", "io0/Relay4") //
-										.build()) //
-								.build()) //
-						.add(essId, JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "Ess.Generic.ManagedSymmetric") //
-								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.addProperty("startStop", "START") //
-										.addProperty("batteryInverter.id", "batteryInverter0") //
-										.addProperty("battery.id", "battery0") //
-										.build()) //
-								.build()) //
-						.add("batteryInverter0", JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "GoodWe.BatteryInverter") //
-								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.addProperty("modbus.id", modbusIdExternal) //
-										.addProperty("modbusUnitId", 247) //
-										.addProperty("safetyCountry", safetyCountry) //
-										.addProperty("backupEnable", "DISABLE") //
-										.addProperty("feedPowerEnable", "ENABLE") //
-										.addProperty("feedPowerPara", 10000) //
-										.addProperty("setfeedInPowerSettings", "LAGGING_0_95") //
-										.addProperty("mpptForShadowEnable", shadowManagmentDisabled ? "DISABLE" : "ENABLE") //
-										.build()) //
-								.build()) //
-						.add("predictor0", JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "Predictor.PersistenceModel") //
-								.addProperty("alias", "Prognose") //
-								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.add("channelAddresses", JsonUtils.buildJsonArray() //
-												.add("_sum/ProductionActivePower") //
-												.add("_sum/ConsumptionActivePower") //
-												.build()) //
-										.build()) //
-								.build()) //
-						.add("ctrlGridOptimizedCharge0", JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "Controller.Ess.GridOptimizedCharge") //
-								.addProperty("alias", "Netzdienliche Beladung") //
-								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.addProperty("ess.id", essId) //
-										.addProperty("meter.id", "meter0") //
-										.addProperty("sellToGridLimitEnabled", true) //
-										.addProperty("maximumSellToGridPower", maxFeedInPower) //
-										.build()) //
-								.build()) //
-						.add("ctrlEssSurplusFeedToGrid0", JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "Controller.Ess.Hybrid.Surplus-Feed-To-Grid") //
-								.addProperty("alias", "Überschusseinspeisung") //
-								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.addProperty("ess.id", essId) //
-										.build()) //
-								.build()) //
-						.add("ctrlBalancing0", JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "Controller.Symmetric.Balancing") //
-								.addProperty("alias", "Eigenverbrauchsoptimierung") //
-								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.addProperty("ess.id", essId) //
-										.addProperty("meter.id", "meter0") //
-										.addProperty("targetGridSetpoint", 0) //
-										.build()) //
-								.build()) //
-						.add("scheduler0", JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", "Scheduler.AllAlphabetically") //
-								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("enabled", true) //
-										.add("controllers.ids", JsonUtils.buildJsonArray() //
-												.add("ctrlGridOptimizedCharge0") //
-												.add("ctrlEssSurplusFeedToGrid0") //
-												.add("ctrlBalancing0") //
-												.build()) //
-										.build()) //
-								.build()) //
-						.add(Host.SINGLETON_COMPONENT_ID, JsonUtils.buildJsonObject() //
-								.addProperty("factoryId", Host.SINGLETON_SERVICE_PID) //
+						.add(JsonUtils.buildJsonObject() //
+								.addProperty("appId", "App.PvSelfConsumption.GridOptimizedCharge") //
 								.addProperty("alias", "") //
+								.addProperty("instanceId", UUID.randomUUID().toString()) //
 								.add("properties", JsonUtils.buildJsonObject() //
-										.addProperty("networkConfiguration", //
-												"{\n" //
-														+ "  \"interfaces\": {\n" //
-														+ "    \"enx*\": {\n" //
-														+ "      \"dhcp\": false,\n" //
-														+ "      \"addresses\": [\n" //
-														+ "        \"10.4.0.1/16\",\n" //
-														+ "        \"192.168.1.9/29\"\n" //
-														+ "      ]\n" //
-														+ "    },\n" //
-														+ "    \"eth0\": {\n" //
-														+ "      \"dhcp\": true,\n" //
-														+ "      \"linkLocalAddressing\": true,\n" //
-														+ "      \"addresses\": [\n" //
-														+ "        \"192.168.100.100/24\"\n" //
-														+ "      ]\n" //
-														+ "    }\n" //
-														+ "  }\n" //
-														+ "}") //
+										.addProperty("SELL_TO_GRID_LIMIT_ENABLED", true) //
+										.addProperty("MAXIMUM_SELL_TO_GRID_POWER", maxFeedInPower) //
 										.build()) //
-								.build()) //
-						.build()) //
-				.add("factories", JsonUtils.buildJsonObject() //
-						.build()) //
-				.build() //
-		);
-		this.componentUtil = new ComponentUtilImpl(this.componentManger, this.cm);
-
-		this.homeApp = new FeneconHome(this.componentManger, getComponentContext("App.FENECON.Home"), this.cm,
-				this.componentUtil);
-
-		this.gridOptimizedCharge = new GridOptimizedCharge(this.componentManger,
-				getComponentContext("App.PvSelfConsumption.GridOptimizedCharge"), this.cm, this.componentUtil);
-
-		this.selfConsumptionOptimization = new SelfConsumptionOptimization(this.componentManger,
-				getComponentContext("App.PvSelfConsumption.SelfConsumptionOptimization"), this.cm, this.componentUtil);
-
-		this.kebaEvcsApp = new KebaEvcs(this.componentManger, getComponentContext("App.Evcs.Keba"), this.cm,
-				this.componentUtil);
-		this.awattarApp = new AwattarHourly(this.componentManger, getComponentContext("App.TimeVariablePrice.Awattar"),
-				this.cm, this.componentUtil);
-		this.stromdao = new StromdaoCorrently(this.componentManger,
-				getComponentContext("App.TimeVariablePrice.Stromdao"), this.cm, this.componentUtil);
-
-		AggregateTask.ComponentAggregateTask componentTask = new ComponentAggregateTaskImpl(this.componentManger);
-		AggregateTask.SchedulerAggregateTask schedulerTask = new SchedulerAggregateTaskImpl(componentTask,
-				this.componentUtil);
-		AggregateTask.StaticIpAggregateTask staticIpTask = new StaticIpAggregateTaskImpl(this.componentUtil);
-
-		var appManagerAppHelper = new AppManagerAppHelperImpl(this.componentManger, this.componentUtil, this.validator,
-				componentTask, schedulerTask, staticIpTask);
-
-		this.sut = new AppManagerImpl();
-		new ComponentTest(this.sut) //
-				.addReference("cm", this.cm) //
-				.addReference("componentManager", this.componentManger) //
-				.addReference("appHelper", appManagerAppHelper) //
-				.addReference("availableApps",
-						ImmutableList.of(this.homeApp, this.gridOptimizedCharge, this.selfConsumptionOptimization,
-								this.kebaEvcsApp, this.awattarApp, this.stromdao)) //
-				.activate(MyConfig.create() //
-						.setApps(JsonUtils.buildJsonArray() //
-								.add(JsonUtils.buildJsonObject() //
-										.addProperty("appId", "App.FENECON.Home") //
-										.addProperty("alias", "FENECON Home") //
-										.addProperty("instanceId", UUID.randomUUID().toString()) //
-										.add("properties", JsonUtils.buildJsonObject() //
-												.addProperty("SAFETY_COUNTRY", safetyCountry) //
-												.addProperty("MAX_FEED_IN_POWER", maxFeedInPower) //
-												.addProperty("FEED_IN_SETTING", feedInSetting) //
-												.addProperty("HAS_AC_METER", false) //
-												.addProperty("HAS_DC_PV1", false) //
-												.addProperty("HAS_DC_PV2", false) //
-												.addProperty("EMERGENCY_RESERVE_ENABLED", emergencyReserveEnabled) //
-												.addProperty("SHADOW_MANAGEMENT_DISABLED", shadowManagmentDisabled) //
-												.build()) //
+								.build())
+						.add(JsonUtils.buildJsonObject() //
+								.addProperty("appId", "App.PvSelfConsumption.SelfConsumptionOptimization") //
+								.addProperty("alias", "") //
+								.addProperty("instanceId", UUID.randomUUID().toString()) //
+								.add("properties", JsonUtils.buildJsonObject() //
+										.addProperty("ESS_ID", essId) //
+										.addProperty("METER_ID", meterId) //
 										.build()) //
-								.add(JsonUtils.buildJsonObject() //
-										.addProperty("appId", "App.PvSelfConsumption.GridOptimizedCharge") //
-										.addProperty("alias", "") //
-										.addProperty("instanceId", UUID.randomUUID().toString()) //
-										.add("properties", JsonUtils.buildJsonObject() //
-												.addProperty("SELL_TO_GRID_LIMIT_ENABLED", true) //
-												.addProperty("MAXIMUM_SELL_TO_GRID_POWER", maxFeedInPower) //
-												.build()) //
-										.build())
-								.add(JsonUtils.buildJsonObject() //
-										.addProperty("appId", "App.PvSelfConsumption.SelfConsumptionOptimization") //
-										.addProperty("alias", "") //
-										.addProperty("instanceId", UUID.randomUUID().toString()) //
-										.add("properties", JsonUtils.buildJsonObject() //
-												.addProperty("ESS_ID", essId) //
-												.addProperty("METER_ID", meterId) //
-												.build()) //
-										.build())
-								.build().toString()) //
-						.build());
+								.build())
+						.build().toString()) //
+				.build();
+
+		this.appManagerTestBundle = new AppManagerTestBundle(componentConfig, initialConfig, t -> {
+
+			this.homeApp = new FeneconHome(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.FENECON.Home"), t.cm, t.componentUtil);
+			this.gridOptimizedCharge = new GridOptimizedCharge(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.PvSelfConsumption.GridOptimizedCharge"), t.cm,
+					t.componentUtil);
+			this.selfConsumptionOptimization = new SelfConsumptionOptimization(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.PvSelfConsumption.SelfConsumptionOptimization"), t.cm,
+					t.componentUtil);
+
+			this.kebaEvcsApp = new KebaEvcs(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.Evcs.Keba"), t.cm, t.componentUtil);
+			this.awattarApp = new AwattarHourly(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.TimeVariablePrice.Awattar"), t.cm, t.componentUtil);
+			this.stromdao = new StromdaoCorrently(t.componentManger,
+					AppManagerTestBundle.getComponentContext("App.TimeVariablePrice.Stromdao"), t.cm, t.componentUtil);
+
+			return ImmutableList.of(this.homeApp, this.gridOptimizedCharge, this.selfConsumptionOptimization,
+					this.kebaEvcsApp, this.awattarApp, this.stromdao);
+		});
+
 	}
 
 	@Test
 	public void testAppValidateWorker() throws OpenemsException, Exception {
-		var worker = new AppValidateWorker(this.sut);
-		worker.validateApps();
+		assertEquals(this.appManagerTestBundle.sut.instantiatedApps.size(), 3);
 
-		assertEquals(this.sut.instantiatedApps.size(), 3);
-
-		// should not have found defective Apps
-		for (Entry<String, String> entry : worker.defectiveApps.entrySet()) {
-			throw new Exception(entry.getKey() + ": " + entry.getValue());
-		}
+		this.appManagerTestBundle.assertNoValidationErrors();
 	}
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void testGetInstantiatedApps() {
-		this.sut.getInstantiatedApps().add(null);
+		this.appManagerTestBundle.sut.getInstantiatedApps().add(null);
 	}
 
 	@Test
 	public void testFindAppById() {
-		assertEquals(this.homeApp, this.sut.findAppById("App.FENECON.Home"));
+		assertEquals(this.homeApp, this.appManagerTestBundle.sut.findAppById("App.FENECON.Home"));
 	}
 
 	@Test
 	public void testCheckCardinalitySingle() throws Exception {
-		var checkable = new CheckCardinality(this.sut, getComponentContext(CheckCardinality.COMPONENT_NAME));
+		var checkable = this.appManagerTestBundle.checkablesBundle.checkCardinality;
 		checkable.setProperties(new ValidatorConfig.MapBuilder<>(new TreeMap<String, Object>()) //
 				.put("openemsApp", this.homeApp) //
 				.build());
@@ -353,11 +306,11 @@ public class AppManagerImplTest {
 
 	@Test
 	public void testCheckCardinalityMultiple() throws Exception {
-		this.sut.instantiatedApps.add(new OpenemsAppInstance(this.kebaEvcsApp.getAppId(), "alias", UUID.randomUUID(),
-				JsonUtils.buildJsonObject().build(), null));
-		this.sut.instantiatedApps.add(new OpenemsAppInstance(this.kebaEvcsApp.getAppId(), "alias", UUID.randomUUID(),
-				JsonUtils.buildJsonObject().build(), null));
-		var checkable = new CheckCardinality(this.sut, getComponentContext(CheckCardinality.COMPONENT_NAME));
+		this.appManagerTestBundle.sut.instantiatedApps.add(new OpenemsAppInstance(this.kebaEvcsApp.getAppId(), "alias",
+				UUID.randomUUID(), JsonUtils.buildJsonObject().build(), null));
+		this.appManagerTestBundle.sut.instantiatedApps.add(new OpenemsAppInstance(this.kebaEvcsApp.getAppId(), "alias",
+				UUID.randomUUID(), JsonUtils.buildJsonObject().build(), null));
+		var checkable = this.appManagerTestBundle.checkablesBundle.checkCardinality;
 		checkable.setProperties(new ValidatorConfig.MapBuilder<>(new TreeMap<String, Object>()) //
 				.put("openemsApp", this.kebaEvcsApp) //
 				.build());
@@ -367,20 +320,14 @@ public class AppManagerImplTest {
 
 	@Test
 	public void testCheckCardinalitySingleInCategorie() throws Exception {
-		this.sut.instantiatedApps.add(new OpenemsAppInstance(this.awattarApp.getAppId(), "alias", UUID.randomUUID(),
-				JsonUtils.buildJsonObject().build(), null));
-		var checkable = new CheckCardinality(this.sut, getComponentContext(CheckCardinality.COMPONENT_NAME));
+		this.appManagerTestBundle.sut.instantiatedApps.add(new OpenemsAppInstance(this.awattarApp.getAppId(), "alias",
+				UUID.randomUUID(), JsonUtils.buildJsonObject().build(), null));
+		var checkable = this.appManagerTestBundle.checkablesBundle.checkCardinality;
 		checkable.setProperties(new ValidatorConfig.MapBuilder<>(new TreeMap<String, Object>()) //
 				.put("openemsApp", this.stromdao) //
 				.build());
 		assertFalse(checkable.check());
 		assertNotNull(checkable.getErrorMessage(Language.DEFAULT));
-	}
-
-	private static ComponentContext getComponentContext(String appId) {
-		Dictionary<String, Object> properties = new Hashtable<>();
-		properties.put(ComponentConstants.COMPONENT_NAME, appId);
-		return new DummyComponentContext(properties);
 	}
 
 }

--- a/io.openems.edge.core/test/io/openems/edge/core/appmanager/AppManagerTestBundle.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/appmanager/AppManagerTestBundle.java
@@ -1,0 +1,204 @@
+package io.openems.edge.core.appmanager;
+
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.osgi.service.component.ComponentConstants;
+import org.osgi.service.component.ComponentContext;
+
+import com.google.gson.JsonObject;
+
+import io.openems.common.utils.JsonUtils;
+import io.openems.common.utils.ReflectionUtils;
+import io.openems.edge.common.host.Host;
+import io.openems.edge.common.test.ComponentTest;
+import io.openems.edge.common.test.DummyComponentContext;
+import io.openems.edge.common.test.DummyComponentManager;
+import io.openems.edge.common.test.DummyConfigurationAdmin;
+import io.openems.edge.core.appmanager.dependency.AppManagerAppHelperImpl;
+import io.openems.edge.core.appmanager.dependency.ComponentAggregateTaskImpl;
+import io.openems.edge.core.appmanager.dependency.DependencyUtil;
+import io.openems.edge.core.appmanager.dependency.SchedulerAggregateTaskImpl;
+import io.openems.edge.core.appmanager.dependency.StaticIpAggregateTaskImpl;
+import io.openems.edge.core.appmanager.validator.CheckCardinality;
+import io.openems.edge.core.appmanager.validator.Checkable;
+import io.openems.edge.core.appmanager.validator.Validator;
+
+public class AppManagerTestBundle {
+
+	public final DummyConfigurationAdmin cm;
+	public final DummyComponentManager componentManger;
+	public final ComponentUtil componentUtil;
+	public final Validator validator;
+
+	public final AppManagerImpl sut;
+	public final AppManagerUtil appManagerUtil;
+
+	public final CheckablesBundle checkablesBundle;
+
+	public AppManagerTestBundle(JsonObject initialComponentConfig, MyConfig initialAppManagerConfig,
+			Function<AppManagerTestBundle, List<OpenemsApp>> availableAppsSupplier) throws Exception {
+		if (initialComponentConfig == null) {
+			initialComponentConfig = JsonUtils.buildJsonObject() //
+					.add("scheduler0", JsonUtils.buildJsonObject() //
+							.addProperty("factoryId", "Scheduler.AllAlphabetically") //
+							.add("properties", JsonUtils.buildJsonObject() //
+									.addProperty("enabled", true) //
+									.add("controllers.ids", JsonUtils.buildJsonArray() //
+											.build()) //
+									.build()) //
+							.build()) //
+					.add(Host.SINGLETON_COMPONENT_ID, JsonUtils.buildJsonObject() //
+							.addProperty("factoryId", Host.SINGLETON_SERVICE_PID) //
+							.addProperty("alias", "") //
+							.add("properties", JsonUtils.buildJsonObject() //
+									.addProperty("networkConfiguration", //
+											"{\n" //
+													+ "  \"interfaces\": {\n" //
+													+ "    \"enx*\": {\n" //
+													+ "      \"dhcp\": false,\n" //
+													+ "      \"addresses\": [\n" //
+													+ "        \"10.4.0.1/16\",\n" //
+													+ "        \"192.168.1.9/29\"\n" //
+													+ "      ]\n" //
+													+ "    },\n" //
+													+ "    \"eth0\": {\n" //
+													+ "      \"dhcp\": true,\n" //
+													+ "      \"linkLocalAddressing\": true,\n" //
+													+ "      \"addresses\": [\n" //
+													+ "        \"192.168.100.100/24\"\n" //
+													+ "      ]\n" //
+													+ "    }\n" //
+													+ "  }\n" //
+													+ "}") //
+									.build()) //
+							.build()) //
+					.build();
+		}
+
+		if (initialAppManagerConfig == null) {
+			initialAppManagerConfig = MyConfig.create() //
+					.setApps(JsonUtils.buildJsonArray() //
+							.build() //
+							.toString())
+					.build();
+		}
+
+		this.cm = new DummyConfigurationAdmin();
+		this.cm.getOrCreateEmptyConfiguration(AppManager.SINGLETON_SERVICE_PID);
+
+		this.componentManger = new DummyComponentManager();
+		this.componentManger.setConfigJson(JsonUtils.buildJsonObject() //
+				.add("components", initialComponentConfig) //
+				.add("factories", JsonUtils.buildJsonObject() //
+						.build()) //
+				.build() //
+		);
+
+		// create config for scheduler
+		this.cm.getOrCreateEmptyConfiguration(
+				this.componentManger.getEdgeConfig().getComponent("scheduler0").get().getPid());
+
+		this.componentUtil = new ComponentUtilImpl(this.componentManger, this.cm);
+
+		final var componentTask = new ComponentAggregateTaskImpl(this.componentManger);
+		final var schedulerTask = new SchedulerAggregateTaskImpl(componentTask, this.componentUtil);
+		final var staticIpTask = new StaticIpAggregateTaskImpl(this.componentUtil);
+
+		this.sut = new AppManagerImpl();
+		this.componentManger.addComponent(this.sut);
+		this.componentManger.setConfigurationAdmin(this.cm);
+		this.appManagerUtil = new AppManagerUtilImpl();
+		ReflectionUtils.setAttribute(this.appManagerUtil.getClass(), this.appManagerUtil, "appManager", this.sut);
+
+		this.checkablesBundle = new CheckablesBundle(new CheckCardinality(this.sut, this.appManagerUtil,
+				getComponentContext(CheckCardinality.COMPONENT_NAME)));
+
+		var dummyValidator = new DummyValidator();
+		dummyValidator.setCheckables(this.checkablesBundle.all());
+		this.validator = dummyValidator;
+
+		var appManagerAppHelper = new AppManagerAppHelperImpl(this.componentManger, this.componentUtil, this.validator,
+				componentTask, schedulerTask, staticIpTask);
+
+		// use this so the appManagerAppHelper does not has to be a OpenemsComponent and
+		// the attribute can still be private
+		ReflectionUtils.setAttribute(appManagerAppHelper.getClass(), appManagerAppHelper, "appManager", this.sut);
+		ReflectionUtils.setAttribute(appManagerAppHelper.getClass(), appManagerAppHelper, "appManagerUtil",
+				this.appManagerUtil);
+
+		ReflectionUtils.setAttribute(DependencyUtil.class, null, "appHelper", appManagerAppHelper);
+
+		new ComponentTest(this.sut) //
+				.addReference("cm", this.cm) //
+				.addReference("componentManager", this.componentManger) //
+				.addReference("appHelper", appManagerAppHelper) //
+				.addReference("validator", this.validator) //
+				.addReference("availableApps", availableAppsSupplier.apply(this)) //
+				.activate(initialAppManagerConfig);
+
+	}
+
+	/**
+	 * Checks if the {@link Validator} has any errors.
+	 * 
+	 * @throws Exception on error
+	 */
+	public void assertNoValidationErrors() throws Exception {
+		var worker = new AppValidateWorker(this.sut);
+		worker.validateApps();
+
+		// should not have found defective Apps
+		if (!worker.defectiveApps.isEmpty()) {
+			throw new Exception(worker.defectiveApps.entrySet().stream() //
+					.map(e -> e.getKey() + "[" + e.getValue() + "]") //
+					.collect(Collectors.joining("|")));
+		}
+	}
+
+	/**
+	 * Prints out the instantiated {@link OpenemsAppInstance}s.
+	 */
+	public void printApps() {
+		JsonUtils.prettyPrint(this.sut.getInstantiatedApps().stream().map(OpenemsAppInstance::toJsonObject)
+				.collect(JsonUtils.toJsonArray()));
+	}
+
+	public static class CheckablesBundle {
+
+		public final CheckCardinality checkCardinality;
+
+		private CheckablesBundle(CheckCardinality checkCardinality) {
+			this.checkCardinality = checkCardinality;
+		}
+
+		/**
+		 * Gets all {@link Checkable}.
+		 * 
+		 * @return the {@link Checkable}
+		 */
+		public final List<Checkable> all() {
+			var result = new ArrayList<Checkable>();
+			result.add(this.checkCardinality);
+			return result;
+		}
+	}
+
+	/**
+	 * Gets the {@link ComponentContext} for an {@link OpenemsApp} of the given
+	 * appId.
+	 * 
+	 * @param appId the {@link OpenemsApp#getAppId()} of the {@link OpenemsApp}
+	 * @return the {@link ComponentContext}
+	 */
+	public static ComponentContext getComponentContext(String appId) {
+		Dictionary<String, Object> properties = new Hashtable<>();
+		properties.put(ComponentConstants.COMPONENT_NAME, appId);
+		return new DummyComponentContext(properties);
+	}
+
+}


### PR DESCRIPTION
Made referencing other Instances more dynamically during installation.
e. g. an Instance that gets currently created now can be referrenced by other Apps that also being created.

Changed Cardinality of Meter to Multiple.

Improved JUnit testing

Picking ID for Components now starts from the number given as the default ID.