### PR TITLE
Two small bugfixes in VirtualMeterAdd

### DIFF
--- a/io.openems.edge.meter.virtual/src/io/openems/edge/meter/virtual/symmetric/add/VirtualAdd.java
+++ b/io.openems.edge.meter.virtual/src/io/openems/edge/meter/virtual/symmetric/add/VirtualAdd.java
@@ -102,8 +102,6 @@ public class VirtualAdd extends AbstractOpenemsComponent
 		}
 
 		final var meterFrequency = new CalculateAverage();
-		final var meterMinActivePower = new CalculateIntegerSum();
-		final var meterMaxActivePower = new CalculateIntegerSum();
 		final var meterActivePower = new CalculateIntegerSum();
 		final var meterReactivePower = new CalculateIntegerSum();
 		final var meterActiveProductionEnergy = new CalculateLongSum();
@@ -113,19 +111,15 @@ public class VirtualAdd extends AbstractOpenemsComponent
 
 		for (SymmetricMeter meter : meters) {
 			meterFrequency.addValue(meter.getFrequencyChannel());
-			meterMinActivePower.addValue(meter.getMinActivePowerChannel());
-			meterMaxActivePower.addValue(meter.getMaxActivePowerChannel());
 			meterActivePower.addValue(meter.getActivePowerChannel());
 			meterReactivePower.addValue(meter.getReactivePowerChannel());
-			meterActiveConsumptionEnergy.addValue(this.getActiveConsumptionEnergyChannel());
+			meterActiveConsumptionEnergy.addValue(meter.getActiveConsumptionEnergyChannel());
 			meterActiveProductionEnergy.addValue(meter.getActiveProductionEnergyChannel());
 			meterVoltage.addValue(meter.getVoltageChannel());
 			meterCurrent.addValue(meter.getCurrentChannel());
 		}
 
 		this.getFrequencyChannel().setNextValue(meterFrequency.calculate());
-		this._setMinActivePower(meterMinActivePower.calculate());
-		this._setMaxActivePower(meterMaxActivePower.calculate());
 		this._setActivePower(meterActivePower.calculate());
 		this._setReactivePower(meterReactivePower.calculate());
 		this._setActiveConsumptionEnergy(meterActiveConsumptionEnergy.calculate());


### PR DESCRIPTION
a) Consumption Energy is now calculated correctly (remained null before)
b) Min- and max active powers are automatically derived from active power and should not be calculated by the meter. (The sum of the max powers is not necessarily the max power of the sum anyway)