### PR TITLE
State-Machine: add debugLog functionality

### DIFF
--- a/io.openems.common/src/io/openems/common/channel/Unit.java
+++ b/io.openems.common/src/io/openems/common/channel/Unit.java
@@ -6,9 +6,8 @@ import java.util.function.Function;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 
-import com.google.common.base.CaseFormat;
-
 import io.openems.common.types.OpenemsType;
+import io.openems.common.utils.EnumUtils;
 
 /**
  * Units of measurement used in OpenEMS.
@@ -364,8 +363,7 @@ public enum Unit {
 
 	@Override
 	public String toString() {
-		return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, this.name())
-				+ (this.symbol.isEmpty() ? "" : " [" + this.symbol + "]");
+		return EnumUtils.nameAsCamelCase(this) + (this.symbol.isEmpty() ? "" : " [" + this.symbol + "]");
 	}
 
 	/**

--- a/io.openems.common/src/io/openems/common/utils/EnumUtils.java
+++ b/io.openems.common/src/io/openems/common/utils/EnumUtils.java
@@ -3,6 +3,7 @@ package io.openems.common.utils;
 import java.util.EnumMap;
 import java.util.Optional;
 
+import com.google.common.base.CaseFormat;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
@@ -11,6 +12,17 @@ import io.openems.common.exceptions.OpenemsError;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 
 public class EnumUtils {
+
+	/**
+	 * Converts the Enum UPPER_UNDERSCORE name to UPPER_CAMEL-case.
+	 * 
+	 * @param <ENUM> the type
+	 * @param e      the enum
+	 * @return the name as Camel-Case
+	 */
+	public static <ENUM extends Enum<ENUM>> String nameAsCamelCase(ENUM e) {
+		return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, e.name());
+	}
 
 	/**
 	 * Gets the member of the {@link EnumMap} as {@link Optional} {@link Boolean}.

--- a/io.openems.common/src/io/openems/common/utils/EnumUtils.java
+++ b/io.openems.common/src/io/openems/common/utils/EnumUtils.java
@@ -14,7 +14,8 @@ import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 public class EnumUtils {
 
 	/**
-	 * Converts the Enum UPPER_UNDERSCORE name to UPPER_CAMEL-case.
+	 * Converts the Enum {@link CaseFormat#UPPER_UNDERSCORE} name to
+	 * {@link CaseFormat#UPPER_CAMEL}-case.
 	 * 
 	 * @param <ENUM> the type
 	 * @param e      the enum

--- a/io.openems.edge.battery.bydcommercial/src/io/openems/edge/battery/bydcommercial/BydBatteryBoxCommercialC130Impl.java
+++ b/io.openems.edge.battery.bydcommercial/src/io/openems/edge/battery/bydcommercial/BydBatteryBoxCommercialC130Impl.java
@@ -172,10 +172,16 @@ public class BydBatteryBoxCommercialC130Impl extends AbstractOpenemsModbusCompon
 
 	@Override
 	public String debugLog() {
-		return "SoC:" + this.getSoc() //
-				+ "|Discharge:" + this.getDischargeMinVoltage() + ";" + this.getDischargeMaxCurrent() //
-				+ "|Charge:" + this.getChargeMaxVoltage() + ";" + this.getChargeMaxCurrent() //
-				+ "|State:" + this.stateMachine.getCurrentState();
+		return new StringBuilder() //
+				.append(this.stateMachine.debugLog()) //
+				.append("|SoC:").append(this.getSoc()) //
+				.append("|Actual:").append(this.getVoltage()) //
+				.append(";").append(this.getCurrent()) //
+				.append("|Charge:").append(this.getChargeMaxVoltage()) //
+				.append(";").append(this.getChargeMaxCurrent()) //
+				.append("|Discharge:").append(this.getDischargeMinVoltage()) //
+				.append(";").append(this.getDischargeMaxCurrent()) //
+				.toString();
 	}
 
 	@Override

--- a/io.openems.edge.battery.fenecon.commercial/src/io/openems/edge/battery/fenecon/commercial/BatteryFeneconCommercialImpl.java
+++ b/io.openems.edge.battery.fenecon.commercial/src/io/openems/edge/battery/fenecon/commercial/BatteryFeneconCommercialImpl.java
@@ -1153,13 +1153,14 @@ public class BatteryFeneconCommercialImpl extends AbstractOpenemsModbusComponent
 	@Override
 	public String debugLog() {
 		return new StringBuilder() //
-				.append("SoC:").append(this.getSoc()) //
+				.append(this.stateMachine.debugLog()) //
+				.append("|SoC:").append(this.getSoc()) //
+				.append("|Actual:").append(this.getVoltage()) //
+				.append(";").append(this.getCurrent()) //
+				.append("|Charge:").append(this.getChargeMaxVoltage()) //
+				.append(";").append(this.getChargeMaxCurrent()) //
 				.append("|Discharge:").append(this.getDischargeMinVoltage()) //
 				.append(";").append(this.getDischargeMaxCurrent()) //
-				.append("|Charge:") //
-				.append(this.getChargeMaxVoltage()) //
-				.append(";").append(this.getChargeMaxCurrent()) //
-				.append("|State:").append(this.stateMachine.getCurrentState()) //
 				.toString();
 	}
 

--- a/io.openems.edge.battery.fenecon.home/src/io/openems/edge/battery/fenecon/home/BatteryFeneconHomeImpl.java
+++ b/io.openems.edge.battery.fenecon.home/src/io/openems/edge/battery/fenecon/home/BatteryFeneconHomeImpl.java
@@ -371,9 +371,16 @@ public class BatteryFeneconHomeImpl extends AbstractOpenemsModbusComponent imple
 
 	@Override
 	public String debugLog() {
-		return "Actual:" + this.getVoltage() + ";" + this.getCurrent() //
-				+ "|Charge:" + this.getChargeMaxVoltage() + ";" + this.getChargeMaxCurrent() //
-				+ "|Discharge:" + this.getDischargeMinVoltage() + ";" + this.getDischargeMaxCurrent(); //
+		return new StringBuilder() //
+				.append(this.stateMachine.debugLog()) //
+				.append("|SoC:").append(this.getSoc()) //
+				.append("|Actual:").append(this.getVoltage()) //
+				.append(";").append(this.getCurrent()) //
+				.append("|Charge:").append(this.getChargeMaxVoltage()) //
+				.append(";").append(this.getChargeMaxCurrent()) //
+				.append("|Discharge:").append(this.getDischargeMinVoltage()) //
+				.append(";").append(this.getDischargeMaxCurrent()) //
+				.toString();
 	}
 
 	@Override

--- a/io.openems.edge.battery.fenecon.home/src/io/openems/edge/battery/fenecon/home/statemachine/GoRunningHandler.java
+++ b/io.openems.edge.battery.fenecon.home/src/io/openems/edge/battery/fenecon/home/statemachine/GoRunningHandler.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.utils.EnumUtils;
 import io.openems.edge.battery.fenecon.home.statemachine.StateMachine.State;
 import io.openems.edge.common.statemachine.StateHandler;
 
@@ -109,4 +110,8 @@ public class GoRunningHandler extends StateHandler<State, Context> {
 		context.batteryStartUpRelayChannel.setNextWriteValue(value);
 	}
 
+	@Override
+	protected String debugLog() {
+		return State.GO_RUNNING.asCamelCase() + "-" + EnumUtils.nameAsCamelCase(this.state);
+	}
 }

--- a/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/cluster/versionc/BatterySoltaroClusterVersionCImpl.java
+++ b/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/cluster/versionc/BatterySoltaroClusterVersionCImpl.java
@@ -789,10 +789,16 @@ public class BatterySoltaroClusterVersionCImpl extends AbstractOpenemsModbusComp
 
 	@Override
 	public String debugLog() {
-		return "SoC:" + this.getSoc() //
-				+ "|Discharge:" + this.getDischargeMinVoltage() + ";" + this.getDischargeMaxCurrent() //
-				+ "|Charge:" + this.getChargeMaxVoltage() + ";" + this.getChargeMaxCurrent() //
-				+ "|State:" + this.stateMachine.getCurrentState().asCamelCase();
+		return new StringBuilder() //
+				.append(this.stateMachine.debugLog()) //
+				.append("|SoC:").append(this.getSoc()) //
+				.append("|Actual:").append(this.getVoltage()) //
+				.append(";").append(this.getCurrent()) //
+				.append("|Charge:").append(this.getChargeMaxVoltage()) //
+				.append(";").append(this.getChargeMaxCurrent()) //
+				.append("|Discharge:").append(this.getDischargeMinVoltage()) //
+				.append(";").append(this.getDischargeMaxCurrent()) //
+				.toString();
 	}
 
 	@Override

--- a/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/single/versionb/BatterySoltaroSingleRackVersionBImpl.java
+++ b/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/single/versionb/BatterySoltaroSingleRackVersionBImpl.java
@@ -226,11 +226,16 @@ public class BatterySoltaroSingleRackVersionBImpl extends AbstractOpenemsModbusC
 
 	@Override
 	public String debugLog() {
-		return "SoC:" + this.getSoc() //
-				+ "|Discharge:" + this.getDischargeMinVoltage() + ";" + this.getDischargeMaxCurrent() //
-				+ "|Charge:" + this.getChargeMaxVoltage() + ";" + this.getChargeMaxCurrent() //
-				+ "|Cell Voltages: Min:" + this.getMinCellVoltage() + "; Max:" + this.getMaxCellVoltage() //
-				+ "|State:" + this.stateMachine.getCurrentState().asCamelCase();
+		return new StringBuilder() //
+				.append(this.stateMachine.debugLog()) //
+				.append("|SoC:").append(this.getSoc()) //
+				.append("|Actual:").append(this.getVoltage()) //
+				.append(";").append(this.getCurrent()) //
+				.append("|Charge:").append(this.getChargeMaxVoltage()) //
+				.append(";").append(this.getChargeMaxCurrent()) //
+				.append("|Discharge:").append(this.getDischargeMinVoltage()) //
+				.append(";").append(this.getDischargeMaxCurrent()) //
+				.toString();
 	}
 
 	@Override

--- a/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/single/versionc/BatterySoltaroSingleRackVersionCImpl.java
+++ b/io.openems.edge.battery.soltaro/src/io/openems/edge/battery/soltaro/single/versionc/BatterySoltaroSingleRackVersionCImpl.java
@@ -215,10 +215,16 @@ public class BatterySoltaroSingleRackVersionCImpl extends AbstractOpenemsModbusC
 
 	@Override
 	public String debugLog() {
-		return "SoC:" + this.getSoc() //
-				+ "|Discharge:" + this.getDischargeMinVoltage() + ";" + this.getDischargeMaxCurrent() //
-				+ "|Charge:" + this.getChargeMaxVoltage() + ";" + this.getChargeMaxCurrent() //
-				+ "|State:" + this.stateMachine.getCurrentState();
+		return new StringBuilder() //
+				.append(this.stateMachine.debugLog()) //
+				.append("|SoC:").append(this.getSoc()) //
+				.append("|Actual:").append(this.getVoltage()) //
+				.append(";").append(this.getCurrent()) //
+				.append("|Charge:").append(this.getChargeMaxVoltage()) //
+				.append(";").append(this.getChargeMaxCurrent()) //
+				.append("|Discharge:").append(this.getDischargeMinVoltage()) //
+				.append(";").append(this.getDischargeMaxCurrent()) //
+				.toString();
 	}
 
 	@Override

--- a/io.openems.edge.batteryinverter.kaco.blueplanetgridsave/src/io/openems/edge/batteryinverter/kaco/blueplanetgridsave/BatteryInverterKacoBlueplanetGridsaveImpl.java
+++ b/io.openems.edge.batteryinverter.kaco.blueplanetgridsave/src/io/openems/edge/batteryinverter/kaco/blueplanetgridsave/BatteryInverterKacoBlueplanetGridsaveImpl.java
@@ -386,8 +386,10 @@ public class BatteryInverterKacoBlueplanetGridsaveImpl extends AbstractSunSpecBa
 
 	@Override
 	public String debugLog() {
-		return this.stateMachine.getCurrentState().asCamelCase() //
-				+ "|" + this.getCurrentState().asCamelCase();
+		return new StringBuilder() //
+				.append(this.stateMachine.debugLog()) //
+				.append("|State:").append(this.getCurrentState().asCamelCase()) //
+				.toString();
 	}
 
 	private final AtomicReference<StartStop> startStopTarget = new AtomicReference<>(StartStop.UNDEFINED);

--- a/io.openems.edge.batteryinverter.refu88k/src/io/openems/edge/batteryinverter/refu88k/BatteryInverterRefuStore88kImpl.java
+++ b/io.openems.edge.batteryinverter.refu88k/src/io/openems/edge/batteryinverter/refu88k/BatteryInverterRefuStore88kImpl.java
@@ -470,7 +470,8 @@ public class BatteryInverterRefuStore88kImpl extends AbstractOpenemsModbusCompon
 
 	@Override
 	public String debugLog() {
-		return "P:" + this.getActivePower().asString() //
+		return this.stateMachine.debugLog() //
+				+ "|P:" + this.getActivePower().asString() //
 				+ "|Q:" + this.getReactivePower().asString() //
 				+ "|DC:" + this.channel(BatteryInverterRefuStore88k.ChannelId.DCV).value().asString() //
 				+ "|" + this.channel(BatteryInverterRefuStore88k.ChannelId.ST).value().asOptionString() //

--- a/io.openems.edge.batteryinverter.sinexcel/src/io/openems/edge/batteryinverter/sinexcel/BatteryInverterSinexcelImpl.java
+++ b/io.openems.edge.batteryinverter.sinexcel/src/io/openems/edge/batteryinverter/sinexcel/BatteryInverterSinexcelImpl.java
@@ -311,8 +311,10 @@ public class BatteryInverterSinexcelImpl extends AbstractOpenemsModbusComponent
 
 	@Override
 	public String debugLog() {
-		return this.stateMachine.getCurrentState().asCamelCase() //
-				+ "|" + this.getGridModeChannel().value().asOptionString();
+		return new StringBuilder() //
+				.append(this.stateMachine.debugLog()) //
+				.append("|Grid:").append(this.getGridModeChannel().value().asOptionString()) //
+				.toString();
 	}
 
 	private final AtomicReference<StartStop> startStopTarget = new AtomicReference<>(StartStop.UNDEFINED);

--- a/io.openems.edge.common/src/io/openems/edge/common/statemachine/AbstractStateMachine.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/statemachine/AbstractStateMachine.java
@@ -45,6 +45,22 @@ public abstract class AbstractStateMachine<STATE extends State<STATE>, CONTEXT e
 	}
 
 	/**
+	 * Gets a message that is suitable for a continuous Debug log. Returns the name
+	 * of the current state in Camel-Case by default.
+	 *
+	 * @return the debug log output
+	 */
+	public String debugLog() {
+		var log = this.stateHandlers //
+				.get(this.state) //
+				.debugLog();
+		if (log != null) {
+			return log;
+		}
+		return this.state.asCamelCase();
+	}
+
+	/**
 	 * Gets the {@link StateHandler} for each State.
 	 *
 	 * <p>

--- a/io.openems.edge.common/src/io/openems/edge/common/statemachine/StateHandler.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/statemachine/StateHandler.java
@@ -36,4 +36,13 @@ public abstract class StateHandler<STATE extends State<STATE>, CONTEXT> {
 	protected void onExit(CONTEXT context) throws OpenemsNamedException {
 	}
 
+	/**
+	 * Gets a message that is suitable for a continuous Debug log. Returns 'null' by
+	 * default which causes output of the name of the State in Camel-Case.
+	 *
+	 * @return the debug log output
+	 */
+	protected String debugLog() {
+		return null;
+	}
 }

--- a/io.openems.edge.ess.generic/src/io/openems/edge/ess/generic/common/AbstractGenericManagedEss.java
+++ b/io.openems.edge.ess.generic/src/io/openems/edge/ess/generic/common/AbstractGenericManagedEss.java
@@ -110,7 +110,7 @@ public abstract class AbstractGenericManagedEss<ESS extends SymmetricEss, BATTER
 	 */
 	protected abstract void handleStateMachine();
 
-	protected StringBuilder genericDebugLog() {
+	protected void genericDebugLog(StringBuilder sb) {
 		// Get DC-PV-Power for Hybrid ESS
 		Integer dcPvPower = null;
 		var batteryInverter = this.getBatteryInverter();
@@ -118,29 +118,27 @@ public abstract class AbstractGenericManagedEss<ESS extends SymmetricEss, BATTER
 			dcPvPower = ((HybridManagedSymmetricBatteryInverter) batteryInverter).getDcPvPower();
 		}
 
-		var result = new StringBuilder() //
-				.append("SoC:").append(this.getSoc().asString()) //
+		sb //
+				.append("|SoC:").append(this.getSoc().asString()) //
 				.append("|L:").append(this.getActivePower().asString());
 
 		// For HybridEss show actual Battery charge power and PV production power
 		if (dcPvPower != null) {
 			HybridEss me = this;
-			result //
+			sb //
 					.append("|Battery:").append(me.getDcDischargePower().asString()) //
 					.append("|PV:").append(dcPvPower);
 		}
 
 		// Show max AC export/import active power:
 		// minimum of MaxAllowedCharge/DischargePower and MaxApparentPower
-		result //
+		sb //
 				.append("|Allowed:") //
 				.append(TypeUtils.min(//
 						this.getAllowedChargePower().get(), TypeUtils.multiply(this.getMaxApparentPower().get(), -1)))
 				.append(";") //
 				.append(TypeUtils.min(//
 						this.getAllowedDischargePower().get(), this.getMaxApparentPower().get()));
-
-		return result;
 	}
 
 	/**

--- a/io.openems.edge.ess.generic/src/io/openems/edge/ess/generic/offgrid/EssGenericOffGridImpl.java
+++ b/io.openems.edge.ess.generic/src/io/openems/edge/ess/generic/offgrid/EssGenericOffGridImpl.java
@@ -140,10 +140,11 @@ public class EssGenericOffGridImpl
 
 	@Override
 	public String debugLog() {
-		return super.genericDebugLog() //
-				.append("|").append(this.channel(EssGenericOffGrid.ChannelId.STATE_MACHINE).value().asOptionString()) //
-				.append("|").append(this.getGridModeChannel().value().asOptionString()) //
-				.toString();
+		var sb = new StringBuilder(this.stateMachine.debugLog());
+		super.genericDebugLog(sb);
+		sb //
+				.append("|").append(this.getGridModeChannel().value().asOptionString()); //
+		return sb.toString();
 	}
 
 	@Override

--- a/io.openems.edge.ess.generic/src/io/openems/edge/ess/generic/symmetric/EssGenericManagedSymmetricImpl.java
+++ b/io.openems.edge.ess.generic/src/io/openems/edge/ess/generic/symmetric/EssGenericManagedSymmetricImpl.java
@@ -125,10 +125,9 @@ public class EssGenericManagedSymmetricImpl
 
 	@Override
 	public String debugLog() {
-		return super.genericDebugLog() //
-				.append("|")
-				.append(this.channel(EssGenericManagedSymmetric.ChannelId.STATE_MACHINE).value().asOptionString()) //
-				.toString();
+		var sb = new StringBuilder(this.stateMachine.debugLog());
+		super.genericDebugLog(sb);
+		return sb.toString();
 	}
 
 	@Override

--- a/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/FeneconMiniEssImpl.java
+++ b/io.openems.edge.fenecon.mini/src/io/openems/edge/fenecon/mini/ess/FeneconMiniEssImpl.java
@@ -510,11 +510,11 @@ public class FeneconMiniEssImpl extends AbstractOpenemsModbusComponent
 			return "SoC:" + this.getSoc().asString() //
 					+ "|L:" + this.getActivePower().asString(); //
 		}
-		return "SoC:" + this.getSoc().asString() //
+		return this.stateMachine.debugLog() //
+				+ "|SoC:" + this.getSoc().asString() //
 				+ "|L:" + this.getActivePower().asString() //
 				+ "|Allowed:" + this.getAllowedChargePower().asStringWithoutUnit() + ";"
-				+ this.getAllowedDischargePower().asString() //
-				+ "|" + this.channel(FeneconMiniEss.ChannelId.STATE_MACHINE).value().asEnum().asCamelCase();
+				+ this.getAllowedDischargePower().asString(); //
 	}
 
 	@Override


### PR DESCRIPTION
This improvement enables better insight into State-Machines at runtime, by providing a convenience method for logging the current state of a State-Machine. It is especially useful if more info than just the name of the State is useful to be logged.

Also we update the debugLog() implementations to use StringBuilder, which has better performance than string concatenation.