### PR TITLE
Channel: catch errors while updating Process-Image

### DIFF
--- a/io.openems.edge.common/src/io/openems/edge/common/channel/internal/AbstractReadChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/internal/AbstractReadChannel.java
@@ -116,7 +116,7 @@ public abstract class AbstractReadChannel<D extends AbstractDoc<T>, T> implement
 			}
 			this.pastValues.put(this.activeValue.getTimestamp(), this.activeValue);
 
-		} catch (Exception e) {
+		} catch (RuntimeException e) {
 			this.log.error("Error while updating process image for [" + this.address() + "]: " + e.getMessage());
 			e.printStackTrace();
 		}

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/internal/AbstractReadChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/internal/AbstractReadChannel.java
@@ -99,21 +99,27 @@ public abstract class AbstractReadChannel<D extends AbstractDoc<T>, T> implement
 
 	@Override
 	public void nextProcessImage() {
-		var oldValue = this.activeValue;
-		final boolean valueHasChanged;
-		if (oldValue == null && this.nextValue == null) {
-			valueHasChanged = false;
-		} else if (oldValue == null || this.nextValue == null) {
-			valueHasChanged = true;
-		} else {
-			valueHasChanged = !Objects.equals(oldValue.get(), this.nextValue.get());
+		try {
+			var oldValue = this.activeValue;
+			final boolean valueHasChanged;
+			if (oldValue == null && this.nextValue == null) {
+				valueHasChanged = false;
+			} else if (oldValue == null || this.nextValue == null) {
+				valueHasChanged = true;
+			} else {
+				valueHasChanged = !Objects.equals(oldValue.get(), this.nextValue.get());
+			}
+			this.activeValue = this.nextValue;
+			this.onUpdateCallbacks.forEach(callback -> callback.accept(this.activeValue));
+			if (valueHasChanged) {
+				this.onChangeCallbacks.forEach(callback -> callback.accept(oldValue, this.activeValue));
+			}
+			this.pastValues.put(this.activeValue.getTimestamp(), this.activeValue);
+
+		} catch (Exception e) {
+			this.log.error("Error while updating process image for [" + this.address() + "]: " + e.getMessage());
+			e.printStackTrace();
 		}
-		this.activeValue = this.nextValue;
-		this.onUpdateCallbacks.forEach(callback -> callback.accept(this.activeValue));
-		if (valueHasChanged) {
-			this.onChangeCallbacks.forEach(callback -> callback.accept(oldValue, this.activeValue));
-		}
-		this.pastValues.put(this.activeValue.getTimestamp(), this.activeValue);
 	}
 
 	@Override


### PR DESCRIPTION
Channel `nextProcessImage()` should not throw an Exception. Currently an IllegalArgumentException on updating of the process image is handled only very late, e.g. in the CycleWorker. This improvement catches the error early in the Channel itself and prints detailed error logs.