### PR TITLE
change contribution doc to describe "Eclipse [built in]" code formatter

### DIFF
--- a/doc/modules/ROOT/pages/contribute/coding-guidelines.adoc
+++ b/doc/modules/ROOT/pages/contribute/coding-guidelines.adoc
@@ -42,30 +42,26 @@ While IntelliJ also works, Eclipse IDE is the officially supported development e
 
 .Eclipse Code formatter
 
-Use OpenEMS Code Formatter Rules
+Use `Eclipse [built-in]` Code Formating Rules
 
- * Eclipse -> Window -> Preferences -> Java -> Code Style -> Formatter -> ActiveProfile -> select
- 
-  Java Conventions [build-in]
-  
-Before you commit files, run the Eclipse code formatter on java sourcecode file (Ctrl + Shift + F).
+ * Eclipse -> Window -> Preferences -> Java -> Code Style -> Formatter -> ActiveProfile -> select -> `Eclipse [built-in]`
+     
+Before you commit files, run the Eclipse code formatter on each java source code file (Ctrl + Shift + F).
 
 .Eclipse Checkstyle plugin
 
 Use Eclipse checkstyle plugin `Eclipse-cs`. Install it with
   
-* Eclipse -> Help -> Eclipse Marketplace -> Find -> Eclipse-cs -> Install 
+* Eclipse -> Help -> Eclipse Marketplace -> Find -> `Eclipse-cs` -> Install 
 
 Configure it with
 
 * Eclipse -> Window -> Preferences -> New -> 
-** Type: Project Relative Configuration 
-** Name: OpenEMS 
-** Location: /cnf/checkstyle.xml
+** Type: `Project Relative Configuration` 
+** Name: `OpenEMS` 
+** Location: `/cnf/checkstyle.xml`
 
-Later set `OpenEMS` as default.
-
-Enable Checkstyle for every bundle you like in the Bndtools Explorer in the bundles context menu.      
+Later set `OpenEMS` as default. Enable Checkstyle for every bundle you like in the Bndtools Explorer in the bundles context menu.      
 
 == OpenEMS UI
 

--- a/doc/modules/ROOT/pages/contribute/coding-guidelines.adoc
+++ b/doc/modules/ROOT/pages/contribute/coding-guidelines.adoc
@@ -42,7 +42,7 @@ While IntelliJ also works, Eclipse IDE is the officially supported development e
 
 .Eclipse Code formatter
 
-Use `Eclipse [built-in]` Code Formating Rules
+Use `Eclipse [built-in]` Code Formatting Rules
 
  * Eclipse -> Window -> Preferences -> Java -> Code Style -> Formatter -> ActiveProfile -> select -> `Eclipse [built-in]`
      


### PR DESCRIPTION
Current "Code Contribution Guidelines" documentation refer to the "Java" code formatter. The documentation should be switched to suggest the "Eclipse [built in]" code formatter.

Reason 1: Most of the code is already checked in with the  "Eclipse [built in]" code formatter.
Reason 2: the  "Eclipse [built in]" code formatter is the default code formatter when starting a new eclipse project. Less configuration lowers the barrier for newcomers to immediately start with programming. 