### PR TITLE
Edge: Fixed grid buy and sell channel assignment

### DIFF
--- a/io.openems.edge.core/src/io/openems/edge/core/sum/SumImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/sum/SumImpl.java
@@ -241,8 +241,8 @@ public class SumImpl extends AbstractOpenemsComponent implements Sum, OpenemsCom
 					gridActivePower.addValue(meter.getActivePowerChannel());
 					gridMinActivePower.addValue(meter.getMinActivePowerChannel());
 					gridMaxActivePower.addValue(meter.getMaxActivePowerChannel());
-					gridBuyActiveEnergy.addValue(meter.getActiveProductionEnergyChannel());
-					gridSellActiveEnergy.addValue(meter.getActiveConsumptionEnergyChannel());
+					gridBuyActiveEnergy.addValue(meter.getActiveConsumptionEnergyChannel());
+					gridSellActiveEnergy.addValue(meter.getActiveProductionEnergyChannel());
 
 					if (meter instanceof AsymmetricMeter) {
 						var m = (AsymmetricMeter) meter;


### PR DESCRIPTION
While setting up an installation with a grid meter, I figured that the values for energy sold to grid and energy bought from grid are mixed up. This PR corrects this. 

Heads-up: this breaks the data which resides in the time-series database. This should not be a big deal as the data for the channels `_sum/GridSellActiveEnergy` and `_sum/GridBuyActiveEnergy` is mixed up anyways.

The following screenshot shows the pre-PR situation and the mix-up.

<img width="1621" alt="Bildschirmfoto 2023-04-27 um 13 23 48" src="https://user-images.githubusercontent.com/298741/234848151-3612f5a0-a63f-4747-8ce5-c3a3574caa46.png">
