### PR TITLE
Simulator Grid-Meter: Ignore Ess-Cluster

### DIFF
--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/meter/grid/acting/GridMeter.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/meter/grid/acting/GridMeter.java
@@ -28,6 +28,7 @@ import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.event.EdgeEventConstants;
 import io.openems.edge.common.type.TypeUtils;
 import io.openems.edge.ess.api.ManagedSymmetricEss;
+import io.openems.edge.ess.api.MetaEss;
 import io.openems.edge.meter.api.AsymmetricMeter;
 import io.openems.edge.meter.api.MeterType;
 import io.openems.edge.meter.api.SymmetricMeter;
@@ -141,6 +142,10 @@ public class GridMeter extends AbstractOpenemsComponent
 		 */
 		var activePower = simulatedActivePower;
 		for (ManagedSymmetricEss ess : this.symmetricEsss) {
+			if (ess instanceof MetaEss) {
+				// ignore this Ess
+				continue;
+			}
 			activePower = TypeUtils.subtract(activePower, ess.getActivePower().get());
 		}
 

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/meter/grid/reacting/GridMeter.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/meter/grid/reacting/GridMeter.java
@@ -26,6 +26,7 @@ import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.event.EdgeEventConstants;
 import io.openems.edge.common.type.TypeUtils;
 import io.openems.edge.ess.api.ManagedSymmetricEss;
+import io.openems.edge.ess.api.MetaEss;
 import io.openems.edge.meter.api.AsymmetricMeter;
 import io.openems.edge.meter.api.MeterType;
 import io.openems.edge.meter.api.SymmetricMeter;
@@ -122,6 +123,10 @@ public class GridMeter extends AbstractOpenemsComponent
 		Integer sum = null;
 
 		for (ManagedSymmetricEss ess : this.symmetricEsss) {
+			if (ess instanceof MetaEss) {
+				// ignore this Ess
+				continue;
+			}
 			sum = subtract(sum, ess.getActivePowerChannel().getNextValue().get());
 		}
 		for (SymmetricMeter sm : this.symmetricMeters) {


### PR DESCRIPTION
Simulator Grid-Meters Acting and Reacting should ignore Ess-Cluster, otherwise values are applied twice.

See https://community.openems.io/t/fehler-bei-verbrauch-mit-ess-cluster/1133/4