### PR TITLE
Tibber: add filter for multiple 'Homes'

### DIFF
--- a/io.openems.edge.timeofusetariff.tibber/bnd.bnd
+++ b/io.openems.edge.timeofusetariff.tibber/bnd.bnd
@@ -12,4 +12,8 @@ Bundle-Version: 1.0.0.${tstamp}
 	io.openems.wrapper.okhttp,\
 
 -testpath: \
+	com.squareup.okio,\
+	io.openems.wrapper.kotlinx-coroutines-core-jvm,\
+	io.openems.wrapper.okhttp,\
+	org.jetbrains.kotlin.osgi-bundle,\
 	${testpath}

--- a/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/Config.java
+++ b/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/Config.java
@@ -21,5 +21,8 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Access Token", description = "Access token for the Tibber API", type = AttributeType.PASSWORD)
 	String accessToken() default "";
 
+	@AttributeDefinition(name = "Filter for Home", description = "For multiple 'Homes', add either an ID (format UUID) or 'appNickname' for unambiguous identification", required = false)
+	String filter() default "";
+
 	String webconsole_configurationFactory_nameHint() default "Time-Of-Use Tariff Tibber [{id}]";
 }

--- a/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/FoundMultipleHomesException.java
+++ b/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/FoundMultipleHomesException.java
@@ -1,0 +1,13 @@
+package io.openems.edge.timeofusetariff.tibber;
+
+import io.openems.common.exceptions.OpenemsException;
+
+public class FoundMultipleHomesException extends OpenemsException {
+
+	private static final long serialVersionUID = 1L;
+
+	public FoundMultipleHomesException() {
+		super("Found multiple 'Homes'");
+	}
+
+}

--- a/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/Tibber.java
+++ b/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/Tibber.java
@@ -1,5 +1,6 @@
 package io.openems.edge.timeofusetariff.tibber;
 
+import io.openems.common.channel.Level;
 import io.openems.common.types.OpenemsType;
 import io.openems.edge.common.channel.Doc;
 import io.openems.edge.common.component.OpenemsComponent;
@@ -8,8 +9,13 @@ import io.openems.edge.timeofusetariff.api.TimeOfUseTariff;
 public interface Tibber extends TimeOfUseTariff, OpenemsComponent {
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
-		HTTP_STATUS_CODE(Doc.of(OpenemsType.INTEGER)//
-				.text("Displays the HTTP status code"))//
+		HTTP_STATUS_CODE(Doc.of(OpenemsType.INTEGER) //
+				.text("The HTTP status code")), //
+		UNABLE_TO_UPDATE_PRICES(Doc.of(Level.WARNING) //
+				.text("Unable to update prices from Tibber API")), //
+		FILTER_IS_REQUIRED(Doc.of(Level.WARNING) //
+				.text("Found multiple 'Homes'. Please configure either an ID (format UUID) "
+						+ "or 'appNickname' for unambiguous identification")) //
 		;
 
 		private final Doc doc;

--- a/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/TibberImpl.java
+++ b/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/TibberImpl.java
@@ -3,11 +3,8 @@ package io.openems.edge.timeofusetariff.tibber;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.TreeMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -22,8 +19,6 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.metatype.annotations.Designate;
 
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.utils.JsonUtils;
@@ -58,8 +53,7 @@ public class TibberImpl extends AbstractOpenemsComponent implements TimeOfUseTar
 
 	private ZonedDateTime updateTimeStamp = null;
 
-	private final Runnable task = () -> {
-
+	protected final Runnable task = () -> {
 		/*
 		 * Update Map of prices
 		 */
@@ -68,27 +62,13 @@ public class TibberImpl extends AbstractOpenemsComponent implements TimeOfUseTar
 				.url(TIBBER_API_URL) //
 				.header("Authorization", this.config.accessToken()) //
 				.post(RequestBody.create(JsonUtils.buildJsonObject() //
-						.addProperty("query", "{\n" //
-								+ "  viewer {\n" //
-								+ "    homes {\n" //
-								+ "      currentSubscription{\n" //
-								+ "        priceInfo{\n" //
-								+ "          today {\n" //
-								+ "            total\n" //
-								+ "            startsAt\n" //
-								+ "          }\n" //
-								+ "          tomorrow {\n" //
-								+ "            total\n" //
-								+ "            startsAt\n" //
-								+ "          }\n" //
-								+ "        }\n" //
-								+ "      }\n" //
-								+ "    }\n" //
-								+ "  }\n" //
-								+ "}") //
+						.addProperty("query", Utils.generateGraphQl()) //
 						.build().toString(), MediaType.parse("application/json"))) //
 				.build();
-		int httpStatusCode;
+		int httpStatusCode = 0;
+		var filterIsRequired = false;
+		var unableToUpdatePrices = false;
+
 		try (var response = client.newCall(request).execute()) {
 			httpStatusCode = response.code();
 
@@ -96,18 +76,27 @@ public class TibberImpl extends AbstractOpenemsComponent implements TimeOfUseTar
 				throw new IOException("Unexpected code " + response);
 			}
 
+			// Initialize status channel to false
+			this.channel(Tibber.ChannelId.FILTER_IS_REQUIRED).setNextValue(false);
+
 			// Parse the response for the prices
-			this.prices.set(TibberImpl.parsePrices(response.body().string()));
+			this.prices.set(Utils.parsePrices(response.body().string(), config.filter()));
 
 			// store the time stamp
 			this.updateTimeStamp = ZonedDateTime.now();
 
 		} catch (IOException | OpenemsNamedException e) {
+			if (e instanceof FoundMultipleHomesException) {
+				filterIsRequired = true;
+			} else {
+				unableToUpdatePrices = true;
+			}
 			e.printStackTrace();
-			httpStatusCode = 0;
 		}
 
 		this.channel(Tibber.ChannelId.HTTP_STATUS_CODE).setNextValue(httpStatusCode);
+		this.channel(Tibber.ChannelId.FILTER_IS_REQUIRED).setNextValue(filterIsRequired);
+		this.channel(Tibber.ChannelId.UNABLE_TO_UPDATE_PRICES).setNextValue(unableToUpdatePrices);
 
 		/*
 		 * Schedule next price update for 2 pm
@@ -135,7 +124,7 @@ public class TibberImpl extends AbstractOpenemsComponent implements TimeOfUseTar
 	}
 
 	@Activate
-	void activate(ComponentContext context, Config config) {
+	private void activate(ComponentContext context, Config config) {
 		super.activate(context, config.id(), config.alias(), config.enabled());
 
 		if (!config.enabled()) {
@@ -161,52 +150,5 @@ public class TibberImpl extends AbstractOpenemsComponent implements TimeOfUseTar
 
 		return TimeOfUseTariffUtils.getNext24HourPrices(Clock.systemDefaultZone() /* can be mocked for testing */,
 				this.prices.get(), this.updateTimeStamp);
-	}
-
-	/**
-	 * Parse the Tibber JSON to the Price Map.
-	 *
-	 * @param jsonData the Tibber JSON
-	 * @return the Price Map
-	 * @throws OpenemsNamedException on error
-	 */
-	public static ImmutableSortedMap<ZonedDateTime, Float> parsePrices(String jsonData) throws OpenemsNamedException {
-		var result = new TreeMap<ZonedDateTime, Float>();
-
-		var line = JsonUtils.parseToJsonObject(jsonData);
-		var homes = JsonUtils.getAsJsonObject(line, "data") //
-				.getAsJsonObject("viewer") //
-				.getAsJsonArray("homes");
-
-		for (JsonElement home : homes) {
-
-			var priceInfo = JsonUtils.getAsJsonObject(home, "currentSubscription") //
-					.getAsJsonObject("priceInfo");
-
-			// Price info for today and tomorrow.
-			var today = JsonUtils.getAsJsonArray(priceInfo, "today");
-			var tomorrow = JsonUtils.getAsJsonArray(priceInfo, "tomorrow");
-
-			// Adding to an array to avoid individual variables for individual for loops.
-			JsonArray[] days = { today, tomorrow };
-
-			// parse the arrays for price and time stamps.
-			for (JsonArray day : days) {
-				for (JsonElement element : day) {
-					// Multiply the price with 1000 to make it EUR/MWh.
-					var marketPrice = JsonUtils.getAsFloat(element, "total") * 1000;
-					var startTimeStamp = ZonedDateTime
-							.parse(JsonUtils.getAsString(element, "startsAt"), DateTimeFormatter.ISO_DATE_TIME)
-							.withZoneSameInstant(ZoneId.systemDefault());
-
-					// Adding the values in the Map.
-					result.put(startTimeStamp, marketPrice);
-					result.put(startTimeStamp.plusMinutes(15), marketPrice);
-					result.put(startTimeStamp.plusMinutes(30), marketPrice);
-					result.put(startTimeStamp.plusMinutes(45), marketPrice);
-				}
-			}
-		}
-		return ImmutableSortedMap.copyOf(result);
 	}
 }

--- a/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/TibberImpl.java
+++ b/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/TibberImpl.java
@@ -80,7 +80,7 @@ public class TibberImpl extends AbstractOpenemsComponent implements TimeOfUseTar
 			this.channel(Tibber.ChannelId.FILTER_IS_REQUIRED).setNextValue(false);
 
 			// Parse the response for the prices
-			this.prices.set(Utils.parsePrices(response.body().string(), config.filter()));
+			this.prices.set(Utils.parsePrices(response.body().string(), this.config.filter()));
 
 			// store the time stamp
 			this.updateTimeStamp = ZonedDateTime.now();

--- a/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/Utils.java
+++ b/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/Utils.java
@@ -1,0 +1,171 @@
+package io.openems.edge.timeofusetariff.tibber;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.utils.JsonUtils;
+
+public class Utils {
+
+	private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
+
+	private Utils() {
+
+	}
+
+	/**
+	 * Parse the Tibber JSON to the Price Map.
+	 * 
+	 * <p>
+	 * If a filter is supplied, it is checked against 'id' (UUID) and 'appNickname'.
+	 * If no filter is supplied, the method tries to be smart with finding the one
+	 * unique correct result, i.e. it ignores empty/null objects.
+	 *
+	 * @param jsonData the Tibber JSON
+	 * @param filter   filter for 'id' or 'appNickname'; null/blank for no filter
+	 * @return the Price Map
+	 * @throws OpenemsNamedException on error
+	 */
+	protected static ImmutableSortedMap<ZonedDateTime, Float> parsePrices(String jsonData, String filter)
+			throws OpenemsNamedException {
+		var line = JsonUtils.parseToJsonObject(jsonData);
+		var homes = JsonUtils.getAsJsonObject(line, "data") //
+				.getAsJsonObject("viewer") //
+				.getAsJsonArray("homes");
+
+		// Parse all homes
+		SortedMap<ZonedDateTime, Float> result = null;
+		OpenemsNamedException error = null;
+		var successCount = 0;
+		for (JsonElement home : homes) {
+			try {
+				var subResult = parseHome(home, filter);
+				if (subResult == null) {
+					continue;
+				}
+				result = subResult;
+				successCount++;
+			} catch (OpenemsNamedException e) {
+				error = e;
+			}
+		}
+
+		// Evaluate result
+		if (successCount < 1) {
+			if (error != null) {
+				throw error;
+			} else if (homes.size() > 1 && filter != null && !filter.isBlank()) {
+				throw new OpenemsException("Unable to parse any of multiple 'Homes'. Please check configured filter");
+			} else {
+				throw new OpenemsException("Unable to parse 'Home'");
+			}
+
+		} else if (successCount == 1) {
+			// Parsed exactly one home successfully
+			return ImmutableSortedMap.copyOf(result);
+
+		} else {
+			// successCount > 1
+			LOG.warn("Found multiple 'Homes'. Please configure a specific Home 'ID' or 'appNickname' from: "
+					+ homes.asList().stream() //
+							.map(home -> JsonUtils.getAsOptionalString(home, "id").orElse("") + ":"
+									+ JsonUtils.getAsOptionalString(home, "appNickname").orElse("")) //
+							.collect(Collectors.joining(", ")));
+			throw new FoundMultipleHomesException();
+		}
+	}
+
+	/**
+	 * Parses one 'home'.
+	 * 
+	 * @param json   the 'home' JsonObject
+	 * @param filter filter for 'id' or 'appNickname'; null/blank for no filter
+	 * @return the parsed prices; null if filter does not match
+	 * @throws OpenemsNamedException on parse error
+	 */
+	private static SortedMap<ZonedDateTime, Float> parseHome(JsonElement json, String filter)
+			throws OpenemsNamedException {
+		// Match filter
+		if (filter != null && !filter.isBlank()) {
+			var id = JsonUtils.getAsString(json, "id"); //
+			var appNickname = JsonUtils.getAsOptionalString(json, "appNickname").orElse(""); //
+			if (!filter.equals(id) && !filter.equals(appNickname)) {
+				return null;
+			}
+		}
+
+		var priceInfo = JsonUtils.getAsJsonObject(json, "currentSubscription") //
+				.getAsJsonObject("priceInfo");
+
+		// Price info for today and tomorrow.
+		var today = JsonUtils.getAsJsonArray(priceInfo, "today");
+		var tomorrow = JsonUtils.getAsJsonArray(priceInfo, "tomorrow");
+
+		// Adding to an array to avoid individual variables for individual for loops.
+		JsonArray[] days = { today, tomorrow };
+
+		var result = new TreeMap<ZonedDateTime, Float>();
+
+		// parse the arrays for price and time stamps.
+		for (JsonArray day : days) {
+			for (JsonElement element : day) {
+				// Multiply the price with 1000 to make it EUR/MWh.
+				var marketPrice = JsonUtils.getAsFloat(element, "total") * 1000;
+				var startTimeStamp = ZonedDateTime
+						.parse(JsonUtils.getAsString(element, "startsAt"), DateTimeFormatter.ISO_DATE_TIME)
+						.withZoneSameInstant(ZoneId.systemDefault());
+
+				// Adding the values in the Map.
+				result.put(startTimeStamp, marketPrice);
+				result.put(startTimeStamp.plusMinutes(15), marketPrice);
+				result.put(startTimeStamp.plusMinutes(30), marketPrice);
+				result.put(startTimeStamp.plusMinutes(45), marketPrice);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Generate a GraphQL query
+	 * 
+	 * @param homeId the Home-ID, or null
+	 * @return a query string
+	 */
+	protected static String generateGraphQl() {
+		return new StringBuilder() //
+				.append("{\n") //
+				.append("  viewer {\n") //
+				.append("    homes {\n") //
+				.append("      id\n") //
+				.append("      appNickname\n") //
+				.append("      currentSubscription{\n") //
+				.append("        priceInfo{\n") //
+				.append("          today {\n") //
+				.append("            total\n") //
+				.append("            startsAt\n") //
+				.append("          }\n") //
+				.append("          tomorrow {\n") //
+				.append("            total\n") //
+				.append("            startsAt\n") //
+				.append("          }\n") //
+				.append("        }\n") //
+				.append("      }\n") //
+				.append("    }\n") //
+				.append("  }\n") //
+				.append("}") //
+				.toString();
+	}
+}

--- a/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/Utils.java
+++ b/io.openems.edge.timeofusetariff.tibber/src/io/openems/edge/timeofusetariff/tibber/Utils.java
@@ -139,9 +139,8 @@ public class Utils {
 	}
 
 	/**
-	 * Generate a GraphQL query
+	 * Generate a GraphQL query.
 	 * 
-	 * @param homeId the Home-ID, or null
 	 * @return a query string
 	 */
 	protected static String generateGraphQl() {

--- a/io.openems.edge.timeofusetariff.tibber/test/io/openems/edge/timeofusetariff/tibber/MyConfig.java
+++ b/io.openems.edge.timeofusetariff.tibber/test/io/openems/edge/timeofusetariff/tibber/MyConfig.java
@@ -8,6 +8,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	public static class Builder {
 		private String id;
 		public String accessToken;
+		public String filter;
 
 		private Builder() {
 		}
@@ -19,6 +20,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 		public Builder setAccessToken(String accessToken) {
 			this.accessToken = accessToken;
+			return this;
+		}
+
+		public Builder setFilter(String filter) {
+			this.filter = filter;
 			return this;
 		}
 
@@ -46,6 +52,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	@Override
 	public String accessToken() {
 		return this.builder.accessToken;
+	}
+
+	@Override
+	public String filter() {
+		return this.builder.filter;
 	}
 
 }

--- a/io.openems.edge.timeofusetariff.tibber/test/io/openems/edge/timeofusetariff/tibber/TibberImplTest.java
+++ b/io.openems.edge.timeofusetariff.tibber/test/io/openems/edge/timeofusetariff/tibber/TibberImplTest.java
@@ -1,0 +1,24 @@
+package io.openems.edge.timeofusetariff.tibber;
+
+import org.junit.Test;
+
+import io.openems.edge.common.test.ComponentTest;
+
+public class TibberImplTest {
+
+	private static final String CTRL_ID = "ctrl0";
+
+	@Test
+	public void test() throws Exception {
+		var tibber = new TibberImpl();
+		new ComponentTest(tibber) //
+				.activate(MyConfig.create() //
+						.setId(CTRL_ID) //
+						.setAccessToken("foo-bar") //
+						.setFilter("") //
+						.build()) //
+		;
+		// tibber.task.run();
+	}
+
+}


### PR DESCRIPTION
The TIbber API allows accessing multiple 'Homes'. This PR introduces a 'filter' config property, that allows filtering for the correct one. 

Also add State-Channels:
- UnableToUpdatePrices: general HTTP error
- FilterIsRequired: multiple Homes where retreived from the API and it is not possible to identify without filter (i.e. more than one valid 'Home' was parsed)

This fixes #2049