### PR TITLE
allowed for language preferences to persist after reload

### DIFF
--- a/ui/src/app/shared/service/websocket.ts
+++ b/ui/src/app/shared/service/websocket.ts
@@ -158,7 +158,7 @@ export class Websocket implements WebsocketInterface {
       this.sendRequest(request).then(r => {
         let authenticateResponse = (r as AuthenticateResponse).result;
 
-        let language = Language.getByKey(authenticateResponse.user.language.toLocaleLowerCase());
+        let language = Language.getByKey(localStorage.LANGUAGE || authenticateResponse.user.language.toLocaleLowerCase());
         localStorage.LANGUAGE = language.key;
         this.service.setLang(language);
         this.status = 'online';


### PR DESCRIPTION
added a check for the locally stored language in the login method in websocket.ts and that made language changes persist after reload.
Train of thought was that since the method would be run to authenticate the user, it would run on every reload and therefore language was always being set to "authenticateResponse.user.language.toLocaleLowerCase()" instead of the specified language.


I'm also not sure why it's being set to that instead of calling navigator.language, but since I don't exactly know what it does I'm leaving it be.

on another fork I just use 
```
public static readonly getBrowserLang = () =>
        (navigator.language || (navigator.languages || ["en"])[0]).substring(0, 2);

```
in the language.ts file and call getBrowserLang to get the initial language at login