### PR TITLE
Implement Comexio-Smarthome

### DIFF
--- a/io.openems.edge.io.comexio/.classpath
+++ b/io.openems.edge.io.comexio/.classpath
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="src" output="bin_test" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/io.openems.edge.io.comexio/.gitignore
+++ b/io.openems.edge.io.comexio/.gitignore
@@ -1,0 +1,3 @@
+/bin_test/
+/generated/
+/generated/*.*

--- a/io.openems.edge.io.comexio/.project
+++ b/io.openems.edge.io.comexio/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openems.edge.io.comexio</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/io.openems.edge.io.comexio/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.io.comexio/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+encoding//src/io/openems/edge/io/comexio/Config.java=UTF-8
+encoding/<project>=UTF-8
+encoding/bnd.bnd=UTF-8
+encoding/readme.adoc=UTF-8

--- a/io.openems.edge.io.comexio/bnd.bnd
+++ b/io.openems.edge.io.comexio/bnd.bnd
@@ -1,0 +1,18 @@
+Bundle-Vendor: Nico Ketzer
+Bundle-License: https://opensource.org/licenses/EPL-2.0
+Bundle-Version: 1.0.0.${tstamp}
+
+-buildpath: \
+	${buildpath},\
+	io.openems.edge.io.generic_http_worker;version=latest,\
+	io.openems.edge.io.api;version=latest,\
+	io.openems.edge.common;version=latest,\
+	io.openems.common;version=latest,\
+	io.openems.edge.meter.api;version=latest
+
+-testpath: \
+	${testpath}
+Bundle-Description: Implements a Generic HTTP IO for Comexio Smarthome
+Bundle-Category: IO / Smarthome
+Bundle-Copyright: Nico Ketzer
+Bundle-Name: IO Generic HTTP Comexio Implementation

--- a/io.openems.edge.io.comexio/readme.adoc
+++ b/io.openems.edge.io.comexio/readme.adoc
@@ -1,0 +1,3 @@
+= io.openems.edge.io.comexio
+
+https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.io.comexio[Source Code icon:github[]]

--- a/io.openems.edge.io.comexio/src/io/openems/edge/io/comexio/Config.java
+++ b/io.openems.edge.io.comexio/src/io/openems/edge/io/comexio/Config.java
@@ -1,0 +1,45 @@
+package io.openems.edge.io.comexio;
+
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+import io.openems.edge.meter.api.MeterType;
+
+@ObjectClassDefinition(//
+		name = "IO Generic HTTP Comexio Implementation", //
+		description = "Implements a Generic HTTP IO for Comexio Smarthome")
+@interface Config {
+
+	@AttributeDefinition(name = "Component-ID", description = "Unique ID of this Component")
+	String id() default "io0";
+
+	@AttributeDefinition(name = "Alias", description = "Human-readable name of this Component; defaults to Component-ID")
+	String alias() default "";
+
+	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
+	boolean enabled() default true;
+
+	@AttributeDefinition(name = "IP", description = "IP of the Comexio-Smarthome-Server")
+	String ip();
+	
+	@AttributeDefinition(name = "Group Prefix", description = "Name of the Server or extension of Comexio-Smarthome e.g. \"IO-Server\"")
+	String group_prefix() default "IO-Server";
+	
+	@AttributeDefinition(name = "Username", description = "If the API is protected by a login please type in the API-Username if not leave it blank")
+	String username() default "";
+	
+	@AttributeDefinition(name = "Password", description = "If the API is protected by a login please type in the API-Password if not leave it blank")
+	String password() default "";
+	
+	@AttributeDefinition(name = "Voltage Level", description = "Comexio only proviedes a Current-Value per Relay. To calculate the Power we need the Voltage-Level applied")
+	String voltage() default "230.0";
+	
+	@AttributeDefinition(name = "Timeout in ms", description = "Please define a timeout in ms for the HTTP-Requests")
+	int timeout() default 5000;	
+	
+	@AttributeDefinition(name = "Meter-Type", description = "What is measured by this Meter?")
+	MeterType type() default MeterType.CONSUMPTION_METERED;
+
+	String webconsole_configurationFactory_nameHint() default "IO Generic HTTP Comexio Implementation [{id}]";
+}

--- a/io.openems.edge.io.comexio/src/io/openems/edge/io/comexio/comexio.java
+++ b/io.openems.edge.io.comexio/src/io/openems/edge/io/comexio/comexio.java
@@ -1,0 +1,543 @@
+package io.openems.edge.io.comexio;
+
+import org.osgi.service.event.EventHandler;
+
+import io.openems.common.channel.AccessMode;
+import io.openems.common.channel.Level;
+import io.openems.common.channel.PersistencePriority;
+import io.openems.common.channel.Unit;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.types.OpenemsType;
+import io.openems.edge.common.channel.BooleanDoc;
+import io.openems.edge.common.channel.BooleanWriteChannel;
+import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.FloatReadChannel;
+import io.openems.edge.common.channel.StateChannel;
+import io.openems.edge.common.channel.value.Value;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.io.api.DigitalOutput;
+import io.openems.edge.meter.api.SymmetricMeter;
+
+public interface comexio extends DigitalOutput, SymmetricMeter, OpenemsComponent, EventHandler {
+
+	public static enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+
+		DEBUG_RELAY_1(Doc.of(OpenemsType.BOOLEAN)),
+		RELAY_1(new BooleanDoc() //
+				.accessMode(AccessMode.READ_WRITE) //
+				.onInit(new BooleanWriteChannel.MirrorToDebugChannel(ChannelId.DEBUG_RELAY_1))),
+		DEBUG_RELAY_2(Doc.of(OpenemsType.BOOLEAN)),
+		RELAY_2(new BooleanDoc() //
+				.accessMode(AccessMode.READ_WRITE) //
+				.onInit(new BooleanWriteChannel.MirrorToDebugChannel(ChannelId.DEBUG_RELAY_2))),
+		DEBUG_RELAY_3(Doc.of(OpenemsType.BOOLEAN)),
+		RELAY_3(new BooleanDoc() //
+				.accessMode(AccessMode.READ_WRITE) //
+				.onInit(new BooleanWriteChannel.MirrorToDebugChannel(ChannelId.DEBUG_RELAY_3))),
+		DEBUG_RELAY_4(Doc.of(OpenemsType.BOOLEAN)),
+		RELAY_4(new BooleanDoc() //
+				.accessMode(AccessMode.READ_WRITE) //
+				.onInit(new BooleanWriteChannel.MirrorToDebugChannel(ChannelId.DEBUG_RELAY_4))),
+		DEBUG_RELAY_5(Doc.of(OpenemsType.BOOLEAN)),
+		RELAY_5(new BooleanDoc() //
+				.accessMode(AccessMode.READ_WRITE) //
+				.onInit(new BooleanWriteChannel.MirrorToDebugChannel(ChannelId.DEBUG_RELAY_5))),
+		DEBUG_RELAY_6(Doc.of(OpenemsType.BOOLEAN)),
+		RELAY_6(new BooleanDoc() //
+				.accessMode(AccessMode.READ_WRITE) //
+				.onInit(new BooleanWriteChannel.MirrorToDebugChannel(ChannelId.DEBUG_RELAY_6))),
+		DEBUG_RELAY_7(Doc.of(OpenemsType.BOOLEAN)),
+		RELAY_7(new BooleanDoc() //
+				.accessMode(AccessMode.READ_WRITE) //
+				.onInit(new BooleanWriteChannel.MirrorToDebugChannel(ChannelId.DEBUG_RELAY_7))),
+		DEBUG_RELAY_8(Doc.of(OpenemsType.BOOLEAN)),
+		RELAY_8(new BooleanDoc() //
+				.accessMode(AccessMode.READ_WRITE) //
+				.onInit(new BooleanWriteChannel.MirrorToDebugChannel(ChannelId.DEBUG_RELAY_8))),
+		DEBUG_RELAY_9(Doc.of(OpenemsType.BOOLEAN)),
+		RELAY_9(new BooleanDoc() //
+				.accessMode(AccessMode.READ_WRITE) //
+				.onInit(new BooleanWriteChannel.MirrorToDebugChannel(ChannelId.DEBUG_RELAY_9))),
+		
+		CURRENT_1(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.AMPERE) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		CURRENT_2(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.AMPERE) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		CURRENT_3(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.AMPERE) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		CURRENT_4(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.AMPERE) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		CURRENT_5(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.AMPERE) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		CURRENT_6(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.AMPERE) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		CURRENT_7(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.AMPERE) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		CURRENT_8(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.AMPERE) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		CURRENT_9(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.AMPERE) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		
+		
+		POWER_1(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.WATT) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		POWER_2(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.WATT) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		POWER_3(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.WATT) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		POWER_4(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.WATT) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		POWER_5(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.WATT) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		POWER_6(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.WATT) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		POWER_7(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.WATT) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		POWER_8(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.WATT) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+		POWER_9(Doc.of(OpenemsType.FLOAT) //
+				.unit(Unit.WATT) //
+				.accessMode(AccessMode.READ_ONLY) //
+				.persistencePriority(PersistencePriority.LOW)),
+
+		
+		
+
+		SLAVE_COMMUNICATION_FAILED(Doc.of(Level.FAULT)); //
+
+		private final Doc doc;
+
+		private ChannelId(Doc doc) {
+			this.doc = doc;
+		}
+
+		@Override
+		public Doc doc() {
+			return this.doc;
+		}
+	}
+	
+	
+	
+	//Relay 1
+	public default BooleanWriteChannel getRelay1Channel() {
+		return this.channel(ChannelId.RELAY_1);
+	}
+
+	public default Value<Boolean> get1Relay() {
+		return this.getRelay1Channel().value();
+	}
+
+
+	public default void _setRelay1(Boolean value) {
+		this.getRelay1Channel().setNextValue(value);
+	}
+
+	public default void setRelay1(boolean value) throws OpenemsNamedException {
+		this.getRelay1Channel().setNextWriteValue(value);
+	}
+	//Relay 2
+	public default BooleanWriteChannel getRelay2Channel() {
+		return this.channel(ChannelId.RELAY_2);
+	}
+	
+	public default Value<Boolean> get2Relay() {
+		return this.getRelay2Channel().value();
+	}
+	
+	public default void _setRelay2(Boolean value) {
+		this.getRelay2Channel().setNextValue(value);
+	}
+
+	public default void setRelay2(boolean value) throws OpenemsNamedException {
+		this.getRelay2Channel().setNextWriteValue(value);
+	}
+	//Relay 3
+	public default BooleanWriteChannel getRelay3Channel() {
+		return this.channel(ChannelId.RELAY_3);
+	}
+
+	public default Value<Boolean> get3Relay() {
+		return this.getRelay3Channel().value();
+	}
+
+
+	public default void _setRelay3(Boolean value) {
+		this.getRelay3Channel().setNextValue(value);
+	}
+
+	public default void setRelay3(boolean value) throws OpenemsNamedException {
+		this.getRelay3Channel().setNextWriteValue(value);
+	}
+	//Relay 4
+	public default BooleanWriteChannel getRelay4Channel() {
+		return this.channel(ChannelId.RELAY_4);
+	}
+
+	public default Value<Boolean> get4Relay() {
+		return this.getRelay4Channel().value();
+	}
+
+
+	public default void _setRelay4(Boolean value) {
+		this.getRelay4Channel().setNextValue(value);
+	}
+
+	public default void setRelay4(boolean value) throws OpenemsNamedException {
+		this.getRelay4Channel().setNextWriteValue(value);
+	}
+	//Relay 5
+	public default BooleanWriteChannel getRelay5Channel() {
+		return this.channel(ChannelId.RELAY_5);
+	}
+
+	public default Value<Boolean> get5Relay() {
+		return this.getRelay5Channel().value();
+	}
+
+
+	public default void _setRelay5(Boolean value) {
+		this.getRelay5Channel().setNextValue(value);
+	}
+
+	public default void setRelay5(boolean value) throws OpenemsNamedException {
+		this.getRelay5Channel().setNextWriteValue(value);
+	}
+	//Relay 6
+	public default BooleanWriteChannel getRelay6Channel() {
+		return this.channel(ChannelId.RELAY_6);
+	}
+
+	public default Value<Boolean> get6Relay() {
+		return this.getRelay6Channel().value();
+	}
+
+
+	public default void _setRelay6(Boolean value) {
+		this.getRelay6Channel().setNextValue(value);
+	}
+
+	public default void setRelay6(boolean value) throws OpenemsNamedException {
+		this.getRelay6Channel().setNextWriteValue(value);
+	}
+	//Relay 7
+	public default BooleanWriteChannel getRelay7Channel() {
+		return this.channel(ChannelId.RELAY_7);
+	}
+
+	public default Value<Boolean> get7Relay() {
+		return this.getRelay7Channel().value();
+	}
+
+
+	public default void _setRelay7(Boolean value) {
+		this.getRelay7Channel().setNextValue(value);
+	}
+
+	public default void setRelay7(boolean value) throws OpenemsNamedException {
+		this.getRelay7Channel().setNextWriteValue(value);
+	}
+	//Relay 8
+	public default BooleanWriteChannel getRelay8Channel() {
+		return this.channel(ChannelId.RELAY_8);
+	}
+
+	public default Value<Boolean> get8Relay() {
+		return this.getRelay8Channel().value();
+	}
+
+
+	public default void _setRelay8(Boolean value) {
+		this.getRelay8Channel().setNextValue(value);
+	}
+
+	public default void setRelay8(boolean value) throws OpenemsNamedException {
+		this.getRelay8Channel().setNextWriteValue(value);
+	}
+	//Relay 9
+	public default BooleanWriteChannel getRelay9Channel() {
+		return this.channel(ChannelId.RELAY_9);
+	}
+
+	public default Value<Boolean> get9Relay() {
+		return this.getRelay9Channel().value();
+	}
+
+	public default void _setRelay9(Boolean value) {
+		this.getRelay9Channel().setNextValue(value);
+	}
+
+	public default void setRelay9(boolean value) throws OpenemsNamedException {
+		this.getRelay9Channel().setNextWriteValue(value);
+	}
+	
+	
+	//Current 1
+		public default FloatReadChannel getCurrent1Channel() {
+			return this.channel(ChannelId.CURRENT_1);
+		}
+
+		public default Value<Float> get1Current() {
+			return this.getCurrent1Channel().value();
+		}
+
+
+		public default void _setCurrent1(float value) {
+			this.getCurrent1Channel().setNextValue(value);
+		}
+		//Current 2
+		public default FloatReadChannel getCurrent2Channel() {
+			return this.channel(ChannelId.CURRENT_2);
+		}
+		
+		public default Value<Float> get2Current() {
+			return this.getCurrent2Channel().value();
+		}
+		
+		public default void _setCurrent2(float value) {
+			this.getCurrent2Channel().setNextValue(value);
+		}
+		//Current 3
+		public default FloatReadChannel getCurrent3Channel() {
+			return this.channel(ChannelId.CURRENT_3);
+		}
+
+		public default Value<Float> get3Current() {
+			return this.getCurrent3Channel().value();
+		}
+
+		public default void _setCurrent3(float value) {
+			this.getCurrent3Channel().setNextValue(value);
+		}
+		//Current 4
+		public default FloatReadChannel getCurrent4Channel() {
+			return this.channel(ChannelId.CURRENT_4);
+		}
+
+		public default Value<Float> get4Current() {
+			return this.getCurrent4Channel().value();
+		}
+
+		public default void _setCurrent4(float value) {
+			this.getCurrent4Channel().setNextValue(value);
+		}
+		//Current 5
+		public default FloatReadChannel getCurrent5Channel() {
+			return this.channel(ChannelId.CURRENT_5);
+		}
+
+		public default Value<Float> get5Current() {
+			return this.getCurrent5Channel().value();
+		}
+
+		public default void _setCurrent5(float value) {
+			this.getCurrent5Channel().setNextValue(value);
+		}
+		//Current 6
+		public default FloatReadChannel getCurrent6Channel() {
+			return this.channel(ChannelId.CURRENT_6);
+		}
+
+		public default Value<Float> get6Current() {
+			return this.getCurrent6Channel().value();
+		}
+
+		public default void _setCurrent6(float value) {
+			this.getCurrent6Channel().setNextValue(value);
+		}
+		//Current 7
+		public default FloatReadChannel getCurrent7Channel() {
+			return this.channel(ChannelId.CURRENT_7);
+		}
+
+		public default Value<Float> get7Current() {
+			return this.getCurrent7Channel().value();
+		}
+		
+		public default void _setCurrent7(float value) {
+			this.getCurrent7Channel().setNextValue(value);
+		}
+		//Current 8
+		public default FloatReadChannel getCurrent8Channel() {
+			return this.channel(ChannelId.CURRENT_8);
+		}
+
+		public default Value<Float> get8Current() {
+			return this.getCurrent8Channel().value();
+		}
+
+		public default void _setCurrent8(float value) {
+			this.getCurrent8Channel().setNextValue(value);
+		}
+		//Current 9
+		public default FloatReadChannel getCurrent9Channel() {
+			return this.channel(ChannelId.CURRENT_9);
+		}
+
+		public default Value<Float> get9Current() {
+			return this.getCurrent9Channel().value();
+		}
+
+		public default void _setCurrent9(float value) {
+			this.getCurrent9Channel().setNextValue(value);
+		}
+		
+		
+		//Power 1
+		public default FloatReadChannel getPower1Channel() {
+			return this.channel(ChannelId.POWER_1);
+		}
+
+		public default Value<Float> get1Power() {
+			return this.getPower1Channel().value();
+		}
+
+
+		public default void _setPower1(float value) {
+			this.getPower1Channel().setNextValue(value);
+		}
+		//Power 2
+		public default FloatReadChannel getPower2Channel() {
+			return this.channel(ChannelId.POWER_2);
+		}
+		
+		public default Value<Float> get2Power() {
+			return this.getPower2Channel().value();
+		}
+		
+		public default void _setPower2(float value) {
+			this.getPower2Channel().setNextValue(value);
+		}
+		//Power 3
+		public default FloatReadChannel getPower3Channel() {
+			return this.channel(ChannelId.POWER_3);
+		}
+
+		public default Value<Float> get3Power() {
+			return this.getPower3Channel().value();
+		}
+
+		public default void _setPower3(float value) {
+			this.getPower3Channel().setNextValue(value);
+		}
+		//Power 4
+		public default FloatReadChannel getPower4Channel() {
+			return this.channel(ChannelId.POWER_4);
+		}
+
+		public default Value<Float> get4Power() {
+			return this.getPower4Channel().value();
+		}
+
+		public default void _setPower4(float value) {
+			this.getPower4Channel().setNextValue(value);
+		}
+		//Power 5
+		public default FloatReadChannel getPower5Channel() {
+			return this.channel(ChannelId.POWER_5);
+		}
+
+		public default Value<Float> get5Power() {
+			return this.getPower5Channel().value();
+		}
+
+		public default void _setPower5(float value) {
+			this.getPower5Channel().setNextValue(value);
+		}
+		//Power 6
+		public default FloatReadChannel getPower6Channel() {
+			return this.channel(ChannelId.POWER_6);
+		}
+
+		public default Value<Float> get6Power() {
+			return this.getPower6Channel().value();
+		}
+
+		public default void _setPower6(float value) {
+			this.getPower6Channel().setNextValue(value);
+		}
+		//Power 7
+		public default FloatReadChannel getPower7Channel() {
+			return this.channel(ChannelId.POWER_7);
+		}
+
+		public default Value<Float> get7Power() {
+			return this.getPower7Channel().value();
+		}
+		
+		public default void _setPower7(float value) {
+			this.getPower7Channel().setNextValue(value);
+		}
+		//Power 8
+		public default FloatReadChannel getPower8Channel() {
+			return this.channel(ChannelId.POWER_8);
+		}
+
+		public default Value<Float> get8Power() {
+			return this.getPower8Channel().value();
+		}
+
+		public default void _setPower8(float value) {
+			this.getPower8Channel().setNextValue(value);
+		}
+		//Power 9
+		public default FloatReadChannel getPower9Channel() {
+			return this.channel(ChannelId.POWER_9);
+		}
+
+		public default Value<Float> get9Power() {
+			return this.getPower9Channel().value();
+		}
+
+		public default void _setPower9(float value) {
+			this.getPower9Channel().setNextValue(value);
+		}
+		
+
+
+	public default StateChannel getSlaveCommunicationFailedChannel() {
+		return this.channel(ChannelId.SLAVE_COMMUNICATION_FAILED);
+	}
+
+	public default Value<Boolean> getSlaveCommunicationFailed() {
+		return this.getSlaveCommunicationFailedChannel().value();
+	}
+
+	public default void _setSlaveCommunicationFailed(boolean value) {
+		this.getSlaveCommunicationFailedChannel().setNextValue(value);
+	}
+}

--- a/io.openems.edge.io.comexio/src/io/openems/edge/io/comexio/comexioImpl.java
+++ b/io.openems.edge.io.comexio/src/io/openems/edge/io/comexio/comexioImpl.java
@@ -1,0 +1,308 @@
+package io.openems.edge.io.comexio;
+
+import java.util.Objects;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.event.propertytypes.EventTopics;
+import org.osgi.service.metatype.annotations.Designate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.edge.common.channel.BooleanWriteChannel;
+import io.openems.edge.common.channel.WriteChannel;
+import io.openems.edge.common.component.AbstractOpenemsComponent;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.event.EdgeEventConstants;
+import io.openems.edge.io.api.DigitalOutput;
+import io.openems.edge.io.generic_http_worker.*;
+import io.openems.edge.meter.api.MeterType;
+import io.openems.edge.meter.api.SymmetricMeter;
+
+@Designate(ocd = Config.class, factory = true)
+@Component(//
+		name = "IO Generic HTTP Comexio Implementation", //
+		immediate = true, //
+		configurationPolicy = ConfigurationPolicy.REQUIRE//
+)
+@EventTopics({ //
+		EdgeEventConstants.TOPIC_CYCLE_BEFORE_PROCESS_IMAGE, //
+		EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE //
+})
+public class comexioImpl extends AbstractOpenemsComponent
+		implements comexio, DigitalOutput, SymmetricMeter, OpenemsComponent, EventHandler {
+
+	private final Logger log = LoggerFactory.getLogger(comexioImpl.class);
+
+	private final BooleanWriteChannel[] digitalOutputChannels;
+	private generic_http_worker worker[] = new generic_http_worker[9];
+	private MeterType meterType = null;
+	Config config = null;
+	float voltage = (float) 0;
+	private String base_url = null;
+	private String on_urls[] = new String[9];
+	private String off_urls[] = new String[9];
+	private String on_successful_return = "1";
+	private String off_successful_retrun = "1";
+	private String state_successful_return = "1";
+
+	public comexioImpl() {
+		super(//
+				OpenemsComponent.ChannelId.values(), //
+				SymmetricMeter.ChannelId.values(), //
+				DigitalOutput.ChannelId.values(), //
+				comexio.ChannelId.values() //
+		);
+		this.digitalOutputChannels = new BooleanWriteChannel[] { //
+				this.channel(comexio.ChannelId.RELAY_1), //
+				this.channel(comexio.ChannelId.RELAY_2), //
+				this.channel(comexio.ChannelId.RELAY_3), //
+				this.channel(comexio.ChannelId.RELAY_4), //
+				this.channel(comexio.ChannelId.RELAY_5), //
+				this.channel(comexio.ChannelId.RELAY_6), //
+				this.channel(comexio.ChannelId.RELAY_7), //
+				this.channel(comexio.ChannelId.RELAY_8), //
+				this.channel(comexio.ChannelId.RELAY_9), //
+		};
+	}
+	void generate_worker() {
+		if(this.config.username() != "" && this.config.password() != "") {
+			this.base_url = "http://" + this.config.username() + ":" + this.config.password() + "@" + this.config.ip() + "/api/?ext=" + this.config.group_prefix() + "&action=";
+		}else {
+			this.base_url = "http://" + this.config.ip() + "/api/?ext=" + this.config.group_prefix() + "&action="; 
+		}
+		for(int i = 0; i < 9; i++) {
+			this.on_urls[i] = this.base_url + "set&io=Q" + (i+1) + "&value=1"; //+1 da Comexio bei 1 zum zählen beginnt		
+			this.off_urls[i] = this.base_url + "set&io=Q" + (i+1) + "&value=0"; // +1 da Comexio bei 1 zum zählen beginnt
+			String state_url = this.base_url + "get&io=Q" + (i+1); // +1 da Comexio bei 1 zum zählen beginnt
+			String meter_url = this.base_url + "get&io=QI" + (i+1); // +1 da Comexio bei 1 zum zählen beginnt
+			int timeout = this.config.timeout();
+			String tmp[] = {state_url,meter_url};
+			this.worker[i] = new generic_http_worker(tmp,timeout);
+		}
+	}
+	void destroy_worker() {
+		for(int i=0; i<this.worker.length; i++) {
+			generic_http_worker tmp_worker = this.worker[i];
+			tmp_worker.deactivate();
+		}
+	}
+	void activate_worker() {
+		for(int i=0; i<this.worker.length; i++) {
+			generic_http_worker tmp_worker = this.worker[i];
+			tmp_worker.activate("Comexio Worker"+String.valueOf(i));
+			tmp_worker.triggerNextRun();
+		}
+	}
+
+	@Activate
+	void activate(ComponentContext context, Config config) {
+		super.activate(context, config.id(), config.alias(), config.enabled());
+		this.config = config;
+		this.voltage = Float.parseFloat(this.config.voltage());
+		this.generate_worker();
+		this.activate_worker();
+		this.meterType = config.type();
+	}
+
+	@Override
+	@Deactivate
+	protected void deactivate() {
+		super.deactivate();
+		//Needed to destroy the API-Workers
+		this.destroy_worker();
+	}
+
+	@Override
+	public BooleanWriteChannel[] digitalOutputChannels() {
+		return this.digitalOutputChannels;
+	}
+
+	@Override
+	public String debugLog() {
+		var b = new StringBuilder();
+		var i = 1;
+		for (WriteChannel<Boolean> channel : this.digitalOutputChannels) {
+			String valueText;
+			var valueOpt = channel.value().asOptional();
+			if (valueOpt.isPresent()) {
+				valueText = valueOpt.get() ? "x" : "-";
+			} else {
+				valueText = "?";
+			}
+			b.append(i + valueText);
+
+			// add space for all but the last
+			if (++i <= this.digitalOutputChannels.length) {
+				b.append(" ");
+			}
+		}
+		return b.toString();
+	}
+
+	@Override
+	public void handleEvent(Event event) {
+		if (!this.isEnabled()) {
+			return;
+		}
+
+		switch (event.getTopic()) {
+		case EdgeEventConstants.TOPIC_CYCLE_BEFORE_PROCESS_IMAGE:
+			this.eventBeforeProcessImage();
+			break;
+
+		case EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE:
+			this.eventExecuteWrite();
+			break;
+		}
+	}
+
+	/**
+	 * Execute on Cycle Event "Before Process Image".
+	 */
+	private void eventBeforeProcessImage() {
+		
+		Boolean relayIson[] = new Boolean[9];
+		float Current_Per_Relay[] = new float[9];
+		Integer Power_Per_Relay[] = new Integer[9];
+		Integer power = 0;
+		Long energy = (long) 0; //Comexio stellt keine Energy-Daten bereit daher können diese auch nicht abgefragt werden.
+		try {
+			for(int i = 0; i < 9; i++) {
+				generic_http_worker tmp_worker = this.worker[i];
+				tmp_worker.triggerNextRun();
+				String state = tmp_worker.get_last_by_id(0).replace("\n", "").replace("\\n", "").replace("\r", "").replace("\\r", "").trim(); //ID "0" ist der State-URL	
+				if(state == "_undefined_") {
+					this.logError(this.log, "Generic HTTP Worker Called on an Undefined Index 0");
+					throw tmp_worker.get_last_error();
+				}else if(state == "_no_value_") {
+					this.logInfo(this.log, "Generic HTTP Worker has not recieved Data yet");
+					relayIson[i] = null;
+				}else if(state == "_com_error_") {
+					this.logError(this.log, "Generic HTTP Worker gave back the State \"Com-Error\"");
+					throw tmp_worker.get_last_error();
+				}else if(state.contains(this.state_successful_return) && state.length() == this.state_successful_return.length()) {
+					relayIson[i] = true; 
+				}else {
+					//Es ist kein Fehler und auch nicht der Erwartete Wert zurück gekommen daher wird false geschrieben
+					relayIson[i] = false;
+				}
+				String non_escaped = tmp_worker.get_last_by_id(1); //ID "1" ist der Meter-URL
+				if(non_escaped == "_undefined_") {
+					this.logError(this.log, "Generic HTTP Worker Called on an Undefined Index 1");
+					throw tmp_worker.get_last_error();
+				}else if(non_escaped == "_no_value_") {
+					this.logInfo(this.log, "Generic HTTP Worker has not recieved Data yet");
+				}else if(non_escaped == "_com_error_") {
+					this.logError(this.log, "Generic HTTP Worker gave back the State \"Com-Error\"");
+					throw tmp_worker.get_last_error();
+				}else {
+					String escaped = non_escaped.replace("\n", "").replace("\\n", "").replace("\r", "").replace("\\r", "").trim();
+					float tmp_current = Float.parseFloat(escaped);
+					Current_Per_Relay[i] = tmp_current;
+					float tmp_power = (tmp_current * this.voltage);
+					
+					
+					Integer rounded_power = Math.round(tmp_power);
+					
+					Power_Per_Relay[i] = rounded_power;
+					
+					power = power + rounded_power;
+				}
+			}
+
+		} catch (Exception e) {
+			this.logError(this.log, "Unable to read from Device: " + e.getMessage());
+			this._setSlaveCommunicationFailed(true);
+		}
+		
+		//Die Array-Werte weichen um -1 ab zu dem _setRelay[x] channel. Comexio beginnt bei 1 zu zählen
+		this._setRelay1(relayIson[0]);
+		this._setRelay2(relayIson[1]);
+		this._setRelay3(relayIson[2]);
+		this._setRelay4(relayIson[3]);
+		this._setRelay5(relayIson[4]);
+		this._setRelay6(relayIson[5]);
+		this._setRelay7(relayIson[6]);
+		this._setRelay8(relayIson[7]);
+		this._setRelay9(relayIson[8]);
+		
+		//Set Current
+		this._setCurrent1(Current_Per_Relay[0]);
+		this._setCurrent2(Current_Per_Relay[1]);
+		this._setCurrent3(Current_Per_Relay[2]);
+		this._setCurrent4(Current_Per_Relay[3]);
+		this._setCurrent5(Current_Per_Relay[4]);
+		this._setCurrent6(Current_Per_Relay[5]);
+		this._setCurrent7(Current_Per_Relay[6]);
+		this._setCurrent8(Current_Per_Relay[7]);
+		this._setCurrent9(Current_Per_Relay[8]);
+
+		//Set Current
+		this._setPower1(Power_Per_Relay[0]);
+		this._setPower2(Power_Per_Relay[1]);
+		this._setPower3(Power_Per_Relay[2]);
+		this._setPower4(Power_Per_Relay[3]);
+		this._setPower5(Power_Per_Relay[4]);
+		this._setPower6(Power_Per_Relay[5]);
+		this._setPower7(Power_Per_Relay[6]);
+		this._setPower8(Power_Per_Relay[7]);
+		this._setPower9(Power_Per_Relay[8]);
+		
+		//Dieser Wert ist die Summe der einzelnen Relay-Werte
+		this._setActivePower(power);
+		//Hier wird immer (long) 0 geschrieben da Comexio keine Daten bereitstellt
+		this._setActiveProductionEnergy(energy);
+	}
+
+	/**
+	 * Execute on Cycle Event "Execute Write".
+	 */
+	private void eventExecuteWrite() {
+		try {
+			this.executeWrite(this.getRelay1Channel(), 0);
+			this.executeWrite(this.getRelay2Channel(), 1);
+			this.executeWrite(this.getRelay3Channel(), 2);
+			this.executeWrite(this.getRelay4Channel(), 3);
+			this.executeWrite(this.getRelay5Channel(), 4);
+			this.executeWrite(this.getRelay6Channel(), 5);
+			this.executeWrite(this.getRelay7Channel(), 6);
+			this.executeWrite(this.getRelay8Channel(), 7);
+			this.executeWrite(this.getRelay9Channel(), 8);
+
+			this._setSlaveCommunicationFailed(false);
+		} catch (OpenemsNamedException e) {
+			this._setSlaveCommunicationFailed(true);
+		}
+	}
+
+	private void executeWrite(BooleanWriteChannel channel, int index) throws OpenemsNamedException {
+		var readValue = channel.value().get();
+		var writeValue = channel.getNextWriteValueAndReset();
+		if (!writeValue.isPresent()) {
+			// no write value
+			return;
+		}
+		if (Objects.equals(readValue, writeValue.get())) {
+			// read value = write value
+			return;
+		}
+		if(writeValue.get()) {
+			this.worker[index].send_external_url(this.on_urls[index], this.on_successful_return);
+		}else {
+			this.worker[index].send_external_url(this.off_urls[index], this.off_successful_retrun);
+		}
+	}
+
+	@Override
+	public MeterType getMeterType() {
+		return this.meterType;
+	}
+
+}

--- a/io.openems.edge.io.generic_http_worker/.classpath
+++ b/io.openems.edge.io.generic_http_worker/.classpath
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="src" output="bin_test" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/io.openems.edge.io.generic_http_worker/.gitignore
+++ b/io.openems.edge.io.generic_http_worker/.gitignore
@@ -1,0 +1,3 @@
+/bin_test/
+/generated/
+/generated/*.*

--- a/io.openems.edge.io.generic_http_worker/.project
+++ b/io.openems.edge.io.generic_http_worker/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openems.edge.io.generic_http_worker</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/io.openems.edge.io.generic_http_worker/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.io.generic_http_worker/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+encoding//src/io/openems/edge/io/generic_http_worker/package-info.java=UTF-8
+encoding/<project>=UTF-8
+encoding/bnd.bnd=UTF-8
+encoding/readme.adoc=UTF-8

--- a/io.openems.edge.io.generic_http_worker/bnd.bnd
+++ b/io.openems.edge.io.generic_http_worker/bnd.bnd
@@ -1,0 +1,13 @@
+Bundle-Name: OpenEMS Edge io.openems.edge.io.generic_http_worker Api
+Bundle-Vendor: Nico Ketzer
+Bundle-License: https://opensource.org/licenses/EPL-2.0
+Bundle-Version: 1.0.0.${tstamp}
+
+-buildpath: \
+	${buildpath},\
+	io.openems.common,\
+	io.openems.edge.common
+
+-testpath: \
+	${testpath}
+Bundle-Copyright: Nico Ketzer

--- a/io.openems.edge.io.generic_http_worker/readme.adoc
+++ b/io.openems.edge.io.generic_http_worker/readme.adoc
@@ -1,0 +1,3 @@
+= io.openems.edge.io.generic_http_worker
+
+https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.io.generic_http_worker[Source Code icon:github[]]

--- a/io.openems.edge.io.generic_http_worker/src/io/openems/edge/io/generic_http_worker/generic_http_worker.java
+++ b/io.openems.edge.io.generic_http_worker/src/io/openems/edge/io/generic_http_worker/generic_http_worker.java
@@ -1,0 +1,161 @@
+package io.openems.edge.io.generic_http_worker;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.worker.AbstractCycleWorker;
+
+
+
+public class generic_http_worker extends AbstractCycleWorker {
+
+	private String[] urls_to_call = {};
+	private String[] response_to_call = {};
+	private boolean com_error = false; //First value is false
+	private int com_error_counter = 0; //To Reset the error
+	private int timeout = 1000; //Default Value
+	private Exception last_error;
+
+	public generic_http_worker(String[] urls_to_call, int timeout) {
+		int elements = urls_to_call.length;
+		this.urls_to_call = new String[elements]; //Redefine Array-Size
+		this.urls_to_call = urls_to_call;
+		this.response_to_call = new String[elements]; //Redefine Array-Size
+		this.timeout = timeout;
+	}
+	
+	//Used Functions
+	private String send_req(String given_url) throws OpenemsNamedException {
+		try {
+			var url = new URL(given_url);
+			var con = (HttpURLConnection) url.openConnection();
+			con.setRequestMethod("GET");
+			con.setConnectTimeout(this.timeout);
+			con.setReadTimeout(this.timeout);
+			var status = con.getResponseCode();
+			String body;
+			try (var in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
+				// Read HTTP response
+				var content = new StringBuilder();
+				String line;
+				while ((line = in.readLine()) != null) {
+					content.append(line);
+					content.append(System.lineSeparator());
+				}
+				body = content.toString();
+			}
+			if (status < 300) {
+				// Parse response to JSON
+				return body;
+			}
+			throw new OpenemsException("Error while reading from Device. Response code: " + status + ". " + body);
+		} catch (OpenemsNamedException | IOException e) {
+			this.last_error = e;
+			throw new OpenemsException(
+					"Unable to read from Device. " + e.getClass().getSimpleName() + ": " + e.getMessage() + " URL:" + given_url);
+		}
+	}
+	
+	public boolean send_external_url(String url,String expected_output) {
+		try {
+			String response = this.send_req(url);
+			if(expected_output == "") {
+				return true;
+			}else{
+				if(response.contains(expected_output) && response.length() == expected_output.length()) {
+					return true;
+				}else {
+					return false;
+				}
+			}
+		} catch (OpenemsNamedException e) {
+			this.last_error = e;
+			return false;
+		}
+	}
+	public Exception get_last_error() {
+		if(this.last_error != null) {
+			return this.last_error;
+		} else {
+			return new Exception();
+		}
+	}
+	
+	public String get_last_by_id(int element) {
+		if(this.com_error) {
+			return "_com_error_";
+		}
+		if(element <= this.response_to_call.length && element > -1) {
+			if(this.response_to_call[element] != null) {
+				return this.response_to_call[element];
+			}else {
+				return "_no_value_";
+			}
+		} else {
+			return "_undefined_";
+		}
+	}
+	public String get_last(String element) {
+		if(this.com_error) {
+			return "_com_error_";
+		}
+		String tmp_element = this.urls_to_call.toString();
+		if(tmp_element.contains(element)) {
+			int index = -1;
+			for(int i=0; i<this.urls_to_call.length; i++) {
+				String tmp_element2 = this.urls_to_call[i];
+				if(tmp_element2 == element) {
+					index = i;
+					break;
+				}
+			}
+			//Catch
+			if(index == -1) {
+				return "_undefined_";
+			}else {
+				return this.get_last_by_id(index);
+			}
+		}else {
+			return "_undefined_";
+		}
+	}
+	
+	//Worker Part
+
+	@Override
+	protected void forever() throws Throwable {
+		try {
+			for(int i=0; i<this.urls_to_call.length; i++) {
+				//Com-Error Handling to not Spam requests
+				if(this.com_error) {
+					if(this.com_error_counter > 500) {
+						this.com_error = false;
+					}else {
+						this.com_error_counter++;
+						break;
+					}
+				}
+				//Normal Process
+				try {
+					String url = this.urls_to_call[i]; //Get URL
+					
+					String response = this.send_req(url); //Get Result
+					this.response_to_call[i] = response; //Write Result
+				} catch (OpenemsNamedException e) {
+					this.last_error = e;
+					throw e;
+				}
+			}
+		} catch (OpenemsNamedException e) {
+			this.last_error = e;
+			//Failed so for this Part a Communication Error is there
+			this.com_error = true;
+		}
+
+	}
+}

--- a/io.openems.edge.io.generic_http_worker/src/io/openems/edge/io/generic_http_worker/package-info.java
+++ b/io.openems.edge.io.generic_http_worker/src/io/openems/edge/io/generic_http_worker/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package io.openems.edge.io.generic_http_worker;


### PR DESCRIPTION
This Implementation is Based on the Generic HTTP Worker (Pull Request #2098 )

As Noted in #2098 here is the first Component that uses the Generic HTTP Worker.

If there are changes to the main pull, I will transfer them to this pull request as well.


This Code is tested on my own Energy-Storage System and with my own Comexio-Smarthome-System.

### Whats Implemented?
Relays can be read out and switched
Current values can be read out
Power values can be calculated by the given voltage and the read out current value.
The total power (of all relays) is returned as "ActivePower" (SymetricMeter).
The group prefix can be used to specify which unit is to be addressed (in the case of several units --> e.g. "IO-Server" and "IO-Extension").
Use with or without username and password (can be set in the Comexio web interface whether necessary or not and then adjusted accordingly in OpenEMS)
