### PR TITLE
ElementToChannelConverter KEEP_POSITIVE fixed

### DIFF
--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/ElementToChannelConverter.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/ElementToChannelConverter.java
@@ -66,7 +66,7 @@ public class ElementToChannelConverter {
 	 */
 	public static final ElementToChannelConverter KEEP_POSITIVE = new ElementToChannelConverter(//
 			// element -> channel
-			value -> StaticConverters.KEEP_POSITIVE, //
+			StaticConverters.KEEP_POSITIVE, //
 			// channel -> element
 			value -> value);
 


### PR DESCRIPTION
In the previous version, the ElementToChannelConverter KEEP_POSITIVE mapped a value to a converter instead of a new value.