### PR TITLE
UI: Inject globalRouteChangeHandler

### DIFF
--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -45,8 +45,8 @@ export class AppComponent implements OnInit, OnDestroy {
   ngOnInit() {
 
     // Checks if sessionStorage is not null, undefined or empty string
-    if (sessionStorage.getItem("DEBUGMODE")) {
-      this.environment.debugMode = JSON.parse(sessionStorage.getItem("DEBUGMODE"));
+    if (localStorage.getItem("DEBUGMODE")) {
+      this.environment.debugMode = JSON.parse(localStorage.getItem("DEBUGMODE"));
     }
 
     this.titleService.setTitle(environment.edgeShortName);

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
 import { environment } from '../environments';
+import { GlobalRouteChangeHandler } from './shared/service/globalRouteChangeHandler';
 import { Service, UserPermission, Websocket } from './shared/shared';
 import { Language } from './shared/type/language';
 
@@ -31,7 +32,8 @@ export class AppComponent implements OnInit, OnDestroy {
     public service: Service,
     public toastController: ToastController,
     public websocket: Websocket,
-    private titleService: Title
+    private titleService: Title,
+    private globalRouteChangeHandler: GlobalRouteChangeHandler
   ) {
     service.setLang(Language.getByKey(localStorage.LANGUAGE) ?? Language.getByBrowserLang(navigator.language));
 

--- a/ui/src/app/edge/settings/settings.component.html
+++ b/ui/src/app/edge/settings/settings.component.html
@@ -170,7 +170,7 @@
             </ion-card-content>
           </ion-card>
         </ion-col>
-        <ion-col size="12" size-sm="4">
+        <ion-col size="12" size-sm="4" *ngIf="!isEdgeBackend">
           <ion-card>
             <ion-item lines="full" color="light">
               <ion-icon slot="start" size="large" color="primary" name="notifications-outline"></ion-icon>

--- a/ui/src/app/edge/settings/settings.component.ts
+++ b/ui/src/app/edge/settings/settings.component.ts
@@ -14,6 +14,7 @@ export class SettingsComponent implements OnInit {
   public environment = environment;
 
   public canSeeAppCenter: boolean | undefined;
+  protected isEdgeBackend: boolean = environment.backend === 'OpenEMS Edge';
 
   constructor(
     private route: ActivatedRoute,


### PR DESCRIPTION
- [x] Inject GlobalRouteChangehandler in app.component.ts
Because not all angular events are firing, when they should, this globalRouteChangeHandler was introduced. Its possible to pass the pagetitle to [routes](https://github.com/OpenEMS/openems/blob/36483e70875e4d92a9a65ca15ba2ebf656817345/ui/src/app/app-routing.module.ts#L52). 
This is also a first step, to avoid setting currentPagetitle with every component.

- [x] Refactor sessionStorage to localStorage for DEBUGMODE
- [x] Hide alerting when using 'OpenEMS Edge' as backend
If you don't know, what is meant with this take a look here: 
[openems-edge-dev](https://github.com/OpenEMS/openems/blob/develop/ui/src/themes/openems/environments/edge-dev.ts) and here [README](https://github.com/OpenEMS/openems/blob/develop/ui/README.md)

