### PR TITLE
EVCS: Improve HardyBarth phase and status detection.

### DIFF
--- a/io.openems.edge.evcs.hardybarth/src/io/openems/edge/evcs/hardybarth/EvcsHardyBarthImpl.java
+++ b/io.openems.edge.evcs.hardybarth/src/io/openems/edge/evcs/hardybarth/EvcsHardyBarthImpl.java
@@ -76,6 +76,7 @@ public class EvcsHardyBarthImpl extends AbstractManagedEvcsComponent
 		this._setFixedMinimumHardwarePower(config.minHwCurrent() / 1000 * 3 * 230);
 		this._setFixedMaximumHardwarePower(config.maxHwCurrent() / 1000 * 3 * 230);
 		this._setPowerPrecision(230);
+		this._setPhases(Phases.THREE_PHASE);
 
 		if (config.enabled()) {
 			this.api = new HardyBarthApi(config.ip(), this);
@@ -249,7 +250,6 @@ public class EvcsHardyBarthImpl extends AbstractManagedEvcsComponent
 		if (current > 0) {
 			// Send stop pause request
 			resultPause = this.api.sendPutRequest("/api/secc", "salia/pausecharging", "" + 0);
-			this.debugLog("Wake up HardyBarth " + this.alias() + " from the pause");
 		} else {
 			// Send pause charging request
 			resultPause = this.api.sendPutRequest("/api/secc", "salia/pausecharging", "" + 1);

--- a/io.openems.edge.evcs.hardybarth/test/io/openems/edge/evcs/hardybarth/EvcsHardyBarthImplTest.java
+++ b/io.openems.edge.evcs.hardybarth/test/io/openems/edge/evcs/hardybarth/EvcsHardyBarthImplTest.java
@@ -15,8 +15,8 @@ public class EvcsHardyBarthImplTest {
 				.activate(MyConfig.create() //
 						.setId(COMPONENT_ID) //
 						.setIp("192.168.8.101") //
-						.setMaxHwCurrent(32) //
-						.setMinHwCurrent(6) //
+						.setMaxHwCurrent(32_000) //
+						.setMinHwCurrent(6_000) //
 						.build())
 				.next(new TestCase());
 	}


### PR DESCRIPTION
Some evcs had less than 300mA on one or two phases, even though it was charging on all three phases.
Another Hardy Barth was returning null for status for an unknown reason, so a debounce was added.