### PR TITLE
proposal version for a new EVCS API (v2)

### DIFF
--- a/io.openems.edge.evcs.api/readme.adoc
+++ b/io.openems.edge.evcs.api/readme.adoc
@@ -1,5 +1,12 @@
 = EVCS (Electric Vehicle Charging Station)
 
 link:https://github.com/OpenEMS/openems/blob/develop/io.openems.edge.evcs.api/src/io/openems/edge/evcs/api/Evcs.java[Evcs icon:code[]]::
-A charging station for electric vehicles like e-cars and e-buses.
-// TODO add channels
+A charging station for electric vehicles like e-cars and e-buses (read only).
+
+link:https://github.com/OpenEMS/openems/blob/develop/io.openems.edge.evcs.api/src/io/openems/edge/evcs/api/ManagedEvcs.java[ManagedEvcs icon:code[]]::
+A controllable charging station.
+
+link:https://github.com/OpenEMS/openems/blob/develop/io.openems.edge.evcs.api/src/io/openems/edge/evcs/api/SocEvcs.java[SocEvcs icon:code[]]::
+A charging station able of providing the vehicle batteries State-of-Charge. 
+
+https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.evcs.api[Source Code icon:github[]]

--- a/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/ChargingType.java
+++ b/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/ChargingType.java
@@ -1,0 +1,46 @@
+package io.openems.edge.evcs.v2.api;
+
+import io.openems.common.types.OptionsEnum;
+
+public enum ChargingType implements OptionsEnum {
+
+    /**
+     * Plug type is unkown.
+     */
+    UNDEFINED(-1, "Undefined"), //
+    /**
+     * Plugs using the Combined Charging System standard.
+     */
+    CCS(0, "CCS"), //
+    /**
+     * Plugs using the Chademo standard.
+     */
+    CHADEMO(1, "Chademo"), //
+    /**
+     * general AC Plugs.
+     */
+    AC(2, "AC");
+
+    private final int value;
+    private final String name;
+
+    private ChargingType(int value, String name) {
+	this.value = value;
+	this.name = name;
+    }
+
+    @Override
+    public int getValue() {
+	return this.value;
+    }
+
+    @Override
+    public String getName() {
+	return this.name;
+    }
+
+    @Override
+    public OptionsEnum getUndefined() {
+	return UNDEFINED;
+    }
+}

--- a/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/Evcs.java
+++ b/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/Evcs.java
@@ -1,0 +1,846 @@
+package io.openems.edge.evcs.v2.api;
+
+import java.util.function.Consumer;
+
+import io.openems.common.channel.AccessMode;
+import io.openems.common.channel.Level;
+import io.openems.common.channel.PersistencePriority;
+import io.openems.common.channel.Unit;
+import io.openems.common.types.OpenemsType;
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.EnumReadChannel;
+import io.openems.edge.common.channel.IntegerReadChannel;
+import io.openems.edge.common.channel.LongReadChannel;
+import io.openems.edge.common.channel.StateChannel;
+import io.openems.edge.common.channel.value.Value;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.modbusslave.ModbusSlaveNatureTable;
+import io.openems.edge.common.modbusslave.ModbusType;
+import io.openems.edge.common.type.TypeUtils;
+
+public interface Evcs extends OpenemsComponent {
+
+    public static final Integer DEFAULT_MAXIMUM_HARDWARE_POWER = 22_080; // W
+    public static final Integer DEFAULT_MINIMUM_HARDWARE_POWER = 4_140; // W
+    public static final Integer DEFAULT_MAXIMUM_HARDWARE_CURRENT = 32_000; // mA
+    public static final Integer DEFAULT_MINIMUM_HARDWARE_CURRENT = 6_000; // mA
+    public static final Integer DEFAULT_VOLTAGE = 230; // V
+    public static final int DEFAULT_POWER_RECISION = 230;
+
+    public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+
+	/**
+	 * Status.
+	 *
+	 * <p>
+	 * The Status of the EVCS charging station.
+	 *
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Type: Status @see {@link Status}
+	 * </ul>
+	 */
+	STATUS(Doc.of(Status.values()) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+
+	/**
+	 * Charge Power.
+	 *
+	 * <p>
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Type: Integer
+	 * <li>Unit: W
+	 * </ul>
+	 */
+	CHARGE_POWER(Doc.of(OpenemsType.INTEGER) //
+		.unit(Unit.WATT).accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+
+	/**
+	 * Minimum Power this hardware needs to run.
+	 * 
+	 * <p>
+	 * The power is always given for all three phases. If MinimumPower = 4140W
+	 * (3*1380W) and a vehicle charges on 2 phases than the MinimumPower the EVCS
+	 * uses is 2706W (2*1380W).
+	 *
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Type: Integer
+	 * <li>Unit: W
+	 * </ul>
+	 */
+	MINIMUM_POWER(Doc.of(OpenemsType.INTEGER) //
+		.unit(Unit.WATT) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+
+	/**
+	 * Maximum Power defined by software.
+	 *
+	 * <p>
+	 * The power is always given for all three phases. If MaximumPower = 22080W
+	 * (3*73600W) and a vehicle charges on 2 phases than the MaximumPower for this
+	 * EVCS is 14720W (2*7360W).
+	 * 
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Type: Integer
+	 * <li>Unit: W
+	 * </ul>
+	 */
+	MAXIMUM_POWER(Doc.of(OpenemsType.INTEGER) //
+		.unit(Unit.WATT) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+
+	/**
+	 * Charging Type.
+	 *
+	 * <p>
+	 * Type of charging.
+	 *
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Type: ChargingType @see {@link ChargingType}
+	 * </ul>
+	 */
+	CHARGING_TYPE(Doc.of(ChargingType.values()) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+
+	/**
+	 * Current.
+	 *
+	 * <p>
+	 * The current for all three phases in mA.
+	 * 
+	 * <p>
+	 * See Evcs.initializeCurrentSumChannels() also.
+	 *
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Type: Integer
+	 * <li>Unit: Milliampere
+	 * </ul>
+	 */
+	CURRENT(Doc.of(OpenemsType.INTEGER) //
+		.unit(Unit.MILLIAMPERE) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)),
+
+	/**
+	 * CurrentL1.
+	 *
+	 * <p>
+	 * The current for phase L1.
+	 * 
+	 * <p>
+	 * In charge parks the phases of chargepoints are rotated when installed. Thus a
+	 * chargepoint measures current on L1 but it may actually be connected to L2 or
+	 * L3.
+	 * 
+	 * <p>
+	 * CurrentL1 needs to reflect the real phase L1, thus the driver is responsible
+	 * to rotating the phases before updating this channel. Thus the controller
+	 * using this channel can always trust that CURRENT_L1 reflects the current on
+	 * Phase 1.
+	 * 
+	 * <p>
+	 * chargepoint driver developer may use the following helper method:
+	 * this.getPhaseRotation().getFirstPhase()
+	 * 
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Type: Integer
+	 * <li>Unit: Milliampere
+	 * </ul>
+	 */
+	CURRENT_L1(Doc.of(OpenemsType.INTEGER) //
+		.unit(Unit.MILLIAMPERE) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)),
+
+	/**
+	 * CurrentL2.
+	 *
+	 * <p>
+	 * The current for phase L2.
+	 * 
+	 * <p>
+	 * In charge parks the phases of chargepoints are rotated when installed. Thus a
+	 * chargepoint measures current on L2 but it may actually be connected to L2 or
+	 * L3.
+	 * 
+	 * <p>
+	 * CurrentL2 needs to reflect the real phase L2, thus the driver is responsible
+	 * to rotating the phases before updating this channel. Thus the controller
+	 * using this channel can always trust that CURRENT_L2 reflects the current on
+	 * Phase 1.
+	 * 
+	 * <p>
+	 * chargepoint driver developer may use the following helper method:
+	 * this.getPhaseRotation().getFirstPhase()
+	 * 
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Type: Integer
+	 * <li>Unit: Milliampere
+	 * </ul>
+	 */
+	CURRENT_L2(Doc.of(OpenemsType.INTEGER) //
+		.unit(Unit.MILLIAMPERE) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)),
+
+	/**
+	 * CurrentL3.
+	 *
+	 * <p>
+	 * The current for phase L3.
+	 * 
+	 * <p>
+	 * In charge parks the phases of chargepoints are rotated when installed. Thus a
+	 * chargepoint measures current on L3 but it may actually be connected to L3 or
+	 * L3.
+	 * 
+	 * <p>
+	 * CurrentL3 needs to reflect the real phase L3, thus the driver is responsible
+	 * to rotating the phases before updating this channel. Thus the controller
+	 * using this channel can always trust that CURRENT_L3 reflects the current on
+	 * Phase 1.
+	 * 
+	 * <p>
+	 * chargepoint driver developer may use the following helper method:
+	 * this.getPhaseRotation().getFirstPhase()
+	 * 
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Type: Integer
+	 * <li>Unit: Milliampere
+	 * </ul>
+	 */
+	CURRENT_L3(Doc.of(OpenemsType.INTEGER) //
+		.unit(Unit.MILLIAMPERE) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)),
+
+	/**
+	 * Count of phases, the EV is charging with.
+	 *
+	 * <p>
+	 * This value is derived from the charging station or calculated during the
+	 * charging. When this value is set, the minimum and maximum limits are set at
+	 * the same time if the EVCS is a {@link ManagedEvcs}.
+	 * 
+	 * <p>
+	 * phases must be set to 3 if undefined or unclear.
+	 * 
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Type: Phases @see @link {@link Phases}
+	 * </ul>
+	 */
+	PHASES(Doc.of(Phases.values()) //
+		.debounce(5) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+
+	/**
+	 * Phase Rotation.
+	 * 
+	 * <p>
+	 * In charge parks the phases of chargepoints are rotated when installed. This
+	 * reduces phase shifting load when the majority of vehicles charge with only
+	 * 2phase or less. Channel provides information on the phase rotation of this
+	 * chargepoint.
+	 *
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Type: PhaseRotation @see {@link PhaseRotation}
+	 * </ul>
+	 */
+	PHASE_ROTATION(Doc.of(PhaseRotation.values()) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+
+	/**
+	 * Energy that was charged during the current or last Session.
+	 *
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Type: Integer
+	 * <li>Unit: Wh
+	 * </ul>
+	 */
+	ENERGY_SESSION(Doc.of(OpenemsType.INTEGER) //
+		.unit(Unit.WATT_HOURS) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+
+	/**
+	 * Active Consumption Energy.
+	 *
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Type: Integer
+	 * <li>Unit: Wh
+	 * </ul>
+	 */
+	ACTIVE_CONSUMPTION_ENERGY(Doc.of(OpenemsType.LONG) //
+		.unit(Unit.WATT_HOURS) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+
+	/**
+	 * Failed state channel for a failed communication to the EVCS.
+	 *
+	 * <ul>
+	 * <li>Interface: Evcs
+	 * <li>Readable
+	 * <li>Level: FAULT
+	 * </ul>
+	 */
+	COMMUNICATION_FAILED(Doc.of(Level.FAULT) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)); //
+
+	private final Doc doc;
+
+	private ChannelId(Doc doc) {
+	    this.doc = doc;
+	}
+
+	@Override
+	public Doc doc() {
+	    return this.doc;
+	}
+    }
+
+    /**
+     * Initializes Channel listeners to sum current for L1 + L2 + L3 and add the
+     * value to the current channel.
+     *
+     * @param evcs the {@link Evcs}
+     */
+    public static void initializeCurrentSumChannels(Evcs evcs) {
+	final Consumer<Value<Integer>> currentSum = ignore -> {
+	    evcs._setCurrent(TypeUtils.sum(//
+		    evcs.getCurrentL1Channel().getNextValue().get(), //
+		    evcs.getCurrentL2Channel().getNextValue().get(), //
+		    evcs.getCurrentL3Channel().getNextValue().get())); //
+	};
+	evcs.getCurrentL1Channel().onSetNextValue(currentSum);
+	evcs.getCurrentL2Channel().onSetNextValue(currentSum);
+	evcs.getCurrentL3Channel().onSetNextValue(currentSum);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#STATUS}.
+     *
+     * @return the Channel
+     */
+    public default Channel<Status> getStatusChannel() {
+	return this.channel(ChannelId.STATUS);
+    }
+
+    /**
+     * Gets the Status of the EVCS charging station. See {@link ChannelId#STATUS}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Status getStatus() {
+	return this.getStatusChannel().value().asEnum();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#STATUS} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setStatus(Status value) {
+	this.getStatusChannel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#CHARGE_POWER}.
+     *
+     * @return the Channel
+     */
+    public default IntegerReadChannel getChargePowerChannel() {
+	return this.channel(ChannelId.CHARGE_POWER);
+    }
+
+    /**
+     * Gets the Charge Power in [W]. See {@link ChannelId#CHARGE_POWER}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getChargePower() {
+	return this.getChargePowerChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#CHARGE_POWER}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setChargePower(Integer value) {
+	this.getChargePowerChannel().setNextValue(value);
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#CHARGE_POWER}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setChargePower(int value) {
+	this.getChargePowerChannel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#MAXIMUM_POWER}.
+     *
+     * @return the Channel
+     */
+    public default IntegerReadChannel getMaximumPowerChannel() {
+	return this.channel(ChannelId.MAXIMUM_POWER);
+    }
+
+    /**
+     * Gets the Maximum Power valid by software in [W]. See
+     * {@link ChannelId#MAXIMUM_POWER}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getMaximumPower() {
+	return this.getMaximumPowerChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#MAXIMUM_POWER}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setMaximumPower(Integer value) {
+	this.getMaximumPowerChannel().setNextValue(value);
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#MAXIMUM_POWER}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setMaximumPower(int value) {
+	this.getMaximumPowerChannel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#MINIMUM_POWER}.
+     *
+     * @return the Channel
+     */
+    public default IntegerReadChannel getMinimumPowerChannel() {
+	return this.channel(ChannelId.MINIMUM_POWER);
+    }
+
+    /**
+     * Gets the Minimum Power valid by software in [W]. See
+     * {@link ChannelId#MINIMUM_POWER}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getMinimumPower() {
+	return this.getMinimumPowerChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#MINIMUM_POWER}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setMinimumPower(Integer value) {
+	this.getMinimumPowerChannel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#CHARGING_TYPE}.
+     *
+     * @return the Channel
+     */
+    public default Channel<ChargingType> getChargingTypeChannel() {
+	return this.channel(ChannelId.CHARGING_TYPE);
+    }
+
+    /**
+     * Gets the Type of charging. See {@link ChannelId#CHARGING_TYPE}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default ChargingType getChargingType() {
+	return this.getChargingTypeChannel().value().asEnum();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#CHARGING_TYPE}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setChargingType(ChargingType value) {
+	this.getChargingTypeChannel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#CURRENT}.
+     *
+     * @return the Channel
+     */
+    public default IntegerReadChannel getCurrentChannel() {
+	return this.channel(ChannelId.CURRENT);
+    }
+
+    /**
+     * Gets the Current. See {@link ChannelId#MINIMUM_POWER}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getCurrent() {
+	return this.getCurrentChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#CURRENT} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setCurrent(Integer value) {
+	this.getCurrentChannel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#CURRENT_L1}.
+     *
+     * @return the Channel
+     */
+    public default IntegerReadChannel getCurrentL1Channel() {
+	return this.channel(ChannelId.CURRENT_L1);
+    }
+
+    /**
+     * Gets the Current. See {@link ChannelId#CURRENT_L1}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getCurrentL1() {
+	return this.getCurrentL1Channel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#CURRENT_L1}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setCurrentL1(Integer value) {
+	this.getCurrentL1Channel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#CURRENT_L2}.
+     *
+     * @return the Channel
+     */
+    public default IntegerReadChannel getCurrentL2Channel() {
+	return this.channel(ChannelId.CURRENT_L2);
+    }
+
+    /**
+     * Gets the Current. See {@link ChannelId#CURRENT_L2}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getCurrentL2() {
+	return this.getCurrentL2Channel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#CURRENT_L3}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setCurrentL2(Integer value) {
+	this.getCurrentL2Channel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#CURRENT_L3}.
+     *
+     * @return the Channel
+     */
+    public default IntegerReadChannel getCurrentL3Channel() {
+	return this.channel(ChannelId.CURRENT_L3);
+    }
+
+    /**
+     * Gets the Current. See {@link ChannelId#CURRENT_L3}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getCurrentL3() {
+	return this.getCurrentL3Channel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#CURRENT_L3}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setCurrentL3(Integer value) {
+	this.getCurrentL3Channel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#PHASES}.
+     *
+     * @return the Channel
+     */
+    public default EnumReadChannel getPhasesChannel() {
+	return this.channel(ChannelId.PHASES);
+    }
+
+    /**
+     * Gets the current Phases definition. See {@link ChannelId#PHASES}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Phases getPhases() {
+	return this.getPhasesChannel().value().asEnum();
+    }
+
+    /**
+     * Gets the Count of phases, the EV is charging with. See
+     * {@link ChannelId#PHASES}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default int getPhasesAsInt() {
+	return this.getPhasesChannel().value().asEnum().getValue();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#PHASES} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setPhases(Phases value) {
+	this.getPhasesChannel().setNextValue(value);
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#PHASES} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setPhases(Integer value) {
+	if (value == null) {
+	    this._setPhases(Phases.THREE_PHASE);
+	    return;
+	}
+	switch (value) {
+	case 1:
+	    this._setPhases(Phases.ONE_PHASE);
+	    break;
+	case 2:
+	    this._setPhases(Phases.TWO_PHASE);
+	    break;
+	case 3:
+	    this._setPhases(Phases.THREE_PHASE);
+	    break;
+	default:
+	    throw new IllegalArgumentException("Value [" + value + "] for _setPhases is invalid");
+	}
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#PHASE_ROTATION}.
+     *
+     * @return the Channel
+     */
+    public default EnumReadChannel getPhaseRotationChannel() {
+	return this.channel(ChannelId.PHASE_ROTATION);
+    }
+
+    /**
+     * Gets the current PhaseRotation. See {@link ChannelId#PHASE_ROTATION}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Phases getPhaseRotation() {
+	return this.getPhaseRotationChannel().value().asEnum();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#PHASES} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setPhaseRotation(PhaseRotation value) {
+	this.getPhaseRotationChannel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#ENERGY_SESSION}.
+     *
+     * @return the Channel
+     */
+    public default IntegerReadChannel getEnergySessionChannel() {
+	return this.channel(ChannelId.ENERGY_SESSION);
+    }
+
+    /**
+     * Gets the Energy that was charged during the current or last Session in [Wh].
+     * See {@link ChannelId#ENERGY_SESSION}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getEnergySession() {
+	return this.getEnergySessionChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#ENERGY_SESSION}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setEnergySession(Integer value) {
+	this.getEnergySessionChannel().setNextValue(value);
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#ENERGY_SESSION}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setEnergySession(int value) {
+	this.getEnergySessionChannel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#ACTIVE_CONSUMPTION_ENERGY}.
+     *
+     * @return the Channel
+     */
+    public default LongReadChannel getActiveConsumptionEnergyChannel() {
+	return this.channel(ChannelId.ACTIVE_CONSUMPTION_ENERGY);
+    }
+
+    /**
+     * Gets the Active Consumption Energy in [Wh]. This relates to negative
+     * ACTIVE_POWER. See {@link ChannelId#ACTIVE_CONSUMPTION_ENERGY}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Long> getActiveConsumptionEnergy() {
+	return this.getActiveConsumptionEnergyChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on
+     * {@link ChannelId#ACTIVE_CONSUMPTION_ENERGY} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setActiveConsumptionEnergy(Long value) {
+	this.getActiveConsumptionEnergyChannel().setNextValue(value);
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on
+     * {@link ChannelId#ACTIVE_CONSUMPTION_ENERGY} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setActiveConsumptionEnergy(long value) {
+	this.getActiveConsumptionEnergyChannel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#COMMUNICATION_FAILED}.
+     *
+     * @return the Channel
+     */
+    public default StateChannel getCommunicationFailedChannel() {
+	return this.channel(ChannelId.COMMUNICATION_FAILED);
+    }
+
+    /**
+     * Gets the Failed state channel for a failed communication to the EVCS. See
+     * {@link ChannelId#COMMUNICATION_FAILED}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Boolean> getCommunicationFailed() {
+	return this.getCommunicationFailedChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on
+     * {@link ChannelId#COMMUNICATION_FAILED} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setCommunicationFailed(boolean value) {
+	this.getCommunicationFailedChannel().setNextValue(value);
+    }
+
+    /**
+     * Used for Modbus/TCP Api Controller. Provides a Modbus table for the Channels
+     * of this Component.
+     *
+     * @param accessMode filters the Modbus-Records that should be shown
+     * @return the {@link ModbusSlaveNatureTable}
+     */
+    public static ModbusSlaveNatureTable getModbusSlaveNatureTable(AccessMode accessMode) {
+	return ModbusSlaveNatureTable.of(Evcs.class, accessMode, 100) //
+		.channel(0, ChannelId.STATUS, ModbusType.UINT16) //
+		.channel(1, ChannelId.CHARGE_POWER, ModbusType.UINT16) //
+		.channel(2, ChannelId.CHARGING_TYPE, ModbusType.UINT16) //
+		.channel(3, ChannelId.PHASES, ModbusType.UINT16) //
+		.channel(4, ChannelId.MINIMUM_POWER, ModbusType.UINT16) //
+		.channel(5, ChannelId.MAXIMUM_POWER, ModbusType.UINT16) //
+		.channel(6, ChannelId.ENERGY_SESSION, ModbusType.UINT16) //
+		.channel(7, ChannelId.COMMUNICATION_FAILED, ModbusType.UINT16) //
+		.channel(8, ChannelId.ACTIVE_CONSUMPTION_ENERGY, ModbusType.UINT16) //
+		.channel(9, ChannelId.CURRENT, ModbusType.UINT16) //
+		.channel(10, ChannelId.CURRENT_L1, ModbusType.UINT16) //
+		.channel(11, ChannelId.CURRENT_L2, ModbusType.UINT16) //
+		.channel(12, ChannelId.CURRENT_L3, ModbusType.UINT16) //
+		.channel(13, ChannelId.PHASE_ROTATION, ModbusType.UINT16) //
+		.build();
+    }
+}

--- a/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/EvcsPower.java
+++ b/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/EvcsPower.java
@@ -1,0 +1,20 @@
+package io.openems.edge.evcs.v2.api;
+
+import io.openems.edge.common.filter.RampFilter;
+
+public interface EvcsPower {
+
+	/**
+	 * Gets the RampFilter instance with the configured variables.
+	 *
+	 * @return an instance of {@link RampFilter}
+	 */
+	public RampFilter getRampFilter();
+
+	/**
+	 * Gets the current increase rate.
+	 *
+	 * @return increase rate
+	 */
+	public float getIncreaseRate();
+}

--- a/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/ManagedEvcs.java
+++ b/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/ManagedEvcs.java
@@ -1,0 +1,531 @@
+package io.openems.edge.evcs.v2.api;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+import io.openems.common.channel.AccessMode;
+import io.openems.common.channel.PersistencePriority;
+import io.openems.common.channel.Unit;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.types.OpenemsType;
+import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.EnumReadChannel;
+import io.openems.edge.common.channel.EnumWriteChannel;
+import io.openems.edge.common.channel.IntegerReadChannel;
+import io.openems.edge.common.channel.IntegerWriteChannel;
+import io.openems.edge.common.channel.value.Value;
+import io.openems.edge.common.modbusslave.ModbusSlaveNatureTable;
+import io.openems.edge.common.modbusslave.ModbusType;
+
+@ProviderType
+public interface ManagedEvcs extends Evcs {
+
+    public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+
+	/**
+	 * Gets the smallest power steps that can be set (given in mW).
+	 *
+	 * <p>
+	 * Example:
+	 * <ul>
+	 * <li>KEBA-series allows setting of milli Ampere. It should return 230 mW
+	 * (0.001A * 230V).
+	 * <li>Hardy Barth allows setting in Ampere. It should return 230.000 mW (1A *
+	 * 230V).
+	 * </ul>
+	 *
+	 * <p>
+	 * <ul>
+	 * <li>Interface: ManagedEvcs
+	 * <li>Writable
+	 * <li>Type: Integer
+	 * <li>Unit: mW
+	 * </ul>
+	 */
+	POWER_PRECISION(Doc.of(OpenemsType.INTEGER) //
+		.unit(Unit.MILLIWATT) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+
+	/**
+	 * Gets a rough estimation of the time precision the chargepoint has.
+	 * 
+	 * <p>
+	 * It is the time in ms between setting charge power and the time the charge
+	 * power is applied to the vehicle. Some chargepoints react within milliseconds
+	 * and some within 30s. This allows some controllers to work with cloud based
+	 * chargepoints as well.
+	 * 
+	 * <p>
+	 * Note that this is only a very rough estimate. It depends on used connection
+	 * and on the response time of vehicles also.
+	 * 
+	 * <p>
+	 * <ul>
+	 * <li>Interface: ManagedEvcs
+	 * <li>Read Only
+	 * <li>Type: Integer
+	 * <li>Unit: Milliseconds
+	 * </ul>
+	 */
+
+	TIME_PRECISION(Doc.of(OpenemsType.INTEGER) //
+		.unit(Unit.MILLISECONDS) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.LOW)),
+
+	/**
+	 * Debug readonly Priority of this EVCS.
+	 *
+	 * <ul>
+	 * <li>Interface: ManagedEvcs
+	 * <li>ReadOnly
+	 * <li>Type: Priority @see {@link Priority}
+	 * </ul>
+	 */
+	DEBUG_PRIORITY(Doc.of(Priority.values()) //
+		.accessMode(AccessMode.READ_ONLY) //
+		.persistencePriority(PersistencePriority.LOW)),
+
+	/**
+	 * Priority of this EVCS.
+	 *
+	 * <ul>
+	 * <li>Interface: ManagedEvcs
+	 * <li>Writable
+	 * <li>Type: Priority @see {@link Priority}
+	 * </ul>
+	 */
+	PRIORITY(Doc.of(Priority.values()) //
+		.accessMode(AccessMode.READ_WRITE) //
+		.persistencePriority(PersistencePriority.LOW)
+		.onInit(new EnumWriteChannel.MirrorToDebugChannel(ManagedEvcs.ChannelId.DEBUG_PRIORITY))), //
+
+	/**
+	 * Sets the charge power limit of the EVCS in [W].
+	 *
+	 * <ul>
+	 * <li>Interface: ManagedEvcs
+	 * <li>Writable
+	 * <li>Type: Integer
+	 * <li>Unit: W
+	 * </ul>
+	 */
+	SET_CHARGE_POWER_EQUALS(Doc.of(OpenemsType.INTEGER).unit(Unit.WATT) //
+		.accessMode(AccessMode.WRITE_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+	// TODO when PowerObject is working -> onInit(new PowerConstraint(...)), siehe
+	// ManagedSymmetricEss
+
+	/**
+	 * Sets the charge power limit of the EVCS in [W].
+	 *
+	 * <ul>
+	 * <li>Interface: ManagedEvcs
+	 * <li>Writable
+	 * <li>Type: Integer
+	 * <li>Unit: W
+	 * </ul>
+	 */
+	SET_CHARGE_POWER_EQUALS_WITH_FILTER(Doc.of(OpenemsType.INTEGER) //
+		.unit(Unit.WATT) //
+		.accessMode(AccessMode.WRITE_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+	// TODO when PowerObject is working -> onInit(new PowerConstraint(...)), siehe
+	// ManagedSymmetricEss
+
+	/**
+	 * Sets the charge power limit of the EVCS in [W].
+	 *
+	 * <ul>
+	 * <li>Interface: ManagedEvcs
+	 * <li>Writable
+	 * <li>Type: Integer
+	 * <li>Unit: W
+	 * </ul>
+	 */
+	SET_CHARGE_POWER_LESS_OR_EQUALS(Doc.of(OpenemsType.INTEGER).unit(Unit.WATT) //
+		.accessMode(AccessMode.WRITE_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+	// TODO when PowerObject is working -> onInit(new PowerConstraint(...)), siehe
+	// ManagedSymmetricEss
+
+	/**
+	 * Sets the charge power limit of the EVCS in [W].
+	 *
+	 * <ul>
+	 * <li>Interface: ManagedEvcs
+	 * <li>Writable
+	 * <li>Type: Integer
+	 * <li>Unit: W
+	 * </ul>
+	 */
+	SET_CHARGE_POWER_GREATER_OR_EQUALS(Doc.of(OpenemsType.INTEGER).unit(Unit.WATT) //
+		.accessMode(AccessMode.WRITE_ONLY) //
+		.persistencePriority(PersistencePriority.HIGH)), //
+	// TODO when PowerObject is working -> onInit(new PowerConstraint(...)), siehe
+	// ManagedSymmetricEss
+
+	;
+
+	private final Doc doc;
+
+	private ChannelId(Doc doc) {
+	    this.doc = doc;
+	}
+
+	@Override
+	public Doc doc() {
+	    return this.doc;
+	}
+    }
+
+    /**
+     * Command to send the given power, to the EVCS.
+     * 
+     * @param power Power that should be send in watt
+     * @return boolean if the power was applied to the EVCS
+     * @throws OpenemsException on error
+     */
+    public boolean applyChargePower(int power) throws Exception;
+
+    /**
+     * Get the corresponding {@link EvcsPower} for this EVCS.
+     * 
+     * @return the {@link EvcsPower}
+     */
+    public EvcsPower getEvcsPower();
+
+    /**
+     * Gets the Channel for {@link ChannelId#POWER_PRECISION}.
+     *
+     * @return the Channel
+     */
+    public default IntegerReadChannel getPowerPrecisionChannel() {
+	return this.channel(ChannelId.POWER_PRECISION);
+    }
+
+    /**
+     * Gets the power precision value of the EVCS in [W]. See
+     * {@link ChannelId#POWER_PRECISION}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getPowerPrecision() {
+	return this.getPowerPrecisionChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#POWER_PRECISION}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setPowerPrecision(Integer value) {
+	this.getPowerPrecisionChannel().setNextValue(value);
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#POWER_PRECISION}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setPowerPrecision(int value) {
+	this.getPowerPrecisionChannel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#TIME_PRECISION}.
+     *
+     * @return the Channel
+     */
+    public default IntegerReadChannel getTimePrecisionChannel() {
+	return this.channel(ChannelId.TIME_PRECISION);
+    }
+
+    /**
+     * Gets the time precision value of the EVCS in [ms]. See
+     * {@link ChannelId#TIME_PRECISION}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getTimePrecision() {
+	return this.getTimePrecisionChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#TIME_PRECISION}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setTimePrecision(Integer value) {
+	this.getTimePrecisionChannel().setNextValue(value);
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#TIME_PRECISION}
+     * Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setTimePrecision(int value) {
+	this.getTimePrecisionChannel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#PRIORITY}.
+     *
+     * @return the Channel
+     */
+    public default EnumReadChannel getPriorityChannel() {
+	return this.channel(ChannelId.PRIORITY);
+    }
+
+    /**
+     * Gets the priority of the EVCS in [ms]. See {@link ChannelId#PRIORITY}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getPriority() {
+	return this.getPriorityChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#PRIORITY} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setPriority(Integer value) {
+	this.getPriorityChannel().setNextValue(value);
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on {@link ChannelId#PRIORITY} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setPriority(int value) {
+	this.getPriorityChannel().setNextValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#SET_CHARGE_POWER_EQUALS}.
+     *
+     * @return the Channel
+     */
+    public default IntegerWriteChannel getSetChargePowerLimitEqualsChannel() {
+	return this.channel(ChannelId.SET_CHARGE_POWER_EQUALS);
+    }
+
+    /**
+     * Gets the set charge power limit of the EVCS in [W]. See
+     * {@link ChannelId#SET_CHARGE_POWER_EQUALS}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getSetChargePowerLimitEquals() {
+	return this.getSetChargePowerLimitEqualsChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on
+     * {@link ChannelId#SET_CHARGE_POWER_EQUALS} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setSetChargePowerLimitEquals(Integer value) {
+	this.getSetChargePowerLimitEqualsChannel().setNextValue(value);
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on
+     * {@link ChannelId#SET_CHARGE_POWER_EQUALS} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setSetChargePowerLimitEquals(int value) {
+	this.getSetChargePowerLimitEqualsChannel().setNextValue(value);
+    }
+
+    /**
+     * Sets the charge power limit of the EVCS in [W]. See
+     * {@link ChannelId#SET_CHARGE_POWER_EQUALS}.
+     *
+     * @param value the next write value
+     * @throws OpenemsNamedException on error
+     */
+    public default void setChargePowerLimitEquals(Integer value) throws OpenemsNamedException {
+	this.getSetChargePowerLimitEqualsChannel().setNextWriteValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#SET_CHARGE_POWER_EQUALS_WITH_FILTER}.
+     *
+     * @return the Channel
+     */
+    public default IntegerWriteChannel getSetChargePowerLimitEqualsWithFilterChannel() {
+	return this.channel(ChannelId.SET_CHARGE_POWER_EQUALS_WITH_FILTER);
+    }
+
+    /**
+     * Gets the set charge power limit of the EVCS in [W]. See
+     * {@link ChannelId#SET_CHARGE_POWER_EQUALS_WITH_FILTER}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getSetChargePowerLimitEqualsWithFilter() {
+	return this.getSetChargePowerLimitEqualsWithFilterChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on
+     * {@link ChannelId#SET_CHARGE_POWER_EQUALS_WITH_FILTER} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setSetChargePowerLimitEqualsWithFilter(Integer value) {
+	this.getSetChargePowerLimitEqualsWithFilterChannel().setNextValue(value);
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on
+     * {@link ChannelId#SET_CHARGE_POWER_EQUALS_WITH_FILTER} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setSetChargePowerLimitEqualsWithFilter(int value) {
+	this.getSetChargePowerLimitEqualsWithFilterChannel().setNextValue(value);
+    }
+
+    /**
+     * Sets the charge power limit of the EVCS in [W]. See
+     * {@link ChannelId#SET_CHARGE_POWER_EQUALS_WITH_FILTER}.
+     *
+     * @param value the next write value
+     * @throws OpenemsNamedException on error
+     */
+    public default void setChargePowerLimitEqualsWithFilter(Integer value) throws OpenemsNamedException {
+	this.getSetChargePowerLimitEqualsWithFilterChannel().setNextWriteValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#SET_CHARGE_POWER_LESS_OR_EQUALS}.
+     *
+     * @return the Channel
+     */
+    public default IntegerWriteChannel getSetChargePowerLimitLessOrEqualsChannel() {
+	return this.channel(ChannelId.SET_CHARGE_POWER_LESS_OR_EQUALS);
+    }
+
+    /**
+     * Gets the set charge power limit of the EVCS in [W]. See
+     * {@link ChannelId#SET_CHARGE_POWER_LESS_OR_EQUALS}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getSetChargePowerLimitLessOrEquals() {
+	return this.getSetChargePowerLimitLessOrEqualsChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on
+     * {@link ChannelId#SET_CHARGE_POWER_LESS_OR_EQUALS} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setSetChargePowerLimitLessOrEquals(Integer value) {
+	this.getSetChargePowerLimitLessOrEqualsChannel().setNextValue(value);
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on
+     * {@link ChannelId#SET_CHARGE_POWER_LESS_OR_EQUALS} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setSetChargePowerLimitLessOrEquals(int value) {
+	this.getSetChargePowerLimitLessOrEqualsChannel().setNextValue(value);
+    }
+
+    /**
+     * Sets the charge power limit of the EVCS in [W]. See
+     * {@link ChannelId#SET_CHARGE_POWER_LESS_OR_EQUALS}.
+     *
+     * @param value the next write value
+     * @throws OpenemsNamedException on error
+     */
+    public default void setChargePowerLimitLessOrEquals(Integer value) throws OpenemsNamedException {
+	this.getSetChargePowerLimitLessOrEqualsChannel().setNextWriteValue(value);
+    }
+
+    /**
+     * Gets the Channel for {@link ChannelId#SET_CHARGE_POWER_GREATER_OR_EQUALS}.
+     *
+     * @return the Channel
+     */
+    public default IntegerWriteChannel getSetChargePowerLimitGreaterOrEqualsChannel() {
+	return this.channel(ChannelId.SET_CHARGE_POWER_GREATER_OR_EQUALS);
+    }
+
+    /**
+     * Gets the set charge power limit of the EVCS in [W]. See
+     * {@link ChannelId#SET_CHARGE_POWER_GREATER_OR_EQUALS}.
+     *
+     * @return the Channel {@link Value}
+     */
+    public default Value<Integer> getSetChargePowerLimitGreaterOrEquals() {
+	return this.getSetChargePowerLimitGreaterOrEqualsChannel().value();
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on
+     * {@link ChannelId#SET_CHARGE_POWER_GREATER_OR_EQUALS} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setSetChargePowerLimitGreaterOrEquals(Integer value) {
+	this.getSetChargePowerLimitGreaterOrEqualsChannel().setNextValue(value);
+    }
+
+    /**
+     * Internal method to set the 'nextValue' on
+     * {@link ChannelId#SET_CHARGE_POWER_GREATER_OR_EQUALS} Channel.
+     *
+     * @param value the next value
+     */
+    public default void _setSetChargePowerLimitGreaterOrEquals(int value) {
+	this.getSetChargePowerLimitGreaterOrEqualsChannel().setNextValue(value);
+    }
+
+    /**
+     * Sets the charge power limit of the EVCS in [W]. See
+     * {@link ChannelId#SET_CHARGE_POWER_GREATER_OR_EQUALS}.
+     *
+     * @param value the next write value
+     * @throws OpenemsNamedException on error
+     */
+    public default void setChargePowerLimitGreaterOrEquals(Integer value) throws OpenemsNamedException {
+	this.getSetChargePowerLimitGreaterOrEqualsChannel().setNextWriteValue(value);
+    }
+
+    /**
+     * Used for Modbus/TCP Api Controller. Provides a Modbus table for the Channels
+     * of this Component.
+     *
+     * @param accessMode filters the Modbus-Records that should be shown
+     * @return the {@link ModbusSlaveNatureTable}
+     */
+    public static ModbusSlaveNatureTable getModbusSlaveNatureTable(AccessMode accessMode) {
+	return ModbusSlaveNatureTable.of(ManagedEvcs.class, accessMode, 100) //
+		.channel(0, ChannelId.POWER_PRECISION, ModbusType.UINT16) //
+		.channel(1, ChannelId.TIME_PRECISION, ModbusType.UINT16) //
+		.channel(2, ChannelId.PRIORITY, ModbusType.UINT16) //
+		.channel(3, ChannelId.SET_CHARGE_POWER_EQUALS, ModbusType.UINT16) //
+		.channel(4, ChannelId.SET_CHARGE_POWER_EQUALS_WITH_FILTER, ModbusType.UINT16) //
+		.channel(5, ChannelId.SET_CHARGE_POWER_LESS_OR_EQUALS, ModbusType.UINT16) //
+		.channel(6, ChannelId.SET_CHARGE_POWER_GREATER_OR_EQUALS, ModbusType.UINT16) //
+		.build();
+    }
+}

--- a/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/PhaseRotation.java
+++ b/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/PhaseRotation.java
@@ -1,0 +1,71 @@
+package io.openems.edge.evcs.v2.api;
+
+import io.openems.common.types.OptionsEnum;
+import io.openems.edge.evcs.v2.api.Evcs.ChannelId;
+
+public enum PhaseRotation implements OptionsEnum {
+    /**
+     * EVCS which use standard hardware connection configuration.
+     * 
+     * <p>
+     * L1 is connect to L1,...
+     */
+    L1_L2_L3(1, "L1_L2_L3", Evcs.ChannelId.CURRENT_L1, Evcs.ChannelId.CURRENT_L2, Evcs.ChannelId.CURRENT_L3), //
+    /**
+     * EVCS which use a rotated hardware connection configuration.
+     * 
+     * <p>
+     * L1 is connect to L2,...
+     */
+    L2_L3_L1(1, "L2_L3_L1", Evcs.ChannelId.CURRENT_L2, Evcs.ChannelId.CURRENT_L3, Evcs.ChannelId.CURRENT_L1), //
+    /**
+     * EVCS which use a rotated hardware connection configuration.
+     * 
+     * <p>
+     * L1 is connect to L3,...
+     */
+    L3_L1_L2(1, "L3_L1_L2", Evcs.ChannelId.CURRENT_L3, Evcs.ChannelId.CURRENT_L1, Evcs.ChannelId.CURRENT_L2);
+
+    private final int value;
+    private final String name;
+
+    private final ChannelId firstPhase;
+    private final ChannelId secondPhase;
+    private final ChannelId thirdPhase;
+
+    PhaseRotation(int value, String name, ChannelId firstPhase, ChannelId secondPhase, ChannelId thirdPhase) {
+	this.value = value;
+	this.name = name;
+	this.firstPhase = firstPhase;
+	this.secondPhase = secondPhase;
+	this.thirdPhase = thirdPhase;
+    }
+
+    public ChannelId getFirstPhase() {
+	return this.firstPhase;
+    }
+
+    public ChannelId getSecondPhase() {
+	return this.secondPhase;
+    }
+
+    public ChannelId getThirdPhase() {
+	return this.thirdPhase;
+    }
+
+    @Override
+    public int getValue() {
+	return this.value;
+    }
+
+    @Override
+    public String getName() {
+	return this.name;
+    }
+
+    @Override
+    public OptionsEnum getUndefined() {
+	return L1_L2_L3;
+    }
+
+}

--- a/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/Phases.java
+++ b/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/Phases.java
@@ -1,0 +1,63 @@
+package io.openems.edge.evcs.v2.api;
+
+import java.util.function.Function;
+
+import io.openems.common.types.OptionsEnum;
+
+public enum Phases implements OptionsEnum {
+    /**
+     * vehicle is charged on one phase only.
+     */
+    ONE_PHASE(1, "One Phase", (max) -> Math.round(max / 3F)), //
+    /**
+     * vehicle is charged on two phases.
+     */
+    TWO_PHASE(2, "Two Phase", (max) -> Math.round((max / 3F) * 2)), //
+    /**
+     * vehicle is charged on all phases.
+     */
+    THREE_PHASE(3, "Three Phase", (max) -> max);
+
+    private final int value;
+    private final String name;
+
+    /**
+     * Calculating the power of a maximum given for three phases.
+     */
+    private final Function<Integer, Integer> convertThreePhaseValue;
+
+    private Phases(int value, String name, Function<Integer, Integer> convertThreePhaseValue) {
+	this.value = value;
+	this.name = name;
+	this.convertThreePhaseValue = convertThreePhaseValue;
+    }
+
+    @Override
+    public int getValue() {
+	return this.value;
+    }
+
+    @Override
+    public String getName() {
+	return this.name;
+    }
+
+    /**
+     * Get value converted from a three phase value.
+     * 
+     * <p>
+     * As the values e.g. hardware limit are most likely given for three phase
+     * charging, this is used to convert the value, depending on the current phases
+     * 
+     * @param threePhaseValue value using all three phases as power
+     * @return converted value
+     */
+    public int getFromThreePhase(int threePhaseValue) {
+	return this.convertThreePhaseValue.apply(threePhaseValue).intValue();
+    }
+
+    @Override
+    public OptionsEnum getUndefined() {
+	return THREE_PHASE;
+    }
+}

--- a/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/Priority.java
+++ b/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/Priority.java
@@ -1,0 +1,47 @@
+package io.openems.edge.evcs.v2.api;
+
+import io.openems.common.types.OptionsEnum;
+
+public enum Priority implements OptionsEnum {
+    /**
+     * priority is unknown.
+     */
+    UNDEFINED(-1, "Undefined"), //
+    /**
+     * EVCS is used for cars with long standing times.
+     */
+    LOW(1, "Low"), //
+    /**
+     * EVCS is used for cars with average standing times.
+     */
+    MEDIUM(2, "Medium"), //
+    /**
+     * EVCS should be charged as fast as possible.
+     */
+    HIGH(3, "High") //
+    ;
+
+    private final int value;
+    private final String name;
+
+    private Priority(int value, String name) {
+	this.value = value;
+	this.name = name;
+    }
+
+    @Override
+    public int getValue() {
+	return this.value;
+    }
+
+    @Override
+    public String getName() {
+	return this.name;
+    }
+
+    @Override
+    public OptionsEnum getUndefined() {
+	return UNDEFINED;
+    }
+
+}

--- a/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/SocEvcs.java
+++ b/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/SocEvcs.java
@@ -1,0 +1,98 @@
+package io.openems.edge.evcs.v2.api;
+
+import io.openems.common.channel.AccessMode;
+import io.openems.common.channel.PersistencePriority;
+import io.openems.common.channel.Unit;
+import io.openems.common.types.OpenemsType;
+import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.IntegerReadChannel;
+import io.openems.edge.common.channel.value.Value;
+import io.openems.edge.common.modbusslave.ModbusSlaveNatureTable;
+import io.openems.edge.common.modbusslave.ModbusType;
+
+public interface SocEvcs extends Evcs {
+
+	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+
+		/**
+		 * Current SoC.
+		 *
+		 * <p>
+		 * The current state of charge of the car
+		 *
+		 * <ul>
+		 * <li>Interface: SocEvcs
+		 * <li>Readable
+		 * <li>Type: Integer
+		 * <li>Unit: Percent
+		 * </ul>
+		 */
+		SOC(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.PERCENT) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.HIGH)); //
+
+		// TODO: If there are EVCSs with more information maybe a Channel
+		// TIME_TILL_CHARGING_FINISHED is possible
+
+		private final Doc doc;
+
+		private ChannelId(Doc doc) {
+			this.doc = doc;
+		}
+
+		@Override
+		public Doc doc() {
+			return this.doc;
+		}
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#SOC}.
+	 *
+	 * @return the Channel
+	 */
+	public default IntegerReadChannel getSocChannel() {
+		return this.channel(ChannelId.SOC);
+	}
+
+	/**
+	 * Gets the current state of charge of the car [%].. See {@link ChannelId#SOC}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Integer> getSoc() {
+		return this.getSocChannel().value();
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#SOC} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setSoc(Integer value) {
+		this.getSocChannel().setNextValue(value);
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#SOC} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setSoc(int value) {
+		this.getSocChannel().setNextValue(value);
+	}
+
+	/**
+	 * Used for Modbus/TCP Api Controller. Provides a Modbus table for the Channels
+	 * of this Component.
+	 *
+	 * @param accessMode filters the Modbus-Records that should be shown
+	 * @return the {@link ModbusSlaveNatureTable}
+	 */
+	public static ModbusSlaveNatureTable getModbusSlaveNatureTable(AccessMode accessMode) {
+		return ModbusSlaveNatureTable.of(SocEvcs.class, accessMode, 50) //
+				.channel(0, ChannelId.SOC, ModbusType.UINT16) //
+				.build();
+	}
+}

--- a/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/Status.java
+++ b/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/Status.java
@@ -1,0 +1,61 @@
+package io.openems.edge.evcs.v2.api;
+
+import io.openems.common.types.OptionsEnum;
+
+public enum Status implements OptionsEnum {
+    /**
+     * state of EVCS is unknown. 
+     */
+    UNDEFINED(-1, "Undefined"), //
+    /**
+     * e.g. unplugged, RFID not enabled,...
+     */
+    NOT_READY_FOR_CHARGING(1, "Not ready for Charging"), //
+    /**
+     * EMS suspended charging process.
+     */
+    SUSPENDED(10, "Suspended"),
+    /**
+     * Waiting for EV charging request.
+     */
+    READY_FOR_CHARGING(2, "Ready for Charging"), //
+    /**
+     * EV is charging.
+     */
+    CHARGING(3, "Charging"), //
+    /**
+     * EVCS has an internal error.
+     */
+    ERROR(4, "Error"), //
+    /**
+     * Charging was rejected by unkown reason.
+     */
+    CHARGING_REJECTED(5, "Charging rejected"), //
+    /**
+     * Charging was finished.
+     */
+    CHARGING_FINISHED(7, "Charging has finished");
+
+    private final int value;
+    private final String name;
+
+    private Status(int value, String name) {
+	this.value = value;
+	this.name = name;
+    }
+
+    @Override
+    public int getValue() {
+	return this.value;
+    }
+
+    @Override
+    public String getName() {
+	return this.name;
+    }
+
+    @Override
+    public OptionsEnum getUndefined() {
+	return UNDEFINED;
+    }
+}

--- a/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/package-info.java
+++ b/io.openems.edge.evcs.api/src/io/openems/edge/evcs/v2/api/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package io.openems.edge.evcs.v2.api;


### PR DESCRIPTION
The current EVCS nature is not suitable for larger chargeparks. It includes unnessecary or unclear information (e.g. MaxPower, MaxHwPower, FixedMaxPower ) and it is missing important information (e.g. PhaseRotation, PowerObject, Constraints).

This pull request opens a proposal for a change on the EVCS nature. It puts a new version of the evcs api  (io.openems.edge.evcs.v2.api) beside the old implementation. It should not be merged into the development branch. It should be taken as a reference for a discussion on a future EVCS nature.

Therefore we also like to introduce multiple EvcsPower objects (analog to EssPower), each responsible for a single electrical cabinet (done in another PR). It makes it a lot easier to limit Currents on a given power line segment and build controller hierarchies.

For more a discussion on this topic see commmunity post [Proposal: New EVCS Api](https://community.openems.io/t/proposal-new-evcs-api/1308)
