### PR TITLE
KACO Bp10: move communication failure to individual components

### DIFF
--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/core/BpCore.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/core/BpCore.java
@@ -1,12 +1,7 @@
 package io.openems.edge.kaco.blueplanet.hybrid10.core;
 
 import com.ed.data.BatteryData;
-import com.ed.data.EnergyMeter;
 import com.ed.data.InverterData;
-import com.ed.data.Settings;
-import com.ed.data.Status;
-import com.ed.data.SystemInfo;
-import com.ed.data.VectisData;
 
 import io.openems.common.channel.Level;
 import io.openems.common.types.OpenemsType;
@@ -19,34 +14,6 @@ import io.openems.edge.common.component.OpenemsComponent;
 public interface BpCore extends OpenemsComponent {
 
 	/**
-	 * Gets the {@link BatteryData}.
-	 * 
-	 * @return {@link BatteryData}
-	 */
-	public BatteryData getBatteryData();
-
-	/**
-	 * Gets the {@link InverterData}.
-	 * 
-	 * @return {@link InverterData}
-	 */
-	public InverterData getInverterData();
-
-	/**
-	 * Gets the {@link Status}.
-	 * 
-	 * @return {@link Status}
-	 */
-	public Status getStatusData();
-
-	/**
-	 * Is the Client connected?.
-	 * 
-	 * @return true if connected
-	 */
-	public boolean isConnected();
-
-	/**
 	 * Is the default user logged in?.
 	 * 
 	 * @return true if the default password for user was not changed
@@ -54,32 +21,13 @@ public interface BpCore extends OpenemsComponent {
 	public boolean isDefaultUser();
 
 	/**
-	 * Gets the {@link Settings}.
+	 * Gets the {@link BpData}, including {@link BatteryData}, {@link InverterData},
+	 * etc.
 	 * 
-	 * @return {@link Settings}
+	 * @return {@link BpData}, null if data is not available - e.g. on communication
+	 *         error
 	 */
-	public Settings getSettings();
-
-	/**
-	 * Gets the {@link VectisData}.
-	 * 
-	 * @return {@link VectisData}
-	 */
-	public VectisData getVectis();
-
-	/**
-	 * Gets the {@link EnergyMeter}.
-	 * 
-	 * @return {@link EnergyMeter}
-	 */
-	public EnergyMeter getEnergyMeter();
-
-	/**
-	 * Gets the {@link SystemInfo}.
-	 * 
-	 * @return {@link SystemInfo}
-	 */
-	public SystemInfo getSystemInfo();
+	public BpData getBpData();
 
 	/**
 	 * Gets the {@link StableVersion}.
@@ -89,8 +37,6 @@ public interface BpCore extends OpenemsComponent {
 	public StableVersion getStableVersion();
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
-		COMMUNICATION_FAILED(Doc.of(Level.FAULT) //
-				.text("Communication to KACO blueplanet hybrid 10 failed. Please check the network connection and the status of the inverter")), //
 		USER_ACCESS_DENIED(Doc.of(Level.FAULT) //
 				/*
 				 * Additional text when we are able to ensure the functionality of the external
@@ -117,35 +63,6 @@ public interface BpCore extends OpenemsComponent {
 		public Doc doc() {
 			return this.doc;
 		}
-	}
-
-	/**
-	 * Gets the Channel for {@link ChannelId#COMMUNICATION_FAILED}.
-	 * 
-	 * @return the Channel
-	 */
-	public default StateChannel getCommunicationFailedChannel() {
-		return this.channel(ChannelId.COMMUNICATION_FAILED);
-	}
-
-	/**
-	 * Gets the Slave Communication Failed State. See
-	 * {@link ChannelId#COMMUNICATION_FAILED}.
-	 * 
-	 * @return the Channel {@link Value}
-	 */
-	public default Value<Boolean> getCommunicationFailed() {
-		return this.getCommunicationFailedChannel().value();
-	}
-
-	/**
-	 * Internal method to set the 'nextValue' on
-	 * {@link ChannelId#USER_ACCESS_DENIED} Channel.
-	 * 
-	 * @param value the next value
-	 */
-	public default void _setCommunicationFailed(boolean value) {
-		this.getCommunicationFailedChannel().setNextValue(value);
 	}
 
 	/**

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/core/BpCoreImpl.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/core/BpCoreImpl.java
@@ -286,7 +286,7 @@ public class BpCoreImpl extends AbstractOpenemsComponent implements BpCore, Open
 		this.client.setUserPass(this.config.userkey());
 
 		// Initialize all DataSets
-		this._bpData = BpData.from(client);
+		this._bpData = BpData.from(this.client);
 
 		this.client.start();
 

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/core/BpCoreImpl.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/core/BpCoreImpl.java
@@ -27,13 +27,6 @@ import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.ed.data.BatteryData;
-import com.ed.data.EnergyMeter;
-import com.ed.data.InverterData;
-import com.ed.data.Settings;
-import com.ed.data.Status;
-import com.ed.data.SystemInfo;
-import com.ed.data.VectisData;
 import com.ed.edcom.Client;
 import com.ed.edcom.ClientListener;
 import com.ed.edcom.Discovery;
@@ -62,13 +55,7 @@ public class BpCoreImpl extends AbstractOpenemsComponent implements BpCore, Open
 	private Config config = null;
 	private ScheduledFuture<?> configFuture = null;
 	private Client client = null;
-	private BatteryData battery = null;
-	private InverterData inverter = null;
-	private Status status = null;
-	private Settings settings = null;
-	private VectisData vectis = null;
-	private EnergyMeter energy = null;
-	private SystemInfo systemInfo = null;
+	private BpData _bpData = null;
 
 	private StableVersion stableVersion;
 
@@ -101,7 +88,6 @@ public class BpCoreImpl extends AbstractOpenemsComponent implements BpCore, Open
 					break; // stop forever loop
 				} catch (Exception e) {
 					this.logError(this.log, e.getMessage());
-					this._setCommunicationFailed(true);
 					e.printStackTrace();
 				}
 				try {
@@ -110,7 +96,6 @@ public class BpCoreImpl extends AbstractOpenemsComponent implements BpCore, Open
 					this.logError(this.log, e.getMessage());
 				}
 			}
-			this._setCommunicationFailed(false);
 		};
 		this.configFuture = this.configExecutor.schedule(initializeLibrary, 0, TimeUnit.SECONDS);
 	}
@@ -247,87 +232,15 @@ public class BpCoreImpl extends AbstractOpenemsComponent implements BpCore, Open
 	}
 
 	@Override
-	public BatteryData getBatteryData() {
-		if (!this.isConnected()) {
+	public BpData getBpData() {
+		var client = this.client;
+		if (client == null) {
 			return null;
 		}
-		if (this.battery != null && this.battery.dataReady()) {
-			this.battery.refresh();
-		}
-		return this.battery;
-	}
-
-	@Override
-	public InverterData getInverterData() {
-		if (this.inverter == null || !this.isConnected()) {
+		if (!client.isConnected()) {
 			return null;
 		}
-		// In some old systems the data was read only once
-		// if (this.inverter != null && this.inverter.dataReady()) {
-		this.inverter.refresh();
-		return this.inverter;
-	}
-
-	@Override
-	public Status getStatusData() {
-		if (!this.isConnected()) {
-			return null;
-		}
-		if (this.status != null && this.status.dataReady()) {
-			this.status.refresh();
-		}
-		return this.status;
-	}
-
-	@Override
-	public boolean isConnected() {
-		boolean isConnected = this.client != null && this.client.isConnected();
-		this._setCommunicationFailed(!isConnected);
-		return isConnected;
-	}
-
-	@Override
-	public Settings getSettings() {
-		if (!this.isConnected()) {
-			return null;
-		}
-		if (this.settings != null && this.settings.dataReady()) {
-			this.settings.refresh();
-		}
-		return this.settings;
-	}
-
-	@Override
-	public VectisData getVectis() {
-		if (!this.isConnected()) {
-			return null;
-		}
-		if (this.vectis != null && this.vectis.dataReady()) {
-			this.vectis.refresh();
-		}
-		return this.vectis;
-	}
-
-	@Override
-	public EnergyMeter getEnergyMeter() {
-		if (!this.isConnected()) {
-			return null;
-		}
-		if (this.energy != null && this.energy.dataReady()) {
-			this.energy.refresh();
-		}
-		return this.energy;
-	}
-
-	@Override
-	public SystemInfo getSystemInfo() {
-		if (!this.isConnected()) {
-			return null;
-		}
-		if (this.systemInfo != null && this.systemInfo.dataReady()) {
-			this.systemInfo.refresh();
-		}
-		return this.systemInfo;
+		return this._bpData;
 	}
 
 	@Override
@@ -372,21 +285,8 @@ public class BpCoreImpl extends AbstractOpenemsComponent implements BpCore, Open
 		// Set user password
 		this.client.setUserPass(this.config.userkey());
 
-		// Initialize all Data classes
-		this.battery = new BatteryData();
-		this.battery.registerData(this.client);
-		this.inverter = new InverterData();
-		this.inverter.registerData(this.client);
-		this.status = new Status();
-		this.status.registerData(this.client);
-		this.settings = new Settings();
-		this.settings.registerData(this.client);
-		this.energy = new EnergyMeter();
-		this.energy.registerData(this.client);
-		this.vectis = new VectisData();
-		this.vectis.registerData(this.client);
-		this.systemInfo = new SystemInfo();
-		this.systemInfo.registerData(this.client);
+		// Initialize all DataSets
+		this._bpData = BpData.from(client);
 
 		this.client.start();
 
@@ -397,7 +297,7 @@ public class BpCoreImpl extends AbstractOpenemsComponent implements BpCore, Open
 			availInitResponse = true;
 
 			// Get current software version
-			Float comVersion = TypeUtils.getAsType(OpenemsType.FLOAT, this.systemInfo.getComVersion());
+			Float comVersion = TypeUtils.getAsType(OpenemsType.FLOAT, this._bpData.systemInfo.getComVersion());
 			this.stableVersion = StableVersion.getCurrentStableVersion(comVersion);
 
 			switch (this.stableVersion) {
@@ -502,26 +402,36 @@ public class BpCoreImpl extends AbstractOpenemsComponent implements BpCore, Open
 	public void handleEvent(Event event) {
 		switch (event.getTopic()) {
 		case EdgeEventConstants.TOPIC_CYCLE_BEFORE_PROCESS_IMAGE:
+			this.refreshBpData();
 			this.updateChannels();
 			break;
 		}
+	}
+
+	private void refreshBpData() {
+		var bpData = this.getBpData();
+		if (bpData == null) {
+			return;
+		}
+		bpData.refreshAll();
 	}
 
 	private void updateChannels() {
 		String serialNumber = null;
 		Float versionCom = null;
 
-		if (this.isConnected()) {
-			SystemInfo systemInfo = this.getSystemInfo();
-			if (systemInfo != null) {
-				serialNumber = systemInfo.getSerialNumber();
+		var bpData = this.getBpData();
+		if (bpData != null) {
+			if (bpData.systemInfo != null) {
+				serialNumber = bpData.systemInfo.getSerialNumber();
 				if (serialNumber != null) {
 					serialNumber = serialNumber.strip();
 				}
 				try {
-					versionCom = Float.parseFloat(systemInfo.getComVersion());
+					versionCom = Float.parseFloat(bpData.systemInfo.getComVersion());
 				} catch (NumberFormatException e) {
-					this.logWarn(this.log, "Unable to parse Com-Version from [" + systemInfo.getComVersion() + "]");
+					this.logWarn(this.log,
+							"Unable to parse Com-Version from [" + bpData.systemInfo.getComVersion() + "]");
 				}
 			}
 		}

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/core/BpData.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/core/BpData.java
@@ -1,0 +1,70 @@
+package io.openems.edge.kaco.blueplanet.hybrid10.core;
+
+import java.util.stream.Stream;
+
+import com.ed.data.BatteryData;
+import com.ed.data.DataSet;
+import com.ed.data.EnergyMeter;
+import com.ed.data.InverterData;
+import com.ed.data.Settings;
+import com.ed.data.Status;
+import com.ed.data.SystemInfo;
+import com.ed.data.VectisData;
+import com.ed.edcom.Client;
+
+public class BpData {
+
+	/**
+	 * Build a {@link BpData} object initialized by {@link Client}.
+	 * 
+	 * @param client the {@link Client}
+	 * @return the {@link BpData}
+	 * @throws Exception on error
+	 */
+	public static BpData from(Client client) throws Exception {
+		var battery = new BatteryData();
+		var inverter = new InverterData();
+		var status = new Status();
+		var settings = new Settings();
+		var energy = new EnergyMeter();
+		var vectis = new VectisData();
+		var systemInfo = new SystemInfo();
+
+		return new BpData(client, battery, inverter, status, settings, vectis, energy, systemInfo);
+	}
+
+	private final DataSet[] all;
+	public final BatteryData battery;
+	public final InverterData inverter;
+	public final Status status;
+	public final Settings settings;
+	public final VectisData vectis;
+	public final EnergyMeter energy;
+	public final SystemInfo systemInfo;
+
+	private BpData(Client client, BatteryData battery, InverterData inverter, Status status, Settings settings,
+			VectisData vectis, EnergyMeter energy, SystemInfo systemInfo) {
+		this.battery = battery;
+		this.inverter = inverter;
+		this.status = status;
+		this.settings = settings;
+		this.vectis = vectis;
+		this.energy = energy;
+		this.systemInfo = systemInfo;
+
+		// Prepare array of all DataSets for convenience
+		this.all = new DataSet[] { battery, inverter, status, settings, energy, vectis, systemInfo };
+
+		// Register DataSets with Client
+		Stream.of(this.all) //
+				.forEach(d -> d.registerData(client));
+	}
+
+	/**
+	 * Refresh all {@link DataSet}s.
+	 */
+	protected void refreshAll() {
+		Stream.of(this.all) //
+				.forEach(d -> d.refresh());
+	}
+}

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/ess/BpEss.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/ess/BpEss.java
@@ -13,6 +13,10 @@ import io.openems.edge.kaco.blueplanet.hybrid10.InverterStatus;
 public interface BpEss extends OpenemsComponent {
 
 	public static enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+		COMMUNICATION_FAILED(Doc.of(Level.FAULT) //
+				.text("Communication to KACO blueplanet hybrid 10 failed. "
+						+ "Please check the network connection and the status of the inverter")), //
+
 		BMS_VOLTAGE(Doc.of(OpenemsType.FLOAT) //
 				.unit(Unit.VOLT)), //
 		RISO(Doc.of(OpenemsType.FLOAT) //
@@ -45,6 +49,25 @@ public interface BpEss extends OpenemsComponent {
 		public Doc doc() {
 			return this.doc;
 		}
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#COMMUNICATION_FAILED}.
+	 * 
+	 * @return the Channel
+	 */
+	public default StateChannel getCommunicationFailedChannel() {
+		return this.channel(ChannelId.COMMUNICATION_FAILED);
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#USER_ACCESS_DENIED} Channel.
+	 * 
+	 * @param value the next value
+	 */
+	public default void _setCommunicationFailed(boolean value) {
+		this.getCommunicationFailedChannel().setNextValue(value);
 	}
 
 	/**

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/ess/BpEssImpl.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/ess/BpEssImpl.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
@@ -19,13 +20,6 @@ import org.osgi.service.event.Event;
 import org.osgi.service.event.EventHandler;
 import org.osgi.service.event.propertytypes.EventTopics;
 import org.osgi.service.metatype.annotations.Designate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.ed.data.BatteryData;
-import com.ed.data.InverterData;
-import com.ed.data.Settings;
-import com.ed.data.Status;
 
 import io.openems.common.channel.AccessMode;
 import io.openems.common.exceptions.OpenemsException;
@@ -68,8 +62,6 @@ public class BpEssImpl extends AbstractOpenemsComponent implements BpEss, Hybrid
 
 	private static final int WATCHDOG_SECONDS = 8;
 	private static final int MAX_POWER_RAMP = 500; // [W/sec]
-
-	private final Logger log = LoggerFactory.getLogger(BpEssImpl.class);
 
 	@Reference(policy = ReferencePolicy.STATIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.MANDATORY)
 	protected BpCore core;
@@ -158,62 +150,51 @@ public class BpEssImpl extends AbstractOpenemsComponent implements BpEss, Hybrid
 		Integer batteryStatus = null;
 		PowerManagementConfiguration powerManagementConfiguration = PowerManagementConfiguration.UNDEFINED;
 
-		if (!this.core.isConnected()) {
-			this.logWarn(this.log, "Core is not connected!");
+		var bpData = this.core.getBpData();
+		this._setCommunicationFailed(bpData == null);
 
-		} else {
-			BatteryData battery = this.core.getBatteryData();
-			Status status = this.core.getStatusData();
-			InverterData inverter = this.core.getInverterData();
+		if (bpData != null) {
+			soc = Math.round(bpData.battery.getSOE());
+			float batteryPower = bpData.battery.getPower();
+			activePower = Math.round(batteryPower - bpData.inverter.getPvPower()) * -1; // invert
+			dcDischargePower = Math.round(batteryPower) * -1; // invert
+			bmsVoltage = bpData.battery.getBmsVoltage();
 
-			if (battery != null) {
-				soc = Math.round(battery.getSOE());
-				float batteryPower = battery.getPower();
-				activePower = Math.round(batteryPower - inverter.getPvPower()) * -1; // invert
-				dcDischargePower = Math.round(batteryPower) * -1; // invert
-				bmsVoltage = battery.getBmsVoltage();
-
-				// Handle MaxApparentPower
-				if (Math.abs(activePower) + MAX_POWER_RAMP > this.getMaxApparentPower().orElse(Integer.MAX_VALUE)) {
-					this._setMaxApparentPower(Math.abs(activePower) + MAX_POWER_RAMP);
-				}
+			// Handle MaxApparentPower
+			if (Math.abs(activePower) + MAX_POWER_RAMP > this.getMaxApparentPower().orElse(Integer.MAX_VALUE)) {
+				this._setMaxApparentPower(Math.abs(activePower) + MAX_POWER_RAMP);
 			}
 
-			if (status != null) {
-				switch (status.getInverterStatus()) {
-				case 12:
-					gridMode = GridMode.OFF_GRID;
-					break;
-				case 13:
-				case 14:
-					gridMode = GridMode.ON_GRID;
-					break;
-				}
-
-				inverterStatus = status.getInverterStatus();
-				batteryStatus = status.getBatteryStatus();
-
-				// Read Power Management Configuration, i.e. External EMS, Charging,...
-				int powerConfig = status.getPowerConfig();
-				for (PowerManagementConfiguration thisEnum : PowerManagementConfiguration.values()) {
-					if (thisEnum.getValue() == powerConfig) {
-						powerManagementConfiguration = thisEnum;
-						break;
-					}
-				}
-
-				// Set error channels
-				List<String> errors = status.getErrors();
-				for (ErrorChannelId channelId : ErrorChannelId.values()) {
-					this.channel(channelId).setNextValue(errors.contains(channelId.getErrorCode()));
-				}
+			switch (bpData.status.getInverterStatus()) {
+			case 12:
+				gridMode = GridMode.OFF_GRID;
+				break;
+			case 13:
+			case 14:
+				gridMode = GridMode.ON_GRID;
+				break;
 			}
 
-			if (inverter != null) {
-				reactivePower = Math.round(
-						inverter.getReactivPower(0) + inverter.getReactivPower(1) + inverter.getReactivPower(2)) * -1;
-				riso = inverter.getRIso();
-			}
+			inverterStatus = bpData.status.getInverterStatus();
+			batteryStatus = bpData.status.getBatteryStatus();
+
+			// Read Power Management Configuration, i.e. External EMS, Charging,...
+			powerManagementConfiguration = Stream.of(PowerManagementConfiguration.values()) //
+					.filter(e -> e.getValue() == bpData.status.getPowerConfig()) //
+					.findFirst() //
+					.orElse(null);
+
+			// Set error channels
+			List<String> errors = bpData.status.getErrors();
+			Stream.of(ErrorChannelId.values()) //
+					.forEach(c -> this.channel(c).setNextValue(errors.contains(c.getErrorCode())));
+
+			reactivePower = Math.round(//
+					/* L1 */ bpData.inverter.getReactivPower(0) + //
+					/* L2 */ bpData.inverter.getReactivPower(1) + //
+					/* L3 */ bpData.inverter.getReactivPower(2)) //
+					* -1;
+			riso = bpData.inverter.getRIso();
 		}
 
 		this._setSoc(soc);
@@ -307,14 +288,13 @@ public class BpEssImpl extends AbstractOpenemsComponent implements BpEss, Hybrid
 
 	@Override
 	public void applyPower(int activePower, int reactivePower) {
-		Status status = this.core.getStatusData();
-		Settings settings = this.core.getSettings();
-		if (status == null || settings == null) {
+		var bpData = this.core.getBpData();
+		if (bpData == null) {
 			return;
 		}
 
 		// Detect if hy-switch Grid-Meter is available for Read-Only mode
-		if (this.config.readOnly() && status.getPowerGridConfig() == 0 /* VECTIS disabled */) {
+		if (this.config.readOnly() && bpData.status.getPowerGridConfig() == 0 /* VECTIS disabled */) {
 			this._setNoGridMeterDetected(true);
 		} else {
 			this._setNoGridMeterDetected(false);
@@ -324,13 +304,11 @@ public class BpEssImpl extends AbstractOpenemsComponent implements BpEss, Hybrid
 		// if the default user password is configured
 		switch (this.core.getStableVersion()) {
 		case VERSION_8:
-			this._setUserPasswordNotChangedWithExternalKacoVersion8(true);
-			if (this.core.isDefaultUser()) {
+			if (!this.config.readOnly() //
+					&& (/* power has been set */ activePower != 0 || reactivePower != 0) //
+					&& this.core.isDefaultUser()) {
+				this._setUserPasswordNotChangedWithExternalKacoVersion8(true);
 				return;
-			}
-			if (!this.core.getUserAccessDenied().orElse(true)) {
-				// If the system is at least running, it should not remain in fault state
-				this._setUserPasswordNotChangedWithExternalKacoVersion8(false);
 			}
 			break;
 		case UNDEFINED:
@@ -346,20 +324,22 @@ public class BpEssImpl extends AbstractOpenemsComponent implements BpEss, Hybrid
 			return;
 		}
 
+		final float pacSetPoint;
 		if (this.config.readOnly()) {
 			activePower = 0;
 			// read-only: activates 'compensator normal operation'
-			settings.setPacSetPoint(0);
+			pacSetPoint = 0;
 
 		} else if (activePower == 0) {
 			// avoid setting active power to zero, because this activates 'compensator
 			// normal operation'
-			settings.setPacSetPoint(0.0001f);
+			pacSetPoint = 0.0001f;
 
 		} else {
 			// apply power
-			settings.setPacSetPoint(activePower);
+			pacSetPoint = activePower;
 		}
+		bpData.settings.setPacSetPoint(pacSetPoint);
 
 		this.lastApplyPower = Instant.now();
 		this.lastSetActivePower = activePower;
@@ -398,18 +378,19 @@ public class BpEssImpl extends AbstractOpenemsComponent implements BpEss, Hybrid
 
 	@Override
 	public Integer getSurplusPower() {
-		// Is battery and inverter data available?
-		BatteryData battery = this.core.getBatteryData();
-		InverterData inverter = this.core.getInverterData();
-		if (battery == null || inverter == null) {
+		var bpData = this.core.getBpData();
+
+		// Is data available?
+		if (bpData == null) {
 			return null;
 		}
+
 		// Is battery full?
-		if (battery.getSOE() < 99) {
+		if (bpData.battery.getSOE() < 99) {
 			return null;
 		}
 		// Is PV producing?
-		int pvPower = Math.round(inverter.getPvPower());
+		int pvPower = Math.round(bpData.inverter.getPvPower());
 		if (pvPower < 10) {
 			return null;
 		}

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/ess/BpEssImpl.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/ess/BpEssImpl.java
@@ -190,9 +190,9 @@ public class BpEssImpl extends AbstractOpenemsComponent implements BpEss, Hybrid
 					.forEach(c -> this.channel(c).setNextValue(errors.contains(c.getErrorCode())));
 
 			reactivePower = Math.round(//
-					/* L1 */ bpData.inverter.getReactivPower(0) + //
-					/* L2 */ bpData.inverter.getReactivPower(1) + //
-					/* L3 */ bpData.inverter.getReactivPower(2)) //
+					/* L1 */ bpData.inverter.getReactivPower(0) //
+							/* L2 */ + bpData.inverter.getReactivPower(1) //
+							/* L3 */ + bpData.inverter.getReactivPower(2)) //
 					* -1;
 			riso = bpData.inverter.getRIso();
 		}

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/ess/charger/BpCharger.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/ess/charger/BpCharger.java
@@ -1,11 +1,18 @@
 package io.openems.edge.kaco.blueplanet.hybrid10.ess.charger;
 
+import io.openems.common.channel.Level;
 import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.StateChannel;
+import io.openems.edge.common.component.OpenemsComponent;
 
-public interface BpCharger {
+public interface BpCharger extends OpenemsComponent {
 
 	public static enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+		COMMUNICATION_FAILED(Doc.of(Level.FAULT) //
+				.text("Communication to KACO blueplanet hybrid 10 failed. "
+						+ "Please check the network connection and the status of the inverter")), //
 		;
+
 		private final Doc doc;
 
 		private ChannelId(Doc doc) {
@@ -16,6 +23,25 @@ public interface BpCharger {
 		public Doc doc() {
 			return this.doc;
 		}
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#COMMUNICATION_FAILED}.
+	 * 
+	 * @return the Channel
+	 */
+	public default StateChannel getCommunicationFailedChannel() {
+		return this.channel(ChannelId.COMMUNICATION_FAILED);
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#USER_ACCESS_DENIED} Channel.
+	 * 
+	 * @param value the next value
+	 */
+	public default void _setCommunicationFailed(boolean value) {
+		this.getCommunicationFailedChannel().setNextValue(value);
 	}
 
 }

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/ess/charger/BpChargerImpl.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/ess/charger/BpChargerImpl.java
@@ -15,8 +15,6 @@ import org.osgi.service.event.EventHandler;
 import org.osgi.service.event.propertytypes.EventTopics;
 import org.osgi.service.metatype.annotations.Designate;
 
-import com.ed.data.InverterData;
-
 import io.openems.common.channel.AccessMode;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
 import io.openems.edge.common.component.OpenemsComponent;
@@ -93,9 +91,12 @@ public class BpChargerImpl extends AbstractOpenemsComponent
 
 	private void updateChannels() {
 		Integer actualPower = null;
-		InverterData inverter = this.core.getInverterData();
-		if (inverter != null) {
-			actualPower = Math.round(inverter.getPvPower());
+
+		var bpData = this.core.getBpData();
+		this._setCommunicationFailed(bpData == null);
+
+		if (bpData != null) {
+			actualPower = Math.round(bpData.inverter.getPvPower());
 		}
 		this._setActualPower(actualPower);
 

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/pvinverter/BpPvInverter.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/pvinverter/BpPvInverter.java
@@ -2,12 +2,17 @@ package io.openems.edge.kaco.blueplanet.hybrid10.pvinverter;
 
 import io.openems.common.channel.Level;
 import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.StateChannel;
+import io.openems.edge.common.component.OpenemsComponent;
 
-public interface BpPvInverter {
+public interface BpPvInverter extends OpenemsComponent {
 
 	public static final int MAX_APPARENT_POWER = 10_000; // [W]
 
 	public static enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+		COMMUNICATION_FAILED(Doc.of(Level.FAULT) //
+				.text("Communication to KACO blueplanet hybrid 10 failed. "
+						+ "Please check the network connection and the status of the inverter")), //
 		PV_LIMIT_FAILED(Doc.of(Level.FAULT) //
 				.text("PV-Limit failed"));
 
@@ -21,6 +26,25 @@ public interface BpPvInverter {
 		public Doc doc() {
 			return this.doc;
 		}
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#COMMUNICATION_FAILED}.
+	 * 
+	 * @return the Channel
+	 */
+	public default StateChannel getCommunicationFailedChannel() {
+		return this.channel(ChannelId.COMMUNICATION_FAILED);
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#USER_ACCESS_DENIED} Channel.
+	 * 
+	 * @param value the next value
+	 */
+	public default void _setCommunicationFailed(boolean value) {
+		this.getCommunicationFailedChannel().setNextValue(value);
 	}
 
 }

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/pvinverter/BpPvInverterImpl.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/pvinverter/BpPvInverterImpl.java
@@ -141,9 +141,9 @@ public class BpPvInverterImpl extends AbstractOpenemsComponent implements BpPvIn
 			this._setCommunicationFailed(false);
 		} else {
 			this._setCommunicationFailed(//
-					/* if has never been successful */ this.lastSuccessfulCommunication == null || //
-					/* or if more than 24 hours ago */ this.lastSuccessfulCommunication
-							.isBefore(Instant.now().minus(24, ChronoUnit.HOURS)));
+					/* if has never been successful */ this.lastSuccessfulCommunication == null //
+							/* or if more than 24 hours ago */ || this.lastSuccessfulCommunication
+									.isBefore(Instant.now().minus(24, ChronoUnit.HOURS)));
 		}
 
 		if (bpData != null) {

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/pvinverter/BpPvInverterImpl.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/pvinverter/BpPvInverterImpl.java
@@ -1,7 +1,10 @@
 package io.openems.edge.kaco.blueplanet.hybrid10.pvinverter;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
@@ -19,10 +22,6 @@ import org.osgi.service.event.propertytypes.EventTopics;
 import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.ed.data.InverterData;
-import com.ed.data.Settings;
-import com.ed.data.Status;
 
 import io.openems.common.channel.AccessMode;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
@@ -72,6 +71,8 @@ public class BpPvInverterImpl extends AbstractOpenemsComponent implements BpPvIn
 
 	private final CalculateEnergyFromPower calculateEnergy = new CalculateEnergyFromPower(this,
 			SymmetricMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY);
+
+	private Instant lastSuccessfulCommunication = null;
 
 	public BpPvInverterImpl() {
 		super(//
@@ -129,30 +130,33 @@ public class BpPvInverterImpl extends AbstractOpenemsComponent implements BpPvIn
 		Integer reactivePower = null;
 		Integer activePowerLimit = null;
 
-		if (!this.core.isConnected()) {
-			this.logWarn(this.log, "Core is not connected!");
+		var bpData = this.core.getBpData();
 
+		/*
+		 * Handle Communication Failed State: Pure PV-Inverter is unreachable during the
+		 * night because it has no battery supply. Ignore error for 24 hours.
+		 */
+		if (bpData != null) {
+			this.lastSuccessfulCommunication = Instant.now();
+			this._setCommunicationFailed(false);
 		} else {
-			Settings settings = this.core.getSettings();
-			if (settings != null) {
-				float eplimitPerc = settings.getEPLimit() / 100;
-				activePowerLimit = (int) (BpPvInverter.MAX_APPARENT_POWER * eplimitPerc);
-			}
+			this._setCommunicationFailed(//
+					/* if has never been successful */ this.lastSuccessfulCommunication == null || //
+					/* or if more than 24 hours ago */ this.lastSuccessfulCommunication
+							.isBefore(Instant.now().minus(24, ChronoUnit.HOURS)));
+		}
 
-			Status status = this.core.getStatusData();
-			if (status != null) {
-				// Set error channels
-				List<String> errors = status.getErrors();
-				for (ErrorChannelId channelId : ErrorChannelId.values()) {
-					this.channel(channelId).setNextValue(errors.contains(channelId.getErrorCode()));
-				}
-			}
+		if (bpData != null) {
+			float eplimitPerc = bpData.settings.getEPLimit() / 100;
+			activePowerLimit = (int) (BpPvInverter.MAX_APPARENT_POWER * eplimitPerc);
 
-			InverterData inverter = this.core.getInverterData();
-			if (inverter != null) {
-				activePower = (int) inverter.getPvPower();
-				reactivePower = 0;
-			}
+			// Set error channels
+			List<String> errors = bpData.status.getErrors();
+			Stream.of(ErrorChannelId.values()) //
+					.forEach(c -> this.channel(c).setNextValue(errors.contains(c.getErrorCode())));
+
+			activePower = Math.round(bpData.inverter.getPvPower());
+			reactivePower = 0;
 		}
 
 		this._setActivePower(activePower);

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/pvinverter/SetPvLimitHandler.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/pvinverter/SetPvLimitHandler.java
@@ -7,8 +7,6 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.ed.data.Settings;
-
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.function.ThrowingRunnable;
 import io.openems.edge.common.channel.ChannelId;
@@ -55,16 +53,13 @@ public class SetPvLimitHandler implements ThrowingRunnable<OpenemsNamedException
 		if (!Objects.equals(this.lastEpLimit, ePLimit) || this.lastWMaxLimPctTime
 				.isBefore(LocalDateTime.now().minusSeconds(60 /* TODO: how often should it be written? */))) {
 			// Value needs to be set
-			Settings settings = this.parent.core.getSettings();
-			if (settings != null) {
+			var bpData = this.parent.core.getBpData();
+			if (bpData != null) {
 				this.parent.logInfo(this.log, "Apply new limit: " + power + " W (" + ePLimit + " %)");
-				settings.setEPLimit(ePLimit);
+				bpData.settings.setEPLimit(ePLimit);
 
 				this.lastEpLimit = ePLimit;
 				this.lastWMaxLimPctTime = LocalDateTime.now();
-
-			} else {
-				this.parent.logWarn(this.log, "Unable to apply limit: no Settings available.");
 			}
 		}
 	}

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/vectis/Vectis.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/vectis/Vectis.java
@@ -1,10 +1,16 @@
 package io.openems.edge.kaco.blueplanet.hybrid10.vectis;
 
+import io.openems.common.channel.Level;
 import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.StateChannel;
+import io.openems.edge.common.component.OpenemsComponent;
 
-public interface Vectis {
+public interface Vectis extends OpenemsComponent {
 
 	public static enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+		COMMUNICATION_FAILED(Doc.of(Level.FAULT) //
+				.text("Communication to KACO blueplanet hybrid 10 failed. "
+						+ "Please check the network connection and the status of the inverter")), //
 		VECTIS_STATUS(Doc.of(VectisStatus.values())) //
 		;
 
@@ -19,4 +25,24 @@ public interface Vectis {
 			return this.doc;
 		}
 	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#COMMUNICATION_FAILED}.
+	 * 
+	 * @return the Channel
+	 */
+	public default StateChannel getCommunicationFailedChannel() {
+		return this.channel(ChannelId.COMMUNICATION_FAILED);
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#USER_ACCESS_DENIED} Channel.
+	 * 
+	 * @param value the next value
+	 */
+	public default void _setCommunicationFailed(boolean value) {
+		this.getCommunicationFailedChannel().setNextValue(value);
+	}
+
 }

--- a/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/vectis/VectisImpl.java
+++ b/io.openems.edge.kaco.blueplanet.hybrid10/src/io/openems/edge/kaco/blueplanet/hybrid10/vectis/VectisImpl.java
@@ -17,10 +17,6 @@ import org.osgi.service.event.EventHandler;
 import org.osgi.service.event.propertytypes.EventTopics;
 import org.osgi.service.metatype.annotations.Designate;
 
-import com.ed.data.InverterData;
-import com.ed.data.Status;
-import com.ed.data.VectisData;
-
 import io.openems.edge.common.component.AbstractOpenemsComponent;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.event.EdgeEventConstants;
@@ -106,43 +102,41 @@ public class VectisImpl extends AbstractOpenemsComponent
 		Integer freq = null;
 		VectisStatus vectisStatus = null;
 
-		if (this.core.isConnected()) {
-			VectisData vectis = this.core.getVectis();
-			InverterData inverter = this.core.getInverterData();
+		var bpData = this.core.getBpData();
+		this._setCommunicationFailed(bpData == null);
+
+		if (bpData != null) {
 
 			if (this.config.external()) {
 				// Use external sensor
-				reactivePowerL1 = Math.round(vectis.getReactivePowerExt(0));
-				reactivePowerL2 = Math.round(vectis.getReactivePowerExt(1));
-				reactivePowerL3 = Math.round(vectis.getReactivePowerExt(2));
+				reactivePowerL1 = Math.round(bpData.vectis.getReactivePowerExt(0));
+				reactivePowerL2 = Math.round(bpData.vectis.getReactivePowerExt(1));
+				reactivePowerL3 = Math.round(bpData.vectis.getReactivePowerExt(2));
 				reactivePower = reactivePowerL1 + reactivePowerL2 + reactivePowerL3;
 
-				activePowerL1 = Math.round(vectis.getACPowerExt(0));
-				activePowerL2 = Math.round(vectis.getACPowerExt(1));
-				activePowerL3 = Math.round(vectis.getACPowerExt(2));
+				activePowerL1 = Math.round(bpData.vectis.getACPowerExt(0));
+				activePowerL2 = Math.round(bpData.vectis.getACPowerExt(1));
+				activePowerL3 = Math.round(bpData.vectis.getACPowerExt(2));
 				activePower = activePowerL1 + activePowerL2 + activePowerL3;
 
-				freq = Math.round(vectis.getFrequencyExt());
+				freq = Math.round(bpData.vectis.getFrequencyExt());
 
 			} else {
 				// Use internal sensor
-				reactivePowerL1 = Math.round(vectis.getReactivePower(0));
-				reactivePowerL2 = Math.round(vectis.getReactivePower(1));
-				reactivePowerL3 = Math.round(vectis.getReactivePower(2));
+				reactivePowerL1 = Math.round(bpData.vectis.getReactivePower(0));
+				reactivePowerL2 = Math.round(bpData.vectis.getReactivePower(1));
+				reactivePowerL3 = Math.round(bpData.vectis.getReactivePower(2));
 				reactivePower = reactivePowerL1 + reactivePowerL2 + reactivePowerL3;
 
-				activePowerL1 = Math.round(vectis.getACPower(0));
-				activePowerL2 = Math.round(vectis.getACPower(1));
-				activePowerL3 = Math.round(vectis.getACPower(2));
+				activePowerL1 = Math.round(bpData.vectis.getACPower(0));
+				activePowerL2 = Math.round(bpData.vectis.getACPower(1));
+				activePowerL3 = Math.round(bpData.vectis.getACPower(2));
 				activePower = activePowerL1 + activePowerL2 + activePowerL3;
 
-				freq = Math.round(inverter.getGridFrequency());
+				freq = Math.round(bpData.inverter.getGridFrequency());
 			}
 
-			Status status = this.core.getStatusData();
-			if (status != null) {
-				vectisStatus = VectisStatus.fromInt(status.getPowerGridStatus());
-			}
+			vectisStatus = VectisStatus.fromInt(bpData.status.getPowerGridStatus());
 		}
 
 		this._setReactivePowerL1(reactivePowerL1);


### PR DESCRIPTION
- Errors become clearer visible to the user (not "kacoCore0" failed, but "ess0" failed)
- Pure PV-Inverter is not reachable during night. New structure allows to avoid/delay the error
- Introduce BpData record to merge all DataSet classes from KACO library