### PR TITLE
bugfix/meter-microcare

### DIFF
--- a/io.openems.edge.meter.microcare.sdm630/src/io/openems/edge/meter/microcare/sdm630/MeterMicrocareSdm630Impl.java
+++ b/io.openems.edge.meter.microcare.sdm630/src/io/openems/edge/meter/microcare/sdm630/MeterMicrocareSdm630Impl.java
@@ -157,20 +157,20 @@ public class MeterMicrocareSdm630Impl extends AbstractOpenemsModbusComponent imp
 						m(SymmetricMeter.ChannelId.FREQUENCY,
 								new FloatDoublewordElement(30071 - offset).wordOrder(WordOrder.MSWLSW)
 										.byteOrder(ByteOrder.BIG_ENDIAN),
-								ElementToChannelConverter.DIRECT_1_TO_1),
-						m(SymmetricMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY,
+								ElementToChannelConverter.SCALE_FACTOR_3),
+						m(SymmetricMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY,
 								new FloatDoublewordElement(30073 - offset).wordOrder(WordOrder.MSWLSW)
 										.byteOrder(ByteOrder.BIG_ENDIAN),
 								ElementToChannelConverter.SCALE_FACTOR_3),
-						m(SymmetricMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY,
+						m(SymmetricMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY,
 								new FloatDoublewordElement(30075 - offset).wordOrder(WordOrder.MSWLSW)
 										.byteOrder(ByteOrder.BIG_ENDIAN),
 								ElementToChannelConverter.SCALE_FACTOR_3),
-						m(MeterMicrocareSdm630.ChannelId.REACTIVE_CONSUMPTION_ENERGY,
+						m(MeterMicrocareSdm630.ChannelId.REACTIVE_PRODUCTION_ENERGY,
 								new FloatDoublewordElement(30077 - offset).wordOrder(WordOrder.MSWLSW)
 										.byteOrder(ByteOrder.BIG_ENDIAN),
 								ElementToChannelConverter.SCALE_FACTOR_3),
-						m(MeterMicrocareSdm630.ChannelId.REACTIVE_PRODUCTION_ENERGY,
+						m(MeterMicrocareSdm630.ChannelId.REACTIVE_CONSUMPTION_ENERGY,
 								new FloatDoublewordElement(30079 - offset).wordOrder(WordOrder.MSWLSW)
 										.byteOrder(ByteOrder.BIG_ENDIAN),
 								ElementToChannelConverter.SCALE_FACTOR_3)));


### PR DESCRIPTION
There were two small bugs in the meter:
1) Production and consumption energy were swapped (for both active and reactive energy)
2) The scale factor 3 for frequency was missing