### PR TITLE
Implement Generic HTTP Worker

### DIFF
--- a/io.openems.edge.io.generic_http_worker/.classpath
+++ b/io.openems.edge.io.generic_http_worker/.classpath
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="src" output="bin_test" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/io.openems.edge.io.generic_http_worker/.gitignore
+++ b/io.openems.edge.io.generic_http_worker/.gitignore
@@ -1,0 +1,3 @@
+/bin_test/
+/generated/
+/generated/*.*

--- a/io.openems.edge.io.generic_http_worker/.project
+++ b/io.openems.edge.io.generic_http_worker/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openems.edge.io.generic_http_worker</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/io.openems.edge.io.generic_http_worker/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.io.generic_http_worker/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+encoding//src/io/openems/edge/io/generic_http_worker/package-info.java=UTF-8
+encoding/<project>=UTF-8
+encoding/bnd.bnd=UTF-8
+encoding/readme.adoc=UTF-8

--- a/io.openems.edge.io.generic_http_worker/bnd.bnd
+++ b/io.openems.edge.io.generic_http_worker/bnd.bnd
@@ -1,0 +1,13 @@
+Bundle-Name: OpenEMS Edge io.openems.edge.io.generic_http_worker Api
+Bundle-Vendor: Nico Ketzer
+Bundle-License: https://opensource.org/licenses/EPL-2.0
+Bundle-Version: 1.0.0.${tstamp}
+
+-buildpath: \
+	${buildpath},\
+	io.openems.common,\
+	io.openems.edge.common
+
+-testpath: \
+	${testpath}
+Bundle-Copyright: Nico Ketzer

--- a/io.openems.edge.io.generic_http_worker/readme.adoc
+++ b/io.openems.edge.io.generic_http_worker/readme.adoc
@@ -1,0 +1,3 @@
+= io.openems.edge.io.generic_http_worker
+
+https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.io.generic_http_worker[Source Code icon:github[]]

--- a/io.openems.edge.io.generic_http_worker/src/io/openems/edge/io/generic_http_worker/generic_http_worker.java
+++ b/io.openems.edge.io.generic_http_worker/src/io/openems/edge/io/generic_http_worker/generic_http_worker.java
@@ -1,0 +1,161 @@
+package io.openems.edge.io.generic_http_worker;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.worker.AbstractCycleWorker;
+
+
+
+public class generic_http_worker extends AbstractCycleWorker {
+
+	private String[] urls_to_call = {};
+	private String[] response_to_call = {};
+	private boolean com_error = false; //First value is false
+	private int com_error_counter = 0; //To Reset the error
+	private int timeout = 1000; //Default Value
+	private Exception last_error;
+
+	public generic_http_worker(String[] urls_to_call, int timeout) {
+		int elements = urls_to_call.length;
+		this.urls_to_call = new String[elements]; //Redefine Array-Size
+		this.urls_to_call = urls_to_call;
+		this.response_to_call = new String[elements]; //Redefine Array-Size
+		this.timeout = timeout;
+	}
+	
+	//Used Functions
+	private String send_req(String given_url) throws OpenemsNamedException {
+		try {
+			var url = new URL(given_url);
+			var con = (HttpURLConnection) url.openConnection();
+			con.setRequestMethod("GET");
+			con.setConnectTimeout(this.timeout);
+			con.setReadTimeout(this.timeout);
+			var status = con.getResponseCode();
+			String body;
+			try (var in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
+				// Read HTTP response
+				var content = new StringBuilder();
+				String line;
+				while ((line = in.readLine()) != null) {
+					content.append(line);
+					content.append(System.lineSeparator());
+				}
+				body = content.toString();
+			}
+			if (status < 300) {
+				// Parse response to JSON
+				return body;
+			}
+			throw new OpenemsException("Error while reading from Device. Response code: " + status + ". " + body);
+		} catch (OpenemsNamedException | IOException e) {
+			this.last_error = e;
+			throw new OpenemsException(
+					"Unable to read from Device. " + e.getClass().getSimpleName() + ": " + e.getMessage() + " URL:" + given_url);
+		}
+	}
+	
+	public boolean send_external_url(String url,String expected_output) {
+		try {
+			String response = this.send_req(url);
+			if(expected_output == "") {
+				return true;
+			}else{
+				if(response.contains(expected_output) && response.length() == expected_output.length()) {
+					return true;
+				}else {
+					return false;
+				}
+			}
+		} catch (OpenemsNamedException e) {
+			this.last_error = e;
+			return false;
+		}
+	}
+	public Exception get_last_error() {
+		if(this.last_error != null) {
+			return this.last_error;
+		} else {
+			return new Exception();
+		}
+	}
+	
+	public String get_last_by_id(int element) {
+		if(this.com_error) {
+			return "_com_error_";
+		}
+		if(element <= this.response_to_call.length && element > -1) {
+			if(this.response_to_call[element] != null) {
+				return this.response_to_call[element];
+			}else {
+				return "_no_value_";
+			}
+		} else {
+			return "_undefined_";
+		}
+	}
+	public String get_last(String element) {
+		if(this.com_error) {
+			return "_com_error_";
+		}
+		String tmp_element = this.urls_to_call.toString();
+		if(tmp_element.contains(element)) {
+			int index = -1;
+			for(int i=0; i<this.urls_to_call.length; i++) {
+				String tmp_element2 = this.urls_to_call[i];
+				if(tmp_element2 == element) {
+					index = i;
+					break;
+				}
+			}
+			//Catch
+			if(index == -1) {
+				return "_undefined_";
+			}else {
+				return this.get_last_by_id(index);
+			}
+		}else {
+			return "_undefined_";
+		}
+	}
+	
+	//Worker Part
+
+	@Override
+	protected void forever() throws Throwable {
+		try {
+			for(int i=0; i<this.urls_to_call.length; i++) {
+				//Com-Error Handling to not Spam requests
+				if(this.com_error) {
+					if(this.com_error_counter > 500) {
+						this.com_error = false;
+					}else {
+						this.com_error_counter++;
+						break;
+					}
+				}
+				//Normal Process
+				try {
+					String url = this.urls_to_call[i]; //Get URL
+					
+					String response = this.send_req(url); //Get Result
+					this.response_to_call[i] = response; //Write Result
+				} catch (OpenemsNamedException e) {
+					this.last_error = e;
+					throw e;
+				}
+			}
+		} catch (OpenemsNamedException e) {
+			this.last_error = e;
+			//Failed so for this Part a Communication Error is there
+			this.com_error = true;
+		}
+
+	}
+}

--- a/io.openems.edge.io.generic_http_worker/src/io/openems/edge/io/generic_http_worker/package-info.java
+++ b/io.openems.edge.io.generic_http_worker/src/io/openems/edge/io/generic_http_worker/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package io.openems.edge.io.generic_http_worker;


### PR DESCRIPTION
Implements a generic-http-worker that can be used like an API by other components.

### Main Idea

For this purpose, a string[] array is passed to the constructor (+timeout). Then each element of the array is always processed "in a circle".

An external component can get the last available result via get_last_by_id or get_last.

The get_last_by_id function refers to the ID of the element of the String[] array that was passed to the constructor. If for some reason this ID is not unambiguously available in the code of the main component, you can also pass the actual URL via get_last and then the ID will be determined automatically.

With get_last_error() it can be queried whether an error has occurred. This can be used e.g. to trigger a SlaveCommunicationError in the "main component".

### Example - How to Call the worker

```
[...]
import io.openems.edge.io.generic_http_worker.generic_http_worker
[...]

String[] urls = new String[]{"http://[device_ip]/[some_url]","http://[another_device]/[another_url]",[...]};
int timeout = 2500;

generic_http_worker worker = new generic_http_worker(urls, timeout);

[...]
```

If you now at some Point in the Code run "this.worker.get_last_by_id(0)" you get the last Result of the First Element of "urls". If you alter the 0 to a 1 than you would get the last Result of the second element. 

If you want to ensure that the possible Communication Error of one Component does not affect the other calls, you could also call it like:
```
[...]
String[] url1 = new String[]{"[First_Device]/[Some_Path]"};
String[] url2 = new String[]{"[Second_Device]/[Some_Path]"};
int timeout = 2500;

generic_http_worker worker1 = new generic_http_worker(url1,timeout);
generic_http_worker worker2 = new generic_http_worker(url2, timeout);
[...]
```

In each case, you have to activate the worker via the standard "activate()" function of the AbstractCycleWorker (also the "deactivate()" function if you disable the Main-Component).
Also, you have to call the "triggerNextRun()" function on each of your Workers in the "handleEvent()" part of the Main-Component.

### External Interface Option

The send_external_url function provides a way to temporarily execute an additional URL for the current worker from outside. This function is needed e.g. for relay implementations because otherwise a separate handler similar to the "send_req" function would have to be implemented for switching on and off.

Important: 
This function does not take advantage of the worker, but actually blocks until a response is available. 
I made this decision because theoretically it is possible that the feedback of the temporary call is needed for further processing. If you use the worker for this and the further processing happens immediately (which is mostly the case) the worker would return a "_no_value_" which would hinder the further processing.


### Possible Feedback-Values

The following results can occur with get_last or get_last_by_id:
_undefined_
_com_error_
_no_value_
Exception
[result of the last query]


### Further Information

In a separate pull request, I will add components that use this generic-http-worker interface.

The advantage of this is that the handleEvent() - function of the main component does not block and therefore the whole OpenEMS cycle does not have to wait for single requests or answers of external components.

The implementation has been extensively tested. Currently, this also runs on my own energy storage without problems. This is used here by several components (These components are carried together in a separate pull). The Cycle blocked before this Project for up to 5 Seconds because of HTTP-Calls to external Devices that took longer than the OpenEMS-Cycle. Now the Cycle can always end at it´s defined time.

Many greetings,
Nico