### PR TITLE
SunSpec PV-Inverters + Meters: improve implementation

### DIFF
--- a/io.openems.edge.meter.api/src/io/openems/edge/meter/api/SinglePhaseMeter.java
+++ b/io.openems.edge.meter.api/src/io/openems/edge/meter/api/SinglePhaseMeter.java
@@ -62,6 +62,7 @@ public interface SinglePhaseMeter extends ElectricityMeter {
 	 * {@link ChannelId#ACTIVE_POWER} by evaluating the provided
 	 * {@link SinglePhase}.
 	 *
+	 * @param <METER>       type that extends {@link ElectricityMeter}
 	 * @param meter         a {@link ElectricityMeter}
 	 * @param phaseProvider a provider for {@link SinglePhase}
 	 */

--- a/io.openems.edge.meter.api/src/io/openems/edge/meter/api/SinglePhaseMeter.java
+++ b/io.openems.edge.meter.api/src/io/openems/edge/meter/api/SinglePhaseMeter.java
@@ -1,5 +1,7 @@
 package io.openems.edge.meter.api;
 
+import java.util.function.Function;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 import io.openems.common.channel.AccessMode;
@@ -32,19 +34,41 @@ public interface SinglePhaseMeter extends ElectricityMeter {
 	public SinglePhase getPhase();
 
 	/**
-	 * Initializes Channel listeners for a Symmetric {@link ElectricityMeter}.
+	 * Initializes Channel listeners for a {@link SinglePhaseMeter}.
 	 * 
 	 * <p>
 	 * Sets the correct value for {@link ChannelId#ACTIVE_POWER_L1},
 	 * {@link ChannelId#ACTIVE_POWER_L2} or {@link ChannelId#ACTIVE_POWER_L3} from
 	 * {@link ChannelId#ACTIVE_POWER} by evaluating the configured
-	 * {@link SinglePhase}.
+	 * {@link SinglePhase} via {@link SinglePhaseMeter#getPhase()}.
 	 *
-	 * @param meter the {@link ElectricityMeter}
+	 * @param meter the {@link SinglePhaseMeter}
 	 */
 	public static void calculateSinglePhaseFromActivePower(SinglePhaseMeter meter) {
+		SinglePhaseMeter.calculateSinglePhaseFromActivePower(meter, SinglePhaseMeter::getPhase);
+	}
+
+	/**
+	 * Initializes Channel listeners for a {@link SinglePhaseMeter}.
+	 * 
+	 * <p>
+	 * Use this method if it is not known at compile time, that the
+	 * {@link ElectricityMeter} is a {@link SinglePhaseMeter}, i.e. it is not
+	 * implementing {@link SinglePhaseMeter}.
+	 * 
+	 * <p>
+	 * Sets the correct value for {@link ChannelId#ACTIVE_POWER_L1},
+	 * {@link ChannelId#ACTIVE_POWER_L2} or {@link ChannelId#ACTIVE_POWER_L3} from
+	 * {@link ChannelId#ACTIVE_POWER} by evaluating the provided
+	 * {@link SinglePhase}.
+	 *
+	 * @param meter         a {@link ElectricityMeter}
+	 * @param phaseProvider a provider for {@link SinglePhase}
+	 */
+	public static <METER extends ElectricityMeter> void calculateSinglePhaseFromActivePower(METER meter,
+			Function<METER, SinglePhase> phaseProvider) {
 		meter.getActivePowerChannel().onSetNextValue(value -> {
-			var phase = meter.getPhase();
+			var phase = phaseProvider.apply(meter);
 			meter.getActivePowerL1Channel().setNextValue(phase == SinglePhase.L1 ? value : null);
 			meter.getActivePowerL2Channel().setNextValue(phase == SinglePhase.L2 ? value : null);
 			meter.getActivePowerL2Channel().setNextValue(phase == SinglePhase.L3 ? value : null);

--- a/io.openems.edge.meter.sunspec/src/io/openems/edge/meter/sunspec/AbstractSunSpecMeter.java
+++ b/io.openems.edge.meter.sunspec/src/io/openems/edge/meter/sunspec/AbstractSunSpecMeter.java
@@ -91,10 +91,7 @@ public abstract class AbstractSunSpecMeter extends AbstractOpenemsSunSpecCompone
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.VOLTAGE, //
 				SCALE_FACTOR_3, //
-				S204.PH_V, S203.PH_V, S202.PH_V, S201.PH_V, //
-				S204.PH_VPH_A, S203.PH_VPH_A, S202.PH_VPH_A, S201.PH_VPH_A, //
-				S204.PH_VPH_B, S203.PH_VPH_B, S202.PH_VPH_B, S201.PH_VPH_B, //
-				S204.PH_VPH_C, S203.PH_VPH_C, S202.PH_VPH_C, S201.PH_VPH_C);
+				S204.PH_V, S203.PH_V, S202.PH_V, S201.PH_V);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.CURRENT, //
 				SCALE_FACTOR_3, //

--- a/io.openems.edge.meter.sunspec/src/io/openems/edge/meter/sunspec/AbstractSunSpecMeter.java
+++ b/io.openems.edge.meter.sunspec/src/io/openems/edge/meter/sunspec/AbstractSunSpecMeter.java
@@ -15,7 +15,10 @@ import org.slf4j.LoggerFactory;
 
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.edge.bridge.modbus.sunspec.AbstractOpenemsSunSpecComponent;
-import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel;
+import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S201;
+import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S202;
+import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S203;
+import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S204;
 import io.openems.edge.bridge.modbus.sunspec.SunSpecModel;
 import io.openems.edge.bridge.modbus.sunspec.SunSpecPoint;
 import io.openems.edge.common.channel.Channel;
@@ -68,135 +71,107 @@ public abstract class AbstractSunSpecMeter extends AbstractOpenemsSunSpecCompone
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.FREQUENCY, //
 				SCALE_FACTOR_3, //
-				DefaultSunSpecModel.S204.HZ, DefaultSunSpecModel.S203.HZ, DefaultSunSpecModel.S202.HZ,
-				DefaultSunSpecModel.S201.HZ);
+				S204.HZ, S203.HZ, S202.HZ, S201.HZ);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_POWER, //
 				INVERT, //
-				DefaultSunSpecModel.S204.W, DefaultSunSpecModel.S203.W, DefaultSunSpecModel.S202.W,
-				DefaultSunSpecModel.S201.W);
+				S204.W, S203.W, S202.W, S201.W);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.REACTIVE_POWER, //
 				INVERT, //
-				DefaultSunSpecModel.S204.VAR, DefaultSunSpecModel.S203.VAR, DefaultSunSpecModel.S202.VAR,
-				DefaultSunSpecModel.S201.VAR);
+				S204.VAR, S203.VAR, S202.VAR, S201.VAR);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S204.TOT_WH_EXP, DefaultSunSpecModel.S203.TOT_WH_EXP,
-				DefaultSunSpecModel.S202.TOT_WH_EXP, DefaultSunSpecModel.S201.TOT_WH_EXP);
+				S204.TOT_WH_EXP, S203.TOT_WH_EXP, S202.TOT_WH_EXP, S201.TOT_WH_EXP);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S204.TOT_WH_IMP, DefaultSunSpecModel.S203.TOT_WH_IMP,
-				DefaultSunSpecModel.S202.TOT_WH_IMP, DefaultSunSpecModel.S201.TOT_WH_IMP);
+				S204.TOT_WH_IMP, S203.TOT_WH_IMP, S202.TOT_WH_IMP, S201.TOT_WH_IMP);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.VOLTAGE, //
 				SCALE_FACTOR_3, //
-				DefaultSunSpecModel.S204.PH_V, DefaultSunSpecModel.S203.PH_V, DefaultSunSpecModel.S202.PH_V,
-				DefaultSunSpecModel.S201.PH_V, //
-				DefaultSunSpecModel.S204.PH_VPH_A, DefaultSunSpecModel.S203.PH_VPH_A, DefaultSunSpecModel.S202.PH_VPH_A,
-				DefaultSunSpecModel.S201.PH_VPH_A, //
-				DefaultSunSpecModel.S204.PH_VPH_B, DefaultSunSpecModel.S203.PH_VPH_B, DefaultSunSpecModel.S202.PH_VPH_B,
-				DefaultSunSpecModel.S201.PH_VPH_B, //
-				DefaultSunSpecModel.S204.PH_VPH_C, DefaultSunSpecModel.S203.PH_VPH_C, DefaultSunSpecModel.S202.PH_VPH_C,
-				DefaultSunSpecModel.S201.PH_VPH_C);
+				S204.PH_V, S203.PH_V, S202.PH_V, S201.PH_V, //
+				S204.PH_VPH_A, S203.PH_VPH_A, S202.PH_VPH_A, S201.PH_VPH_A, //
+				S204.PH_VPH_B, S203.PH_VPH_B, S202.PH_VPH_B, S201.PH_VPH_B, //
+				S204.PH_VPH_C, S203.PH_VPH_C, S202.PH_VPH_C, S201.PH_VPH_C);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.CURRENT, //
 				SCALE_FACTOR_3, //
-				DefaultSunSpecModel.S204.A, DefaultSunSpecModel.S203.A, DefaultSunSpecModel.S202.A,
-				DefaultSunSpecModel.S201.A);
+				S204.A, S203.A, S202.A, S201.A);
 
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_POWER_L1, //
 				INVERT, //
-				DefaultSunSpecModel.S204.WPH_A, DefaultSunSpecModel.S203.WPH_A, DefaultSunSpecModel.S202.WPH_A,
-				DefaultSunSpecModel.S201.WPH_A);
+				S204.WPH_A, S203.WPH_A, S202.WPH_A, S201.WPH_A);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_POWER_L2, //
 				INVERT, //
-				DefaultSunSpecModel.S204.WPH_B, DefaultSunSpecModel.S203.WPH_B, DefaultSunSpecModel.S202.WPH_B,
-				DefaultSunSpecModel.S201.WPH_B);
+				S204.WPH_B, S203.WPH_B, S202.WPH_B, S201.WPH_B);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_POWER_L3, //
 				INVERT, //
-				DefaultSunSpecModel.S204.WPH_C, DefaultSunSpecModel.S203.WPH_C, DefaultSunSpecModel.S202.WPH_C,
-				DefaultSunSpecModel.S201.WPH_C);
+				S204.WPH_C, S203.WPH_C, S202.WPH_C, S201.WPH_C);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.CURRENT_L1, //
 				SCALE_FACTOR_3, //
-				DefaultSunSpecModel.S204.APH_A, DefaultSunSpecModel.S203.APH_A, DefaultSunSpecModel.S202.APH_A,
-				DefaultSunSpecModel.S201.APH_A);
+				S204.APH_A, S203.APH_A, S202.APH_A, S201.APH_A);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.CURRENT_L2, //
 				SCALE_FACTOR_3, //
-				DefaultSunSpecModel.S204.APH_B, DefaultSunSpecModel.S203.APH_B, DefaultSunSpecModel.S202.APH_B,
-				DefaultSunSpecModel.S201.APH_B);
+				S204.APH_B, S203.APH_B, S202.APH_B, S201.APH_B);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.CURRENT_L3, //
 				SCALE_FACTOR_3, //
-				DefaultSunSpecModel.S204.APH_C, DefaultSunSpecModel.S203.APH_C, DefaultSunSpecModel.S202.APH_C,
-				DefaultSunSpecModel.S201.APH_C);
+				S204.APH_C, S203.APH_C, S202.APH_C, S201.APH_C);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.REACTIVE_POWER_L1, //
 				INVERT, //
-				DefaultSunSpecModel.S204.V_A_RPH_A, DefaultSunSpecModel.S203.V_A_RPH_A,
-				DefaultSunSpecModel.S202.V_A_RPH_A, DefaultSunSpecModel.S201.V_A_RPH_A);
+				S204.V_A_RPH_A, S203.V_A_RPH_A, S202.V_A_RPH_A, S201.V_A_RPH_A);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.REACTIVE_POWER_L2, //
 				INVERT, //
-				DefaultSunSpecModel.S204.V_A_RPH_B, DefaultSunSpecModel.S203.V_A_RPH_B,
-				DefaultSunSpecModel.S202.V_A_RPH_B, DefaultSunSpecModel.S201.V_A_RPH_B);
+				S204.V_A_RPH_B, S203.V_A_RPH_B, S202.V_A_RPH_B, S201.V_A_RPH_B);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.REACTIVE_POWER_L3, //
 				INVERT, //
-				DefaultSunSpecModel.S204.V_A_RPH_C, DefaultSunSpecModel.S203.V_A_RPH_C,
-				DefaultSunSpecModel.S202.V_A_RPH_C, DefaultSunSpecModel.S201.V_A_RPH_C);
+				S204.V_A_RPH_C, S203.V_A_RPH_C, S202.V_A_RPH_C, S201.V_A_RPH_C);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.VOLTAGE_L1, //
 				SCALE_FACTOR_3, //
-				DefaultSunSpecModel.S204.PH_VPH_A, DefaultSunSpecModel.S203.PH_VPH_A, DefaultSunSpecModel.S202.PH_VPH_A,
-				DefaultSunSpecModel.S201.PH_VPH_A);
+				S204.PH_VPH_A, S203.PH_VPH_A, S202.PH_VPH_A, S201.PH_VPH_A);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.VOLTAGE_L2, //
 				SCALE_FACTOR_3, //
-				DefaultSunSpecModel.S204.PH_VPH_B, DefaultSunSpecModel.S203.PH_VPH_B, DefaultSunSpecModel.S202.PH_VPH_B,
-				DefaultSunSpecModel.S201.PH_VPH_B);
+				S204.PH_VPH_B, S203.PH_VPH_B, S202.PH_VPH_B, S201.PH_VPH_B);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.VOLTAGE_L3, //
 				SCALE_FACTOR_3, //
-				DefaultSunSpecModel.S204.PH_VPH_C, DefaultSunSpecModel.S203.PH_VPH_C, DefaultSunSpecModel.S202.PH_VPH_C,
-				DefaultSunSpecModel.S201.PH_VPH_C);
+				S204.PH_VPH_C, S203.PH_VPH_C, S202.PH_VPH_C, S201.PH_VPH_C);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY_L1, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S204.TOT_WH_EXP_PH_A, DefaultSunSpecModel.S203.TOT_WH_EXP_PH_A,
-				DefaultSunSpecModel.S202.TOT_WH_EXP_PH_A, DefaultSunSpecModel.S201.TOT_WH_EXP_PH_A);
+				S204.TOT_WH_EXP_PH_A, S203.TOT_WH_EXP_PH_A, S202.TOT_WH_EXP_PH_A, S201.TOT_WH_EXP_PH_A);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY_L2, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S204.TOT_WH_EXP_PH_B, DefaultSunSpecModel.S203.TOT_WH_EXP_PH_B,
-				DefaultSunSpecModel.S202.TOT_WH_EXP_PH_B, DefaultSunSpecModel.S201.TOT_WH_EXP_PH_B);
+				S204.TOT_WH_EXP_PH_B, S203.TOT_WH_EXP_PH_B, S202.TOT_WH_EXP_PH_B, S201.TOT_WH_EXP_PH_B);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY_L3, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S204.TOT_WH_EXP_PH_C, DefaultSunSpecModel.S203.TOT_WH_EXP_PH_C,
-				DefaultSunSpecModel.S202.TOT_WH_EXP_PH_C, DefaultSunSpecModel.S201.TOT_WH_EXP_PH_C);
+				S204.TOT_WH_EXP_PH_C, S203.TOT_WH_EXP_PH_C, S202.TOT_WH_EXP_PH_C, S201.TOT_WH_EXP_PH_C);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY_L1, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S204.TOT_WH_IMP_PH_A, DefaultSunSpecModel.S203.TOT_WH_IMP_PH_A,
-				DefaultSunSpecModel.S202.TOT_WH_IMP_PH_A, DefaultSunSpecModel.S201.TOT_WH_IMP_PH_A);
+				S204.TOT_WH_IMP_PH_A, S203.TOT_WH_IMP_PH_A, S202.TOT_WH_IMP_PH_A, S201.TOT_WH_IMP_PH_A);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY_L2, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S204.TOT_WH_IMP_PH_B, DefaultSunSpecModel.S203.TOT_WH_IMP_PH_B,
-				DefaultSunSpecModel.S202.TOT_WH_IMP_PH_B, DefaultSunSpecModel.S201.TOT_WH_IMP_PH_B);
+				S204.TOT_WH_IMP_PH_B, S203.TOT_WH_IMP_PH_B, S202.TOT_WH_IMP_PH_B, S201.TOT_WH_IMP_PH_B);
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY_L3, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S204.TOT_WH_IMP_PH_C, DefaultSunSpecModel.S203.TOT_WH_IMP_PH_C,
-				DefaultSunSpecModel.S202.TOT_WH_IMP_PH_C, DefaultSunSpecModel.S201.TOT_WH_IMP_PH_C);
+				S204.TOT_WH_IMP_PH_C, S203.TOT_WH_IMP_PH_C, S202.TOT_WH_IMP_PH_C, S201.TOT_WH_IMP_PH_C);
 	}
 
 	@Override

--- a/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/AbstractSunSpecPvInverter.java
+++ b/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/AbstractSunSpecPvInverter.java
@@ -239,13 +239,13 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 
 		// Voltage
 		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L1, //
-				DIRECT_1_TO_1, //
+				SCALE_FACTOR_3, //
 				S111.PH_VPH_A, S112.PH_VPH_A, S113.PH_VPH_A, S101.PH_VPH_A, S102.PH_VPH_A, S103.PH_VPH_A);
 		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L2, //
-				DIRECT_1_TO_1, //
+				SCALE_FACTOR_3, //
 				S111.PH_VPH_B, S112.PH_VPH_B, S113.PH_VPH_B, S101.PH_VPH_B, S102.PH_VPH_B, S103.PH_VPH_B);
 		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L3, //
-				DIRECT_1_TO_1, //
+				SCALE_FACTOR_3, //
 				S111.PH_VPH_C, S112.PH_VPH_C, S113.PH_VPH_C, S101.PH_VPH_C, S102.PH_VPH_C, S103.PH_VPH_C);
 
 		// Current
@@ -254,13 +254,13 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 				SCALE_FACTOR_3, //
 				S111.A, S112.A, S113.A, S101.A, S102.A, S103.A);
 		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.CURRENT_L1, //
-				DIRECT_1_TO_1, //
+				SCALE_FACTOR_3, //
 				S111.APH_A, S112.APH_A, S113.APH_A, S101.APH_A, S102.APH_A, S103.APH_A);
 		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.CURRENT_L2, //
-				DIRECT_1_TO_1, //
+				SCALE_FACTOR_3, //
 				S111.APH_B, S112.APH_B, S113.APH_B, S101.APH_B, S102.APH_B, S103.APH_B);
 		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.CURRENT_L3, //
-				DIRECT_1_TO_1, //
+				SCALE_FACTOR_3, //
 				S111.APH_C, S112.APH_C, S113.APH_C, S101.APH_C, S102.APH_C, S103.APH_C);
 	}
 

--- a/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/AbstractSunSpecPvInverter.java
+++ b/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/AbstractSunSpecPvInverter.java
@@ -2,7 +2,14 @@ package io.openems.edge.pvinverter.sunspec;
 
 import static io.openems.edge.bridge.modbus.api.ElementToChannelConverter.DIRECT_1_TO_1;
 import static io.openems.edge.bridge.modbus.api.ElementToChannelConverter.SCALE_FACTOR_3;
+import static io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S_101;
+import static io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S_102;
+import static io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S_103;
+import static io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S_111;
+import static io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S_112;
+import static io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S_113;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -20,6 +27,13 @@ import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.edge.bridge.modbus.sunspec.AbstractOpenemsSunSpecComponent;
 import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel;
+import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S101;
+import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S102;
+import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S103;
+import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S111;
+import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S112;
+import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S113;
+import io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S120;
 import io.openems.edge.bridge.modbus.sunspec.SunSpecModel;
 import io.openems.edge.bridge.modbus.sunspec.SunSpecPoint;
 import io.openems.edge.common.channel.Channel;
@@ -33,6 +47,10 @@ import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 
 public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecComponent
 		implements SunSpecPvInverter, ManagedSymmetricPvInverter, ElectricityMeter, OpenemsComponent, EventHandler {
+
+	private static final List<DefaultSunSpecModel> SINGLE_PHASE_BLOCKS = Lists.newArrayList(S_101, S_111);
+	private static final List<DefaultSunSpecModel> SPLIT_PHASE_BLOCKS = Lists.newArrayList(S_102, S_112);
+	private static final List<DefaultSunSpecModel> THREE_PHASE_BLOCKS = Lists.newArrayList(S_103, S_113);
 
 	private final Logger log = LoggerFactory.getLogger(AbstractSunSpecPvInverter.class);
 	private final SetPvLimitHandler setPvLimitHandler = new SetPvLimitHandler(this);
@@ -167,37 +185,32 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.FREQUENCY, //
 				SCALE_FACTOR_3, //
-				DefaultSunSpecModel.S111.HZ, DefaultSunSpecModel.S112.HZ, DefaultSunSpecModel.S113.HZ,
-				DefaultSunSpecModel.S101.HZ, DefaultSunSpecModel.S102.HZ, DefaultSunSpecModel.S103.HZ);
+				S111.HZ, S112.HZ, S113.HZ, S101.HZ, S102.HZ, S103.HZ);
 
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_POWER, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S111.W, DefaultSunSpecModel.S112.W, DefaultSunSpecModel.S113.W,
-				DefaultSunSpecModel.S101.W, DefaultSunSpecModel.S102.W, DefaultSunSpecModel.S103.W);
+				S111.W, S112.W, S113.W, S101.W, S102.W, S103.W);
 
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.REACTIVE_POWER, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S111.V_AR, DefaultSunSpecModel.S112.V_AR, DefaultSunSpecModel.S113.V_AR,
-				DefaultSunSpecModel.S101.V_AR, DefaultSunSpecModel.S102.V_AR, DefaultSunSpecModel.S103.V_AR);
+				S111.V_AR, S112.V_AR, S113.V_AR, S101.V_AR, S102.V_AR, S103.V_AR);
 
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S111.WH, DefaultSunSpecModel.S112.WH, DefaultSunSpecModel.S113.WH,
-				DefaultSunSpecModel.S101.WH, DefaultSunSpecModel.S102.WH, DefaultSunSpecModel.S103.WH);
+				S111.WH, S112.WH, S113.WH, S101.WH, S102.WH, S103.WH);
 
 		this.mapFirstPointToChannel(//
 				ManagedSymmetricPvInverter.ChannelId.MAX_APPARENT_POWER, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S120.W_RTG);
+				S120.W_RTG);
 
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.CURRENT, //
 				SCALE_FACTOR_3, //
-				DefaultSunSpecModel.S111.A, DefaultSunSpecModel.S112.A, DefaultSunSpecModel.S113.A,
-				DefaultSunSpecModel.S101.A, DefaultSunSpecModel.S102.A, DefaultSunSpecModel.S103.A);
+				S111.A, S112.A, S113.A, S101.A, S102.A, S103.A);
 
 		/*
 		 * ElectricityMeter
@@ -206,14 +219,10 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 			this.mapFirstPointToChannel(//
 					ElectricityMeter.ChannelId.VOLTAGE, //
 					SCALE_FACTOR_3, //
-					DefaultSunSpecModel.S112.PH_VPH_A, DefaultSunSpecModel.S112.PH_VPH_B,
-					DefaultSunSpecModel.S112.PH_VPH_C, //
-					DefaultSunSpecModel.S113.PH_VPH_A, DefaultSunSpecModel.S113.PH_VPH_B,
-					DefaultSunSpecModel.S113.PH_VPH_C, //
-					DefaultSunSpecModel.S102.PH_VPH_A, DefaultSunSpecModel.S102.PH_VPH_B,
-					DefaultSunSpecModel.S102.PH_VPH_C, //
-					DefaultSunSpecModel.S103.PH_VPH_A, DefaultSunSpecModel.S103.PH_VPH_B,
-					DefaultSunSpecModel.S103.PH_VPH_C);
+					S112.PH_VPH_A, S112.PH_VPH_B, S112.PH_VPH_C, //
+					S113.PH_VPH_A, S113.PH_VPH_B, S113.PH_VPH_C, //
+					S102.PH_VPH_A, S102.PH_VPH_B, S102.PH_VPH_C, //
+					S103.PH_VPH_A, S103.PH_VPH_B, S103.PH_VPH_C);
 			return;
 		}
 
@@ -223,26 +232,24 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 		case L1:
 			this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L1, //
 					DIRECT_1_TO_1, //
-					DefaultSunSpecModel.S101.PH_VPH_A, DefaultSunSpecModel.S111.PH_VPH_A);
+					S101.PH_VPH_A, S111.PH_VPH_A);
 			break;
 		case L2:
 			this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L2, //
 					DIRECT_1_TO_1, //
-					DefaultSunSpecModel.S101.PH_VPH_B, DefaultSunSpecModel.S111.PH_VPH_B);
+					S101.PH_VPH_B, S111.PH_VPH_B);
 			break;
 		case L3:
 			this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L3, //
 					DIRECT_1_TO_1, //
-					DefaultSunSpecModel.S101.PH_VPH_C, DefaultSunSpecModel.S111.PH_VPH_C);
+					S101.PH_VPH_C, S111.PH_VPH_C);
 			break;
 		}
 
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.VOLTAGE, //
 				DIRECT_1_TO_1, //
-				DefaultSunSpecModel.S101.PH_VPH_A, DefaultSunSpecModel.S111.PH_VPH_A, //
-				DefaultSunSpecModel.S101.PH_VPH_B, DefaultSunSpecModel.S111.PH_VPH_B, //
-				DefaultSunSpecModel.S101.PH_VPH_C, DefaultSunSpecModel.S111.PH_VPH_C);
+				S101.PH_VPH_A, S111.PH_VPH_A, S101.PH_VPH_B, S111.PH_VPH_B, S101.PH_VPH_C, S111.PH_VPH_C);
 
 	}
 
@@ -250,26 +257,21 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 	protected void addBlock(int startAddress, SunSpecModel model, Priority priority) throws OpenemsException {
 		super.addBlock(startAddress, model, priority);
 
-		if (Lists.newArrayList(DefaultSunSpecModel.S_101, //
-				DefaultSunSpecModel.S_111) //
-				.stream() //
+		if (SINGLE_PHASE_BLOCKS.stream() //
 				.anyMatch(t -> t.equals(model))) {
 			// single phase
 			this.isSinglePhase = true;
-		} else if (Lists.newArrayList(DefaultSunSpecModel.S_102, //
-				DefaultSunSpecModel.S_112) //
-				.stream() //
+
+		} else if (SPLIT_PHASE_BLOCKS.stream() //
 				.anyMatch(t -> t.equals(model))) {
 			// split Phase
 			this.isSinglePhase = false;
-		} else if (Lists.newArrayList(DefaultSunSpecModel.S_103, //
-				DefaultSunSpecModel.S_113) //
-				.stream() //
+
+		} else if (THREE_PHASE_BLOCKS.stream() //
 				.anyMatch(t -> t.equals(model))) {
 			// three Phase
 			this.isSinglePhase = false;
 		}
-
 	}
 
 	protected final boolean isSinglePhase() {

--- a/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/AbstractSunSpecPvInverter.java
+++ b/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/AbstractSunSpecPvInverter.java
@@ -12,6 +12,7 @@ import static io.openems.edge.bridge.modbus.sunspec.DefaultSunSpecModel.S_113;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
@@ -43,27 +44,40 @@ import io.openems.edge.common.event.EdgeEventConstants;
 import io.openems.edge.common.taskmanager.Priority;
 import io.openems.edge.meter.api.ElectricityMeter;
 import io.openems.edge.meter.api.MeterType;
+import io.openems.edge.meter.api.SinglePhase;
+import io.openems.edge.meter.api.SinglePhaseMeter;
 import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 
 public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecComponent
 		implements SunSpecPvInverter, ManagedSymmetricPvInverter, ElectricityMeter, OpenemsComponent, EventHandler {
 
-	private static final List<DefaultSunSpecModel> SINGLE_PHASE_BLOCKS = Lists.newArrayList(S_101, S_111);
-	private static final List<DefaultSunSpecModel> SPLIT_PHASE_BLOCKS = Lists.newArrayList(S_102, S_112);
-	private static final List<DefaultSunSpecModel> THREE_PHASE_BLOCKS = Lists.newArrayList(S_103, S_113);
+	private static enum InverterType {
+		SINGLE_PHASE(S_101, S_111), //
+		SPLIT_PHASE(S_102, S_112), //
+		THREE_PHASE(S_103, S_113);
+
+		private final List<DefaultSunSpecModel> blocks;
+
+		private InverterType(DefaultSunSpecModel... blocks) {
+			this.blocks = Lists.newArrayList(blocks);
+		}
+	}
 
 	private final Logger log = LoggerFactory.getLogger(AbstractSunSpecPvInverter.class);
 	private final SetPvLimitHandler setPvLimitHandler = new SetPvLimitHandler(this);
 
 	private boolean readOnly;
-	private boolean isSinglePhase;
 	private Phase phase;
+	private InverterType inverterType = null;
 
 	public AbstractSunSpecPvInverter(Map<SunSpecModel, Priority> activeModels,
 			io.openems.edge.common.channel.ChannelId[] firstInitialChannelIds,
 			io.openems.edge.common.channel.ChannelId[]... furtherInitialChannelIds) throws OpenemsException {
 		super(activeModels, firstInitialChannelIds, furtherInitialChannelIds);
 		this._setActiveConsumptionEnergy(0);
+
+		// Automatically calculate sum values from L1/L2/L3
+		ElectricityMeter.calculateAverageVoltageFromPhases(this);
 	}
 
 	/**
@@ -179,8 +193,8 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 	protected void onSunSpecInitializationCompleted() {
 		this.logInfo(this.log, "SunSpec initialization finished. " + this.channels().size() + " Channels available.");
 
-		this.channel(SunSpecPvInverter.ChannelId.WRONG_PHASE_CONFIGURED)
-				.setNextValue(this.isSinglePhase() ? this.phase == Phase.ALL : this.phase != Phase.ALL);
+		this.channel(SunSpecPvInverter.ChannelId.WRONG_PHASE_CONFIGURED).setNextValue(
+				this.inverterType == InverterType.SINGLE_PHASE ? this.phase == Phase.ALL : this.phase != Phase.ALL);
 
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.FREQUENCY, //
@@ -191,91 +205,74 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 				ElectricityMeter.ChannelId.ACTIVE_POWER, //
 				DIRECT_1_TO_1, //
 				S111.W, S112.W, S113.W, S101.W, S102.W, S103.W);
-
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.REACTIVE_POWER, //
 				DIRECT_1_TO_1, //
 				S111.V_AR, S112.V_AR, S113.V_AR, S101.V_AR, S102.V_AR, S103.V_AR);
 
+		// Individual Phases Power
+		switch (this.inverterType) {
+		case SINGLE_PHASE -> {
+			var phase = switch (this.phase) {
+			case ALL, L1 -> SinglePhase.L1; // Fallback to L1 on wrong configuration
+			case L2 -> SinglePhase.L2;
+			case L3 -> SinglePhase.L3;
+			};
+			if (phase != null) {
+				SinglePhaseMeter.calculateSinglePhaseFromActivePower(this, (meter) -> phase);
+			}
+		}
+		case SPLIT_PHASE, THREE_PHASE -> {
+			ElectricityMeter.calculatePhasesFromActivePower(this);
+			ElectricityMeter.calculatePhasesFromReactivePower(this);
+		}
+		}
+
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY, //
 				DIRECT_1_TO_1, //
 				S111.WH, S112.WH, S113.WH, S101.WH, S102.WH, S103.WH);
-
 		this.mapFirstPointToChannel(//
 				ManagedSymmetricPvInverter.ChannelId.MAX_APPARENT_POWER, //
 				DIRECT_1_TO_1, //
 				S120.W_RTG);
 
+		// Voltage
+		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L1, //
+				DIRECT_1_TO_1, //
+				S111.PH_VPH_A, S112.PH_VPH_A, S113.PH_VPH_A, S101.PH_VPH_A, S102.PH_VPH_A, S103.PH_VPH_A);
+		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L2, //
+				DIRECT_1_TO_1, //
+				S111.PH_VPH_B, S112.PH_VPH_B, S113.PH_VPH_B, S101.PH_VPH_B, S102.PH_VPH_B, S103.PH_VPH_B);
+		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L3, //
+				DIRECT_1_TO_1, //
+				S111.PH_VPH_C, S112.PH_VPH_C, S113.PH_VPH_C, S101.PH_VPH_C, S102.PH_VPH_C, S103.PH_VPH_C);
+
+		// Current
 		this.mapFirstPointToChannel(//
 				ElectricityMeter.ChannelId.CURRENT, //
 				SCALE_FACTOR_3, //
 				S111.A, S112.A, S113.A, S101.A, S102.A, S103.A);
-
-		/*
-		 * ElectricityMeter
-		 */
-		if (!this.isSinglePhase) {
-			this.mapFirstPointToChannel(//
-					ElectricityMeter.ChannelId.VOLTAGE, //
-					SCALE_FACTOR_3, //
-					S112.PH_VPH_A, S112.PH_VPH_B, S112.PH_VPH_C, //
-					S113.PH_VPH_A, S113.PH_VPH_B, S113.PH_VPH_C, //
-					S102.PH_VPH_A, S102.PH_VPH_B, S102.PH_VPH_C, //
-					S103.PH_VPH_A, S103.PH_VPH_B, S103.PH_VPH_C);
-			return;
-		}
-
-		switch (this.phase) {
-		case ALL:
-			// use l1 when 'ALL' is configured and its not a tree phase inverter
-		case L1:
-			this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L1, //
-					DIRECT_1_TO_1, //
-					S101.PH_VPH_A, S111.PH_VPH_A);
-			break;
-		case L2:
-			this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L2, //
-					DIRECT_1_TO_1, //
-					S101.PH_VPH_B, S111.PH_VPH_B);
-			break;
-		case L3:
-			this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L3, //
-					DIRECT_1_TO_1, //
-					S101.PH_VPH_C, S111.PH_VPH_C);
-			break;
-		}
-
-		this.mapFirstPointToChannel(//
-				ElectricityMeter.ChannelId.VOLTAGE, //
+		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.CURRENT_L1, //
 				DIRECT_1_TO_1, //
-				S101.PH_VPH_A, S111.PH_VPH_A, S101.PH_VPH_B, S111.PH_VPH_B, S101.PH_VPH_C, S111.PH_VPH_C);
-
+				S111.APH_A, S112.APH_A, S113.APH_A, S101.APH_A, S102.APH_A, S103.APH_A);
+		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.CURRENT_L2, //
+				DIRECT_1_TO_1, //
+				S111.APH_B, S112.APH_B, S113.APH_B, S101.APH_B, S102.APH_B, S103.APH_B);
+		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.CURRENT_L3, //
+				DIRECT_1_TO_1, //
+				S111.APH_C, S112.APH_C, S113.APH_C, S101.APH_C, S102.APH_C, S103.APH_C);
 	}
 
 	@Override
 	protected void addBlock(int startAddress, SunSpecModel model, Priority priority) throws OpenemsException {
 		super.addBlock(startAddress, model, priority);
 
-		if (SINGLE_PHASE_BLOCKS.stream() //
-				.anyMatch(t -> t.equals(model))) {
-			// single phase
-			this.isSinglePhase = true;
-
-		} else if (SPLIT_PHASE_BLOCKS.stream() //
-				.anyMatch(t -> t.equals(model))) {
-			// split Phase
-			this.isSinglePhase = false;
-
-		} else if (THREE_PHASE_BLOCKS.stream() //
-				.anyMatch(t -> t.equals(model))) {
-			// three Phase
-			this.isSinglePhase = false;
-		}
-	}
-
-	protected final boolean isSinglePhase() {
-		return this.isSinglePhase;
+		// Can we evaluate the InverterType from this Block?
+		Stream.of(InverterType.values()) //
+				.filter(type -> type.blocks.stream().anyMatch(t -> t.equals(model))) //
+				.findFirst() //
+				.ifPresent(type -> this.inverterType = type);
 	}
 
 	@Override


### PR DESCRIPTION
Applies to
- PV-Inverter.Fronius
- PV-Inverter.KACO.blueplanet
- PV-Inverter.Kostal
- PV-Inverter.SMA.SunnyTripower
- SolarEdge.PV-Inverter

Improvements:
- Set individual phases power, current & voltage for new `ElectricityMeter`
- Evaluate more blocks (= improves device compatibility)
- Code cleanup