### PR TITLE
Virtual meter bug fix: average is computed correctly fixed

### DIFF
--- a/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
@@ -2,6 +2,7 @@ package io.openems.edge.common.type;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import com.google.gson.JsonElement;
@@ -412,6 +413,17 @@ public class TypeUtils {
 	 * @param values the {@link Integer} values
 	 * @return the sum
 	 */
+	public static Integer sumInt(List<Integer> values) {
+		return sum(values.toArray(new Integer[0]));
+	}
+
+	/**
+	 * Safely add Integers. If one of them is null it is considered '0'. If all of
+	 * them are null, 'null' is returned.
+	 *
+	 * @param values the {@link Integer} values
+	 * @return the sum
+	 */
 	public static Integer sum(Integer... values) {
 		Integer result = null;
 		for (Integer value : values) {
@@ -425,6 +437,17 @@ public class TypeUtils {
 			}
 		}
 		return result;
+	}
+
+	/**
+	 * Safely add Longs. If one of them is null it is considered '0'. If all of them
+	 * are null, 'null' is returned.
+	 *
+	 * @param values the {@link Long} values
+	 * @return the sum
+	 */
+	public static Long sum(List<Long> values) {
+		return sum(values.toArray(new Long[0]));
 	}
 
 	/**
@@ -727,6 +750,16 @@ public class TypeUtils {
 			return null;
 		}
 		return Math.round(sum / count);		
+	}
+
+	/**
+	 * Safely finds the average value of all values.
+	 *
+	 * @param values the {@link Integer} values
+	 * @return the average value; or null if all values are null
+	 */
+	public static Integer averageInt(List<Integer> values) {
+		return averageInt(values.toArray(new Integer[0]));
 	}
 
 	/**

--- a/io.openems.edge.meter.virtual/test/io/openems/edge/meter/virtual/symmetric/add/VirtualSymmetricMeterAddTest.java
+++ b/io.openems.edge.meter.virtual/test/io/openems/edge/meter/virtual/symmetric/add/VirtualSymmetricMeterAddTest.java
@@ -45,16 +45,16 @@ public class VirtualSymmetricMeterAddTest {
 						.setType(MeterType.GRID) //
 						.build())
 				.next(new TestCase("one") //
-						.input(METER_ID_1_ACTIVEPOWER, 2_000) //
+						.input(METER_ID_1_ACTIVEPOWER, 1_500) //
 						.input(METER_ID_2_ACTIVEPOWER, 2_000) //
-						.input(METER_ID_3_ACTIVEPOWER, 2_000) //
-						.input(METER_ID_4_ACTIVEPOWER, 2_000) //
+						.input(METER_ID_3_ACTIVEPOWER, 2_500) //
+						.input(METER_ID_4_ACTIVEPOWER, 3_000) //
 						.input(METER_ID_1_FREQUENCY, 49) //
 						.input(METER_ID_2_FREQUENCY, 51) //
 						.input(METER_ID_3_FREQUENCY, 49) //
 						.input(METER_ID_4_FREQUENCY, 51)) //
 				.next(new TestCase() //
-						.output(METER_POWER, 8_000) //
-						.output(METER_FREQ, 51));
+						.output(METER_POWER, 9_000) //
+						.output(METER_FREQ, 50));
 	}
 }


### PR DESCRIPTION
Hi team,

The average channel value for channels such as frequency was incorrectly calculated. Instead of taking the average of all channel values the average was computed as follows. (4 meter example) avg(avg(avg(avg(null, 1), 2), 3, 4) == 3.125 while 2.5 is expected.

The test case has also been corrected.

My only doubt is that I had to add overloads for sum and average to `TypeUtils` has varargs cannot be safely expressed as a Function or BiFunction, such as [here](https://github.com/OpenEMS/openems/compare/develop...JoopAue:openems:bug/virtual-meter-average?expand=1#diff-4f07af2e879a748e7a34c4328eb4361740d85af2d56e82a0f6602ba0ac24ea81R17)

Let me know if there are any questions.

Thanks!
Joop

(@pooran-c for transparency as I believe I'm adjusting [your code](https://github.com/OpenEMS/openems/pull/2062))