### PR TITLE
ESS Fix Active Power: handle Hybrid-ESS

### DIFF
--- a/io.openems.edge.controller.ess.fixactivepower/bnd.bnd
+++ b/io.openems.edge.controller.ess.fixactivepower/bnd.bnd
@@ -8,7 +8,7 @@ Bundle-Version: 1.0.0.${tstamp}
 	io.openems.common,\
 	io.openems.edge.common,\
 	io.openems.edge.controller.api,\
-	io.openems.edge.ess.api
+	io.openems.edge.ess.api,\
 
 -testpath: \
 	${testpath}

--- a/io.openems.edge.controller.ess.fixactivepower/src/io/openems/edge/controller/ess/fixactivepower/Config.java
+++ b/io.openems.edge.controller.ess.fixactivepower/src/io/openems/edge/controller/ess/fixactivepower/Config.java
@@ -20,6 +20,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Mode", description = "Set the type of mode.")
 	Mode mode() default Mode.MANUAL_ON;
 
+	@AttributeDefinition(name = "Hybrid-ESS Mode", description = "For Hybrid-ESS (ESS with attached DC-side PV system): apply target power to AC or DC side of inverter?")
+	HybridEssMode hybridEssMode() default HybridEssMode.TARGET_DC;
+
 	@AttributeDefinition(name = "Ess-ID", description = "ID of Ess device.")
 	String ess_id();
 

--- a/io.openems.edge.controller.ess.fixactivepower/src/io/openems/edge/controller/ess/fixactivepower/EssFixActivePowerImpl.java
+++ b/io.openems.edge.controller.ess.fixactivepower/src/io/openems/edge/controller/ess/fixactivepower/EssFixActivePowerImpl.java
@@ -17,6 +17,7 @@ import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.controller.api.Controller;
+import io.openems.edge.ess.api.HybridEss;
 import io.openems.edge.ess.api.ManagedSymmetricEss;
 
 @Designate(ocd = Config.class, factory = true)
@@ -76,12 +77,39 @@ public class EssFixActivePowerImpl extends AbstractOpenemsComponent
 		switch (this.config.mode()) {
 		case MANUAL_ON:
 			// Apply Active-Power Set-Point
-			this.ess.setActivePowerEquals(this.config.power());
+			var acPower = getAcPower(this.ess, this.config.hybridEssMode(), this.config.power());
+			this.ess.setActivePowerEquals(acPower);
 			break;
 
 		case MANUAL_OFF:
 			// Do nothing
 			break;
 		}
+	}
+
+	/**
+	 * Gets the required AC power set-point for AC- or Hybrid-ESS.
+	 * 
+	 * @param ess           the {@link ManagedSymmetricEss}; checked for
+	 *                      {@link HybridEss}
+	 * @param hybridEssMode the {@link HybridEssMode}
+	 * @param power         the configured target power
+	 * @return the AC power set-point
+	 */
+	protected static Integer getAcPower(ManagedSymmetricEss ess, HybridEssMode hybridEssMode, int power) {
+		switch (hybridEssMode) {
+		case TARGET_AC:
+			return power;
+
+		case TARGET_DC:
+			if (ess instanceof HybridEss) {
+				var pv = ess.getActivePower().orElse(0) - ((HybridEss) ess).getDcDischargePower().orElse(0);
+				return pv + power;
+			} else {
+				return power;
+			}
+		}
+
+		return null; /* should never happen */
 	}
 }

--- a/io.openems.edge.controller.ess.fixactivepower/src/io/openems/edge/controller/ess/fixactivepower/HybridEssMode.java
+++ b/io.openems.edge.controller.ess.fixactivepower/src/io/openems/edge/controller/ess/fixactivepower/HybridEssMode.java
@@ -1,0 +1,5 @@
+package io.openems.edge.controller.ess.fixactivepower;
+
+public enum HybridEssMode {
+	TARGET_AC, TARGET_DC;
+}

--- a/io.openems.edge.controller.ess.fixactivepower/test/io/openems/edge/controller/ess/fixactivepower/EssFixActivePowerImplTest.java
+++ b/io.openems.edge.controller.ess.fixactivepower/test/io/openems/edge/controller/ess/fixactivepower/EssFixActivePowerImplTest.java
@@ -1,5 +1,7 @@
 package io.openems.edge.controller.ess.fixactivepower;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 import io.openems.common.exceptions.OpenemsException;
@@ -7,6 +9,7 @@ import io.openems.common.types.ChannelAddress;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
 import io.openems.edge.common.test.DummyConfigurationAdmin;
 import io.openems.edge.controller.test.ControllerTest;
+import io.openems.edge.ess.test.DummyHybridEss;
 import io.openems.edge.ess.test.DummyManagedAsymmetricEss;
 
 public class EssFixActivePowerImplTest {
@@ -27,6 +30,7 @@ public class EssFixActivePowerImplTest {
 						.setId(CTRL_ID) //
 						.setEssId(ESS_ID) //
 						.setMode(Mode.MANUAL_ON) //
+						.setHybridEssMode(HybridEssMode.TARGET_DC) //
 						.setPower(1234) //
 						.build()) //
 				.next(new TestCase() //
@@ -42,10 +46,24 @@ public class EssFixActivePowerImplTest {
 						.setId(CTRL_ID) //
 						.setEssId(ESS_ID) //
 						.setMode(Mode.MANUAL_OFF) //
+						.setHybridEssMode(HybridEssMode.TARGET_DC) //
 						.setPower(1234) //
 						.build()) //
 				.next(new TestCase() //
 						.output(ESS_SET_ACTIVE_POWER_EQUALS, null));
+	}
+
+	@Test
+	public void testGetAcPower() throws OpenemsException, Exception {
+		var hybridEss = new DummyHybridEss(ESS_ID) //
+				.withActivePower(7000) //
+				.withDcDischargePower(3000); //
+
+		assertEquals(Integer.valueOf(5000), //
+				EssFixActivePowerImpl.getAcPower(hybridEss, HybridEssMode.TARGET_AC, 5000));
+
+		assertEquals(Integer.valueOf(9000), //
+				EssFixActivePowerImpl.getAcPower(hybridEss, HybridEssMode.TARGET_DC, 5000));
 	}
 
 }

--- a/io.openems.edge.controller.ess.fixactivepower/test/io/openems/edge/controller/ess/fixactivepower/MyConfig.java
+++ b/io.openems.edge.controller.ess.fixactivepower/test/io/openems/edge/controller/ess/fixactivepower/MyConfig.java
@@ -11,6 +11,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 		private String essId = null;
 		public int power;
 		public Mode mode;
+		public HybridEssMode hybridEssMode;
 
 		private Builder() {
 		}
@@ -35,6 +36,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 			return this;
 		}
 
+		public Builder setHybridEssMode(HybridEssMode hybridEssMode) {
+			this.hybridEssMode = hybridEssMode;
+			return this;
+		}
+		
 		public MyConfig build() {
 			return new MyConfig(this);
 		}
@@ -74,6 +80,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	@Override
 	public Mode mode() {
 		return this.builder.mode;
+	}
+
+	@Override
+	public HybridEssMode hybridEssMode() {
+		return this.builder.hybridEssMode;
 	}
 
 }

--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/test/DummyHybridEss.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/test/DummyHybridEss.java
@@ -48,6 +48,7 @@ public class DummyHybridEss extends AbstractOpenemsComponent
 				OpenemsComponent.ChannelId.values(), //
 				ManagedSymmetricEss.ChannelId.values(), //
 				SymmetricEss.ChannelId.values(), //
+				HybridEss.ChannelId.values(), //
 				ChannelId.values() //
 		);
 		this.power = power;
@@ -73,6 +74,32 @@ public class DummyHybridEss extends AbstractOpenemsComponent
 	@Override
 	public int getPowerPrecision() {
 		return 1;
+	}
+
+	/**
+	 * Set {@link SymmetricEss.ChannelId#ACTIVE_POWER} of this
+	 * {@link DummyHybridEss}.
+	 *
+	 * @param value the active power
+	 * @return myself
+	 */
+	public DummyHybridEss withActivePower(Integer value) {
+		this._setActivePower(value);
+		this.getActivePowerChannel().nextProcessImage();
+		return this;
+	}
+
+	/**
+	 * Set {@link HybridEss.ChannelId#DC_DISCHARGE_POWER} of this
+	 * {@link DummyHybridEss}.
+	 *
+	 * @param value the DC discharge power
+	 * @return myself
+	 */
+	public DummyHybridEss withDcDischargePower(Integer value) {
+		this._setDcDischargePower(value);
+		this.getDcDischargePowerChannel().nextProcessImage();
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
Add a configuration setting `hybridEssMode`, that allows defining the DC-side power set-point