### PR TITLE
Bug: CalculateAverage now supports all numbers instead of integer

### DIFF
--- a/io.openems.edge.common/src/io/openems/edge/common/channel/calculate/CalculateAverage.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/calculate/CalculateAverage.java
@@ -14,7 +14,7 @@ import io.openems.edge.common.channel.Channel;
  */
 public class CalculateAverage {
 
-	private final Logger log = LoggerFactory.getLogger(CalculateLongSum.class);
+	private final Logger log = LoggerFactory.getLogger(CalculateAverage.class);
 	private final List<Double> values = new ArrayList<>();
 
 	/**
@@ -22,11 +22,11 @@ public class CalculateAverage {
 	 *
 	 * @param channel the channel
 	 */
-	public void addValue(Channel<Integer> channel) {
+	public void addValue(Channel<? extends Number> channel) {
 		var value = channel.value().asOptional();
 		if (value.isPresent()) {
 			try {
-				this.values.add(Double.valueOf(value.get()));
+				this.values.add(value.get().doubleValue());
 			} catch (Exception e) {
 				this.log.error("Adding Channel [" + channel.address() + "] value [" + value + "] failed. "
 						+ e.getClass().getSimpleName() + ": " + e.getMessage());
@@ -63,7 +63,7 @@ public class CalculateAverage {
 		}
 		var longValue = Math.round(value);
 		if (longValue >= Integer.MIN_VALUE && longValue <= Integer.MAX_VALUE) {
-			return Integer.valueOf((int) longValue);
+			return (int) longValue;
 		}
 		throw new IllegalArgumentException("Cannot convert. Double [" + value + "] is not fitting in Integer range.");
 	}

--- a/io.openems.edge.common/test/io/openems/edge/common/channel/calculate/CalculateAverageTest.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/channel/calculate/CalculateAverageTest.java
@@ -1,0 +1,134 @@
+package io.openems.edge.common.channel.calculate;
+
+import io.openems.common.types.OpenemsType;
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.channel.ChannelId;
+import io.openems.edge.common.channel.Doc;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CalculateAverageTest {
+
+    private enum TestChannelId implements ChannelId {
+        TEST_INTEGER_CHANNEL(Doc.of(OpenemsType.INTEGER)),
+        TEST_DOUBLE_CHANNEL(Doc.of(OpenemsType.DOUBLE)),
+        TEST_FLOAT_CHANNEL(Doc.of(OpenemsType.FLOAT)),
+        TEST_SHORT_CHANNEL(Doc.of(OpenemsType.SHORT)),
+        TEST_LONG_CHANNEL(Doc.of(OpenemsType.LONG)),
+        ;
+
+        private final Doc doc;
+
+        TestChannelId(Doc doc) {
+            this.doc = doc;
+        }
+
+        @Override
+        public Doc doc() {
+            return this.doc;
+        }
+    }
+
+    @Test
+    public void testIntegerAverage() {
+        Channel<Integer> channel = createChannel(TestChannelId.TEST_INTEGER_CHANNEL);
+        CalculateAverage calculateAverage = new CalculateAverage();
+
+        setNextAndProcessChannelValue(channel, 2);
+        calculateAverage.addValue(channel);
+        setNextAndProcessChannelValue(channel, 4);
+        calculateAverage.addValue(channel);
+        setNextAndProcessChannelValue(channel, 6);
+        calculateAverage.addValue(channel);
+
+        Integer average = calculateAverage.calculateRounded();
+
+        Assert.assertNotNull(average);
+        Assert.assertEquals(4, (int) average);
+    }
+
+    @Test
+    public void testDoubleAverage() {
+        Channel<Double> channel = createChannel(TestChannelId.TEST_DOUBLE_CHANNEL);
+        CalculateAverage calculateAverage = new CalculateAverage();
+
+        setNextAndProcessChannelValue(channel, 1.0d);
+        calculateAverage.addValue(channel);
+        setNextAndProcessChannelValue(channel, 4.0d);
+        calculateAverage.addValue(channel);
+
+        Integer averageRounded = calculateAverage.calculateRounded();
+        Assert.assertNotNull(averageRounded);
+        Assert.assertEquals(3, (int) averageRounded);
+
+        Double average = calculateAverage.calculate();
+        Assert.assertNotNull(average);
+        Assert.assertEquals(2.5d, average, 0.01);
+    }
+
+    @Test
+    public void testFloatAverage() {
+        Channel<Float> channel = createChannel(TestChannelId.TEST_FLOAT_CHANNEL);
+        CalculateAverage calculateAverage = new CalculateAverage();
+
+        setNextAndProcessChannelValue(channel, 1.0f);
+        calculateAverage.addValue(channel);
+        setNextAndProcessChannelValue(channel, 4.0f);
+        calculateAverage.addValue(channel);
+
+        Integer averageRounded = calculateAverage.calculateRounded();
+        Assert.assertNotNull(averageRounded);
+        Assert.assertEquals(3, (int) averageRounded);
+
+        Double average = calculateAverage.calculate();
+        Assert.assertNotNull(average);
+        Assert.assertEquals(2.5d, average, 0.01);
+    }
+
+    @Test
+    public void testShortAverage() {
+        Channel<Short> channel = createChannel(TestChannelId.TEST_SHORT_CHANNEL);
+        CalculateAverage calculateAverage = new CalculateAverage();
+
+        setNextAndProcessChannelValue(channel, (short) 2);
+        calculateAverage.addValue(channel);
+        setNextAndProcessChannelValue(channel,  (short) 4);
+        calculateAverage.addValue(channel);
+
+        Integer averageRounded = calculateAverage.calculateRounded();
+        Assert.assertNotNull(averageRounded);
+        Assert.assertEquals(3, (int) averageRounded);
+
+        Double average = calculateAverage.calculate();
+        Assert.assertNotNull(average);
+        Assert.assertEquals(3d, average, 0.01);
+    }
+
+    @Test
+    public void testLongAverage() {
+        Channel<Long> channel = createChannel(TestChannelId.TEST_LONG_CHANNEL);
+        CalculateAverage calculateAverage = new CalculateAverage();
+
+        setNextAndProcessChannelValue(channel, 1L);
+        calculateAverage.addValue(channel);
+        setNextAndProcessChannelValue(channel, 4L);
+        calculateAverage.addValue(channel);
+
+        Integer averageRounded = calculateAverage.calculateRounded();
+        Assert.assertNotNull(averageRounded);
+        Assert.assertEquals(3, (int) averageRounded);
+
+        Double average = calculateAverage.calculate();
+        Assert.assertNotNull(average);
+        Assert.assertEquals(2.5d, average, 0.01);
+    }
+
+    private static <T extends Number> void setNextAndProcessChannelValue(Channel<T> channel, T value) {
+        channel.setNextValue(value);
+        channel.nextProcessImage();
+    }
+
+    private static <T extends Number> Channel<T> createChannel(TestChannelId channelId) {
+        return channelId.doc().createChannelInstance(null, channelId);
+    }
+}


### PR DESCRIPTION
Hi team,

Thank you for the wonderful project! 

During development I ran into, what seems to me, a bug in the CalculateAverage class.

---

- CalculateAverage::addValue resulted in ClassCastExceptions when the channel was not of type Integer
- This happened because the parameter of the method was Channel<Integer>

- Now supports any implementation of Number

---
Let me know if there is anything I can improve