### PR TITLE
Virtual meter bug fix: average is computed correctly

### DIFF
--- a/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
@@ -2,6 +2,7 @@ package io.openems.edge.common.type;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import com.google.gson.JsonElement;
@@ -412,6 +413,17 @@ public class TypeUtils {
 	 * @param values the {@link Integer} values
 	 * @return the sum
 	 */
+	public static Integer sumInt(List<Integer> values) {
+		return sum(values.toArray(new Integer[0]));
+	}
+
+	/**
+	 * Safely add Integers. If one of them is null it is considered '0'. If all of
+	 * them are null, 'null' is returned.
+	 *
+	 * @param values the {@link Integer} values
+	 * @return the sum
+	 */
 	public static Integer sum(Integer... values) {
 		Integer result = null;
 		for (Integer value : values) {
@@ -425,6 +437,17 @@ public class TypeUtils {
 			}
 		}
 		return result;
+	}
+
+	/**
+	 * Safely add Longs. If one of them is null it is considered '0'. If all of them
+	 * are null, 'null' is returned.
+	 *
+	 * @param values the {@link Long} values
+	 * @return the sum
+	 */
+	public static Long sum(List<Long> values) {
+		return sum(values.toArray(new Long[0]));
 	}
 
 	/**
@@ -727,6 +750,16 @@ public class TypeUtils {
 			return null;
 		}
 		return Math.round(sum / count);
+	}
+
+	/**
+	 * Safely finds the average value of all values.
+	 *
+	 * @param values the {@link Integer} values
+	 * @return the average value; or null if all values are null
+	 */
+	public static Integer averageInt(List<Integer> values) {
+		return averageInt(values.toArray(new Integer[0]));
 	}
 
 	/**

--- a/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
@@ -414,7 +414,7 @@ public class TypeUtils {
 	 * @return the sum
 	 */
 	public static Integer sumInt(List<Integer> values) {
-		return sum(values.toArray(new Integer[0]));
+		return sum(values.toArray(Integer[]::new));
 	}
 
 	/**
@@ -446,8 +446,8 @@ public class TypeUtils {
 	 * @param values the {@link Long} values
 	 * @return the sum
 	 */
-	public static Long sum(List<Long> values) {
-		return sum(values.toArray(new Long[0]));
+	public static Long sumLong(List<Long> values) {
+		return sum(values.toArray(Long[]::new));
 	}
 
 	/**
@@ -759,7 +759,7 @@ public class TypeUtils {
 	 * @return the average value; or null if all values are null
 	 */
 	public static Integer averageInt(List<Integer> values) {
-		return averageInt(values.toArray(new Integer[0]));
+		return averageInt(values.toArray(Integer[]::new));
 	}
 
 	/**

--- a/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/type/TypeUtils.java
@@ -418,6 +418,17 @@ public class TypeUtils {
 	}
 
 	/**
+	 * Safely add Longs. If one of them is null it is considered '0'. If all of them
+	 * are null, 'null' is returned.
+	 *
+	 * @param values the {@link Long} values
+	 * @return the sum
+	 */
+	public static Long sumLong(List<Long> values) {
+		return sum(values.toArray(Long[]::new));
+	}
+
+	/**
 	 * Safely add Integers. If one of them is null it is considered '0'. If all of
 	 * them are null, 'null' is returned.
 	 *
@@ -437,17 +448,6 @@ public class TypeUtils {
 			}
 		}
 		return result;
-	}
-
-	/**
-	 * Safely add Longs. If one of them is null it is considered '0'. If all of them
-	 * are null, 'null' is returned.
-	 *
-	 * @param values the {@link Long} values
-	 * @return the sum
-	 */
-	public static Long sumLong(List<Long> values) {
-		return sum(values.toArray(Long[]::new));
 	}
 
 	/**

--- a/io.openems.edge.meter.virtual/test/io/openems/edge/meter/virtual/add/MeterVirtualAddImplTest.java
+++ b/io.openems.edge.meter.virtual/test/io/openems/edge/meter/virtual/add/MeterVirtualAddImplTest.java
@@ -37,6 +37,15 @@ public class MeterVirtualAddImplTest {
 	private static final ChannelAddress METER_ID_2_ACTIVEPOWER_L1 = new ChannelAddress(METER_ID_2, "ActivePowerL1");
 	private static final ChannelAddress METER_ID_2_ACTIVEPOWER_L2 = new ChannelAddress(METER_ID_2, "ActivePowerL2");
 	private static final ChannelAddress METER_ID_2_ACTIVEPOWER_L3 = new ChannelAddress(METER_ID_2, "ActivePowerL3");
+	
+	private static final String METER_ID_3 = "meter3";
+	private static final ChannelAddress METER_ID_3_ACTIVEPOWER = new ChannelAddress(METER_ID_3, "ActivePower");
+	private static final ChannelAddress METER_ID_3_VOLTAGE = new ChannelAddress(METER_ID_3, "Voltage");
+	private static final ChannelAddress METER_ID_3_FREQUENCY = new ChannelAddress(METER_ID_3, "Frequency");
+
+	private static final ChannelAddress METER_ID_3_ACTIVEPOWER_L1 = new ChannelAddress(METER_ID_3, "ActivePowerL1");
+	private static final ChannelAddress METER_ID_3_ACTIVEPOWER_L2 = new ChannelAddress(METER_ID_3, "ActivePowerL2");
+	private static final ChannelAddress METER_ID_3_ACTIVEPOWER_L3 = new ChannelAddress(METER_ID_3, "ActivePowerL3");
 
 	@Test
 	public void test() throws Exception {
@@ -44,9 +53,10 @@ public class MeterVirtualAddImplTest {
 				.addReference("cm", new DummyConfigurationAdmin()) //
 				.addReference("addMeter", new DummyElectricityMeter(METER_ID_1))
 				.addReference("addMeter", new DummyElectricityMeter(METER_ID_2)) //
+				.addReference("addMeter", new DummyElectricityMeter(METER_ID_3)) //
 				.activate(MyConfig.create() //
 						.setId(METER_ID) //
-						.setMeterIds(METER_ID_1, METER_ID_2) //
+						.setMeterIds(METER_ID_1, METER_ID_2, METER_ID_3) //
 						.setType(MeterType.GRID) //
 						.build())
 				.next(new TestCase("one") //
@@ -58,16 +68,22 @@ public class MeterVirtualAddImplTest {
 						.input(METER_ID_2_ACTIVEPOWER_L1, 2_500) //
 						.input(METER_ID_2_ACTIVEPOWER_L2, 2_500) //
 						.input(METER_ID_2_ACTIVEPOWER_L3, 2_500) //
+						.input(METER_ID_3_ACTIVEPOWER, 9_000) //
+						.input(METER_ID_3_ACTIVEPOWER_L1, 3_000) //
+						.input(METER_ID_3_ACTIVEPOWER_L2, 3_000) //
+						.input(METER_ID_3_ACTIVEPOWER_L3, 3_000) //
 						.input(METER_ID_1_VOLTAGE, 10) //
 						.input(METER_ID_2_VOLTAGE, 20) //
+						.input(METER_ID_3_VOLTAGE, 30) //
 						.input(METER_ID_1_FREQUENCY, 49) //
-						.input(METER_ID_2_FREQUENCY, 51)) //
+						.input(METER_ID_2_FREQUENCY, 51) //
+						.input(METER_ID_3_FREQUENCY, 56)) //
 				.next(new TestCase("two") //
-						.output(METER_POWER, 13_500) //
-						.output(METER_POWER_L1, 4_500) //
-						.output(METER_POWER_L2, 4_500) //
-						.output(METER_POWER_L3, 4_500) //
-						.output(METER_VOLTAGE, 15) //
-						.output(METER_FREQ, 50));
+						.output(METER_POWER, 22_500) //
+						.output(METER_POWER_L1, 7_500) //
+						.output(METER_POWER_L2, 7_500) //
+						.output(METER_POWER_L3, 7_500) //
+						.output(METER_VOLTAGE, 20) //
+						.output(METER_FREQ, 52));
 	}
 }


### PR DESCRIPTION
New pull request after applying changes to latest version of OpenEMS. Closing original PR #2166

The average channel value for channels such as frequency and voltage was incorrectly calculated. Instead of taking the average of all channel values the average was computed as follows. 

Example based on the adjusted test case for voltage:
**old:** avg(avg(avg(null, 10), 20), 30) == 22.5 ❌
**new** avg(10, 20, 30) == 20 ✅

The test case has also been adjusted surface the problem without the fix and pass correctly with the new code.

@sfeilmeier, hope this addresses your concerns in #2166
