### PR TITLE
PV-Inverters: add read-only mode

### DIFF
--- a/io.openems.edge.pvinverter.fronius/src/io/openems/edge/pvinverter/fronius/Config.java
+++ b/io.openems.edge.pvinverter.fronius/src/io/openems/edge/pvinverter/fronius/Config.java
@@ -16,6 +16,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
 	boolean enabled() default true;
 
+	@AttributeDefinition(name = "Read-Only mode", description = "In Read-Only mode no power-limitation commands are sent to the inverter")
+	boolean readOnly() default true;
+
 	@AttributeDefinition(name = "Modbus-ID", description = "ID of Modbus bridge.")
 	String modbus_id() default "modbus0";
 

--- a/io.openems.edge.pvinverter.fronius/src/io/openems/edge/pvinverter/fronius/FroniusPvInverter.java
+++ b/io.openems.edge.pvinverter.fronius/src/io/openems/edge/pvinverter/fronius/FroniusPvInverter.java
@@ -87,9 +87,9 @@ public class FroniusPvInverter extends AbstractSunSpecPvInverter
 	}
 
 	@Activate
-	void activate(ComponentContext context, Config config) throws OpenemsException {
-		if (super.activate(context, config.id(), config.alias(), config.enabled(), config.modbusUnitId(), this.cm,
-				"Modbus", config.modbus_id(), READ_FROM_MODBUS_BLOCK, Phase.ALL)) {
+	private void activate(ComponentContext context, Config config) throws OpenemsException {
+		if (super.activate(context, config.id(), config.alias(), config.enabled(), config.readOnly(),
+				config.modbusUnitId(), this.cm, "Modbus", config.modbus_id(), READ_FROM_MODBUS_BLOCK, Phase.ALL)) {
 			return;
 		}
 	}

--- a/io.openems.edge.pvinverter.kaco.blueplanet/bnd.bnd
+++ b/io.openems.edge.pvinverter.kaco.blueplanet/bnd.bnd
@@ -13,4 +13,5 @@ Bundle-Version: 1.0.0.${tstamp}
 	io.openems.edge.pvinverter.sunspec
 
 -testpath: \
-	${testpath}
+	${testpath},\
+	com.ghgande.j2mod

--- a/io.openems.edge.pvinverter.kaco.blueplanet/src/io/openems/edge/pvinverter/kaco/blueplanet/Config.java
+++ b/io.openems.edge.pvinverter.kaco.blueplanet/src/io/openems/edge/pvinverter/kaco/blueplanet/Config.java
@@ -16,6 +16,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
 	boolean enabled() default true;
 
+	@AttributeDefinition(name = "Read-Only mode", description = "In Read-Only mode no power-limitation commands are sent to the inverter")
+	boolean readOnly() default true;
+
 	@AttributeDefinition(name = "Modbus-ID", description = "ID of Modbus bridge.")
 	String modbus_id() default "modbus0";
 

--- a/io.openems.edge.pvinverter.kaco.blueplanet/src/io/openems/edge/pvinverter/kaco/blueplanet/KacoBlueplanet.java
+++ b/io.openems.edge.pvinverter.kaco.blueplanet/src/io/openems/edge/pvinverter/kaco/blueplanet/KacoBlueplanet.java
@@ -96,9 +96,9 @@ public class KacoBlueplanet extends AbstractSunSpecPvInverter implements SunSpec
 	}
 
 	@Activate
-	void activate(ComponentContext context, Config config) throws OpenemsException {
-		if (super.activate(context, config.id(), config.alias(), config.enabled(), config.modbusUnitId(), this.cm, "Modbus",
-				config.modbus_id(), READ_FROM_MODBUS_BLOCK, Phase.ALL)) {
+	private void activate(ComponentContext context, Config config) throws OpenemsException {
+		if (super.activate(context, config.id(), config.alias(), config.enabled(), config.readOnly(),
+				config.modbusUnitId(), this.cm, "Modbus", config.modbus_id(), READ_FROM_MODBUS_BLOCK, Phase.ALL)) {
 			return;
 		}
 	}

--- a/io.openems.edge.pvinverter.kaco.blueplanet/test/io/openems/edge/pvinverter/kaco/blueplanet/KacoBlueplanetTest.java
+++ b/io.openems.edge.pvinverter.kaco.blueplanet/test/io/openems/edge/pvinverter/kaco/blueplanet/KacoBlueplanetTest.java
@@ -1,4 +1,4 @@
-package io.openems.edge.pvinverter.fronius;
+package io.openems.edge.pvinverter.kaco.blueplanet;
 
 import org.junit.Test;
 
@@ -6,14 +6,14 @@ import io.openems.edge.bridge.modbus.test.DummyModbusBridge;
 import io.openems.edge.common.test.ComponentTest;
 import io.openems.edge.common.test.DummyConfigurationAdmin;
 
-public class FroniusPvInverterTest {
+public class KacoBlueplanetTest {
 
 	private static final String PV_INVERTER_ID = "pvInverter0";
 	private static final String MODBUS_ID = "modbus0";
 
 	@Test
 	public void test() throws Exception {
-		new ComponentTest(new FroniusPvInverter()) //
+		new ComponentTest(new KacoBlueplanet()) //
 				.addReference("cm", new DummyConfigurationAdmin()) //
 				.addReference("setModbus", new DummyModbusBridge(MODBUS_ID)) //
 				.activate(MyConfig.create() //

--- a/io.openems.edge.pvinverter.kaco.blueplanet/test/io/openems/edge/pvinverter/kaco/blueplanet/MyConfig.java
+++ b/io.openems.edge.pvinverter.kaco.blueplanet/test/io/openems/edge/pvinverter/kaco/blueplanet/MyConfig.java
@@ -1,4 +1,4 @@
-package io.openems.edge.pvinverter.fronius;
+package io.openems.edge.pvinverter.kaco.blueplanet;
 
 import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
@@ -42,7 +42,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 	/**
 	 * Create a Config builder.
-	 * 
+	 *
 	 * @return a {@link Builder}
 	 */
 	public static Builder create() {

--- a/io.openems.edge.pvinverter.kostal/src/io/openems/edge/pvinverter/kostal/Config.java
+++ b/io.openems.edge.pvinverter.kostal/src/io/openems/edge/pvinverter/kostal/Config.java
@@ -17,6 +17,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
 	boolean enabled() default true;
 
+	@AttributeDefinition(name = "Read-Only mode", description = "In Read-Only mode no power-limitation commands are sent to the inverter")
+	boolean readOnly() default true;
+
 	@AttributeDefinition(name = "Modbus-ID", description = "ID of Modbus bridge.")
 	String modbus_id() default "modbus2";
 

--- a/io.openems.edge.pvinverter.kostal/src/io/openems/edge/pvinverter/kostal/KostalPvInverter.java
+++ b/io.openems.edge.pvinverter.kostal/src/io/openems/edge/pvinverter/kostal/KostalPvInverter.java
@@ -88,8 +88,8 @@ public class KostalPvInverter extends AbstractSunSpecPvInverter
 
 	@Activate
 	private void activate(ComponentContext context, Config config) throws OpenemsException {
-		if (super.activate(context, config.id(), config.alias(), config.enabled(), config.modbusUnitId(), this.cm,
-				"Modbus", config.modbus_id(), READ_FROM_MODBUS_BLOCK, Phase.ALL)) {
+		if (super.activate(context, config.id(), config.alias(), config.enabled(), config.readOnly(),
+				config.modbusUnitId(), this.cm, "Modbus", config.modbus_id(), READ_FROM_MODBUS_BLOCK, Phase.ALL)) {
 			return;
 		}
 	}

--- a/io.openems.edge.pvinverter.kostal/test/io/openems/edge/pvinverter/kostal/KostalPvInverterTest.java
+++ b/io.openems.edge.pvinverter.kostal/test/io/openems/edge/pvinverter/kostal/KostalPvInverterTest.java
@@ -18,6 +18,7 @@ public class KostalPvInverterTest {
 				.addReference("setModbus", new DummyModbusBridge(MODBUS_ID)) //
 				.activate(MyConfig.create() //
 						.setId(PV_INVERTER_ID) //
+						.setReadOnly(true) //
 						.setModbusId(MODBUS_ID) //
 						.setModbusUnitId(1) //
 						.build()) //

--- a/io.openems.edge.pvinverter.kostal/test/io/openems/edge/pvinverter/kostal/MyConfig.java
+++ b/io.openems.edge.pvinverter.kostal/test/io/openems/edge/pvinverter/kostal/MyConfig.java
@@ -8,6 +8,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 	protected static class Builder {
 		private String id = null;
+		private boolean readOnly;
 		private String modbusId = null;
 		private int modbusUnitId;
 
@@ -16,6 +17,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 		public Builder setId(String id) {
 			this.id = id;
+			return this;
+		}
+
+		public Builder setReadOnly(boolean readOnly) {
+			this.readOnly = readOnly;
 			return this;
 		}
 
@@ -48,6 +54,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	private MyConfig(Builder builder) {
 		super(Config.class, builder.id);
 		this.builder = builder;
+	}
+
+	@Override
+	public boolean readOnly() {
+		return this.builder.readOnly;
 	}
 
 	@Override

--- a/io.openems.edge.pvinverter.sma/bnd.bnd
+++ b/io.openems.edge.pvinverter.sma/bnd.bnd
@@ -13,4 +13,5 @@ Bundle-Version: 1.0.0.${tstamp}
 	io.openems.edge.pvinverter.sunspec
 
 -testpath: \
-	${testpath}
+	${testpath},\
+	com.ghgande.j2mod

--- a/io.openems.edge.pvinverter.sma/src/io/openems/edge/pvinverter/sma/Config.java
+++ b/io.openems.edge.pvinverter.sma/src/io/openems/edge/pvinverter/sma/Config.java
@@ -18,6 +18,9 @@ import io.openems.edge.pvinverter.sunspec.Phase;
 	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
 	boolean enabled() default true;
 
+	@AttributeDefinition(name = "Read-Only mode", description = "In Read-Only mode no power-limitation commands are sent to the inverter")
+	boolean readOnly() default true;
+
 	@AttributeDefinition(name = "Modbus-ID", description = "ID of Modbus bridge.")
 	String modbus_id() default "modbus0";
 

--- a/io.openems.edge.pvinverter.sma/src/io/openems/edge/pvinverter/sma/SmaPvInverter.java
+++ b/io.openems.edge.pvinverter.sma/src/io/openems/edge/pvinverter/sma/SmaPvInverter.java
@@ -98,9 +98,9 @@ public class SmaPvInverter extends AbstractSunSpecPvInverter implements SunSpecP
 	}
 
 	@Activate
-	void activate(ComponentContext context, Config config) throws OpenemsException {
-		if (super.activate(context, config.id(), config.alias(), config.enabled(), config.modbusUnitId(), this.cm,
-				"Modbus", config.modbus_id(), READ_FROM_MODBUS_BLOCK, config.phase())) {
+	private void activate(ComponentContext context, Config config) throws OpenemsException {
+		if (super.activate(context, config.id(), config.alias(), config.enabled(), config.readOnly(),
+				config.modbusUnitId(), this.cm, "Modbus", config.modbus_id(), READ_FROM_MODBUS_BLOCK, config.phase())) {
 			return;
 		}
 	}

--- a/io.openems.edge.pvinverter.sma/test/io/openems/edge/pvinverter/sma/MyConfig.java
+++ b/io.openems.edge.pvinverter.sma/test/io/openems/edge/pvinverter/sma/MyConfig.java
@@ -1,7 +1,8 @@
-package io.openems.edge.pvinverter.fronius;
+package io.openems.edge.pvinverter.sma;
 
 import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.utils.ConfigUtils;
+import io.openems.edge.pvinverter.sunspec.Phase;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {
@@ -11,6 +12,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 		private boolean readOnly;
 		private String modbusId = null;
 		private int modbusUnitId;
+		private Phase phase;
 
 		private Builder() {
 		}
@@ -34,6 +36,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 			this.modbusUnitId = modbusUnitId;
 			return this;
 		}
+		
+		public Builder setPhase(Phase phase) {
+			this.phase = phase;
+			return this;
+		}
 
 		public MyConfig build() {
 			return new MyConfig(this);
@@ -42,7 +49,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 	/**
 	 * Create a Config builder.
-	 * 
+	 *
 	 * @return a {@link Builder}
 	 */
 	public static Builder create() {
@@ -74,6 +81,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	@Override
 	public int modbusUnitId() {
 		return this.builder.modbusUnitId;
+	}
+
+	@Override
+	public Phase phase() {
+		return this.builder.phase;
 	}
 
 }

--- a/io.openems.edge.pvinverter.sma/test/io/openems/edge/pvinverter/sma/SmaPvInverterTest.java
+++ b/io.openems.edge.pvinverter.sma/test/io/openems/edge/pvinverter/sma/SmaPvInverterTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import io.openems.edge.bridge.modbus.test.DummyModbusBridge;
 import io.openems.edge.common.test.ComponentTest;
 import io.openems.edge.common.test.DummyConfigurationAdmin;
+import io.openems.edge.pvinverter.sunspec.Phase;
 
 public class SmaPvInverterTest {
 
@@ -21,6 +22,7 @@ public class SmaPvInverterTest {
 						.setReadOnly(true) //
 						.setModbusId(MODBUS_ID) //
 						.setModbusUnitId(1) //
+						.setPhase(Phase.ALL) //
 						.build()) //
 		;
 	}

--- a/io.openems.edge.pvinverter.sma/test/io/openems/edge/pvinverter/sma/SmaPvInverterTest.java
+++ b/io.openems.edge.pvinverter.sma/test/io/openems/edge/pvinverter/sma/SmaPvInverterTest.java
@@ -1,4 +1,4 @@
-package io.openems.edge.pvinverter.fronius;
+package io.openems.edge.pvinverter.sma;
 
 import org.junit.Test;
 
@@ -6,14 +6,14 @@ import io.openems.edge.bridge.modbus.test.DummyModbusBridge;
 import io.openems.edge.common.test.ComponentTest;
 import io.openems.edge.common.test.DummyConfigurationAdmin;
 
-public class FroniusPvInverterTest {
+public class SmaPvInverterTest {
 
 	private static final String PV_INVERTER_ID = "pvInverter0";
 	private static final String MODBUS_ID = "modbus0";
 
 	@Test
 	public void test() throws Exception {
-		new ComponentTest(new FroniusPvInverter()) //
+		new ComponentTest(new SmaPvInverter()) //
 				.addReference("cm", new DummyConfigurationAdmin()) //
 				.addReference("setModbus", new DummyModbusBridge(MODBUS_ID)) //
 				.activate(MyConfig.create() //

--- a/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/AbstractSunSpecPvInverter.java
+++ b/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/AbstractSunSpecPvInverter.java
@@ -122,7 +122,7 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 		switch (event.getTopic()) {
 		case EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE:
 			// Get ActivePowerLimit that should be applied
-			IntegerWriteChannel activePowerLimitChannel = (IntegerWriteChannel) this
+			var activePowerLimitChannel = (IntegerWriteChannel) this
 					.channel(ManagedSymmetricPvInverter.ChannelId.ACTIVE_POWER_LIMIT);
 			var activePowerLimitOpt = activePowerLimitChannel.getNextWriteValueAndReset();
 

--- a/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/AbstractSunSpecPvInverter.java
+++ b/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/AbstractSunSpecPvInverter.java
@@ -21,6 +21,7 @@ import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel;
 import io.openems.edge.bridge.modbus.sunspec.SunSpecModel;
 import io.openems.edge.bridge.modbus.sunspec.SunSpecPoint;
 import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.channel.IntegerWriteChannel;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.event.EdgeEventConstants;
 import io.openems.edge.common.taskmanager.Priority;
@@ -35,6 +36,7 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 	private final Logger log = LoggerFactory.getLogger(AbstractSunSpecPvInverter.class);
 	private final SetPvLimitHandler setPvLimitHandler = new SetPvLimitHandler(this);
 
+	private boolean readOnly;
 	private boolean isSinglePhase;
 	private Phase phase;
 
@@ -55,6 +57,8 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 	 *                              'config.alias()'. Defaults to 'id' if empty
 	 * @param enabled               Whether the component should be enabled.
 	 *                              Typically 'config.enabled()'
+	 * @param readOnly              In Read-Only mode no power-limitation commands
+	 *                              are sent to the inverter
 	 * @param unitId                Unit-ID of the Modbus target
 	 * @param cm                    An instance of ConfigurationAdmin. Receive it
 	 *                              using @Reference
@@ -69,9 +73,10 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 	 *         activate() method.
 	 * @throws OpenemsException on error
 	 */
-	protected boolean activate(ComponentContext context, String id, String alias, boolean enabled, int unitId,
-			ConfigurationAdmin cm, String modbusReference, String modbusId, int readFromCommonBlockNo, Phase phase)
-			throws OpenemsException {
+	protected boolean activate(ComponentContext context, String id, String alias, boolean enabled, boolean readOnly,
+			int unitId, ConfigurationAdmin cm, String modbusReference, String modbusId, int readFromCommonBlockNo,
+			Phase phase) throws OpenemsException {
+		this.readOnly = readOnly;
 		this.phase = phase;
 		return super.activate(context, id, alias, enabled, unitId, cm, modbusReference, modbusId,
 				readFromCommonBlockNo);
@@ -110,13 +115,28 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 	public void handleEvent(Event event) {
 		if (!this.isEnabled() || !this.isSunSpecInitializationCompleted()) {
 			this.channel(SunSpecPvInverter.ChannelId.PV_LIMIT_FAILED).setNextValue(false);
+			this.channel(SunSpecPvInverter.ChannelId.READ_ONLY_MODE_PV_LIMIT_FAILED).setNextValue(false);
 			return;
 		}
 
 		switch (event.getTopic()) {
 		case EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE:
+			// Get ActivePowerLimit that should be applied
+			IntegerWriteChannel activePowerLimitChannel = (IntegerWriteChannel) this
+					.channel(ManagedSymmetricPvInverter.ChannelId.ACTIVE_POWER_LIMIT);
+			var activePowerLimitOpt = activePowerLimitChannel.getNextWriteValueAndReset();
+
+			// Set warning if read-only mode is active but a PV limit was requested
+			this.channel(SunSpecPvInverter.ChannelId.READ_ONLY_MODE_PV_LIMIT_FAILED)
+					.setNextValue(this.readOnly && activePowerLimitOpt.isPresent());
+
+			// In read-only mode: stop here
+			if (this.readOnly) {
+				return;
+			}
+
 			try {
-				this.setPvLimitHandler.run();
+				this.setPvLimitHandler.accept(activePowerLimitOpt);
 
 				this.channel(SunSpecPvInverter.ChannelId.PV_LIMIT_FAILED).setNextValue(false);
 			} catch (OpenemsNamedException e) {

--- a/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/SetPvLimitHandler.java
+++ b/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/SetPvLimitHandler.java
@@ -2,19 +2,18 @@ package io.openems.edge.pvinverter.sunspec;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Optional;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
-import io.openems.common.function.ThrowingRunnable;
+import io.openems.common.function.ThrowingConsumer;
 import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel;
 import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S123_WMaxLim_Ena;
 import io.openems.edge.common.channel.EnumWriteChannel;
 import io.openems.edge.common.channel.FloatReadChannel;
 import io.openems.edge.common.channel.FloatWriteChannel;
 import io.openems.edge.common.channel.IntegerReadChannel;
-import io.openems.edge.common.channel.IntegerWriteChannel;
-import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 
-public class SetPvLimitHandler implements ThrowingRunnable<OpenemsNamedException> {
+public class SetPvLimitHandler implements ThrowingConsumer<Optional<Integer>, OpenemsNamedException> {
 
 	private static final float COMPARE_THRESHOLD = 0.0001F;
 
@@ -26,13 +25,15 @@ public class SetPvLimitHandler implements ThrowingRunnable<OpenemsNamedException
 
 	private Instant lastWMaxLimPctTime = Instant.MIN;
 
+	/**
+	 * Handles a PV-Inverter power limitation request.
+	 * 
+	 * @param activePowerLimitOpt an Optional power limit; empty value sets the
+	 *                            allowed inverter power to 100 %, i.e. no limit
+	 * @throws OpenemsNamedException on error
+	 */
 	@Override
-	public void run() throws OpenemsNamedException {
-		// Get ActivePowerLimit that should be applied
-		IntegerWriteChannel activePowerLimitChannel = this.parent
-				.channel(ManagedSymmetricPvInverter.ChannelId.ACTIVE_POWER_LIMIT);
-		var activePowerLimitOpt = activePowerLimitChannel.getNextWriteValueAndReset();
-
+	public void accept(Optional<Integer> activePowerLimitOpt) throws OpenemsNamedException {
 		FloatWriteChannel wMaxLimPctChannel;
 		FloatReadChannel wRtgChannel;
 		EnumWriteChannel wMaxLimEnaChannel;

--- a/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/SunSpecPvInverter.java
+++ b/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/SunSpecPvInverter.java
@@ -8,6 +8,8 @@ public interface SunSpecPvInverter {
 	public static enum ChannelId implements io.openems.edge.common.channel.ChannelId {
 		PV_LIMIT_FAILED(Doc.of(Level.FAULT) //
 				.text("PV-Limit failed")), //
+		READ_ONLY_MODE_PV_LIMIT_FAILED(Doc.of(Level.WARNING) //
+				.text("Read-Only mode is active: PV-Limit failed")), //
 		WRONG_PHASE_CONFIGURED(Doc.of(Level.WARNING) //
 				.text("Configured Phase does not match the Model")), //
 		;

--- a/io.openems.edge.solaredge/src/io/openems/edge/solaredge/pvinverter/Config.java
+++ b/io.openems.edge.solaredge/src/io/openems/edge/solaredge/pvinverter/Config.java
@@ -18,6 +18,9 @@ import io.openems.edge.pvinverter.sunspec.Phase;
 	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
 	boolean enabled() default true;
 
+	@AttributeDefinition(name = "Read-Only mode", description = "In Read-Only mode no power-limitation commands are sent to the inverter")
+	boolean readOnly() default true;
+
 	@AttributeDefinition(name = "Modbus-ID", description = "ID of Modbus bridge.")
 	String modbus_id() default "modbus0";
 

--- a/io.openems.edge.solaredge/src/io/openems/edge/solaredge/pvinverter/SolarEdgePvInverter.java
+++ b/io.openems.edge.solaredge/src/io/openems/edge/solaredge/pvinverter/SolarEdgePvInverter.java
@@ -48,8 +48,9 @@ import io.openems.edge.pvinverter.sunspec.SunSpecPvInverter;
 @EventTopics({ //
 		EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE //
 })
-public class SolarEdgePvInverter extends AbstractSunSpecPvInverter implements SunSpecPvInverter, ManagedSymmetricPvInverter,
-		AsymmetricMeter, SymmetricMeter, ModbusComponent, OpenemsComponent, EventHandler, ModbusSlave {
+public class SolarEdgePvInverter extends AbstractSunSpecPvInverter
+		implements SunSpecPvInverter, ManagedSymmetricPvInverter, AsymmetricMeter, SymmetricMeter, ModbusComponent,
+		OpenemsComponent, EventHandler, ModbusSlave {
 
 	private static final int READ_FROM_MODBUS_BLOCK = 1;
 
@@ -94,9 +95,9 @@ public class SolarEdgePvInverter extends AbstractSunSpecPvInverter implements Su
 	}
 
 	@Activate
-	void activate(ComponentContext context, Config config) throws OpenemsException {
-		if (super.activate(context, config.id(), config.alias(), config.enabled(), config.modbusUnitId(), this.cm,
-				"Modbus", config.modbus_id(), READ_FROM_MODBUS_BLOCK, config.phase())) {
+	private void activate(ComponentContext context, Config config) throws OpenemsException {
+		if (super.activate(context, config.id(), config.alias(), config.enabled(), config.readOnly(),
+				config.modbusUnitId(), this.cm, "Modbus", config.modbus_id(), READ_FROM_MODBUS_BLOCK, config.phase())) {
 			return;
 		}
 	}

--- a/io.openems.edge.solaredge/test/io/openems/edge/solaredge/pvinverter/MyConfig.java
+++ b/io.openems.edge.solaredge/test/io/openems/edge/solaredge/pvinverter/MyConfig.java
@@ -9,6 +9,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 	protected static class Builder {
 		private String id = null;
+		private boolean readOnly;
 		private String modbusId = null;
 		private int modbusUnitId;
 		public Phase phase;
@@ -21,6 +22,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 			return this;
 		}
 
+		public Builder setReadOnly(boolean readOnly) {
+			this.readOnly = readOnly;
+			return this;
+		}
+
 		public Builder setModbusId(String modbusId) {
 			this.modbusId = modbusId;
 			return this;
@@ -30,7 +36,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 			this.modbusUnitId = modbusUnitId;
 			return this;
 		}
-		
+
 		public Builder setPhase(Phase phase) {
 			this.phase = phase;
 			return this;
@@ -55,6 +61,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	private MyConfig(Builder builder) {
 		super(Config.class, builder.id);
 		this.builder = builder;
+	}
+
+	@Override
+	public boolean readOnly() {
+		return this.builder.readOnly;
 	}
 
 	@Override

--- a/io.openems.edge.solaredge/test/io/openems/edge/solaredge/pvinverter/SolarEdgePvInverterTest.java
+++ b/io.openems.edge.solaredge/test/io/openems/edge/solaredge/pvinverter/SolarEdgePvInverterTest.java
@@ -19,6 +19,7 @@ public class SolarEdgePvInverterTest {
 				.addReference("setModbus", new DummyModbusBridge(MODBUS_ID)) //
 				.activate(MyConfig.create() //
 						.setId(PV_INVERTER_ID) //
+						.setReadOnly(true) //
 						.setModbusId(MODBUS_ID) //
 						.setModbusUnitId(1) //
 						.setPhase(Phase.L1) //


### PR DESCRIPTION
Currently all `ManagedSymmetricPvInverter`s set the power limitation - even if in most cases this is not required, because no PV-Limit controller is active. In these cases currently a power limit to 100 % is set via Modbus (i.e. 'no limit'). PV-Inverters often distinguish between Modbus read-only and read/write access. The current behaviour causes Modbus errors if write-access to the PV inverter is not allowed.

This PR adds a new 'readOnly' setting that is activated by default. The idea of a 'read-only mode' is already existing in other places in OpenEMS for such use cases. In 'read-only mode' no PV limit is ever written. If there is a demand for pv limit anyway (e.g. via a `Controller.PvInverter.FixPowerLimit`), then a warning "Read-Only mode is active: PV-Limit failed" (Channel-ID: READ_ONLY_MODE_PV_LIMIT_FAILED) is shown.