### PR TITLE
EdgeWebsocket and UiWebsocket does not start reliable

### DIFF
--- a/io.openems.backend.common/src/io/openems/backend/common/metadata/AbstractMetadata.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/metadata/AbstractMetadata.java
@@ -23,8 +23,10 @@ public abstract class AbstractMetadata extends AbstractOpenemsBackendComponent i
 	 * Make sure to call this method once initialized!.
 	 */
 	protected void setInitialized() {
-		this.isInitialized.set(true);
-		EventBuilder.post(this.getEventAdmin(), Events.AFTER_IS_INITIALIZED);
+		if (this.isInitialized.get() == false) {
+			this.isInitialized.set(true);
+			EventBuilder.post(this.getEventAdmin(), Events.AFTER_IS_INITIALIZED);
+		}
 	}
 
 	@Override

--- a/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/EdgeWebsocketImpl.java
+++ b/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/EdgeWebsocketImpl.java
@@ -85,6 +85,11 @@ public class EdgeWebsocketImpl extends AbstractOpenemsBackendComponent implement
 					.append(this.server != null ? this.server.getConnections().size() : "initializing") //
 					.toString());
 		}, 10, 10, TimeUnit.SECONDS);
+
+		if (this.metadata.isInitialized()) {
+			this.startServer(this.config.port(), this.config.poolSize(), this.config.debugMode());
+		}
+
 	}
 
 	@Deactivate
@@ -101,8 +106,10 @@ public class EdgeWebsocketImpl extends AbstractOpenemsBackendComponent implement
 	 * @param debugMode activate a regular debug log about the state of the tasks
 	 */
 	private synchronized void startServer(int port, int poolSize, DebugMode debugMode) {
-		this.server = new WebsocketServer(this, this.getName(), port, poolSize, debugMode);
-		this.server.start();
+		if (this.server == null) {
+			this.server = new WebsocketServer(this, this.getName(), port, poolSize, debugMode);
+			this.server.start();
+		}
 	}
 
 	/**

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/UiWebsocketImpl.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/UiWebsocketImpl.java
@@ -68,6 +68,10 @@ public class UiWebsocketImpl extends AbstractOpenemsBackendComponent implements 
 	@Activate
 	private void activate(Config config) {
 		this.config = config;
+
+		if (this.metadata.isInitialized()) {
+			this.startServer(this.config.port(), this.config.poolSize(), this.config.debugMode());
+		}
 	}
 
 	@Deactivate
@@ -84,8 +88,10 @@ public class UiWebsocketImpl extends AbstractOpenemsBackendComponent implements 
 	 * @param debugMode activate a regular debug log about the state of the tasks
 	 */
 	private synchronized void startServer(int port, int poolSize, DebugMode debugMode) {
-		this.server = new WebsocketServer(this, "Ui.Websocket", port, poolSize, debugMode);
-		this.server.start();
+		if (this.server == null) {
+			this.server = new WebsocketServer(this, "Ui.Websocket", port, poolSize, debugMode);
+			this.server.start();
+		}
 	}
 
 	/**


### PR DESCRIPTION
EdgeWebsocket and UiWebsocket does not start reliable if FileMetadata is used. Due to asynchronous Event Handling and the given FileMetadata implementation Metadata.Events.AFTER_IS_INITIALIZED may not be received by the socket bundles OR it may be received multiple times. FileMetadata may be very fast (Testenv with few users only) and Odoo Metadata may be too slow (huge number of users). The socket servers are now started either by Event or within the activate() method, whatever comes first.
