### PR TITLE
AbstractSunSpecMeter Energy value fix

### DIFF
--- a/io.openems.edge.meter.sunspec/src/io/openems/edge/meter/sunspec/AbstractSunSpecMeter.java
+++ b/io.openems.edge.meter.sunspec/src/io/openems/edge/meter/sunspec/AbstractSunSpecMeter.java
@@ -82,15 +82,15 @@ public abstract class AbstractSunSpecMeter extends AbstractOpenemsSunSpecCompone
 				DefaultSunSpecModel.S204.VAR, DefaultSunSpecModel.S203.VAR, DefaultSunSpecModel.S202.VAR,
 				DefaultSunSpecModel.S201.VAR);
 		this.mapFirstPointToChannel(//
-				SymmetricMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY, //
-				ElementToChannelConverter.INVERT, //
-				DefaultSunSpecModel.S204.TOT_WH_IMP, DefaultSunSpecModel.S203.TOT_WH_IMP,
-				DefaultSunSpecModel.S202.TOT_WH_IMP, DefaultSunSpecModel.S201.TOT_WH_IMP);
-		this.mapFirstPointToChannel(//
 				SymmetricMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY, //
-				ElementToChannelConverter.INVERT, //
+				ElementToChannelConverter.DIRECT_1_TO_1, //
 				DefaultSunSpecModel.S204.TOT_WH_EXP, DefaultSunSpecModel.S203.TOT_WH_EXP,
 				DefaultSunSpecModel.S202.TOT_WH_EXP, DefaultSunSpecModel.S201.TOT_WH_EXP);
+		this.mapFirstPointToChannel(//
+				SymmetricMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY, //
+				ElementToChannelConverter.DIRECT_1_TO_1, //
+				DefaultSunSpecModel.S204.TOT_WH_IMP, DefaultSunSpecModel.S203.TOT_WH_IMP,
+				DefaultSunSpecModel.S202.TOT_WH_IMP, DefaultSunSpecModel.S201.TOT_WH_IMP);
 		this.mapFirstPointToChannel(//
 				SymmetricMeter.ChannelId.VOLTAGE, //
 				ElementToChannelConverter.SCALE_FACTOR_3, //
@@ -171,16 +171,6 @@ public abstract class AbstractSunSpecMeter extends AbstractOpenemsSunSpecCompone
 				ElementToChannelConverter.SCALE_FACTOR_3, //
 				DefaultSunSpecModel.S204.PH_VPH_C, DefaultSunSpecModel.S203.PH_VPH_C, DefaultSunSpecModel.S202.PH_VPH_C,
 				DefaultSunSpecModel.S201.PH_VPH_C);
-		this.mapFirstPointToChannel(//
-				SymmetricMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY, //
-				ElementToChannelConverter.DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S204.TOT_WH_EXP, DefaultSunSpecModel.S203.TOT_WH_EXP,
-				DefaultSunSpecModel.S202.TOT_WH_EXP, DefaultSunSpecModel.S201.TOT_WH_EXP);
-		this.mapFirstPointToChannel(//
-				SymmetricMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY, //
-				ElementToChannelConverter.DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S204.TOT_WH_IMP, DefaultSunSpecModel.S203.TOT_WH_IMP,
-				DefaultSunSpecModel.S202.TOT_WH_IMP, DefaultSunSpecModel.S201.TOT_WH_IMP);
 	}
 
 	@Override


### PR DESCRIPTION
Energy values were mapped twice in AbstractSunspecMeter, once with the wrong converter.