### PR TITLE
Added option for use without an ESS attached

### DIFF
--- a/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/Config.java
+++ b/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/Config.java
@@ -40,7 +40,7 @@ import io.openems.edge.evcs.api.ChargeMode;
 	@AttributeDefinition(name = "Priority of charging", description = "Decide which Component should be preferred.")
 	Priority priority() default Priority.CAR;
 
-	@AttributeDefinition(name = "Ess-ID", description = "ID of Ess device.")
+	@AttributeDefinition(name = "Ess-ID", description = "ID of Ess device.'NONE' for no ESS")
 	String ess_id() default "ess0";
 
 	@AttributeDefinition(name = "Energy limit in this session in [Wh]", description = "Set the Energylimit in this Session in Wh. The charging station will only charge till this limit; '0' is no limit.")


### PR DESCRIPTION
One can configure "NONE" for ess-id. In that case SoC is not used for calculating charge power