### PR TITLE
Feature/default sunspec update and enhancement

### DIFF
--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/AbstractOpenemsSunSpecComponent.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/AbstractOpenemsSunSpecComponent.java
@@ -39,12 +39,13 @@ public abstract class AbstractOpenemsSunSpecComponent extends AbstractOpenemsMod
 	private final Logger log = LoggerFactory.getLogger(AbstractOpenemsSunSpecComponent.class);
 
 	// The active SunSpec-Models and their reading-priority
-	private final Map<SunSpecModel, Priority> activeModels;
+	protected Map<SunSpecModel, Priority> activeModels;
 	private final ModbusProtocol modbusProtocol;
 
 	private int readFromCommonBlockNo = 1;
 	private int commonBlockCounter = 0;
 
+	private boolean readOnly = false;
 	private boolean isSunSpecInitializationCompleted = false;
 
 	/**
@@ -73,6 +74,14 @@ public abstract class AbstractOpenemsSunSpecComponent extends AbstractOpenemsMod
 		throw new IllegalArgumentException("Use the other activate() method.");
 	}
 
+	protected boolean activate(ComponentContext context, String id, String alias, boolean enabled, int unitId,
+			ConfigurationAdmin cm, String modbusReference, String modbusId, int readFromCommonBlockNo, boolean readOnly)
+			throws OpenemsException {
+		this.readOnly = readOnly;
+		return this.activate(context, id, alias, enabled, unitId, cm, modbusReference, modbusId, readFromCommonBlockNo);
+	}
+
+	
 	protected boolean activate(ComponentContext context, String id, String alias, boolean enabled, int unitId,
 			ConfigurationAdmin cm, String modbusReference, String modbusId, int readFromCommonBlockNo)
 			throws OpenemsException {
@@ -335,6 +344,9 @@ public abstract class AbstractOpenemsSunSpecComponent extends AbstractOpenemsMod
 				break;
 			case READ_WRITE:
 			case WRITE_ONLY:
+				if(this.readOnly) {
+					break;
+				}
 				// Add a Write-Task
 				final Task writeTask = new FC16WriteRegistersTask(element.getStartAddress(), element);
 				this.modbusProtocol.addTask(writeTask);

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/AbstractOpenemsSunSpecComponent.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/AbstractOpenemsSunSpecComponent.java
@@ -344,7 +344,7 @@ public abstract class AbstractOpenemsSunSpecComponent extends AbstractOpenemsMod
 				break;
 			case READ_WRITE:
 			case WRITE_ONLY:
-				if(this.readOnly) {
+				if (this.readOnly) {
 					break;
 				}
 				// Add a Write-Task

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/DefaultSunSpecModel.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/DefaultSunSpecModel.java
@@ -162,6 +162,14 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 			DefaultSunSpecModel.S145.values(), //
 			SunSpecModelType.INVERTER //
 	), //
+	S_160(//
+			"Mutliple MPPT Inverter Extension Model", //
+			"Mutliple MPPT Inverter Extension Model", //
+			"", //
+			88, //
+			DefaultSunSpecModel.S160.values(), //
+			SunSpecModelType.INVERTER //
+	), //
 	S_201(//
 			"Meter (Single Phase)single phase (AN or AB) meter", //
 			"Include this model for single phase (AN or AB) metering", //
@@ -236,7 +244,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 	), //
 	S_307(//
 			"Base Met", //
-			"Base Meteorolgical Model", //
+			"Base Meteorological Model", //
 			"This model supersedes model 301", //
 			11, //
 			DefaultSunSpecModel.S307.values(), //
@@ -5754,7 +5762,8 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 	public static enum S124_StorCtl_Mod implements OptionsEnum {
 		UNDEFINED(-1, "Undefined"), //
 		CHARGE(0, "CHARGE"), //
-		DI_S_C_H_A_R_G_E(1, "DI_S_C_H_A_R_G_E"); //
+		DI_S_C_H_A_R_G_E(1, "DI_S_C_H_A_R_G_E"),
+		ALLOW_BOTH(3, "ALLOW BOTH"); //TS: Probably Only for Fronius GEN24
 
 		private final int value;
 		private final String name;
@@ -5847,7 +5856,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 		MOD_ENA(new PointImpl(//
 				"S125_MOD_ENA", //
 				"ModEna", //
-				"Is price-based charge/dischage mode active?", //
+				"Is price-based charge/discharge mode active?", //
 				"", //
 				PointType.BITFIELD16, //
 				true, //
@@ -6042,7 +6051,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 		HYS_ENA(new PointImpl(//
 				"S127_HYS_ENA", //
 				"HysEna", //
-				"Enable hysterisis", //
+				"Enable hysteresis", //
 				"", //
 				PointType.BITFIELD16, //
 				true, //
@@ -6512,6 +6521,562 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 		}
 	}
 
+	public static enum S160 implements SunSpecPoint {
+		DCA_S_F(new PointImpl(//
+				"S160_DCA_S_F", //
+				"Dca_SF", //
+				"", //
+				"", //
+				PointType.SUNSSF, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //
+		DCV_S_F(new PointImpl(//
+				"S160_DCV_S_F", //
+				"Dcv_SF", //
+				"", //
+				"", //
+				PointType.SUNSSF, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //
+		DCW_S_F(new PointImpl(//
+				"S160_DCW_S_F", //
+				"Dcw_SF", //
+				"", //
+				"", //
+				PointType.SUNSSF, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //
+		DCWH_S_F(new PointImpl(//
+				"S160_DCWH_S_F", //
+				"Dcwh_SF", //
+				"", //
+				"", //
+				PointType.SUNSSF, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //
+		Evt(new PointImpl(//
+				"S160_EVT", //
+				"Evt", //
+				"Global Events", //
+				"", //
+				PointType.UINT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //
+		N(new PointImpl(//
+				"S160_N", //
+				"N", //
+				"Number of Modules", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //
+		TmsPer(new PointImpl(//
+				"S160_TMS_PER", //
+				"TmsPer", //
+				"TmsPer", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+
+		
+		
+		MODULE_1_I_D(new PointImpl(//
+				"S160_MODULE_1_I_D", //
+				"Module1Id", //
+				"Module1Id", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_1_I_D_STR(new PointImpl(//
+				"S160_MODULE_1_I_D_STR", //
+				"Module1IdStr", //
+				"Module1IdStr", //
+				"", //
+				PointType.STRING8, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_1_D_C_A(new PointImpl(//
+				"S160_MODULE_1_D_C_A", //
+				"Module1Dca", //
+				"Module1Dca", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.AMPERE, //
+				"Dca_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_1_D_C_V(new PointImpl(//
+				"S160_MODULE_1_D_C_V", //
+				"Module1Dcv", //
+				"Module1Dcv", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.VOLT, //
+				"Dcv_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_1_D_C_W(new PointImpl(//
+				"S160_MODULE_1_D_C_W", //
+				"Module1Dcw", //
+				"Module1Dcw", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.WATT, //
+				"Dcw_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_1_D_C_W_H(new PointImpl(//
+				"S160_MODULE_1_D_C_W_H", //
+				"Module1Dcwh", //
+				"Module1Dcwh", //
+				"", //
+				PointType.UINT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.WATT_HOURS, //
+				"Dcwh_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_1_TMS(new PointImpl(//
+				"S160_MODULE_1_TMS", //
+				"Module1Timestamp", //
+				"Module1Tms", //
+				"", //
+				PointType.UINT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.SECONDS, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_1_TEMP(new PointImpl(//
+				"S160_MODULE_1_TEMP", //
+				"Module1Temp", //
+				"Module1Temp", //
+				"", //
+				PointType.INT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.DEGREE_CELSIUS, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_1_OP_STATES(new PointImpl(//
+				"S160_MODULE_1_OP_STATES", //
+				"Module1OpStates", //
+				"Module1OpStates", //
+				"", //
+				PointType.BITFIELD16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_1_EVENTS(new PointImpl(//
+				"S160_MODULE_1_EVENTS", //
+				"Module1Events", //
+				"Module1Events", //
+				"", //
+				PointType.INT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		
+
+		
+		
+		MODULE_2_I_D(new PointImpl(//
+				"S160_MODULE_2_I_D", //
+				"Module2Id", //
+				"Module2Id", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_2_I_D_STR(new PointImpl(//
+				"S160_MODULE_2_I_D_STR", //
+				"Module2IdStr", //
+				"Module2IdStr", //
+				"", //
+				PointType.STRING8, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_2_D_C_A(new PointImpl(//
+				"S160_MODULE_2_D_C_A", //
+				"Module2Dca", //
+				"Module2Dca", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.AMPERE, //
+				"Dca_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_2_D_C_V(new PointImpl(//
+				"S160_MODULE_2_D_C_V", //
+				"Module2Dcv", //
+				"Module2Dcv", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.VOLT, //
+				"Dcv_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_2_D_C_W(new PointImpl(//
+				"S160_MODULE_2_D_C_W", //
+				"Module2Dcw", //
+				"Module2Dcw", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.WATT, //
+				"Dcw_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_2_D_C_W_H(new PointImpl(//
+				"S160_MODULE_2_D_C_W_H", //
+				"Module2Dcwh", //
+				"Module2Dcwh", //
+				"", //
+				PointType.UINT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.WATT_HOURS, //
+				"Dcwh_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_2_TMS(new PointImpl(//
+				"S160_MODULE_2_TMS", //
+				"Module2Tms", //
+				"Module2Tms", //
+				"", //
+				PointType.UINT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.SECONDS, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_2_TEMP(new PointImpl(//
+				"S160_MODULE_2_TEMP", //
+				"Module2Temp", //
+				"Module2Temp", //
+				"", //
+				PointType.INT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.DEGREE_CELSIUS, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_2_OP_STATES(new PointImpl(//
+				"S160_MODULE_2_OP_STATES", //
+				"Module2OpStates", //
+				"Module2OpStates", //
+				"", //
+				PointType.BITFIELD16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_2_EVENTS(new PointImpl(//
+				"S160_MODULE_2_EVENTS", //
+				"Module2Events", //
+				"Module2Events", //
+				"", //
+				PointType.INT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		
+
+
+		
+		
+		MODULE_3_I_D(new PointImpl(//
+				"S160_MODULE_3_I_D", //
+				"Module3Id", //
+				"Module3Id", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_3_I_D_STR(new PointImpl(//
+				"S160_MODULE_3_I_D_STR", //
+				"Module3IdStr", //
+				"Module3IdStr", //
+				"", //
+				PointType.STRING8, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_3_D_C_A(new PointImpl(//
+				"S160_MODULE_3_D_C_A", //
+				"Module3Dca", //
+				"Module3Dca", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.AMPERE, //
+				"Dca_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_3_D_C_V(new PointImpl(//
+				"S160_MODULE_3_D_C_V", //
+				"Module3Dcv", //
+				"Module3Dcv", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.VOLT, //
+				"Dcv_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_3_D_C_W(new PointImpl(//
+				"S160_MODULE_3_D_C_W", //
+				"Module3Dcw", //
+				"Module3Dcw", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.WATT, //
+				"Dcw_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_3_D_C_W_H(new PointImpl(//
+				"S160_MODULE_3_D_C_W_H", //
+				"Module3Dcwh", //
+				"Module3Dcwh", //
+				"", //
+				PointType.UINT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.WATT_HOURS, //
+				"Dcwh_S_F", //
+				new OptionsEnum[0])), //	
+		MODULE_3_TMS(new PointImpl(//
+				"S160_MODULE_3_TMS", //
+				"Module3Tms", //
+				"Module3Tms", //
+				"", //
+				PointType.UINT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.SECONDS, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_3_TEMP(new PointImpl(//
+				"S160_MODULE_3_TEMP", //
+				"Module3Temp", //
+				"Module3Temp", //
+				"", //
+				PointType.INT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.DEGREE_CELSIUS, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_3_OP_STATES(new PointImpl(//
+				"S160_MODULE_3_OP_STATES", //
+				"Module3OpStates", //
+				"Module3OpStates", //
+				"", //
+				PointType.BITFIELD16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_3_EVENTS(new PointImpl(//
+				"S160_MODULE_3_EVENTS", //
+				"Module3Events", //
+				"Module3Events", //
+				"", //
+				PointType.INT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		
+
+		
+		
+		
+		
+		MODULE_4_I_D(new PointImpl(//
+				"S160_MODULE_4_I_D", //
+				"Module4Id", //
+				"Module4Id", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_4_I_D_STR(new PointImpl(//
+				"S160_MODULE_4_I_D_STR", //
+				"Module4IdStr", //
+				"Module4IdStr", //
+				"", //
+				PointType.STRING8, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_4_D_C_A(new PointImpl(//
+				"S160_MODULE_4_D_C_A", //
+				"Module4Dca", //
+				"Module4Dca", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.AMPERE, //
+				"Dca_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_4_D_C_V(new PointImpl(//
+				"S160_MODULE_4_D_C_V", //
+				"Module4Dcv", //
+				"Module4Dcv", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.VOLT, //
+				"Dcv_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_4_D_C_W(new PointImpl(//
+				"S160_MODULE_4_D_C_W", //
+				"Module4Dcw", //
+				"Module4Dcw", //
+				"", //
+				PointType.UINT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.WATT, //
+				"Dcw_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_4_D_C_W_H(new PointImpl(//
+				"S160_MODULE_4_D_C_W_H", //
+				"Module4Dcwh", //
+				"Module4Dcwh", //
+				"", //
+				PointType.UINT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.WATT_HOURS, //
+				"Dcwh_SF", //
+				new OptionsEnum[0])), //	
+		MODULE_4_TMS(new PointImpl(//
+				"S160_MODULE_4_TMS", //
+				"Module4Tms", //
+				"Module4Tms", //
+				"", //
+				PointType.UINT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.SECONDS, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_4_TEMP(new PointImpl(//
+				"S160_MODULE_4_TEMP", //
+				"Module4Temp", //
+				"Module4Temp", //
+				"", //
+				PointType.INT16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.DEGREE_CELSIUS, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_4_OP_STATES(new PointImpl(//
+				"S160_MODULE_4_OP_STATES", //
+				"Module4OpStates", //
+				"Module4OpStates", //
+				"", //
+				PointType.BITFIELD16, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])), //	
+		MODULE_4_EVENTS(new PointImpl(//
+				"S160_MODULE_4_EVENTS", //
+				"Module4Events", //
+				"Module4Events", //
+				"", //
+				PointType.INT32, //
+				false, //
+				AccessMode.READ_ONLY, //
+				Unit.NONE, //
+				null, //
+				new OptionsEnum[0])) //	
+		
+
+		
+		
+
+		; //
+
+		protected final PointImpl impl;
+
+		private S160(PointImpl impl) {
+			this.impl = impl;
+		}
+
+		@Override
+		public PointImpl get() {
+			return this.impl;
+		}
+	}
+	
+	
 	public static enum S201 implements SunSpecPoint {
 		A(new PointImpl(//
 				"S201_A", //
@@ -7142,7 +7707,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		TOT_V_ARH_IMP_Q1_PH_C(new PointImpl(//
 				"S201_TOT_V_ARH_IMP_Q1_PH_C", //
-				"Total VAr-hourse Imported Q1 phase C", //
+				"Total VAr-hours Imported Q1 phase C", //
 				"", //
 				"", //
 				PointType.ACC32, //
@@ -7263,7 +7828,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		TOT_V_ARH_EXP_Q4_PH_B(new PointImpl(//
 				"S201_TOT_V_ARH_EXP_Q4_PH_B", //
-				"", //
+				"Total VAr-hours Exported Q4 Imported phase B", //
 				"", //
 				"", //
 				PointType.ACC32, //
@@ -7479,8 +8044,8 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		PH_VPH_A_B(new PointImpl(//
 				"S202_PH_VPH_A_B", //
-				"", //
-				"", //
+				"Phase Voltage AB", //
+				"Phase Voltage AB", //
 				"", //
 				PointType.INT16, //
 				true, //
@@ -7490,8 +8055,8 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		PH_VPH_B_C(new PointImpl(//
 				"S202_PH_VPH_B_C", //
-				"", //
-				"", //
+				"Phase Voltage BC", //
+				"Phase Voltage BC", //
 				"", //
 				PointType.INT16, //
 				false, //
@@ -7501,8 +8066,8 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		PH_VPH_C_A(new PointImpl(//
 				"S202_PH_VPH_C_A", //
-				"", //
-				"", //
+				"Phase Voltage CA", //
+				"Phase Voltage CA", //
 				"", //
 				PointType.INT16, //
 				false, //
@@ -7996,7 +8561,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		TOT_V_ARH_IMP_Q1_PH_C(new PointImpl(//
 				"S202_TOT_V_ARH_IMP_Q1_PH_C", //
-				"Total VAr-hourse Imported Q1 phase C", //
+				"Total VAr-hours Imported Q1 phase C", //
 				"", //
 				"", //
 				PointType.ACC32, //
@@ -8341,8 +8906,8 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		PH_VPH_A_B(new PointImpl(//
 				"S203_PH_VPH_A_B", //
-				"", //
-				"", //
+				"Phase Voltage AB", //
+				"Phase Voltage AB", //
 				"", //
 				PointType.INT16, //
 				true, //
@@ -8352,8 +8917,8 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		PH_VPH_B_C(new PointImpl(//
 				"S203_PH_VPH_B_C", //
-				"", //
-				"", //
+				"Phase Voltage BC", //
+				"Phase Voltage BC", //
 				"", //
 				PointType.INT16, //
 				true, //
@@ -8363,8 +8928,8 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		PH_VPH_C_A(new PointImpl(//
 				"S203_PH_VPH_C_A", //
-				"", //
-				"", //
+				"Phase Voltage CA", //
+				"Phase Voltage CA", //
 				"", //
 				PointType.INT16, //
 				true, //
@@ -8858,7 +9423,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		TOT_V_ARH_IMP_Q1_PH_C(new PointImpl(//
 				"S203_TOT_V_ARH_IMP_Q1_PH_C", //
-				"Total VAr-hourse Imported Q1 phase C", //
+				"Total VAr-hours Imported Q1 phase C", //
 				"", //
 				"", //
 				PointType.ACC32, //
@@ -8979,7 +9544,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		TOT_V_ARH_EXP_Q4_PH_B(new PointImpl(//
 				"S203_TOT_V_ARH_EXP_Q4_PH_B", //
-				"", //
+				"Total VAr-hours Exported Q4 Imported phase B", //
 				"", //
 				"", //
 				PointType.ACC32, //
@@ -9203,8 +9768,8 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		PH_VPH_A_B(new PointImpl(//
 				"S204_PH_VPH_A_B", //
-				"", //
-				"", //
+				"Phase Voltage AB", //
+				"Phase Voltage AB", //
 				"", //
 				PointType.INT16, //
 				true, //
@@ -9214,8 +9779,8 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		PH_VPH_B_C(new PointImpl(//
 				"S204_PH_VPH_B_C", //
-				"", //
-				"", //
+				"Phase Voltage BC", //
+				"Phase Voltage BC", //
 				"", //
 				PointType.INT16, //
 				true, //
@@ -9225,8 +9790,8 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		PH_VPH_C_A(new PointImpl(//
 				"S204_PH_VPH_C_A", //
-				"", //
-				"", //
+				"Phase Voltage CA", //
+				"Phase Voltage CA", //
 				"", //
 				PointType.INT16, //
 				true, //
@@ -9720,7 +10285,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		TOT_V_ARH_IMP_Q1_PH_C(new PointImpl(//
 				"S204_TOT_V_ARH_IMP_Q1_PH_C", //
-				"Total VAr-hourse Imported Q1 phase C", //
+				"Total VAr-hours Imported Q1 phase C", //
 				"", //
 				"", //
 				PointType.ACC32, //
@@ -9841,7 +10406,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		TOT_V_ARH_EXP_Q4_PH_B(new PointImpl(//
 				"S204_TOT_V_ARH_EXP_Q4_PH_B", //
-				"", //
+				"Total VAr-hours Exported Q4 Imported phase B", //
 				"", //
 				"", //
 				PointType.ACC32, //
@@ -10177,7 +10742,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 		GHI(new PointImpl(//
 				"S306_GHI", //
 				"GHI", //
-				"Global Horizontal Irrandiance", //
+				"Global Horizontal Irradiance", //
 				"", //
 				PointType.UINT16, //
 				false, //
@@ -10485,7 +11050,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		W_DIS_CHA_RTE_MAX(new PointImpl(//
 				"S802_W_DIS_CHA_RTE_MAX", //
-				"Namplate Max Discharge Rate", //
+				"Nameplate Max Discharge Rate", //
 				"Maximum rate of energy transfer out of the storage device in DC watts.", //
 				"", //
 				PointType.UINT16, //
@@ -11047,7 +11612,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 		A_MAX_S_F(new PointImpl(//
 				"S802_A_MAX_S_F", //
 				"", //
-				"Scale factor for instantationous DC charge/discharge current.", //
+				"Scale factor for instantaneous DC charge/discharge current.", //
 				"", //
 				PointType.SUNSSF, //
 				true, //
@@ -13252,7 +13817,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		C_C_CONFIG_A_U_X_NLITE_ON_HIST(new PointImpl(//
 				"S64112_C_C_CONFIG_A_U_X_NLITE_ON_HIST", //
-				"AUX Night Light On Hysterisis", //
+				"AUX Night Light On Hysteresis", //
 				"", //
 				"", //
 				PointType.UINT16, //
@@ -13263,7 +13828,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		C_C_CONFIG_A_U_X_NLITE_OFF_HIST(new PointImpl(//
 				"S64112_C_C_CONFIG_A_U_X_NLITE_OFF_HIST", //
-				"AUX Night Light Off Hysterisis", //
+				"AUX Night Light Off Hysteresis", //
 				"", //
 				"", //
 				PointType.UINT16, //
@@ -13318,7 +13883,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		C_C_CONFIG_A_U_X_DIVERT_HYST_V(new PointImpl(//
 				"S64112_C_C_CONFIG_A_U_X_DIVERT_HYST_V", //
-				"AUX Divert Hysterisis", //
+				"AUX Divert Hysteresis", //
 				"", //
 				"", //
 				PointType.UINT16, //
@@ -13384,7 +13949,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		C_C_CONFIG_DATA_LOG_DAILY_A_H(new PointImpl(//
 				"S64112_C_C_CONFIG_DATA_LOG_DAILY_A_H", //
-				"Data Log Daily", //
+				"Data Log Daily (Ah)", //
 				"", //
 				"", //
 				PointType.UINT16, //
@@ -13395,7 +13960,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		C_C_CONFIG_DATA_LOG_DAILY_K_W_H(new PointImpl(//
 				"S64112_C_C_CONFIG_DATA_LOG_DAILY_K_W_H", //
-				"Data Log Daily", //
+				"Data Log Daily (kWh)", //
 				"", //
 				"", //
 				PointType.UINT16, //
@@ -13406,7 +13971,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		C_C_CONFIG_DATA_LOG_MAX_OUT_A(new PointImpl(//
 				"S64112_C_C_CONFIG_DATA_LOG_MAX_OUT_A", //
-				"Data Log Daily Maximum Output", //
+				"Data Log Daily Maximum Output (A)", //
 				"", //
 				"", //
 				PointType.UINT16, //
@@ -13417,7 +13982,7 @@ public enum DefaultSunSpecModel implements SunSpecModel {
 				new OptionsEnum[0])), //
 		C_C_CONFIG_DATA_LOG_MAX_OUT_W(new PointImpl(//
 				"S64112_C_C_CONFIG_DATA_LOG_MAX_OUT_W", //
-				"Data Log Daily Maximum Output", //
+				"Data Log Daily Maximum Output (W)", //
 				"", //
 				"", //
 				PointType.UINT16, //

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/SunSpecCodeGenerator.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/SunSpecCodeGenerator.java
@@ -35,7 +35,11 @@ import io.openems.edge.bridge.modbus.sunspec.SunSpecPoint.PointType;
  * OpenEMS SunSpec implementation.
  *
  * <p>
- * Download XML files from https://github.com/sunspec/models.
+ * <ul>
+ * <li>Clone XML files from https://github.com/sunspec/models (must fit with SUNSPEC_XML_PATHs</li>
+ * <li>Run this Code Generator</li>
+ * <li>Replace DefaultSunspecModel.java with the newly generated version in OUT_FILE_PATH</li>
+ * </ul>
  */
 public class SunSpecCodeGenerator {
 
@@ -594,6 +598,9 @@ public class SunSpecCodeGenerator {
 	 */
 	private void writeSunSpecModelJavaFile(List<Model> models) throws IOException {
 		try (var w = Files.newBufferedWriter(Paths.get(OUT_FILE_PATH))) {
+			w.write("// CHECKSTYLE:OFF");
+			w.newLine();
+			w.newLine();
 			w.write("package io.openems.edge.bridge.modbus.sunspec;");
 			w.newLine();
 			w.newLine();
@@ -610,7 +617,7 @@ public class SunSpecCodeGenerator {
 			w.newLine();
 			w.write(" */");
 			w.newLine();
-			w.write("public enum SunSpecModel {");
+			w.write("public enum DefaultSunSpecModel implements SunSpecModel {");
 			w.newLine();
 
 			/*
@@ -628,7 +635,7 @@ public class SunSpecCodeGenerator {
 				w.newLine();
 				w.write("			" + model.len + ", //");
 				w.newLine();
-				w.write("			SunSpecModel.S" + model.id + ".values(), //");
+				w.write("			DefaultSunSpecModel.S" + model.id + ".values(), //");
 				w.newLine();
 				w.write("			SunSpecModelType." + model.modelType + " //");
 				w.newLine();
@@ -758,7 +765,7 @@ public class SunSpecCodeGenerator {
 					w.newLine();
 					w.write("		public int getValue() {");
 					w.newLine();
-					w.write("			return value;");
+					w.write("			return this.value;");
 					w.newLine();
 					w.write("		}");
 					w.newLine();
@@ -767,7 +774,7 @@ public class SunSpecCodeGenerator {
 					w.newLine();
 					w.write("		public String getName() {");
 					w.newLine();
-					w.write("			return name;");
+					w.write("			return this.name;");
 					w.newLine();
 					w.write("		}");
 					w.newLine();
@@ -799,7 +806,7 @@ public class SunSpecCodeGenerator {
 			w.write("	public final SunSpecModelType modelType;");
 			w.newLine();
 			w.newLine();
-			w.write("	private SunSpecModel(String label, String description, String notes, int length, SunSpecPoint[] points,");
+			w.write("	private DefaultSunSpecModel(String label, String description, String notes, int length, SunSpecPoint[] points,");
 			w.newLine();
 			w.write("			SunSpecModelType modelType) {");
 			w.newLine();
@@ -817,7 +824,27 @@ public class SunSpecCodeGenerator {
 			w.newLine();
 			w.write("	}");
 			w.newLine();
+			w.newLine();
+			w.write("	@Override");
+			w.newLine();
+			w.write("	public SunSpecPoint[] points() {");
+			w.newLine();
+			w.write("		return this.points;");
+			w.newLine();
+			w.write("	}");
+			w.newLine();
+			w.newLine();
+			w.write("	@Override");
+			w.newLine();
+			w.write("	public String label() {");
+			w.newLine();
+			w.write("		return this.label;");
+			w.newLine();
+			w.write("	}");
+			w.newLine();
 			w.write("}");
+			w.newLine();
+			w.write("// CHECKSTYLE:ON");
 			w.newLine();
 		}
 	}


### PR DESCRIPTION
- updated DefaultSunSpecModel from smdx model from date 02-2023 (mainly typos)
- added S160 to DefaultSunSpecModel
- fixed SunSpecCodeGenerator to produce the output of DefaultSunSpecModel
- Added readonly option to AbstractOpenemsModbusComponent.activate()

Note: S160 is needed for a new PR regarding fronius gen 24 (coming soon)
