### PR TITLE
Fix/UI consumption energy display

### DIFF
--- a/ui/src/app/edge/history/consumption/widget.component.html
+++ b/ui/src/app/edge/history/consumption/widget.component.html
@@ -12,7 +12,7 @@
                     <tr>
                         <td style="width:65%"></td>
                         <td style="width:35%" class="align_right">
-                            {{ data["_sum/ConsumptionActiveEnergy"] | unitvalue:'kWh' }}
+                            {{ data[CHANNEL_SUM_CONSUMPTION_ACTIVE_ENERGY.toString()] | unitvalue:'kWh' }}
                         </td>
                     </tr>
                 </ng-container>
@@ -22,17 +22,17 @@
                             <td style="width:65%">{{ component.alias }}
                             </td>
                             <td style="width:35%" class="align_right">
-                                {{ data[component.id + "/ActiveConsumptionEnergy"] ?? 0 | unitvalue:'kWh' }}
+                                {{ data[this.getChannelAddressString(component, CHANNEL_ID_ACTIVE_CONSUMPTION_ENERGY)] ?? 0 | unitvalue:'kWh' }}
                             </td>
                         </tr>
                     </ng-container>
                 </ng-container>
                 <ng-container *ngFor="let component of consumptionMeterComponents">
                     <ng-container>
-                        <tr>
+                        <tr data-test-id="consumption-meter-component-entry">
                             <td style="width:65%">{{ component.alias }}</td>
                             <td style="width:35%" class="align_right">
-                                {{ (data[component.id + "/ActiveProductionEnergy"]| unitvalue:'kWh') ?? "-" }}
+                                {{ (data[this.getChannelAddressString(component, CHANNEL_ID_ACTIVE_CONSUMPTION_ENERGY)] | unitvalue:'kWh') ?? "-" }}
                             </td>
                         </tr>
                     </ng-container>

--- a/ui/src/app/edge/history/consumption/widget.component.spec.ts
+++ b/ui/src/app/edge/history/consumption/widget.component.spec.ts
@@ -1,0 +1,100 @@
+import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {ConsumptionComponent} from "./widget.component";
+import {Service} from "../../../shared/service/service";
+import {Edge} from "../../../shared/edge/edge";
+import {Role} from "../../../shared/type/role";
+import {ActivatedRoute} from "@angular/router";
+import {By} from "@angular/platform-browser";
+import {DebugElement} from "@angular/core";
+import {EdgeConfig} from "../../../shared/edge/edgeconfig";
+import ComponentChannel = EdgeConfig.ComponentChannel;
+import {DefaultTypes} from "../../../shared/service/defaulttypes";
+import {
+  QueryHistoricTimeseriesEnergyResponse
+} from "../../../shared/jsonrpc/response/queryHistoricTimeseriesEnergyResponse";
+import {PipeModule} from "../../../shared/pipe/pipe";
+
+describe('history/ConsumptionComponent widget', () => {
+  let component: ConsumptionComponent;
+  let fixture: ComponentFixture<ConsumptionComponent>;
+
+  const consumptionMeterFactory = new EdgeConfig.Factory(
+    "Meter Microcare SDM 630", "Implements the Microcare SDM630 meter.",
+    ["io.openems.edge.meter.api.SymmetricMeter"]
+  );
+
+  const meterFactoryId = 'Meter.Microcare.SDM630';
+
+  const consumerActiveConsumptionEnergy: ComponentChannel = {
+    accessMode: "RO",
+    level: "INFO",
+    type: "FLOAT",
+    category: "OPENEMS_TYPE",
+    unit: "kWh"
+  };
+  const consumptionMeter = new EdgeConfig.Component(
+    meterFactoryId, {
+      'type': 'CONSUMPTION_METERED'
+    }, {
+      'ActiveConsumptionEnergy': consumerActiveConsumptionEnergy
+    }
+  );
+  consumptionMeter.alias="Heatpump Consumer"
+  consumptionMeter.isEnabled = true;
+
+  const edge = new Edge("edge0", "comment", "producttype", "1234.56.78", Role.ADMIN, true, new Date());
+
+  // @ts-ignore
+  const edgeConfig = new EdgeConfig(edge, {
+    components: {
+      'consumptionMeter': consumptionMeter
+    },
+    factories: {
+      [meterFactoryId]: consumptionMeterFactory
+    }
+  })
+
+  const queryHistoricTimeseriesEnergyResponse: QueryHistoricTimeseriesEnergyResponse = {
+    id: 'random',
+    jsonrpc: '2.0',
+    result: {
+      data: {
+        'consumptionMeter/ActiveConsumptionEnergy': 2323.46
+      }
+    }
+  };
+
+  beforeEach(async () => {
+    const service = jasmine.createSpyObj('Service', ['setCurrentComponent', 'getConfig', 'queryEnergy']);
+    service.setCurrentComponent.and.returnValue(Promise.resolve(edge));
+    service.getConfig.and.returnValue(Promise.resolve(edgeConfig))
+    service.queryEnergy.and.returnValue(Promise.resolve(queryHistoricTimeseriesEnergyResponse))
+
+    TestBed.configureTestingModule({
+      declarations: [ConsumptionComponent],
+      providers: [
+        {provide: Service, useValue: service},
+        {provide: ActivatedRoute, useValue: {}}
+      ],
+      imports: [PipeModule]
+    });
+  });
+
+  it('should display consumption meter entries on period change', async () => {
+    fixture = TestBed.createComponent(ConsumptionComponent);
+    component = fixture.componentInstance;
+    await component.ngOnInit();
+
+    component.period = new DefaultTypes.HistoryPeriod();
+    await component.ngOnChanges();
+    fixture.detectChanges();
+
+    await fixture.whenStable();
+    const del: DebugElement = fixture.debugElement;
+    const consumptionMeterEntry = del.query(
+      By.css('[data-test-id="consumption-meter-component-entry"]')
+    );
+    expect(consumptionMeterEntry).toBeTruthy();
+    expect(consumptionMeterEntry.nativeElement.textContent.trim()).toContain("Heatpump Consumer 2.3" + '\u00A0' + "kWh");
+  });
+});

--- a/ui/src/app/shared/service/test/dummyservice.ts
+++ b/ui/src/app/shared/service/test/dummyservice.ts
@@ -4,7 +4,6 @@ import { QueryHistoricTimeseriesEnergyResponse } from "../../jsonrpc/response/qu
 import { ChannelAddress, Edge, EdgeConfig } from "../../shared";
 import { Language } from "../../type/language";
 import { Role } from "../../type/role";
-import { AdvertWidgets } from "../../type/widget";
 import { AbstractService } from "../abstractservice";
 import { DefaultTypes } from "../defaulttypes";
 
@@ -56,9 +55,6 @@ export class DummyService extends AbstractService {
         throw new Error("Method not implemented.");
     }
     toast(message: string, level: "success" | "warning" | "danger") {
-        throw new Error("Method not implemented.");
-    }
-    showAdvertWidgets(advertWidgets: AdvertWidgets) {
         throw new Error("Method not implemented.");
     }
     isPartnerAllowed(edge: Edge): boolean {

--- a/ui/src/app/shared/service/test/dummywebsocket.ts
+++ b/ui/src/app/shared/service/test/dummywebsocket.ts
@@ -15,7 +15,7 @@ export class DummyWebsocket implements WebsocketInterface {
 
     public sendRequest(request: JsonrpcRequest): Promise<JsonrpcResponseSuccess> {
         return new Promise((accept, reject) => {
-            reject("DummyComponent");
+            reject("Method not implemented.");
         });
     }
 


### PR DESCRIPTION
When having a consumption meter (type: CONSUMPTION_METERED) sending **ActiveConsumptionEnergy** values, they weren't shown in the consumption widget below the chart area for historic values. 

We identified the issue that the consumption area was filtering for **ActiveProductionEnergy** from a consumption meter instead of **ActiveConsumptionEnergy**.

This MR solves this issue. We also added a test with example data to validate the fix. 