### PR TITLE
Enhance influx bundle to use either FluxQL or InfluxQL language

### DIFF
--- a/io.openems.backend.timedata.influx/src/io/openems/backend/timedata/influx/Config.java
+++ b/io.openems.backend.timedata.influx/src/io/openems/backend/timedata/influx/Config.java
@@ -13,15 +13,18 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 	@AttributeDefinition(name = "Org", description = "The Organisation; '-' for InfluxDB v1")
 	String org() default "-";
-	
+
 	@AttributeDefinition(name = "ApiKey", description = "The ApiKey; 'username:password' for InfluxDB v1")
 	String apiKey();
 
 	@AttributeDefinition(name = "Bucket", description = "The bucket name; 'database/retentionPolicy' for InfluxDB v1")
 	String bucket();
-	
+
 	@AttributeDefinition(name = "Measurement", description = "The InfluxDB measurement")
 	String measurement() default "data";
+
+	@AttributeDefinition(name = "Use FLUX Queries?", description = "If enabled FLUX query language is used, else InfluxQL will be used")
+	boolean useFluxQueries() default true;
 
 	@AttributeDefinition(name = "Read-Only mode", description = "Activates the read-only mode. Then no data is written to InfluxDB.")
 	boolean isReadOnly() default false;

--- a/io.openems.edge.timedata.influxdb/src/io/openems/edge/timedata/influxdb/Config.java
+++ b/io.openems.edge.timedata.influxdb/src/io/openems/edge/timedata/influxdb/Config.java
@@ -32,6 +32,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "No of Cycles", description = "How many Cycles till data is written to InfluxDB.")
 	int noOfCycles() default 1;
 
+	@AttributeDefinition(name = "Use FLUX Queries?", description = "If true FLUX query language is used, else InfluxQL will be used.")
+	boolean useFluxQueries() default true;
+
 	@AttributeDefinition(name = "Read-Only mode", description = "Activates the read-only mode. Then no data is written to InfluxDB.")
 	boolean isReadOnly() default false;
 

--- a/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnector.java
+++ b/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnector.java
@@ -1,307 +1,25 @@
 package io.openems.shared.influxdb;
 
-import java.net.URI;
-import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAdjusters;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
-import com.google.gson.JsonPrimitive;
-import com.influxdb.client.InfluxDBClient;
-import com.influxdb.client.InfluxDBClientFactory;
-import com.influxdb.client.InfluxDBClientOptions;
-import com.influxdb.client.WriteApiBlocking;
 import com.influxdb.client.write.Point;
-import com.influxdb.query.FluxRecord;
-import com.influxdb.query.FluxTable;
-import com.influxdb.query.dsl.Flux;
-import com.influxdb.query.dsl.functions.restriction.Restrictions;
 
-import io.openems.common.OpenemsOEM;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.timedata.Resolution;
 import io.openems.common.types.ChannelAddress;
-import io.openems.common.utils.JsonUtils;
-import io.openems.common.utils.StringUtils;
-import io.openems.common.utils.ThreadPoolUtils;
-import okhttp3.OkHttpClient;
 
-public class InfluxConnector {
-
+public interface InfluxConnector {
 	public static final String MEASUREMENT = "data";
 
-	private static final Logger LOG = LoggerFactory.getLogger(InfluxConnector.class);
-	private static final int CONNECT_TIMEOUT = 10; // [s]
-	private static final int READ_TIMEOUT = 60; // [s]
-	private static final int WRITE_TIMEOUT = 10; // [s]
-
-	private static final int EXECUTOR_MIN_THREADS = 10;
-	private static final int EXECUTOR_MAX_THREADS = 50;
-	private static final int EXECUTOR_QUEUE_SIZE = 500;
-	private static final int POINTS_QUEUE_SIZE = 1_000_000;
-	private static final int MAX_POINTS_PER_WRITE = 1_000;
-	private static final int MAX_AGGREGATE_WAIT = 10; // [s]
-
-	private final Logger log = LoggerFactory.getLogger(InfluxConnector.class);
-
-	private final URI url;
-	private final String org;
-	private final String apiKey;
-	private final String bucket;
-	private final boolean isReadOnly;
-	private final Consumer<Throwable> onWriteError;
-	private final ThreadPoolExecutor executor = new ThreadPoolExecutor(EXECUTOR_MIN_THREADS, EXECUTOR_MAX_THREADS, 60L,
-			TimeUnit.SECONDS, //
-			new ArrayBlockingQueue<>(EXECUTOR_QUEUE_SIZE), //
-			new ThreadFactoryBuilder().setNameFormat("InfluxConnector-%d").build(), //
-			new ThreadPoolExecutor.DiscardOldestPolicy());
-	private final ScheduledExecutorService debugLogExecutor = Executors.newSingleThreadScheduledExecutor();
-	private final ExecutorService mergePointsExecutor = Executors.newSingleThreadExecutor();
-	private final BlockingQueue<Point> pointsQueue = new LinkedBlockingQueue<>(POINTS_QUEUE_SIZE);
-
 	/**
-	 * The Constructor.
-	 *
-	 * @param url          URL of the InfluxDB-Server (http://ip:port)
-	 * @param org          The organisation; '-' for InfluxDB v1
-	 * @param apiKey       The apiKey; 'username:password' for InfluxDB v1
-	 * @param bucket       The bucket name; 'database/retentionPolicy' for InfluxDB
-	 *                     v1
-	 * @param isReadOnly   If true, a 'Read-Only-Mode' is activated, where no data
-	 *                     is actually written to the database
-	 * @param onWriteError A consumer for write-errors
+	 * deactivates the influx connector.
 	 */
-	public InfluxConnector(URI url, String org, String apiKey, String bucket, boolean isReadOnly,
-			Consumer<Throwable> onWriteError) {
-		this.url = url;
-		this.org = org;
-		this.apiKey = apiKey;
-		this.bucket = bucket;
-		this.isReadOnly = isReadOnly;
-		this.onWriteError = onWriteError;
-
-		this.debugLogExecutor.scheduleWithFixedDelay(() -> {
-			int pointsQueueSize = this.pointsQueue.size();
-			this.log.info(new StringBuilder("[InfluxDB] [monitor] ") //
-					.append(ThreadPoolUtils.debugLog(this.executor)) //
-					.append(" Queue:") //
-					.append(pointsQueueSize) //
-					.append("/") //
-					.append(POINTS_QUEUE_SIZE) //
-					.append((pointsQueueSize == POINTS_QUEUE_SIZE) ? " !!!POINTS BACKPRESSURE!!!" : "") //
-					.toString());
-		}, 10, 10, TimeUnit.SECONDS);
-
-		this.mergePointsExecutor.execute(() -> {
-			/**
-			 * This task merges single Points to Lists of Points, which are then sent to
-			 * InfluxDB. This approach improves speed as not every single Point gets sent
-			 * via HTTP individually.
-			 * 
-			 * In theory the async implementation in the InfluxDB library would work also,
-			 * but it fails in production (without providing any error message/exception).
-			 */
-			while (true) {
-				try {
-					/*
-					 * Merge Points. Wait max 10 seconds in total.
-					 */
-					final Instant maxWait = Instant.now().plusSeconds(MAX_AGGREGATE_WAIT);
-					List<Point> points = new ArrayList<>(MAX_POINTS_PER_WRITE);
-					for (int i = 0; i < MAX_POINTS_PER_WRITE; i++) {
-						var point = this.pointsQueue.poll(MAX_AGGREGATE_WAIT, TimeUnit.SECONDS);
-						if (point == null) {
-							break;
-						}
-						points.add(point);
-						if (Instant.now().isAfter(maxWait)) {
-							break;
-						}
-					}
-					/*
-					 * Write points async.
-					 */
-					if (!points.isEmpty()) {
-						this.executor.execute(() -> {
-							try {
-								this.getInfluxConnection().writeApi.writePoints(points);
-							} catch (Throwable t) {
-								this.log.warn("Unable to write points. " + t.getMessage());
-								this.onWriteError.accept(t);
-							}
-						});
-					}
-
-				} catch (InterruptedException e) {
-					this.log.info("MergePointsExecutor was interrupted");
-					break;
-
-				} catch (Throwable e) {
-					this.log.error("Unhandled Error in 'MergePointsExecutor': " + e.getClass().getName() + ". "
-							+ e.getMessage());
-					e.printStackTrace();
-				}
-			}
-		});
-	}
-
-	private static class InfluxConnection {
-		private final InfluxDBClient client;
-		private final WriteApiBlocking writeApi;
-
-		public InfluxConnection(InfluxDBClient client, WriteApiBlocking writeApi) {
-			this.client = client;
-			this.writeApi = writeApi;
-		}
-	}
-
-	private InfluxConnection influxConnection = null;
-
-	/**
-	 * Get InfluxDB Connection.
-	 *
-	 * @return the {@link InfluxDB} connection
-	 */
-	private synchronized InfluxConnection getInfluxConnection() {
-		if (this.influxConnection != null) {
-			// Use existing Singleton instance
-			return this.influxConnection;
-		}
-
-		var okHttpClientBuilder = new OkHttpClient().newBuilder() //
-				.connectTimeout(CONNECT_TIMEOUT, TimeUnit.SECONDS) //
-				.readTimeout(READ_TIMEOUT, TimeUnit.SECONDS) //
-				.writeTimeout(WRITE_TIMEOUT, TimeUnit.SECONDS);
-
-		// copied options from InfluxDBClientFactory.createV1
-		// to set timeout
-		var options = InfluxDBClientOptions.builder() //
-				.url(this.url.toString()) //
-				.org(this.org) //
-				.bucket(this.bucket) //
-				.okHttpClient(okHttpClientBuilder); //
-		if (this.apiKey != null && !this.apiKey.isBlank()) {
-			options.authenticateToken(String.format(this.apiKey).toCharArray()); //
-		}
-
-		var client = InfluxDBClientFactory //
-				.create(options.build()) //
-				.enableGzip();
-
-		// Keep default WriteOptions from
-		// https://github.com/influxdata/influxdb-client-java/tree/master/client#writes
-		var writeApi = client.getWriteApiBlocking();
-
-		this.influxConnection = new InfluxConnection(client, writeApi);
-		return this.influxConnection;
-	}
-
-	/**
-	 * Close current {@link InfluxDBClient}.
-	 */
-	public synchronized void deactivate() {
-		ThreadPoolUtils.shutdownAndAwaitTermination(this.executor, 0);
-		ThreadPoolUtils.shutdownAndAwaitTermination(this.mergePointsExecutor, 0);
-		ThreadPoolUtils.shutdownAndAwaitTermination(this.debugLogExecutor, 0);
-		if (this.influxConnection != null) {
-			this.influxConnection.client.close();
-		}
-	}
-
-	private static class RandomLimit {
-		private static final double MAX_LIMIT = 0.95;
-		private static final double MIN_LIMIT = 0;
-		private static final double STEP = 0.01;
-
-		private double limit = 0;
-
-		protected synchronized void increase() {
-			this.limit += STEP;
-			if (this.limit > MAX_LIMIT) {
-				this.limit = MAX_LIMIT;
-			}
-		}
-
-		protected synchronized void decrease() {
-			this.limit -= STEP;
-			if (this.limit <= MIN_LIMIT) {
-				this.limit = MIN_LIMIT;
-			}
-		}
-
-		protected double getLimit() {
-			return this.limit;
-		}
-
-		@Override
-		public String toString() {
-			return String.format("%.3f", this.limit);
-		}
-	}
-
-	private final RandomLimit queryLimit = new RandomLimit();
-
-	/**
-	 * Execute given {@link Flux} query.
-	 *
-	 * @param query {@link Flux} to execute
-	 * @return Result from database as {@link List} of {@link FluxTable}
-	 * @throws OpenemsException on error
-	 */
-	public List<FluxTable> executeQuery(Flux query) throws OpenemsException {
-		return this.executeQuery(query.toString());
-	}
-
-	/**
-	 * Execute given query.
-	 *
-	 * @param query to execute
-	 * @return Result from database as {@link List} of {@link FluxTable}
-	 * @throws OpenemsException on error
-	 */
-	public List<FluxTable> executeQuery(String query) throws OpenemsException {
-		if (Math.random() < this.queryLimit.getLimit()) {
-			throw new OpenemsException(
-					"InfluxDB read is temporarily blocked [" + this.queryLimit + "]. Query: " + query);
-		}
-
-		// Parse result
-		List<FluxTable> queryResult;
-		try {
-			queryResult = this.getInfluxConnection().client.getQueryApi().query(query);
-		} catch (RuntimeException e) {
-			this.queryLimit.increase();
-			this.log.error("InfluxDB query runtime error. Query: " + query + ", Error: " + e.getMessage());
-			throw new OpenemsException(e.getMessage());
-		}
-		this.queryLimit.decrease();
-		return queryResult;
-	}
+	public void deactivate();
 
 	/**
 	 * Queries historic energy.
@@ -314,45 +32,7 @@ public class InfluxConnector {
 	 * @throws OpenemsException on error
 	 */
 	public SortedMap<ChannelAddress, JsonElement> queryHistoricEnergy(Optional<Integer> influxEdgeId,
-			ZonedDateTime fromDate, ZonedDateTime toDate, Set<ChannelAddress> channels) throws OpenemsNamedException {
-		if (Math.random() * 4 < this.queryLimit.getLimit()) {
-			throw new OpenemsException("InfluxDB read is temporarily blocked for Energy values [" + this.queryLimit
-					+ "]. Edge [" + influxEdgeId + "] FromDate [" + fromDate + "] ToDate [" + toDate + "]");
-		}
-
-		// handle empty call
-		if (channels.isEmpty()) {
-			return new TreeMap<>();
-		}
-
-		// prepare query
-		var builder = new StringBuilder() //
-				.append("data = from(bucket: \"").append(this.bucket).append("\")") //
-
-				.append("|> range(start: ").append(fromDate.toInstant()) //
-				.append(", stop: ").append(toDate.toInstant()).append(")") //
-				.append("|> filter(fn: (r) => r._measurement == \"").append(MEASUREMENT).append("\")");
-
-		if (influxEdgeId.isPresent()) {
-			builder.append("|> filter(fn: (r) => r." + OpenemsOEM.INFLUXDB_TAG + " == \"" + influxEdgeId.get() + "\")");
-		}
-
-		builder //
-				.append("|> filter(fn : (r) => ") //
-				.append(InfluxConnector.toChannelAddressFieldList(channels).toString()) //
-				.append(")")
-
-				.append("first = data |> first()") //
-				.append("last = data |> last()") //
-				.append("union(tables: [first, last])") //
-				.append("|> difference()");
-		var query = builder.toString();
-
-		// Execute query
-		var queryResult = this.executeQuery(query);
-
-		return InfluxConnector.convertHistoricEnergyResult(query, queryResult);
-	}
+			ZonedDateTime fromDate, ZonedDateTime toDate, Set<ChannelAddress> channels) throws OpenemsNamedException;
 
 	/**
 	 * Queries historic energy per period.
@@ -367,45 +47,11 @@ public class InfluxConnector {
 	 */
 	public SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> queryHistoricEnergyPerPeriod(
 			Optional<Integer> influxEdgeId, ZonedDateTime fromDate, ZonedDateTime toDate, Set<ChannelAddress> channels,
-			Resolution resolution) throws OpenemsNamedException {
-		if (Math.random() * 4 < this.queryLimit.getLimit()) {
-			throw new OpenemsException("InfluxDB read is temporarily blocked for Energy values [" + this.queryLimit
-					+ "]. Edge [" + influxEdgeId + "] FromDate [" + fromDate + "] ToDate [" + toDate + "]");
-		}
-
-		if (resolution.getUnit().equals(ChronoUnit.MONTHS)) {
-			fromDate = fromDate.with(TemporalAdjusters.firstDayOfMonth());
-			if (!toDate.equals(toDate.with(TemporalAdjusters.firstDayOfMonth()))) {
-				toDate = toDate.with(TemporalAdjusters.lastDayOfMonth()).plusDays(1);
-			}
-		}
-
-		// handle empty call
-		if (channels.isEmpty()) {
-			return new TreeMap<>();
-		}
-
-		// prepare query
-		Flux flux = Flux.from(this.bucket) //
-				.range(fromDate.toInstant(), toDate.toInstant()) //
-				.filter(Restrictions.measurement().equal(MEASUREMENT));
-
-		if (influxEdgeId.isPresent()) {
-			flux = flux.filter(Restrictions.tag(OpenemsOEM.INFLUXDB_TAG).equal(influxEdgeId.get().toString()));
-		}
-
-		flux = flux.filter(InfluxConnector.toChannelAddressFieldList(channels)) //
-				.aggregateWindow(resolution.getValue(), resolution.getUnit(), "last") //
-				.difference(true);
-
-		var queryResult = this.executeQuery(flux);
-
-		return InfluxConnector.convertHistoricDataQueryResult(queryResult, fromDate, resolution);
-	}
+			Resolution resolution) throws OpenemsNamedException;
 
 	/**
 	 * Queries historic data.
-	 *
+	 * 
 	 * @param influxEdgeId the unique, numeric Edge-ID; or Empty to query all Edges
 	 * @param fromDate     the From-Date
 	 * @param toDate       the To-Date
@@ -416,33 +62,7 @@ public class InfluxConnector {
 	 */
 	public SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> queryHistoricData(
 			Optional<Integer> influxEdgeId, ZonedDateTime fromDate, ZonedDateTime toDate, Set<ChannelAddress> channels,
-			Resolution resolution) throws OpenemsNamedException {
-
-		// handle empty call
-		if (channels.isEmpty()) {
-			return new TreeMap<>();
-		}
-
-		// remove 5 minutes to prevent shifted timeline
-		var fromInstant = fromDate.toInstant().minus(5, ChronoUnit.MINUTES);
-
-		// prepare query
-		Flux flux = Flux.from(this.bucket) //
-				.range(fromInstant, toDate.toInstant()) //
-				.filter(Restrictions.measurement().equal(MEASUREMENT));
-
-		if (influxEdgeId.isPresent()) {
-			flux = flux.filter(Restrictions.tag(OpenemsOEM.INFLUXDB_TAG).equal(influxEdgeId.get().toString()));
-		}
-
-		flux = flux.filter(InfluxConnector.toChannelAddressFieldList(channels)) //
-				.aggregateWindow(resolution.getValue(), resolution.getUnit(), "mean");
-
-		// Execute query
-		var queryResult = this.executeQuery(flux);
-
-		return InfluxConnector.convertHistoricDataQueryResult(queryResult, fromDate, resolution);
-	}
+			Resolution resolution) throws OpenemsNamedException;
 
 	/**
 	 * Queries the latest available channel values.
@@ -453,159 +73,8 @@ public class InfluxConnector {
 	 * @return a map of {@link ChannelAddress}es and values
 	 * @throws OpenemsException on error
 	 */
-	public Map<ChannelAddress, JsonElement> queryChannelValues(Optional<Integer> influxEdgeId,
-			Set<ChannelAddress> channelAddresses) {
-		var result = channelAddresses.stream()
-				.collect(Collectors.toMap(Function.identity(), c -> (JsonElement) JsonNull.INSTANCE));
-		try {
-			for (var channelAddress : channelAddresses) {
-				// prepare query
-				var builder = new StringBuilder() //
-						.append("from(bucket: \"").append("db/default").append("\")") //
-						.append("|> range(start: -5m)") //
-						.append("|> filter(fn: (r) => ") //
-						.append("r._measurement == \"").append(MEASUREMENT).append("\" ");
-				if (influxEdgeId.isPresent()) {
-					builder.append("and r." + OpenemsOEM.INFLUXDB_TAG + " == \"" + influxEdgeId.get() + "\" ");
-				}
-				builder //
-						.append("and r._field == \"").append(channelAddress.toString()).append("\")") //
-						.append("|> last()");
-				var query = builder.toString();
-
-				// Execute query
-				var queryResult = this.executeQuery(query);
-
-				for (FluxTable fluxTable : queryResult) {
-					for (FluxRecord record : fluxTable.getRecords()) {
-						result.put(channelAddress, JsonUtils.getAsJsonElement(record.getValue()));
-					}
-				}
-			}
-
-		} catch (OpenemsException e) {
-			this.log.error(e.getMessage());
-			e.printStackTrace();
-
-		}
-		return result;
-	}
-
-	/**
-	 * Converts the QueryResult of a Historic-Data query to a properly typed Table.
-	 *
-	 * @param queryResult the Query-Result
-	 * @param fromDate    start date from query
-	 * @param resolution  {@link Resolution} to revert InfluxDB offset
-	 * @return the historic data as Map
-	 * @throws OpenemsException on error
-	 */
-	private static SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> convertHistoricDataQueryResult(
-			List<FluxTable> queryResult, ZonedDateTime fromDate, Resolution resolution) throws OpenemsNamedException {
-		SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> table = new TreeMap<>();
-
-		for (FluxTable fluxTable : queryResult) {
-			for (FluxRecord record : fluxTable.getRecords()) {
-				var timestamp = ZonedDateTime.ofInstant(record.getTime(), fromDate.getZone());
-
-				// ignore first timestamp is before from date
-				if (timestamp.isBefore(fromDate)) {
-					continue;
-				}
-				timestamp = resolution.revertInfluxDbOffset(timestamp);
-
-				var valueObj = record.getValue();
-				final JsonElement value;
-				if (valueObj == null) {
-					value = JsonNull.INSTANCE;
-				} else if (valueObj instanceof Number) {
-					value = new JsonPrimitive((Number) valueObj);
-				} else {
-					value = new JsonPrimitive(valueObj.toString());
-				}
-
-				var channelAddresss = ChannelAddress.fromString(record.getField());
-
-				var row = table.get(timestamp);
-				if (row == null) {
-					row = new TreeMap<>();
-				}
-				row.put(channelAddresss, value);
-
-				table.put(timestamp, row);
-			}
-		}
-
-		return table;
-	}
-
-	/**
-	 * Converts the QueryResult of a Historic-Energy query to a properly typed Map.
-	 *
-	 * @param query       was executed
-	 * @param queryResult the Query-Result
-	 * @return the historic energy as Map
-	 * @throws OpenemsException on error
-	 */
-	private static SortedMap<ChannelAddress, JsonElement> convertHistoricEnergyResult(String query,
-			List<FluxTable> queryResult) throws OpenemsNamedException {
-		SortedMap<ChannelAddress, JsonElement> map = new TreeMap<>();
-
-		for (FluxTable fluxTable : queryResult) {
-			for (FluxRecord record : fluxTable.getRecords()) {
-
-				var valueObj = record.getValue();
-				final JsonElement value;
-				if (valueObj == null) {
-					value = JsonNull.INSTANCE;
-				} else if (valueObj instanceof Number) {
-					var number = (Number) valueObj;
-					if (number.intValue() < 0) {
-						// do not consider negative values
-						LOG.warn("Got negative Energy value [" + number + "] for query: " + query);
-						value = JsonNull.INSTANCE;
-					} else {
-						value = new JsonPrimitive(number);
-					}
-				} else {
-					value = new JsonPrimitive(valueObj.toString());
-				}
-
-				var channelAddresss = ChannelAddress.fromString(record.getField());
-
-				map.put(channelAddresss, value);
-			}
-		}
-
-		// Check if all values are null
-		var areAllValuesNull = true;
-		for (JsonElement value : map.values()) {
-			if (!value.isJsonNull()) {
-				areAllValuesNull = false;
-				break;
-			}
-		}
-		if (areAllValuesNull) {
-			throw new OpenemsException("Energy values are not available for query: " + query);
-		}
-
-		return map;
-	}
-
-	/**
-	 * Converts given {@link Set} of {@link ChannelAddress} to {@link Restrictions}
-	 * separated by or.
-	 *
-	 * @param channels {@link Set} of {@link ChannelAddress}
-	 * @return {@link Restrictions} separated by or
-	 */
-	private static Restrictions toChannelAddressFieldList(Set<ChannelAddress> channels) {
-		var restrictions = channels.stream() //
-				.map(channel -> Restrictions.field().equal(channel.toString())) //
-				.toArray(restriction -> new Restrictions[restriction]);
-
-		return Restrictions.or(restrictions);
-	}
+	public SortedMap<ChannelAddress, JsonElement> queryChannelValues(Optional<Integer> influxEdgeId,
+			Set<ChannelAddress> channelAddresses);
 
 	/**
 	 * Actually write the Point to InfluxDB.
@@ -613,13 +82,5 @@ public class InfluxConnector {
 	 * @param point the InfluxDB Point
 	 * @throws OpenemsException on error
 	 */
-	public void write(Point point) {
-		if (this.isReadOnly) {
-			this.log.info("Read-Only-Mode is activated. Not writing points: "
-					+ StringUtils.toShortString(point.toLineProtocol(), 100));
-			return;
-		}
-		this.pointsQueue.offer(point);
-	}
-
+	public void write(Point point);
 }

--- a/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnectorCommon.java
+++ b/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnectorCommon.java
@@ -1,0 +1,259 @@
+package io.openems.shared.influxdb;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.InfluxDBClientFactory;
+import com.influxdb.client.InfluxDBClientOptions;
+import com.influxdb.client.WriteApiBlocking;
+import com.influxdb.client.write.Point;
+
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.utils.StringUtils;
+import io.openems.common.utils.ThreadPoolUtils;
+import okhttp3.OkHttpClient;
+
+public class InfluxConnectorCommon {
+
+	private static final int CONNECT_TIMEOUT = 10; // [s]
+	private static final int READ_TIMEOUT = 60; // [s]
+	private static final int WRITE_TIMEOUT = 10; // [s]
+
+	private static final int EXECUTOR_MIN_THREADS = 10;
+	private static final int EXECUTOR_MAX_THREADS = 50;
+	private static final int EXECUTOR_QUEUE_SIZE = 500;
+	private static final int POINTS_QUEUE_SIZE = 1_000_000;
+	private static final int MAX_POINTS_PER_WRITE = 1_000;
+	private static final int MAX_AGGREGATE_WAIT = 10; // [s]
+
+	protected final Logger log = LoggerFactory.getLogger(InfluxConnector.class);
+
+	private final URI url;
+	private final String org;
+	private final String apiKey;
+	protected final String bucket;
+	private final boolean isReadOnly;
+	private final Consumer<Throwable> onWriteError;
+	private final ThreadPoolExecutor executor = new ThreadPoolExecutor(EXECUTOR_MIN_THREADS, EXECUTOR_MAX_THREADS, 60L,
+			TimeUnit.SECONDS, //
+			new ArrayBlockingQueue<>(EXECUTOR_QUEUE_SIZE), //
+			new ThreadFactoryBuilder().setNameFormat("InfluxConnector-%d").build(), //
+			new ThreadPoolExecutor.DiscardOldestPolicy());
+	private final ScheduledExecutorService debugLogExecutor = Executors.newSingleThreadScheduledExecutor();
+	private final ExecutorService mergePointsExecutor = Executors.newSingleThreadExecutor();
+	private final BlockingQueue<Point> pointsQueue = new LinkedBlockingQueue<>(POINTS_QUEUE_SIZE);
+
+	/**
+	 * The Constructor.
+	 *
+	 * @param url          URL of the InfluxDB-Server (http://ip:port)
+	 * @param org          The organisation; '-' for InfluxDB v1
+	 * @param apiKey       The apiKey; 'username:password' for InfluxDB v1
+	 * @param bucket       The bucket name; 'database/retentionPolicy' for InfluxDB
+	 *                     v1
+	 * @param isReadOnly   If true, a 'Read-Only-Mode' is activated, where no data
+	 *                     is actually written to the database
+	 * @param onWriteError A consumer for write-errors
+	 */
+	protected InfluxConnectorCommon(URI url, String org, String apiKey, String bucket, boolean isReadOnly,
+			Consumer<Throwable> onWriteError) {
+		this.url = url;
+		this.org = org;
+		this.apiKey = apiKey;
+		this.bucket = bucket;
+		this.isReadOnly = isReadOnly;
+		this.onWriteError = onWriteError;
+
+		this.debugLogExecutor.scheduleWithFixedDelay(() -> {
+			int pointsQueueSize = this.pointsQueue.size();
+			this.log.info(new StringBuilder("[InfluxDB] [monitor] ") //
+					.append(ThreadPoolUtils.debugLog(this.executor)) //
+					.append(" Queue:") //
+					.append(pointsQueueSize) //
+					.append("/") //
+					.append(POINTS_QUEUE_SIZE) //
+					.append((pointsQueueSize == POINTS_QUEUE_SIZE) ? " !!!POINTS BACKPRESSURE!!!" : "") //
+					.toString());
+		}, 10, 10, TimeUnit.SECONDS);
+
+		this.mergePointsExecutor.execute(() -> {
+			/**
+			 * This task merges single Points to Lists of Points, which are then sent to
+			 * InfluxDB. This approach improves speed as not every single Point gets sent
+			 * via HTTP individually.
+			 * 
+			 * In theory the async implementation in the InfluxDB library would work also,
+			 * but it fails in production (without providing any error message/exception).
+			 */
+			while (true) {
+				try {
+					/*
+					 * Merge Points. Wait max 10 seconds in total.
+					 */
+					final Instant maxWait = Instant.now().plusSeconds(MAX_AGGREGATE_WAIT);
+					List<Point> points = new ArrayList<>(MAX_POINTS_PER_WRITE);
+					for (int i = 0; i < MAX_POINTS_PER_WRITE; i++) {
+						var point = this.pointsQueue.poll(MAX_AGGREGATE_WAIT, TimeUnit.SECONDS);
+						if (point == null) {
+							break;
+						}
+						points.add(point);
+						if (Instant.now().isAfter(maxWait)) {
+							break;
+						}
+					}
+					/*
+					 * Write points async.
+					 */
+					if (!points.isEmpty()) {
+						this.executor.execute(() -> {
+							try {
+								this.getInfluxConnection().writeApi.writePoints(points);
+							} catch (Throwable t) {
+								this.log.warn("Unable to write points. " + t.getMessage());
+								this.onWriteError.accept(t);
+							}
+						});
+					}
+
+				} catch (InterruptedException e) {
+					this.log.info("MergePointsExecutor was interrupted");
+					break;
+
+				} catch (Throwable e) {
+					this.log.error("Unhandled Error in 'MergePointsExecutor': " + e.getClass().getName() + ". "
+							+ e.getMessage());
+					e.printStackTrace();
+				}
+			}
+		});
+	}
+
+	protected static class InfluxConnection {
+		protected final InfluxDBClient client;
+		protected final WriteApiBlocking writeApi;
+
+		public InfluxConnection(InfluxDBClient client, WriteApiBlocking writeApi) {
+			this.client = client;
+			this.writeApi = writeApi;
+		}
+	}
+
+	private InfluxConnection influxConnection = null;
+
+	/**
+	 * Get InfluxDB Connection.
+	 *
+	 * @return the {@link InfluxDB} connection
+	 */
+	protected synchronized InfluxConnection getInfluxConnection() {
+		if (this.influxConnection != null) {
+			// Use existing Singleton instance
+			return this.influxConnection;
+		}
+
+		var okHttpClientBuilder = new OkHttpClient().newBuilder() //
+				.connectTimeout(CONNECT_TIMEOUT, TimeUnit.SECONDS) //
+				.readTimeout(READ_TIMEOUT, TimeUnit.SECONDS) //
+				.writeTimeout(WRITE_TIMEOUT, TimeUnit.SECONDS);
+
+		// copied options from InfluxDBClientFactory.createV1
+		// to set timeout
+		var options = InfluxDBClientOptions.builder() //
+				.url(this.url.toString()) //
+				.org(this.org) //
+				.bucket(this.bucket) //
+				.okHttpClient(okHttpClientBuilder); //
+		if (this.apiKey != null && !this.apiKey.isBlank()) {
+			options.authenticateToken(String.format(this.apiKey).toCharArray()); //
+		}
+
+		var client = InfluxDBClientFactory //
+				.create(options.build()) //
+				.enableGzip();
+
+		// Keep default WriteOptions from
+		// https://github.com/influxdata/influxdb-client-java/tree/master/client#writes
+		var writeApi = client.getWriteApiBlocking();
+
+		this.influxConnection = new InfluxConnection(client, writeApi);
+		return this.influxConnection;
+	}
+
+	/**
+	 * Close current {@link InfluxDBClient}.
+	 */
+	public synchronized void deactivate() {
+		ThreadPoolUtils.shutdownAndAwaitTermination(this.executor, 0);
+		ThreadPoolUtils.shutdownAndAwaitTermination(this.mergePointsExecutor, 0);
+		ThreadPoolUtils.shutdownAndAwaitTermination(this.debugLogExecutor, 0);
+		if (this.influxConnection != null) {
+			this.influxConnection.client.close();
+		}
+	}
+
+	public static class RandomLimit {
+		private static final double MAX_LIMIT = 0.95;
+		private static final double MIN_LIMIT = 0;
+		private static final double STEP = 0.01;
+
+		private double limit = 0;
+
+		protected synchronized void increase() {
+			this.limit += STEP;
+			if (this.limit > MAX_LIMIT) {
+				this.limit = MAX_LIMIT;
+			}
+		}
+
+		protected synchronized void decrease() {
+			this.limit -= STEP;
+			if (this.limit <= MIN_LIMIT) {
+				this.limit = MIN_LIMIT;
+			}
+		}
+
+		protected double getLimit() {
+			return this.limit;
+		}
+
+		@Override
+		public String toString() {
+			return String.format("%.3f", this.limit);
+		}
+	}
+
+	protected final RandomLimit queryLimit = new RandomLimit();
+
+	/**
+	 * Actually write the Point to InfluxDB.
+	 *
+	 * @param point the InfluxDB Point
+	 * @throws OpenemsException on error
+	 */
+	public void write(Point point) {
+		if (this.isReadOnly) {
+			this.log.info("Read-Only-Mode is activated. Not writing points: "
+					+ StringUtils.toShortString(point.toLineProtocol(), 100));
+			return;
+		}
+		this.pointsQueue.offer(point);
+	}
+
+}

--- a/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnectorFluxQL.java
+++ b/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnectorFluxQL.java
@@ -1,0 +1,414 @@
+package io.openems.shared.influxdb;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.influxdb.query.FluxRecord;
+import com.influxdb.query.FluxTable;
+import com.influxdb.query.dsl.Flux;
+import com.influxdb.query.dsl.functions.restriction.Restrictions;
+
+import io.openems.common.OpenemsOEM;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.timedata.Resolution;
+import io.openems.common.types.ChannelAddress;
+import io.openems.common.utils.JsonUtils;
+
+public class InfluxConnectorFluxQL extends InfluxConnectorCommon implements InfluxConnector {
+
+	/**
+	 * The Constructor.
+	 *
+	 * @param url          URL of the InfluxDB-Server (http://ip:port)
+	 * @param org          The organisation; '-' for InfluxDB v1
+	 * @param apiKey       The apiKey; 'username:password' for InfluxDB v1
+	 * @param bucket       The bucket name; 'database/retentionPolicy' for InfluxDB
+	 *                     v1
+	 * @param isReadOnly   If true, a 'Read-Only-Mode' is activated, where no data
+	 *                     is actually written to the database
+	 * @param onWriteError A consumer for write-errors
+	 */
+	public InfluxConnectorFluxQL(URI url, String org, String apiKey, String bucket, boolean isReadOnly,
+			Consumer<Throwable> onWriteError) {
+		super(url, org, apiKey, bucket, isReadOnly, onWriteError);
+
+	}
+
+	@Override
+	public synchronized void deactivate() {
+		super.deactivate();
+	}
+
+	/**
+	 * Execute given {@link Flux} query.
+	 *
+	 * @param query {@link Flux} to execute
+	 * @return Result from database as {@link List} of {@link FluxTable}
+	 * @throws OpenemsException on error
+	 */
+	public List<FluxTable> executeQuery(Flux query) throws OpenemsException {
+		return this.executeQuery(query.toString());
+	}
+
+	/**
+	 * Execute given query.
+	 *
+	 * @param query to execute
+	 * @return Result from database as {@link List} of {@link FluxTable}
+	 * @throws OpenemsException on error
+	 */
+	public List<FluxTable> executeQuery(String query) throws OpenemsException {
+		if (Math.random() < this.queryLimit.getLimit()) {
+			throw new OpenemsException(
+					"InfluxDB read is temporarily blocked [" + this.queryLimit + "]. Query: " + query);
+		}
+
+		// Parse result
+		List<FluxTable> queryResult;
+		try {
+			queryResult = this.getInfluxConnection().client.getQueryApi().query(query);
+		} catch (RuntimeException e) {
+			this.queryLimit.increase();
+			this.log.error("InfluxDB query runtime error. Query: " + query + ", Error: " + e.getMessage());
+			throw new OpenemsException(e.getMessage());
+		}
+		this.queryLimit.decrease();
+		return queryResult;
+	}
+
+	/**
+	 * Queries historic energy.
+	 *
+	 * @param influxEdgeId the unique, numeric Edge-ID; or Empty to query all Edges
+	 * @param fromDate     the From-Date
+	 * @param toDate       the To-Date
+	 * @param channels     the Channels to query
+	 * @return a map between ChannelAddress and value
+	 * @throws OpenemsException on error
+	 */
+	public SortedMap<ChannelAddress, JsonElement> queryHistoricEnergy(Optional<Integer> influxEdgeId,
+			ZonedDateTime fromDate, ZonedDateTime toDate, Set<ChannelAddress> channels) throws OpenemsNamedException {
+		if (Math.random() * 4 < this.queryLimit.getLimit()) {
+			throw new OpenemsException("InfluxDB read is temporarily blocked for Energy values [" + this.queryLimit
+					+ "]. Edge [" + influxEdgeId + "] FromDate [" + fromDate + "] ToDate [" + toDate + "]");
+		}
+
+		// handle empty call
+		if (channels.isEmpty()) {
+			return new TreeMap<>();
+		}
+
+		// prepare query
+		var builder = new StringBuilder() //
+				.append("data = from(bucket: \"").append(this.bucket).append("\")") //
+
+				.append("|> range(start: ").append(fromDate.toInstant()) //
+				.append(", stop: ").append(toDate.toInstant()).append(")") //
+				.append("|> filter(fn: (r) => r._measurement == \"").append(InfluxConnector.MEASUREMENT).append("\")");
+
+		if (influxEdgeId.isPresent()) {
+			builder.append("|> filter(fn: (r) => r." + OpenemsOEM.INFLUXDB_TAG + " == \"" + influxEdgeId.get() + "\")");
+		}
+
+		builder //
+				.append("|> filter(fn : (r) => ") //
+				.append(InfluxConnectorFluxQL.toChannelAddressFieldList(channels).toString()) //
+				.append(")")
+
+				.append("first = data |> first()") //
+				.append("last = data |> last()") //
+				.append("union(tables: [first, last])") //
+				.append("|> difference()");
+		var query = builder.toString();
+
+		// Execute query
+		var queryResult = this.executeQuery(query);
+
+		return this.convertHistoricEnergyResult(query, queryResult);
+	}
+
+	/**
+	 * Queries historic energy per period.
+	 *
+	 * @param influxEdgeId the unique, numeric Edge-ID; or Empty to query all Edges
+	 * @param fromDate     the From-Date
+	 * @param toDate       the To-Date
+	 * @param channels     the Channels to query
+	 * @param resolution   the resolution in seconds
+	 * @return the historic data as Map
+	 * @throws OpenemsException on error
+	 */
+	public SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> queryHistoricEnergyPerPeriod(
+			Optional<Integer> influxEdgeId, ZonedDateTime fromDate, ZonedDateTime toDate, Set<ChannelAddress> channels,
+			Resolution resolution) throws OpenemsNamedException {
+		if (Math.random() * 4 < this.queryLimit.getLimit()) {
+			throw new OpenemsException("InfluxDB read is temporarily blocked for Energy values [" + this.queryLimit
+					+ "]. Edge [" + influxEdgeId + "] FromDate [" + fromDate + "] ToDate [" + toDate + "]");
+		}
+
+		if (resolution.getUnit().equals(ChronoUnit.MONTHS)) {
+			fromDate = fromDate.with(TemporalAdjusters.firstDayOfMonth());
+			if (!toDate.equals(toDate.with(TemporalAdjusters.firstDayOfMonth()))) {
+				toDate = toDate.with(TemporalAdjusters.lastDayOfMonth()).plusDays(1);
+			}
+		}
+
+		// handle empty call
+		if (channels.isEmpty()) {
+			return new TreeMap<>();
+		}
+
+		// prepare query
+		Flux flux = Flux.from(this.bucket) //
+				.range(fromDate.toInstant(), toDate.toInstant()) //
+				.filter(Restrictions.measurement().equal(InfluxConnector.MEASUREMENT));
+
+		if (influxEdgeId.isPresent()) {
+			flux = flux.filter(Restrictions.tag(OpenemsOEM.INFLUXDB_TAG).equal(influxEdgeId.get().toString()));
+		}
+
+		flux = flux.filter(InfluxConnectorFluxQL.toChannelAddressFieldList(channels)) //
+				.aggregateWindow(resolution.getValue(), resolution.getUnit(), "last") //
+				.difference(true);
+
+		var queryResult = this.executeQuery(flux);
+
+		return InfluxConnectorFluxQL.convertHistoricDataQueryResult(queryResult, fromDate, resolution);
+	}
+
+	/**
+	 * Queries historic data.
+	 *
+	 * @param influxEdgeId the unique, numeric Edge-ID; or Empty to query all Edges
+	 * @param fromDate     the From-Date
+	 * @param toDate       the To-Date
+	 * @param channels     the Channels to query
+	 * @param resolution   the resolution in seconds
+	 * @return the historic data as Map
+	 * @throws OpenemsException on error
+	 */
+	public SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> queryHistoricData(
+			Optional<Integer> influxEdgeId, ZonedDateTime fromDate, ZonedDateTime toDate, Set<ChannelAddress> channels,
+			Resolution resolution) throws OpenemsNamedException {
+
+		// handle empty call
+		if (channels.isEmpty()) {
+			return new TreeMap<>();
+		}
+
+		// remove 5 minutes to prevent shifted timeline
+		var fromInstant = fromDate.toInstant().minus(5, ChronoUnit.MINUTES);
+
+		// prepare query
+		Flux flux = Flux.from(this.bucket) //
+				.range(fromInstant, toDate.toInstant()) //
+				.filter(Restrictions.measurement().equal(InfluxConnector.MEASUREMENT));
+
+		if (influxEdgeId.isPresent()) {
+			flux = flux.filter(Restrictions.tag(OpenemsOEM.INFLUXDB_TAG).equal(influxEdgeId.get().toString()));
+		}
+
+		flux = flux.filter(InfluxConnectorFluxQL.toChannelAddressFieldList(channels)) //
+				.aggregateWindow(resolution.getValue(), resolution.getUnit(), "mean");
+
+		// Execute query
+		var queryResult = this.executeQuery(flux);
+
+		return InfluxConnectorFluxQL.convertHistoricDataQueryResult(queryResult, fromDate, resolution);
+	}
+
+	/**
+	 * Queries the latest available channel values.
+	 *
+	 * @param influxEdgeId     the unique, numeric Edge-ID; or Empty to query all
+	 *                         Edges
+	 * @param channelAddresses the {@link ChannelAddress}es
+	 * @return a map of {@link ChannelAddress}es and values
+	 * @throws OpenemsException on error
+	 */
+	public Map<ChannelAddress, JsonElement> queryChannelValuesMap(Optional<Integer> influxEdgeId,
+			Set<ChannelAddress> channelAddresses) {
+		var result = channelAddresses.stream()
+				.collect(Collectors.toMap(Function.identity(), c -> (JsonElement) JsonNull.INSTANCE));
+		try {
+			for (var channelAddress : channelAddresses) {
+				// prepare query
+				var builder = new StringBuilder() //
+						.append("from(bucket: \"").append(this.bucket).append("\")") //
+						.append("|> range(start: -16m)") //
+						.append("|> filter(fn: (r) => ") //
+						.append("r._measurement == \"").append(InfluxConnector.MEASUREMENT).append("\" ");
+				if (influxEdgeId.isPresent()) {
+					builder.append("and r." + OpenemsOEM.INFLUXDB_TAG + " == \"" + influxEdgeId.get() + "\" ");
+				}
+				builder //
+						.append("and r._field == \"").append(channelAddress.toString()).append("\")") //
+						.append("|> last()");
+				var query = builder.toString();
+
+				// Execute query
+				var queryResult = this.executeQuery(query);
+
+				for (FluxTable fluxTable : queryResult) {
+					for (FluxRecord record : fluxTable.getRecords()) {
+						result.put(channelAddress, JsonUtils.getAsJsonElement(record.getValue()));
+					}
+				}
+			}
+
+		} catch (OpenemsException e) {
+			this.log.error(e.getMessage());
+			e.printStackTrace();
+
+		}
+		return result;
+	}
+
+	/**
+	 * queries the given channel values.
+	 * 
+	 * @param influxEdgeId     the edge id
+	 * @param channelAddresses channel addresses to query
+	 * @return the sorted map of results
+	 */
+	public SortedMap<ChannelAddress, JsonElement> queryChannelValues(Optional<Integer> influxEdgeId,
+			Set<ChannelAddress> channelAddresses) {
+		var map = this.queryChannelValuesMap(influxEdgeId, channelAddresses);
+		var sortedMap = map.entrySet().stream().sorted(Map.Entry.<ChannelAddress, JsonElement>comparingByKey())
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> oldValue,
+						TreeMap::new));
+		return sortedMap;
+	}
+
+	/**
+	 * Converts the QueryResult of a Historic-Data query to a properly typed Table.
+	 *
+	 * @param queryResult the Query-Result
+	 * @param fromDate    start date from query
+	 * @param resolution  {@link Resolution} to revert InfluxDB offset
+	 * @return the historic data as Map
+	 * @throws OpenemsException on error
+	 */
+	private static SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> convertHistoricDataQueryResult(
+			List<FluxTable> queryResult, ZonedDateTime fromDate, Resolution resolution) throws OpenemsNamedException {
+		SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> table = new TreeMap<>();
+
+		for (FluxTable fluxTable : queryResult) {
+			for (FluxRecord record : fluxTable.getRecords()) {
+				var timestamp = ZonedDateTime.ofInstant(record.getTime(), fromDate.getZone());
+
+				// ignore first timestamp is before from date
+				if (timestamp.isBefore(fromDate)) {
+					continue;
+				}
+				timestamp = resolution.revertInfluxDbOffset(timestamp);
+
+				var valueObj = record.getValue();
+				final JsonElement value;
+				if (valueObj == null) {
+					value = JsonNull.INSTANCE;
+				} else if (valueObj instanceof Number) {
+					value = new JsonPrimitive((Number) valueObj);
+				} else {
+					value = new JsonPrimitive(valueObj.toString());
+				}
+
+				var channelAddresss = ChannelAddress.fromString(record.getField());
+
+				var row = table.get(timestamp);
+				if (row == null) {
+					row = new TreeMap<>();
+				}
+				row.put(channelAddresss, value);
+
+				table.put(timestamp, row);
+			}
+		}
+
+		return table;
+	}
+
+	/**
+	 * Converts the QueryResult of a Historic-Energy query to a properly typed Map.
+	 *
+	 * @param query       was executed
+	 * @param queryResult the Query-Result
+	 * @return the historic energy as Map
+	 * @throws OpenemsException on error
+	 */
+	private SortedMap<ChannelAddress, JsonElement> convertHistoricEnergyResult(String query,
+			List<FluxTable> queryResult) throws OpenemsNamedException {
+		SortedMap<ChannelAddress, JsonElement> map = new TreeMap<>();
+
+		for (FluxTable fluxTable : queryResult) {
+			for (FluxRecord record : fluxTable.getRecords()) {
+
+				var valueObj = record.getValue();
+				final JsonElement value;
+				if (valueObj == null) {
+					value = JsonNull.INSTANCE;
+				} else if (valueObj instanceof Number) {
+					var number = (Number) valueObj;
+					if (number.intValue() < 0) {
+						// do not consider negative values
+						this.log.warn("Got negative Energy value [" + number + "] for query: " + query);
+						value = JsonNull.INSTANCE;
+					} else {
+						value = new JsonPrimitive(number);
+					}
+				} else {
+					value = new JsonPrimitive(valueObj.toString());
+				}
+
+				var channelAddresss = ChannelAddress.fromString(record.getField());
+
+				map.put(channelAddresss, value);
+			}
+		}
+
+		// Check if all values are null
+		var areAllValuesNull = true;
+		for (JsonElement value : map.values()) {
+			if (!value.isJsonNull()) {
+				areAllValuesNull = false;
+				break;
+			}
+		}
+		if (areAllValuesNull) {
+			throw new OpenemsException("Energy values are not available for query: " + query);
+		}
+
+		return map;
+	}
+
+	/**
+	 * Converts given {@link Set} of {@link ChannelAddress} to {@link Restrictions}
+	 * separated by or.
+	 *
+	 * @param channels {@link Set} of {@link ChannelAddress}
+	 * @return {@link Restrictions} separated by or
+	 */
+	private static Restrictions toChannelAddressFieldList(Set<ChannelAddress> channels) {
+		var restrictions = channels.stream() //
+				.map(channel -> Restrictions.field().equal(channel.toString())) //
+				.toArray(restriction -> new Restrictions[restriction]);
+
+		return Restrictions.or(restrictions);
+	}
+
+}

--- a/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnectorInfluxQL.java
+++ b/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnectorInfluxQL.java
@@ -1,0 +1,465 @@
+package io.openems.shared.influxdb;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.influxdb.client.domain.InfluxQLQuery;
+import com.influxdb.query.InfluxQLQueryResult;
+import com.influxdb.query.InfluxQLQueryResult.Series.Record;
+
+import io.openems.common.OpenemsOEM;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.timedata.Resolution;
+import io.openems.common.types.ChannelAddress;
+
+public class InfluxConnectorInfluxQL extends InfluxConnectorCommon implements InfluxConnector {
+	private String database;
+
+	private final Resolution fiveteenMinResolution = new Resolution(15, ChronoUnit.MINUTES);
+
+	/**
+	 * The Constructor.
+	 *
+	 * @param url          URL of the InfluxDB-Server (http://ip:port)
+	 * @param org          The organisation; '-' for InfluxDB v1
+	 * @param apiKey       The apiKey; 'username:password' for InfluxDB v1
+	 * @param bucket       The bucket name; 'database/retentionPolicy' for InfluxDB
+	 *                     v1
+	 * @param isReadOnly   If true, a 'Read-Only-Mode' is activated, where no data
+	 *                     is actually written to the database
+	 * @param onWriteError A consumer for write-errors
+	 */
+	public InfluxConnectorInfluxQL(URI url, String org, String apiKey, String bucket, boolean isReadOnly,
+			Consumer<Throwable> onWriteError) {
+		super(url, org, apiKey, bucket, isReadOnly, onWriteError);
+
+		String[] b = bucket.split("/");
+		this.database = b[0];
+	}
+
+	@Override
+	public synchronized void deactivate() {
+		super.deactivate();
+	}
+
+	/**
+	 * Execute given query.
+	 *
+	 * @param query to execute
+	 * @return the {@link InfluxQLQueryResult}
+	 * @throws OpenemsException on error
+	 */
+	public InfluxQLQueryResult executeQuery(String query) throws OpenemsException {
+		if (Math.random() < this.queryLimit.getLimit()) {
+			throw new OpenemsException(
+					"InfluxDB read is temporarily blocked [" + this.queryLimit + "]. Query: " + query);
+		}
+
+		// see (https://github.com/influxdata/influxdb-client-java/tree/master/client ->
+		// InfluxQL queries) for example request
+
+		try {
+			var influxDB = this.getInfluxConnection();
+			InfluxQLQueryResult queryResult = influxDB.client.getInfluxQLQueryApi().query(
+					new InfluxQLQuery(query, this.database).setPrecision(InfluxQLQuery.InfluxQLPrecision.MILLISECONDS)); // .getclient.getQueryApi().query(query);
+			this.queryLimit.decrease();
+			return queryResult;
+
+		} catch (RuntimeException e) {
+			this.queryLimit.increase();
+			this.log.error("InfluxDB query runtime error. Query: " + query + ", Error: " + e.getMessage());
+			throw new OpenemsException("InfluxDB query runtime error. Query: " + query + ", Error: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * Queries historic energy.
+	 *
+	 * @param influxEdgeId the unique, numeric Edge-ID; or Empty to query all Edges
+	 * @param fromDate     the From-Date
+	 * @param toDate       the To-Date
+	 * @param channels     the Channels to query
+	 * @return a map between ChannelAddress and value
+	 * @throws OpenemsException on error
+	 */
+	public SortedMap<ChannelAddress, JsonElement> queryHistoricEnergy(Optional<Integer> influxEdgeId,
+			ZonedDateTime fromDate, ZonedDateTime toDate, Set<ChannelAddress> channels) throws OpenemsNamedException {
+		if (Math.random() * 4 < this.queryLimit.getLimit()) {
+			throw new OpenemsException("InfluxDB read is temporarily blocked for Energy values [" + this.queryLimit
+					+ "]. Edge [" + influxEdgeId + "] FromDate [" + fromDate + "] ToDate [" + toDate + "]");
+		}
+
+		if (channels.isEmpty()) {
+			return new TreeMap<>();
+		}
+
+		// Prepare query string
+		var b = new StringBuilder("SELECT ");
+		b.append(this.toChannelAddressStringEnergy(channels));
+		b.append(" FROM data WHERE ");
+		if (influxEdgeId.isPresent()) {
+			b.append(OpenemsOEM.INFLUXDB_TAG + " = '" + influxEdgeId.get() + "' AND ");
+		}
+		b.append("time > ");
+		b.append(String.valueOf(fromDate.toEpochSecond()));
+		b.append("s");
+		b.append(" AND time < ");
+		b.append(String.valueOf(toDate.toEpochSecond()));
+		b.append("s");
+		var query = b.toString();
+
+		var queryResult = this.executeQuery(query);
+
+		var result = this.convertHistoricEnergyResult(query, queryResult, fromDate.getZone());
+		return result;
+	}
+
+	/**
+	 * Queries historic energy per period.
+	 *
+	 * @param influxEdgeId the unique, numeric Edge-ID; or Empty to query all Edges
+	 * @param fromDate     the From-Date
+	 * @param toDate       the To-Date
+	 * @param channels     the Channels to query
+	 * @param resolution   the resolution in seconds
+	 * @return the historic data as Map
+	 * @throws OpenemsException on error
+	 */
+	public SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> queryHistoricEnergyPerPeriod(
+			Optional<Integer> influxEdgeId, ZonedDateTime fromDate, ZonedDateTime toDate, Set<ChannelAddress> channels,
+			Resolution resolution) throws OpenemsNamedException {
+		if (Math.random() * 4 < this.queryLimit.getLimit()) {
+			throw new OpenemsException("InfluxDB read is temporarily blocked for Energy values [" + this.queryLimit
+					+ "]. Edge [" + influxEdgeId + "] FromDate [" + fromDate + "] ToDate [" + toDate + "]");
+		}
+
+		if (resolution.getUnit().equals(ChronoUnit.MONTHS)) {
+			fromDate = fromDate.with(TemporalAdjusters.firstDayOfMonth());
+			if (!toDate.equals(toDate.with(TemporalAdjusters.firstDayOfMonth()))) {
+				toDate = toDate.with(TemporalAdjusters.lastDayOfMonth()).plusDays(1);
+			}
+			// TODO use 31 days as approx. for 1 month, because influxQL is unable to use
+			// exact month values
+			resolution = new Resolution(31, ChronoUnit.DAYS);
+		}
+
+		if (channels.isEmpty()) {
+			return new TreeMap<>();
+		}
+		final var resolutionOffset = this.getResolutionOffset(fromDate, resolution);
+
+		// Prepare query string
+		var b = new StringBuilder("SELECT ");
+		b.append(this.toChannelAddressStringNonNegativeDifferenceLast(channels));
+		b.append(" FROM data WHERE ");
+		if (influxEdgeId.isPresent()) {
+			b.append(OpenemsOEM.INFLUXDB_TAG + " = '" + influxEdgeId.get() + "' AND ");
+		}
+		b.append("time > ");
+		b.append(String.valueOf(fromDate.toEpochSecond()));
+		b.append("s");
+		b.append(" AND time < ");
+		b.append(String.valueOf(toDate.toEpochSecond()));
+		b.append("s");
+		b.append(" GROUP BY time( ");
+		b.append(resolution.toSeconds());
+		b.append("s, ");
+		b.append(resolutionOffset);
+		b.append("s) fill(null)");
+		String query = b.toString();
+
+		var queryResult = this.executeQuery(query);
+
+		var result = InfluxConnectorInfluxQL.convertHistoricDataQueryResult(queryResult, fromDate, resolution);
+		return result;
+	}
+
+	/**
+	 * calculate the resolution offset for the given date and resolution.
+	 * 
+	 * @implNote 2022.02.23 Hint to understand the behavior of the influx "group by
+	 *           time()" function: InfluxDB is using timestamp 0
+	 *           (1970-01-01T00:00:00Z) as start time and for each timestamp that is
+	 *           dividable by the group interval, it creates a boundary so if group
+	 *           by time is 420 the boundarys are 0, timestamp 420, timestamp
+	 *           840,... timestamp 1577836680 (2019-12-31 23:58:00) So if fromDate
+	 *           starts at 2020-01-01 00:00:00 the first chunk goes from 2019-12-31
+	 *           23:58:00 to 2020-01-01 00:05:00
+	 * 
+	 *           see
+	 *           https://www.fromkk.com/posts/time-boundary-in-influxdb-group-by-time-statement/
+	 * @param fromDate   the date to calculate the offset from
+	 * @param resolution the resolution
+	 * @return the resolution offset in seconds
+	 */
+	private int getResolutionOffset(ZonedDateTime fromDate, Resolution resolution) {
+		var res = resolution.toSeconds();
+		return (int) (fromDate.toEpochSecond() % res);
+	}
+
+	/**
+	 * Queries historic data.
+	 * 
+	 * @param influxEdgeId the unique, numeric Edge-ID; or Empty to query all Edges
+	 * @param fromDate     the From-Date
+	 * @param toDate       the To-Date
+	 * @param channels     the Channels to query
+	 * @param resolution   the resolution in seconds
+	 * @return the historic data as Map
+	 * @throws OpenemsException on error
+	 */
+	public SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> queryHistoricData(
+			Optional<Integer> influxEdgeId, ZonedDateTime fromDate, ZonedDateTime toDate, Set<ChannelAddress> channels,
+			Resolution resolution) throws OpenemsNamedException {
+
+		if (channels.isEmpty()) {
+			return new TreeMap<>();
+		}
+
+		// Prepare query string
+		StringBuilder query = new StringBuilder("SELECT ");
+		query.append(this.toChannelAddressStringData(channels));
+		query.append(" FROM data WHERE ");
+		if (influxEdgeId.isPresent()) {
+			query.append(OpenemsOEM.INFLUXDB_TAG + " = '" + influxEdgeId.get() + "' AND ");
+		}
+		query.append("time > ");
+		query.append(String.valueOf(fromDate.toInstant().getEpochSecond()));
+		query.append("s");
+		query.append(" AND time < ");
+		query.append(String.valueOf(toDate.toEpochSecond()));
+		query.append("s");
+		query.append(" GROUP BY time(");
+		query.append(resolution.toSeconds());
+		query.append("s) fill(null)");
+
+		var queryResult = this.executeQuery(query.toString());
+		return InfluxConnectorInfluxQL.convertHistoricDataQueryResult(queryResult, fromDate, resolution);
+	}
+
+	/**
+	 * Queries the latest available channel values.
+	 *
+	 * @param influxEdgeId     the unique, numeric Edge-ID; or Empty to query all
+	 *                         Edges
+	 * @param channelAddresses the {@link ChannelAddress}es
+	 * @return a map of {@link ChannelAddress}es and values
+	 * @throws OpenemsException on error
+	 */
+	public SortedMap<ChannelAddress, JsonElement> queryChannelValues(Optional<Integer> influxEdgeId,
+			Set<ChannelAddress> channelAddresses) {
+		try {
+			var query = new StringBuilder("SELECT ");
+			query.append(this.toChannelAddressStringDataLast(channelAddresses));
+			query.append(" FROM data WHERE ");
+			if (influxEdgeId.isPresent()) {
+				query.append(OpenemsOEM.INFLUXDB_TAG + " = '" + influxEdgeId.get() + "' AND ");
+			}
+
+			// peek into the last 7 days NOTE: within FLUX code 5min peek time is used
+			var fromDate = ZonedDateTime.now().minus(7, ChronoUnit.DAYS);
+			query.append("time > now() - 7d ");
+
+			query.append(" GROUP BY time(");
+			query.append(this.fiveteenMinResolution.toSeconds());
+			query.append("s) fill(null) ");
+			query.append("ORDER BY time DESC LIMIT 1;");
+
+			var queryResult = this.executeQuery(query.toString());
+			SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> convertedTable = InfluxConnectorInfluxQL
+					.convertHistoricDataQueryResult(queryResult, fromDate, this.fiveteenMinResolution);
+			return convertedTable.get(convertedTable.firstKey());
+		} catch (OpenemsNamedException e) {
+			this.log.error(e.getMessage());
+			e.printStackTrace();
+
+		}
+		return new TreeMap<ChannelAddress, JsonElement>();
+	}
+
+	/**
+	 * Converts the QueryResult of a Historic-Data query to a properly typed Table.
+	 *
+	 * @param queryResult the Query-Result
+	 * @param fromDate    start date from query
+	 * @param resolution  {@link Resolution} to revert InfluxDB offset
+	 * @return the historic data as Map
+	 * @throws OpenemsException on error
+	 */
+	private static SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> convertHistoricDataQueryResult(
+			InfluxQLQueryResult queryResult, ZonedDateTime fromDate, Resolution resolution)
+			throws OpenemsNamedException {
+		SortedMap<ZonedDateTime, SortedMap<ChannelAddress, JsonElement>> table = new TreeMap<>();
+
+		for (InfluxQLQueryResult.Result result : queryResult.getResults()) {
+			var seriess = result.getSeries();
+			if (seriess != null) {
+				for (InfluxQLQueryResult.Series series : seriess) {
+					// create ChannelAddress index
+					ArrayList<ChannelAddress> addressIndex = new ArrayList<>();
+					for (Map.Entry<String, Integer> column : series.getColumns().entrySet()) {
+						if (column.getKey().equals("time")) {
+							continue;
+						}
+						addressIndex.add(ChannelAddress.fromString(column.getKey()));
+					}
+					// add all data
+					List<Record> values = series.getValues();
+					for (Record rec : values) {
+
+						// get timestamp
+						Double d = Double.parseDouble(rec.getValues()[0].toString());
+						Instant timestampInstant = Instant.ofEpochMilli((long) d.longValue());
+						ZonedDateTime timestamp = ZonedDateTime.ofInstant(timestampInstant, fromDate.getZone());
+						if (timestamp.isBefore(fromDate)) {
+							continue;
+						}
+						// timestamp = resolution.revertInfluxDbOffset(timestamp);
+
+						SortedMap<ChannelAddress, JsonElement> tableRow = new TreeMap<>();
+						Object[] objs = rec.getValues();
+						for (int columnIndex = 0; columnIndex < addressIndex.size(); columnIndex++) {
+							// Note: ignoring index '0' here as it is the 'timestamp'
+							var address = addressIndex.get(columnIndex);
+							var valueObj = objs[columnIndex + 1];
+							JsonElement value;
+							if (valueObj == null) {
+								value = JsonNull.INSTANCE;
+							} else if (valueObj instanceof Number) {
+								value = new JsonPrimitive((Number) valueObj);
+							} else {
+								value = new JsonPrimitive(valueObj.toString());
+							}
+							tableRow.put(address, value);
+						}
+						table.put(timestamp, tableRow);
+					}
+				}
+			}
+		}
+		return table;
+	}
+
+	/**
+	 * Converts the QueryResult of a Historic-Energy query to a properly typed Map.
+	 *
+	 * @param query       was executed
+	 * @param queryResult the Query-Result
+	 * @param timezone    the timezone
+	 * @return the historic energy as Map
+	 * @throws OpenemsException on error
+	 */
+	private SortedMap<ChannelAddress, JsonElement> convertHistoricEnergyResult(String query,
+			InfluxQLQueryResult queryResult, ZoneId timezone) throws OpenemsNamedException {
+		SortedMap<ChannelAddress, JsonElement> map = new TreeMap<>();
+		for (InfluxQLQueryResult.Result result : queryResult.getResults()) {
+			var seriess = result.getSeries();
+			if (seriess != null) {
+				for (InfluxQLQueryResult.Series series : seriess) {
+					// create ChannelAddress index
+					ArrayList<ChannelAddress> addressIndex = new ArrayList<>();
+					for (Map.Entry<String, Integer> column : series.getColumns().entrySet()) {
+						if (column.getKey().equals("time")) {
+							continue;
+						}
+						addressIndex.add(ChannelAddress.fromString(column.getKey()));
+					}
+
+					// add all data
+					List<Record> values = series.getValues();
+					for (Record rec : values) {
+						Object[] objs = rec.getValues();
+						for (int columnIndex = 0; columnIndex < addressIndex.size(); columnIndex++) {
+							// Note: ignoring index '0' here as it is the 'timestamp'
+							var address = addressIndex.get(columnIndex);
+							Object valueObj = objs[columnIndex + 1];
+							JsonElement value;
+							if (valueObj == null) {
+								value = JsonNull.INSTANCE;
+							} else if (valueObj instanceof Number) {
+								var number = (Number) valueObj;
+								if (number.intValue() < 0) {
+									// do not consider negative values
+									this.log.warn("Got negative Energy value [" + number + "] for query: " + query);
+									value = JsonNull.INSTANCE;
+								} else {
+									value = new JsonPrimitive(number);
+								}
+							} else {
+								value = new JsonPrimitive(valueObj.toString());
+							}
+							map.put(address, value);
+						}
+					}
+
+				}
+			}
+		}
+
+		// Check if all values are null
+		var areAllValuesNull = true;
+		for (JsonElement value : map.values()) {
+			if (!value.isJsonNull()) {
+				areAllValuesNull = false;
+				break;
+			}
+		}
+		if (areAllValuesNull) {
+			throw new OpenemsException("Energy values are not available for query: " + query);
+		}
+
+		return map;
+	}
+
+	protected String toChannelAddressStringData(Set<ChannelAddress> channels) throws OpenemsException {
+		ArrayList<String> channelAddresses = new ArrayList<>();
+		for (ChannelAddress channel : channels) {
+			channelAddresses.add("MEAN(\"" + channel.toString() + "\") AS \"" + channel.toString() + "\"");
+		}
+		return String.join(", ", channelAddresses);
+	}
+
+	protected String toChannelAddressStringDataLast(Set<ChannelAddress> channels) throws OpenemsException {
+		ArrayList<String> channelAddresses = new ArrayList<>();
+		for (ChannelAddress channel : channels) {
+			channelAddresses.add("LAST(\"" + channel.toString() + "\") AS \"" + channel.toString() + "\"");
+		}
+		return String.join(", ", channelAddresses);
+	}
+
+	protected String toChannelAddressStringEnergy(Set<ChannelAddress> channels) throws OpenemsException {
+		ArrayList<String> channelAddresses = new ArrayList<>();
+		for (var channel : channels) {
+			channelAddresses.add("LAST(\"" + channel.toString() + "\") - FIRST(\"" + channel.toString() + "\") AS \""
+					+ channel.toString() + "\"");
+		}
+		return String.join(", ", channelAddresses);
+	}
+
+	protected String toChannelAddressStringNonNegativeDifferenceLast(Set<ChannelAddress> channels)
+			throws OpenemsException {
+		ArrayList<String> channelAddresses = new ArrayList<>();
+		for (var channel : channels) {
+			channelAddresses.add(
+					"NON_NEGATIVE_DIFFERENCE(LAST(\"" + channel.toString() + "\")) AS \"" + channel.toString() + "\"");
+		}
+		return String.join(", ", channelAddresses);
+	}
+
+}


### PR DESCRIPTION
FluxQL raises performance issues on systems with high load. Especially the loading of the history view is significantly slower with FLUXQL as it is with InfluxQL. The new java influx library supports both ways to access an influx DB. This pull requests adds functionality to configure which query language should be used. It
* adds a configuration option to backend/timedata/influx/Config.java (with configuration backward compatibility)
* adds a configuration option to edge/timedata/influxdb/Config.java (with configuration backward compatibility)
* io.openems/shared/influxdb 
** is splitted into an Interface InfluxConnector
** a Common and a FluxQL implementation
** added a InfluxQL implementation
Notes:
* provide a getLatestValue implementation also
* FluxQL should have only very minor changes in InfluxConnectorFluxQL:queryChannelValuesMap. The hardcoded DB name "db/default" is now configurable. Also the data fetch range is increased from "-5m" to "-16m" (fix UI history display issue for systems which update DB channels only every 15min).