### PR TITLE
Include keys in components object in edge config

### DIFF
--- a/io.openems.common/src/io/openems/common/types/EdgeConfig.java
+++ b/io.openems.common/src/io/openems/common/types/EdgeConfig.java
@@ -517,6 +517,7 @@ public class EdgeConfig {
 				properties.add(property.getKey(), property.getValue());
 			}
 			var result = JsonUtils.buildJsonObject() //
+					.addProperty("id", this.getId()) //
 					.addProperty("alias", this.getAlias()) //
 					.addProperty("factoryId", this.getFactoryId()) //
 					.add("properties", properties); //
@@ -527,7 +528,9 @@ public class EdgeConfig {
 			case COMPLETE:
 				var channels = new JsonObject();
 				for (Entry<String, Channel> channel : this.getChannels().entrySet()) {
-					channels.add(channel.getKey(), channel.getValue().toJson());
+					var channelJson = channel.getValue().toJson();
+					channelJson.addProperty("key", channel.getKey());
+					channels.add(channel.getKey(), channelJson);
 				}
 				result.add("channels", channels); //
 				break;
@@ -1112,7 +1115,7 @@ public class EdgeConfig {
 
 			/**
 			 * Gets the {@link Component}s in the builder.
-			 * 
+			 *
 			 * @return components
 			 */
 			public TreeMap<String, Component> getComponents() {
@@ -1133,7 +1136,7 @@ public class EdgeConfig {
 
 			/**
 			 * Gets the {@link Factory}s in the builder.
-			 * 
+			 *
 			 * @return components
 			 */
 			public TreeMap<String, Factory> getFactories() {
@@ -1142,7 +1145,7 @@ public class EdgeConfig {
 
 			/**
 			 * Builds the {@link ActualEdgeConfig}.
-			 * 
+			 *
 			 * @return {@link ActualEdgeConfig}
 			 */
 			public ActualEdgeConfig build() {
@@ -1152,7 +1155,7 @@ public class EdgeConfig {
 
 			/**
 			 * Builds the {@link EdgeConfig}.
-			 * 
+			 *
 			 * @return {@link EdgeConfig}
 			 */
 			public EdgeConfig buildEdgeConfig() {
@@ -1162,7 +1165,7 @@ public class EdgeConfig {
 
 		/**
 		 * Creates an empty {@link ActualEdgeConfig}.
-		 * 
+		 *
 		 * @return {@link ActualEdgeConfig}
 		 */
 		public static ActualEdgeConfig empty() {
@@ -1171,7 +1174,7 @@ public class EdgeConfig {
 
 		/**
 		 * Create a {@link ActualEdgeConfig.Builder} builder.
-		 * 
+		 *
 		 * @return a {@link Builder}
 		 */
 		public static ActualEdgeConfig.Builder create() {
@@ -1190,7 +1193,7 @@ public class EdgeConfig {
 
 	/**
 	 * Creates an empty {@link EdgeConfig}.
-	 * 
+	 *
 	 * @return {@link EdgeConfig}
 	 */
 	public static EdgeConfig empty() {
@@ -1199,7 +1202,7 @@ public class EdgeConfig {
 
 	/**
 	 * Creates an {@link EdgeConfig} from a {@link JsonObject}.
-	 * 
+	 *
 	 * @param json the {@link JsonObject}
 	 * @return {@link EdgeConfig}
 	 */
@@ -1219,7 +1222,7 @@ public class EdgeConfig {
 
 	/**
 	 * Build from {@link ActualEdgeConfig} using a {@link Builder}.
-	 * 
+	 *
 	 * @param actual the {@link ActualEdgeConfig}
 	 */
 	private EdgeConfig(ActualEdgeConfig actual) {
@@ -1233,7 +1236,7 @@ public class EdgeConfig {
 	/**
 	 * Gets the {@link ActualEdgeConfig}. Either by parsing it from {@link #json} or
 	 * by returning from cache.
-	 * 
+	 *
 	 * @return {@link ActualEdgeConfig}; empty on JSON parse error
 	 */
 	private synchronized ActualEdgeConfig getActual() {

--- a/io.openems.edge.controller.api.rest/readme.adoc
+++ b/io.openems.edge.controller.api.rest/readme.adoc
@@ -118,6 +118,18 @@ and the existing factories available for creating new ones.
 }
 ```
 
+Each component is represented by an object with five properties. Three strings, for identification
+and alias. The component's properties and channels are included in a nested object.
+```
+{
+    "id": "",
+    "alias": "",
+    "factoryId": "",
+    "properties": {},
+    "channels": {}
+}
+```
+
 === componentJsonApi
 
 Forwards a JSON-RPC payload to a given Component, identified by its Component-ID.

--- a/io.openems.edge.controller.api.rest/readme.adoc
+++ b/io.openems.edge.controller.api.rest/readme.adoc
@@ -1,6 +1,6 @@
 = REST-Api Controller
 
-A REST-Api for external access to OpenEMS Edge. This Controller provides access to Channels and JSON-RPC Requests from an external device via JSON/REST. 
+A REST-Api for external access to OpenEMS Edge. This Controller provides access to Channels and JSON-RPC Requests from an external device via JSON/REST.
 
 The default port for the server is *8084*; so the default base address for REST calls is `http://x:<PASSWORD>@<IP>:8084/rest`, where
 
@@ -33,7 +33,7 @@ Use a HTTP request with method `GET` to read the current value of a Channel.
   "unit":"%",
   "value":50
 }
-``` 
+```
 
 The `GET` api also understands regular expressions. Send a GET request to http://x:user@localhost:8084/rest/channel/.*/Active.*Power to read all `ActivePower` and `ReactivePower` channels of all components. It returns a response like:
 
@@ -97,10 +97,24 @@ Following JSON-RPC commands are available:
 
 Gets the current configuration of the OpenEMS Edge.
 
+Request body.
 ```
 {
   "method": "getEdgeConfig",
   "params": {}
+}
+```
+
+Expected reponse body structure. Should contain a result object with all of the defined components
+and the existing factories available for creating new ones.
+```
+{
+    "jsonrpc": "2.0",
+    "id": <uuid>,
+    "result": {
+        "components": {},
+        "factories": {}
+    }
 }
 ```
 


### PR DESCRIPTION
The id is a property of the model that is represented by each object, so including it in that representation is desirable.
Same goes for the channels when included in the components.

This benefits (de)serialization in clients for the edge config api.