### PR TITLE
Rework of Timer

### DIFF
--- a/io.openems.edge.common/src/io/openems/edge/common/timer/Timer.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/timer/Timer.java
@@ -1,0 +1,37 @@
+package io.openems.edge.common.timer;
+
+/**
+ * The Timer interface. Provides easy access to a timer.
+ * 
+ * @see io.openems.edge.core.timer.TimerHandler
+ */
+public interface Timer {
+
+    /**
+     * check if the Time is up.
+     * 
+     * @return true if the time is up, false else
+     */
+    public boolean check();
+
+    /**
+     * Restarts the Timer.
+     * 
+     * @implNote method will remove a configured startDelay immediately.
+     */
+    public void reset();
+
+    /**
+     * check and restart the timer, when the timer is up.
+     * 
+     * @return when the timer is up method will return true once, in that case the
+     *         timer is restarted. In any other case method returns false.
+     */
+    public default boolean checkAndReset() {
+	if (this.check()) {
+	    this.reset();
+	    return true;
+	}
+	return false;
+    }
+}

--- a/io.openems.edge.common/src/io/openems/edge/common/timer/package-info.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/timer/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package io.openems.edge.common.timer;

--- a/io.openems.edge.core/readme.adoc
+++ b/io.openems.edge.core/readme.adoc
@@ -27,7 +27,7 @@ A service that provides 'OpenemsConstants' as Channels so that they are availabl
 
 == Sum
 
-A service that holds summed up information on the power and energy flows, like aggregated production, consumption and energy storage charge/discharge. 
+A service that holds summed up information on the power and energy flows, like aggregated production, consumption and energy storage charge/discharge.
 
 == AppManager
 
@@ -36,3 +36,11 @@ A service for managing Apps. It creates, deletes and updates Components, Network
 == App
 
 The predefined Apps for the AppManager.
+
+== TimerManager
+
+Access to different kind of timers. Can be used to
+
+* `timerManager.getTimerCount()` - count each call to the timer.
+* `timerManager.getTimerCoreCycles()` - count each core cycle.
+* `timerManager.getTimerTimer()` - count a given time in seconds.

--- a/io.openems.edge.core/src/io/openems/edge/core/timer/AbstractTimer.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/timer/AbstractTimer.java
@@ -1,0 +1,32 @@
+package io.openems.edge.core.timer;
+
+import java.util.Optional;
+
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.timer.Timer;
+
+public abstract class AbstractTimer implements Timer {
+
+    protected final Timer delayTimer;
+    protected final Channel<Integer> channel;
+
+    protected AbstractTimer(TimerManager tm, //
+	    Channel<Integer> channel, //
+	    final int startDelayInSecs) {
+
+	this.channel = channel;
+	if (startDelayInSecs > 0) {
+	    this.delayTimer = tm.getTimerByTime(null, 0, startDelayInSecs);
+	} else {
+	    this.delayTimer = null;
+	}
+    }
+
+    protected boolean delayStart() {
+	return this.delayTimer != null && this.delayTimer.check() == false;
+    }
+
+    protected void updateChannel(int value) {
+	Optional.ofNullable(this.channel).ifPresent(channel -> channel.setNextValue(value));
+    }
+}

--- a/io.openems.edge.core/src/io/openems/edge/core/timer/Config.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/timer/Config.java
@@ -1,0 +1,12 @@
+package io.openems.edge.core.timer;
+
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@ObjectClassDefinition(//
+        name = "Core TimerManager", //
+        description = "Global Access to different kind of timers.")
+@interface Config {
+
+    String webconsole_configurationFactory_nameHint() default "Core TimerManager";
+
+}

--- a/io.openems.edge.core/src/io/openems/edge/core/timer/DummyTimerByCoreCycles.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/timer/DummyTimerByCoreCycles.java
@@ -1,0 +1,37 @@
+package io.openems.edge.core.timer;
+
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.timer.Timer;
+
+public class DummyTimerByCoreCycles extends AbstractTimer implements Timer {
+
+    private final int maxCoreCycles;
+    private final DummyTimerManager tm;
+    private int refCount;
+
+    public DummyTimerByCoreCycles(DummyTimerManager tm, //
+								  Channel<Integer> channel, //
+								  int maxCoreCycles, //
+								  int startDelayInSecs) {
+	super(tm, channel, startDelayInSecs);
+	this.tm = tm;
+	this.maxCoreCycles = maxCoreCycles;
+	this.refCount = tm.coreCyclesCount;
+    }
+
+    @Override
+    public boolean check() {
+	if (this.delayStart()) {
+	    return false;
+	}
+	this.updateChannel(this.refCount);
+
+	// Note: ignore possible integer overflow (needs ~68years uptime)
+	return this.refCount + this.maxCoreCycles <= this.tm.coreCyclesCount;
+    }
+
+    @Override
+    public void reset() {
+	this.refCount = this.tm.coreCyclesCount;
+    }
+}

--- a/io.openems.edge.core/src/io/openems/edge/core/timer/DummyTimerManager.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/timer/DummyTimerManager.java
@@ -1,0 +1,50 @@
+package io.openems.edge.core.timer;
+
+import io.openems.edge.common.timer.Timer;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.event.propertytypes.EventTopics;
+
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.component.AbstractOpenemsComponent;
+import io.openems.edge.common.component.ComponentManager;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.event.EdgeEventConstants;
+
+@EventTopics({ //
+	EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE//
+})
+public class DummyTimerManager extends AbstractOpenemsComponent
+	implements TimerManager, OpenemsComponent, EventHandler {
+
+    private final ComponentManager cpm;
+    public int coreCyclesCount = 0;
+
+    public DummyTimerManager(ComponentManager cpm) {
+	super(OpenemsComponent.ChannelId.values() //
+	);
+	this.cpm = cpm;
+	this.channels().forEach(Channel::nextProcessImage);
+	super.activate(null, "SingleComponentTimer", "", true);
+    }
+
+    @Override
+    public void handleEvent(Event event) {
+	this.coreCyclesCount++;
+    }
+
+    @Override
+    public Timer getTimerByCount(Channel<Integer> channel, int countCheckCalls, int startDelayInSecs) {
+	return new TimerByCount(this, channel, countCheckCalls, startDelayInSecs);
+    }
+
+    @Override
+    public Timer getTimerByCoreCycles(Channel<Integer> channel, int count, int startDelayInSecs) {
+	return new DummyTimerByCoreCycles(this, channel, count, startDelayInSecs);
+    }
+
+    @Override
+    public Timer getTimerByTime(Channel<Integer> channel, int seconds, int startDelayInSecs) {
+	return new TimerByTime(this, this.cpm.getClock(), channel, seconds, startDelayInSecs);
+    }
+}

--- a/io.openems.edge.core/src/io/openems/edge/core/timer/TimerByCoreCycles.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/timer/TimerByCoreCycles.java
@@ -1,0 +1,38 @@
+package io.openems.edge.core.timer;
+
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.timer.Timer;
+
+public class TimerByCoreCycles extends AbstractTimer implements Timer {
+
+    private final int maxCoreCycles;
+    private final TimerManagerImpl tm;
+    private int refCount;
+
+    public TimerByCoreCycles(TimerManagerImpl tm, //
+	    Channel<Integer> channel, //
+	    int maxCoreCycles, //
+	    int startDelayInSecs) {
+	super(tm, channel, startDelayInSecs);
+	this.tm = tm;
+	this.maxCoreCycles = maxCoreCycles;
+	this.refCount = this.tm.getCoreCyclesCount();
+    }
+
+    @Override
+    public boolean check() {
+	if (this.delayStart()) {
+	    return false;
+	}
+	this.updateChannel(this.refCount);
+
+	// Note: ignore possible integer overflow (needs ~68years uptime)
+	return this.refCount + this.maxCoreCycles <= this.tm.getCoreCyclesCount();
+    }
+
+    @Override
+    public void reset() {
+	this.refCount = this.tm.getCoreCyclesCount();
+    }
+
+}

--- a/io.openems.edge.core/src/io/openems/edge/core/timer/TimerByCount.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/timer/TimerByCount.java
@@ -1,0 +1,36 @@
+package io.openems.edge.core.timer;
+
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.timer.Timer;
+
+public class TimerByCount extends AbstractTimer implements Timer {
+
+    private final int maxCount;
+    private int count;
+
+    public TimerByCount(TimerManager tm, //
+	    Channel<Integer> channel, //
+	    int maxCheckCalls, //
+	    int startDelayInSecs) {
+	super(tm, channel, startDelayInSecs);
+
+	this.maxCount = maxCheckCalls;
+	this.count = this.maxCount;
+    }
+
+    @Override
+    public boolean check() {
+	if (this.delayStart()) {
+	    return false;
+	}
+	this.updateChannel(this.count);
+
+	return this.count-- <= 0;
+    }
+
+    @Override
+    public void reset() {
+	this.count = this.maxCount;
+    }
+
+}

--- a/io.openems.edge.core/src/io/openems/edge/core/timer/TimerByTime.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/timer/TimerByTime.java
@@ -1,0 +1,41 @@
+package io.openems.edge.core.timer;
+
+import java.time.Clock;
+
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.timer.Timer;
+
+public class TimerByTime extends AbstractTimer implements Timer {
+
+    private final Clock clock;
+    private final int waitTimeSeconds;
+    private long expirationTimeMillis;
+
+    public TimerByTime(TimerManager tm, //
+	    Clock clock, Channel<Integer> channel, //
+	    int waitTimeSeconds, //
+	    int startDelayInSecs) {
+	// startDelayInSecs must not be handled in AbstractTimerImpl
+	super(tm, channel, 0);
+	this.waitTimeSeconds = waitTimeSeconds;
+	this.clock = clock;
+	this.expirationTimeMillis = this.clock.millis() + (this.waitTimeSeconds + startDelayInSecs) * 1000L;
+    }
+
+    @Override
+    public boolean check() {
+	long diffTime = this.expirationTimeMillis - this.clock.millis();
+
+	diffTime = Math.max(diffTime, 0);
+	this.updateChannel(((int) diffTime / 1000));
+
+	return this.expirationTimeMillis <= this.clock.millis();
+    }
+
+    @Override
+    public void reset() {
+	this.expirationTimeMillis = this.clock.millis() + this.waitTimeSeconds * 1000L;
+	this.updateChannel(this.waitTimeSeconds);
+    }
+
+}

--- a/io.openems.edge.core/src/io/openems/edge/core/timer/TimerManager.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/timer/TimerManager.java
@@ -1,0 +1,185 @@
+package io.openems.edge.core.timer;
+
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.timer.Timer;
+
+/**
+ * TimerManager - This package provides easy access to different kind of timers.
+ * Use it to
+ * 
+ * <ul>
+ * <li>getTimerCount() - count each call to the timer.check() method.
+ * <li>getTimerCoreCycles() - count each core cycle.
+ * <li>getTimerTimer() - count a given time in s.
+ * </ul>
+ * 
+ */
+public interface TimerManager extends OpenemsComponent {
+
+    public static final String SINGLETON_SERVICE_PID = "Core.TimerManager";
+    public static final String SINGLETON_COMPONENT_ID = "_timermanager";
+
+    /**
+     * Get a timer to count every call to the timer.check() or the
+     * timer.checkAndRestart() method.
+     * 
+     * @param countCheckCalls the count to use.
+     * 
+     * @return true if the given count has been reached, false else
+     */
+    public default Timer getTimerByCount(int countCheckCalls) {
+	return this.getTimerByCount(null, countCheckCalls, 0);
+    }
+
+    /**
+     * Get a timer to count every call to the timer.check() or the
+     * timer.checkAndRestart() method.
+     * 
+     * @param countCheckCalls  the count to use.
+     * @param startDelayInSecs the timer will return false, as long as the
+     *                         startDelayInSecs is not reached. This is especially
+     *                         useful for heaters which are very sensitive against
+     *                         frequent condition changes (can happen in systems
+     *                         which restart OpenEMS frequently).
+     * @return true if the given count has been reached, false else
+     */
+    public default Timer getTimerByCount(int countCheckCalls, int startDelayInSecs) {
+	return this.getTimerByCount(null, countCheckCalls, startDelayInSecs);
+    }
+
+    /**
+     * Get a timer to count every call to the timer.check() or the
+     * timer.checkAndRestart() method.
+     * 
+     * @param channel         if this channel is provided, this channel is used to
+     *                        hold the state of the timer.
+     * @param countCheckCalls the count to use.
+     * @return true if the given count has been reached, false else
+     */
+    public default Timer getTimerByCount(Channel<Integer> channel, int countCheckCalls) {
+	return this.getTimerByCount(channel, countCheckCalls, 0);
+    }
+
+    /**
+     * Get a timer to count every call to the timer.check() or the
+     * timer.checkAndRestart() method.
+     * 
+     * @param channel          if this channel is provided, this channel is used to
+     *                         hold the state of the timer.
+     * @param countCheckCalls  the count to use.
+     * @param startDelayInSecs the timer will return false, as long as the
+     *                         startDelayInSecs is not reached. This is especially
+     *                         useful for heaters which are very sensitive against
+     *                         frequent condition changes (can happen in systems
+     *                         which restart OpenEMS frequently).
+     * @return true if the given count has been reached, false else
+     */
+    public Timer getTimerByCount(Channel<Integer> channel, int countCheckCalls, int startDelayInSecs);
+
+    /**
+     * Get a timer to count every core cycle.
+     * 
+     * @param count the count to use.
+     * 
+     * @return true if the given count has been reached, false else
+     */
+    public default Timer getTimerByCoreCycles(int count) {
+	return this.getTimerByCoreCycles(null, count, 0);
+    }
+
+    /**
+     * Get a timer to count every core cycle.
+     * 
+     * @param count            the count to use.
+     * @param startDelayInSecs the timer will return false, as long as the
+     *                         startDelayInSecs is not reached. This is especially
+     *                         useful for heaters which are very sensitive against
+     *                         frequent condition changes (can happen in systems
+     *                         which restart OpenEMS frequently).
+     * @return true if the given count has been reached, false else
+     */
+    public default Timer getTimerByCoreCycles(int count, int startDelayInSecs) {
+	return this.getTimerByCoreCycles(null, count, startDelayInSecs);
+    }
+
+    /**
+     * Get a timer to count every core cycle.
+     * 
+     * @param channel if this channel is provided, this channel is used to hold the
+     *                state of the timer.
+     * @param count   the count to use.
+     * @return true if the given count has been reached, false else
+     */
+    public default Timer getTimerByCoreCycles(Channel<Integer> channel, int count) {
+	return this.getTimerByCoreCycles(channel, count);
+    }
+
+    /**
+     * Get a timer to count every core cycle.
+     * 
+     * @param channel          if this channel is provided, this channel is used to
+     *                         hold the state of the timer.
+     * @param count            the count to use.
+     * @param startDelayInSecs the timer will return false, as long as the
+     *                         startDelayInSecs is not reached. This is especially
+     *                         useful for heaters which are very sensitive against
+     *                         frequent condition changes (can happen in systems
+     *                         which restart OpenEMS frequently).
+     * @return true if the given count has been reached, false else
+     */
+    public Timer getTimerByCoreCycles(Channel<Integer> channel, int count, int startDelayInSecs);
+
+    /**
+     * Get a timer to count the time in seconds.
+     * 
+     * @param seconds the count in seconds to use.
+     * 
+     * @return true if the given count has been reached, false else
+     */
+    public default Timer getTimerByTime(int seconds) {
+	return this.getTimerByTime(null,  seconds, 0);
+    }
+
+    /**
+     * Get a timer to count the time in seconds.
+     * 
+     * @param seconds          the count in seconds to use.
+     * @param startDelayInSecs the timer will return false, as long as the
+     *                         startDelayInSecs is not reached. This is especially
+     *                         useful for heaters which are very sensitive against
+     *                         frequent condition changes (can happen in systems
+     *                         which restart OpenEMS frequently).
+     * @return true if the given count has been reached, false else
+     */
+    public default Timer getTimerByTime(int seconds, int startDelayInSecs) {
+	return this.getTimerByTime(null,  seconds, startDelayInSecs);
+    }
+
+    /**
+     * Get a timer to count the time in seconds.
+     * 
+     * @param channel if this channel is provided, this channel is used to hold the
+     *                state of the timer.
+     * @param seconds the count in seconds to use.
+     * @return true if the given count has been reached, false else
+     */
+    public default Timer getTimerByTime(Channel<Integer> channel, int seconds) {
+	return this.getTimerByTime(channel,  seconds, 0);
+    }
+
+    /**
+     * Get a timer to count the time in seconds.
+     * 
+     * @param channel          if this channel is provided, this channel is used to
+     *                         hold the state of the timer.
+     * @param seconds          the count in seconds to use.
+     * @param startDelayInSecs the timer will return false, as long as the
+     *                         startDelayInSecs is not reached. This is especially
+     *                         useful for heaters which are very sensitive against
+     *                         frequent condition changes (can happen in systems
+     *                         which restart OpenEMS frequently).
+     * @return true if the given count has been reached, false else
+     */
+    public Timer getTimerByTime(Channel<Integer> channel, int seconds, int startDelayInSecs);
+}

--- a/io.openems.edge.core/src/io/openems/edge/core/timer/TimerManagerImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/timer/TimerManagerImpl.java
@@ -1,0 +1,85 @@
+package io.openems.edge.core.timer;
+
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.event.propertytypes.EventTopics;
+import org.osgi.service.metatype.annotations.Designate;
+
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.component.AbstractOpenemsComponent;
+import io.openems.edge.common.component.ComponentManager;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.event.EdgeEventConstants;
+import io.openems.edge.common.timer.Timer;
+
+@Designate(ocd = Config.class, factory = false)
+@Component(//
+	name = TimerManager.SINGLETON_SERVICE_PID, //
+	immediate = true, //
+	property = { //
+		"enabled=true" //
+	})
+@EventTopics({ //
+	EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE//
+})
+public class TimerManagerImpl extends AbstractOpenemsComponent implements TimerManager, EventHandler, OpenemsComponent {
+
+    private int coreCyclesCount = 0;
+
+    @Reference
+    private ConfigurationAdmin cm;
+
+    @Reference
+    protected ComponentManager componentManager;
+
+    public TimerManagerImpl() {
+	super(//
+		OpenemsComponent.ChannelId.values() //
+	);
+    }
+
+    @Activate
+    private void activate(ComponentContext context, Config config) {
+	super.activate(context, SINGLETON_COMPONENT_ID, SINGLETON_SERVICE_PID, true);
+	if (OpenemsComponent.validateSingleton(this.cm, SINGLETON_SERVICE_PID, SINGLETON_COMPONENT_ID)) {
+	    return;
+	}
+    }
+
+    @Override
+    @Deactivate
+    protected void deactivate() {
+	super.deactivate();
+    }
+
+    @Override
+    public void handleEvent(Event event) {
+	this.coreCyclesCount++;
+    }
+
+    protected int getCoreCyclesCount() {
+	return this.coreCyclesCount;
+    }
+
+    @Override
+    public Timer getTimerByCount(Channel<Integer> channel, int countCheckCalls, int startDelayInSecs) {
+	return new TimerByCount(this, channel, countCheckCalls, startDelayInSecs);
+    }
+
+    @Override
+    public Timer getTimerByCoreCycles(Channel<Integer> channel, int count, int startDelayInSecs) {
+	return new TimerByCoreCycles(this, channel, count, startDelayInSecs);
+    }
+
+    @Override
+    public Timer getTimerByTime(Channel<Integer> channel, int seconds, int startDelayInSecs) {
+	return new TimerByTime(this, this.componentManager.getClock(), channel, seconds, startDelayInSecs);
+    }
+
+}

--- a/io.openems.edge.core/src/io/openems/edge/core/timer/package-info.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/timer/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package io.openems.edge.core.timer;

--- a/io.openems.edge.core/src/io/openems/edge/core/timer/readme.adoc
+++ b/io.openems.edge.core/src/io/openems/edge/core/timer/readme.adoc
@@ -1,0 +1,65 @@
+
+== TimerManager 
+
+Access to different kind of timers. Can be used to 
+
+* `timerManager.getTimerCount()` - count each call to the timer.  
+* `timerManager.getTimerCoreCycles()` - count each core cycle.
+* `timerManager.getTimerTimer()` - count a given time in seconds.
+
+
+=== Usage Example 
+
+[source,java]
+----
+@Reference 
+TimerManager timerManager;
+
+Timer countTimer;
+Timer countTimer2;
+Timer timeTimer;
+Timer cyclesTimer;
+
+activate() {
+    //counts down on each call of countTimer.check()
+    countTimer        = timerManager.getTimerCount( 104 );                             
+
+    //counts down on each call to countTimer.check(), but has an initial start delay, 
+    //helpful for e.g. heatpumps
+    countTimer2       = timerManager.getTimerCount( 104, config.getStartDelay() );
+	
+	//counts down on each core cycle
+    coreCyclesTimer   = timerManager.getTimerCoreCycles(100 );
+              		     
+	//counts down seconds from now
+    oneMinTimer       = timerManager.getTimerTime( 120 );
+                                   
+    //counts down seconds, writes state of timer to the given channel
+    twoMinTimer       = timerManager.getTimerTime( this.channel, 180 );            
+}
+
+doSomething() {
+    if(oneMinTimer.check()){
+        // do stuff ...
+        oneMinTimer.reset();
+    }
+
+    if(oneMinTimer.checkAndReset()){
+        // do stuff ...
+        //no need to reset the timer 
+    }
+}
+
+----
+
+== Implementation Hints
+
+* Timer relevant actions in OpenEMS typically depends on the running context. Therefore the timer 
+is implemented as synchronous function interface and does not provide asynchrounous callbacks. 
+  
+* Count timers and time timers are simple utility classes. Nevertheless this package 
+is designed as singleton OpenEMS component. Reason are the core cycle timers. This reduces
+ coding expenses within the concrete implementations.
+   
+ 
+

--- a/io.openems.edge.core/test/io/openems/edge/core/timer/MyConfig.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/timer/MyConfig.java
@@ -1,0 +1,33 @@
+package io.openems.edge.core.timer;
+
+import io.openems.common.test.AbstractComponentConfig;
+
+@SuppressWarnings("all")
+public class MyConfig extends AbstractComponentConfig implements Config {
+
+    public static class Builder {
+	private Builder() {
+	}
+
+	public MyConfig build() {
+	    return new MyConfig(this);
+	}
+    }
+
+    /**
+     * Create a Config builder.
+     *
+     * @return a {@link Builder}
+     */
+    public static Builder create() {
+	return new Builder();
+    }
+
+    private final Builder builder;
+
+    private MyConfig(Builder builder) {
+	super(Config.class, TimerManager.SINGLETON_COMPONENT_ID);
+	this.builder = builder;
+    }
+
+}

--- a/io.openems.edge.core/test/io/openems/edge/core/timer/TimerManagerImplTest.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/timer/TimerManagerImplTest.java
@@ -1,0 +1,59 @@
+package io.openems.edge.core.timer;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.edge.common.timer.Timer;
+
+public class TimerManagerImplTest {
+
+    private TimerManagerImpl tm;
+
+    @Before
+    public void setup() throws Exception {
+	TimerManagerTestBundle tmTestBundle = new TimerManagerTestBundle();
+	this.tm = tmTestBundle.getTimerManager();
+    }
+
+    @Test
+    public void testTimerByCount() throws OpenemsException, Exception {
+	Timer t = this.tm.getTimerByCount(3);
+	assertFalse(t.check());
+	assertFalse(t.check());
+	assertFalse(t.check());
+	assertTrue(t.check());
+	t.reset();
+	assertFalse(t.check());
+    }
+
+    @Test
+    public void testTimerByCoreCycles() throws OpenemsException, Exception {
+	Timer t = this.tm.getTimerByCoreCycles(3);
+
+	assertFalse(t.check());
+	this.tm.handleEvent(null);
+	assertFalse(t.check());
+	this.tm.handleEvent(null);
+	assertFalse(t.check());
+	this.tm.handleEvent(null);
+
+	assertTrue(t.check());
+	t.reset();
+
+	this.tm.handleEvent(null);
+	assertFalse(t.check());
+	this.tm.handleEvent(null);
+	assertFalse(t.check());
+	this.tm.handleEvent(null);
+	assertTrue(t.check());
+	this.tm.handleEvent(null);
+	assertTrue(t.check());
+    }
+
+    // TODO add test for time timer and test delay and channels also
+    // Note that time timer tests would slow down build process
+}

--- a/io.openems.edge.core/test/io/openems/edge/core/timer/TimerManagerTestBundle.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/timer/TimerManagerTestBundle.java
@@ -1,0 +1,53 @@
+package io.openems.edge.core.timer;
+
+import com.google.gson.JsonObject;
+
+import io.openems.common.utils.JsonUtils;
+import io.openems.edge.common.test.ComponentTest;
+import io.openems.edge.common.test.DummyComponentManager;
+import io.openems.edge.common.test.DummyConfigurationAdmin;
+
+public class TimerManagerTestBundle {
+    public final DummyConfigurationAdmin cm;
+    public final DummyComponentManager componentManger;
+    public final TimerManagerImpl tm;
+
+    public TimerManagerTestBundle() throws Exception {
+
+	this.cm = new DummyConfigurationAdmin();
+	this.cm.getOrCreateEmptyConfiguration(TimerManager.SINGLETON_SERVICE_PID);
+
+	this.componentManger = new DummyComponentManager();
+	JsonObject initialComponentConfig = JsonUtils.buildJsonObject() //
+		.add(TimerManager.SINGLETON_COMPONENT_ID, JsonUtils.buildJsonObject() //
+			.addProperty("factoryId", TimerManager.SINGLETON_SERVICE_PID) //
+			.addProperty("alias", "") //
+			.add("properties", JsonUtils.buildJsonObject() //
+				.addProperty("no", "{}") //
+				.build()) //
+			.build()) //
+		.build();
+	this.componentManger.setConfigJson(JsonUtils.buildJsonObject() //
+		.add("components", initialComponentConfig) //
+		.add("factories", JsonUtils.buildJsonObject() //
+			.build()) //
+		.build() //
+	);
+
+	this.tm = new TimerManagerImpl();
+	this.componentManger.addComponent(this.tm);
+	this.componentManger.setConfigurationAdmin(this.cm);
+
+	MyConfig config = MyConfig.create().build();
+
+	new ComponentTest(this.tm) //
+		.addReference("cm", this.cm) //
+		.addReference("componentManager", this.componentManger) //
+		.activate(config);
+    }
+
+    protected TimerManagerImpl getTimerManager() {
+	return this.tm;
+    }
+
+}


### PR DESCRIPTION
Previous PR #1754  of Timer reworked 
with @clehne 

This compared to the old PR #1754

is easier to use and easier to understand

TimerManager is kinda like a factory. 
OpenEmsComponent  that needs Timer/want to use Timer
uses @Reference of the TimerManager
And calls TimerManager methods to create a cycles/count/time Timer.