### PR TITLE
Modbus Elements: add JUnit tests

### DIFF
--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/test/DummyModbusBridge.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/test/DummyModbusBridge.java
@@ -32,7 +32,7 @@ public class DummyModbusBridge extends AbstractModbusBridge implements BridgeMod
 		for (Channel<?> channel : this.channels()) {
 			channel.nextProcessImage();
 		}
-		super.activate(null, id, "", true, LogVerbosity.NONE, 1);
+		super.activate(null, id, "", true, LogVerbosity.NONE, 2);
 	}
 
 	@Override

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/DummyModbusComponent.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/DummyModbusComponent.java
@@ -4,19 +4,32 @@ import org.osgi.framework.Constants;
 
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.utils.ConfigUtils;
-import io.openems.edge.bridge.modbus.api.AbstractModbusBridge;
 import io.openems.edge.bridge.modbus.api.AbstractOpenemsModbusComponent;
+import io.openems.edge.bridge.modbus.api.BridgeModbus;
 import io.openems.edge.bridge.modbus.api.ModbusComponent;
 import io.openems.edge.bridge.modbus.api.ModbusProtocol;
+import io.openems.edge.bridge.modbus.test.DummyModbusBridge;
 import io.openems.edge.common.channel.Channel;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.test.DummyComponentContext;
 import io.openems.edge.common.test.DummyConfigurationAdmin;
 import io.openems.edge.common.test.DummyConfigurationAdmin.DummyConfiguration;
 
-public abstract class DummyModbusComponent extends AbstractOpenemsModbusComponent implements ModbusComponent {
+public class DummyModbusComponent extends AbstractOpenemsModbusComponent implements ModbusComponent {
 
-	public DummyModbusComponent(String id, AbstractModbusBridge bridge, int unitId,
+	public static final String DEFAULT_COMPONENT_ID = "device0";
+	public static final String DEFAULT_BRIDGE_ID = "modbus0";
+	public static final int DEFAULT_UNIT_ID = 1;
+
+	public DummyModbusComponent() throws OpenemsException {
+		this(DEFAULT_COMPONENT_ID, DEFAULT_BRIDGE_ID);
+	}
+
+	public DummyModbusComponent(String id, String bridgeId) throws OpenemsException {
+		this(id, new DummyModbusBridge(bridgeId), DEFAULT_UNIT_ID, new io.openems.edge.common.channel.ChannelId[0]);
+	}
+
+	public DummyModbusComponent(String id, BridgeModbus bridge, int unitId,
 			io.openems.edge.common.channel.ChannelId[] additionalChannelIds) throws OpenemsException {
 		super(//
 				OpenemsComponent.ChannelId.values(), //
@@ -37,7 +50,18 @@ public abstract class DummyModbusComponent extends AbstractOpenemsModbusComponen
 		super.activate(context, id, "", true, unitId, cm, "Modbus", bridge.id());
 	}
 
+	protected ModbusProtocol defineModbusProtocol() throws OpenemsException {
+		return new ModbusProtocol(this);
+	}
+
 	@Override
-	protected abstract ModbusProtocol defineModbusProtocol() throws OpenemsException;
+	public ModbusProtocol getModbusProtocol() throws OpenemsException {
+		return super.getModbusProtocol();
+	}
+
+	@Override
+	public Channel<?> addChannel(io.openems.edge.common.channel.ChannelId channelId) {
+		return super.addChannel(channelId);
+	}
 
 }

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/BitsWordElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/BitsWordElementTest.java
@@ -1,0 +1,162 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import static io.openems.common.channel.AccessMode.READ_WRITE;
+import static io.openems.common.types.OpenemsType.BOOLEAN;
+import static io.openems.common.types.OpenemsType.INTEGER;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import com.ghgande.j2mod.modbus.procimg.Register;
+import com.ghgande.j2mod.modbus.procimg.SimpleRegister;
+
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.types.OpenemsType;
+import io.openems.edge.bridge.modbus.api.AbstractOpenemsModbusComponent.BitConverter;
+import io.openems.edge.common.channel.BooleanWriteChannel;
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.channel.ChannelId.ChannelIdImpl;
+import io.openems.edge.common.channel.Doc;
+
+public class BitsWordElementTest {
+
+	@Test
+	public void testRead() throws Exception {
+		var sut = generateSut();
+
+		var channel0 = addBit(sut, 0);
+		var channel1 = addBit(sut, 1);
+		var channel2 = addBit(sut, 2, BitConverter.INVERT);
+
+		// TODO ByteOrder is not handled here
+		sut.element.setInputRegisters(new Register[] { new SimpleRegister((byte) 0x00, (byte) 0x01) });
+
+		assertTrue(channel0.getNextValue().get());
+		assertFalse(channel1.getNextValue().get());
+		assertTrue(channel2.getNextValue().get());
+	}
+
+	@Test
+	public void testWriteNone1() throws Exception {
+		var sut = generateSut();
+
+		addBit(sut, 0);
+		addBit(sut, 1);
+		addBit(sut, 2, BitConverter.INVERT);
+		addBit(sut, 3);
+
+		assertEquals(Optional.empty(), sut.element.getNextWriteValueAndReset());
+	}
+
+	@Test
+	public void testWriteNone2() throws Exception {
+		var sut = generateSut();
+
+		var channel0 = addBit(sut, 0);
+		var channel1 = addBit(sut, 1);
+		var channel2 = addBit(sut, 2, BitConverter.INVERT);
+		addBit(sut, 3);
+
+		channel0.setNextWriteValue(false);
+		channel1.setNextWriteValue(true);
+		channel2.setNextWriteValue(false);
+
+		System.out.println("NOTE: the following IllegalArgumentException is expected");
+		assertEquals(Optional.empty(), sut.element.getNextWriteValueAndReset());
+	}
+
+	@Test
+	public void testWriteBigEndian() throws Exception {
+		var sut = generateSut();
+
+		var channel0 = addBit(sut, 0);
+		var channel1 = addBit(sut, 1);
+		var channel2 = addBit(sut, 2, BitConverter.INVERT);
+		var channel8 = addBit(sut, 8);
+
+		channel0.setNextWriteValue(false);
+		channel1.setNextWriteValue(true);
+		channel2.setNextWriteValue(false);
+		channel8.setNextWriteValue(true);
+
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0x01, (byte) 0x06 }, registers[0].toBytes());
+	}
+
+	@Test
+	public void testWriteLittleEndian() throws Exception {
+		var sut = generateSut();
+		sut.element.byteOrder(LITTLE_ENDIAN);
+
+		var channel0 = addBit(sut, 0);
+		var channel1 = addBit(sut, 1);
+		var channel2 = addBit(sut, 2, BitConverter.INVERT);
+		var channel8 = addBit(sut, 8);
+
+		channel0.setNextWriteValue(false);
+		channel1.setNextWriteValue(true);
+		channel2.setNextWriteValue(false);
+		channel8.setNextWriteValue(true);
+
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0x06, (byte) 0x01 }, registers[0].toBytes());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHighIndex() throws Exception {
+		var sut = generateSut();
+		addBit(sut, 16);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testLowIndex() throws Exception {
+		var sut = generateSut();
+		addBit(sut, -1);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testNotBoolean() throws Exception {
+		var sut = generateSut();
+		addBit(sut, 0, null, OpenemsType.INTEGER);
+	}
+
+	private static ModbusTest.FC3ReadRegisters<BitsWordElement, ?> generateSut() throws IllegalArgumentException,
+			IllegalAccessException, OpenemsException, NoSuchFieldException, SecurityException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(new BitsWordElement(0, null), INTEGER);
+
+		// Some Reflection to properly initialize the BitsWordElement
+		var field = BitsWordElement.class.getDeclaredField("component");
+		field.setAccessible(true);
+		field.set(sut.element, sut);
+
+		return sut;
+	}
+
+	private static BooleanWriteChannel addBit(ModbusTest.FC3ReadRegisters<BitsWordElement, ?> sut, int i) {
+		return addBit(sut, i, null);
+	}
+
+	private static BooleanWriteChannel addBit(ModbusTest.FC3ReadRegisters<BitsWordElement, ?> sut, int i,
+			BitConverter bitConverter) {
+		return addBit(sut, i, bitConverter, BOOLEAN);
+	}
+
+	private static <T extends Channel<?>> T addBit(ModbusTest.FC3ReadRegisters<BitsWordElement, ?> sut, int i,
+			BitConverter bitConverter, OpenemsType openemsType) {
+		var channelId = new ChannelIdImpl("CHANNEL_" + i, Doc.of(openemsType).accessMode(READ_WRITE));
+		@SuppressWarnings("unchecked")
+		var channel = (T) sut.addChannel(channelId);
+		if (bitConverter != null) {
+			sut.element.bit(i, channelId, bitConverter);
+		} else {
+			sut.element.bit(i, channelId);
+		}
+		return channel;
+	}
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/BitsWordElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/BitsWordElementTest.java
@@ -30,9 +30,9 @@ public class BitsWordElementTest {
 	public void testRead() throws Exception {
 		var sut = generateSut();
 
-		var channel0 = addBit(sut, 0);
-		var channel1 = addBit(sut, 1);
-		var channel2 = addBit(sut, 2, BitConverter.INVERT);
+		final var channel0 = addBit(sut, 0);
+		final var channel1 = addBit(sut, 1);
+		final var channel2 = addBit(sut, 2, BitConverter.INVERT);
 
 		// TODO ByteOrder is not handled here
 		sut.element.setInputRegisters(new Register[] { new SimpleRegister((byte) 0x00, (byte) 0x01) });
@@ -58,9 +58,9 @@ public class BitsWordElementTest {
 	public void testWriteNone2() throws Exception {
 		var sut = generateSut();
 
-		var channel0 = addBit(sut, 0);
-		var channel1 = addBit(sut, 1);
-		var channel2 = addBit(sut, 2, BitConverter.INVERT);
+		final var channel0 = addBit(sut, 0);
+		final var channel1 = addBit(sut, 1);
+		final var channel2 = addBit(sut, 2, BitConverter.INVERT);
 		addBit(sut, 3);
 
 		channel0.setNextWriteValue(false);
@@ -75,10 +75,10 @@ public class BitsWordElementTest {
 	public void testWriteBigEndian() throws Exception {
 		var sut = generateSut();
 
-		var channel0 = addBit(sut, 0);
-		var channel1 = addBit(sut, 1);
-		var channel2 = addBit(sut, 2, BitConverter.INVERT);
-		var channel8 = addBit(sut, 8);
+		final var channel0 = addBit(sut, 0);
+		final var channel1 = addBit(sut, 1);
+		final var channel2 = addBit(sut, 2, BitConverter.INVERT);
+		final var channel8 = addBit(sut, 8);
 
 		channel0.setNextWriteValue(false);
 		channel1.setNextWriteValue(true);
@@ -94,10 +94,10 @@ public class BitsWordElementTest {
 		var sut = generateSut();
 		sut.element.byteOrder(LITTLE_ENDIAN);
 
-		var channel0 = addBit(sut, 0);
-		var channel1 = addBit(sut, 1);
-		var channel2 = addBit(sut, 2, BitConverter.INVERT);
-		var channel8 = addBit(sut, 8);
+		final var channel0 = addBit(sut, 0);
+		final var channel1 = addBit(sut, 1);
+		final var channel2 = addBit(sut, 2, BitConverter.INVERT);
+		final var channel8 = addBit(sut, 8);
 
 		channel0.setNextWriteValue(false);
 		channel1.setNextWriteValue(true);

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/CoilElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/CoilElementTest.java
@@ -1,0 +1,38 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import static io.openems.common.types.OpenemsType.BOOLEAN;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+
+public class CoilElementTest {
+
+	@Test
+	public void testRead() throws OpenemsException {
+		var sut = new ModbusTest.FC1ReadCoils<>(new CoilElement(0), BOOLEAN);
+		sut.element.setInputCoil(true);
+		assertEquals(true, sut.channel.getNextValue().get());
+
+		sut.element.setInputCoil(false);
+		assertEquals(false, sut.channel.getNextValue().get());
+
+		sut.element.setInputCoil(null);
+		assertEquals(null, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testWrite() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC5WriteCoil<>(new CoilElement(0), BOOLEAN);
+		sut.channel.setNextWriteValueFromObject(true);
+		assertEquals(true, ((CoilElement) sut.element).getNextWriteValueAndReset().get());
+
+		sut.channel.setNextWriteValueFromObject(null);
+		assertEquals(Optional.empty(), ((CoilElement) sut.element).getNextWriteValueAndReset());
+	}
+
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/DummyCoilElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/DummyCoilElementTest.java
@@ -1,0 +1,12 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import org.junit.Test;
+
+public class DummyCoilElementTest {
+
+	@Test
+	public void test() {
+		new DummyCoilElement(0);
+	}
+
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/DummyRegisterElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/DummyRegisterElementTest.java
@@ -1,0 +1,12 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import org.junit.Test;
+
+public class DummyRegisterElementTest {
+
+	@Test
+	public void test() {
+		new DummyRegisterElement(0);
+	}
+
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/FloatDoublewordElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/FloatDoublewordElementTest.java
@@ -1,0 +1,77 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import static io.openems.common.types.OpenemsType.FLOAT;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ghgande.j2mod.modbus.procimg.Register;
+import com.ghgande.j2mod.modbus.procimg.SimpleRegister;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+
+public class FloatDoublewordElementTest {
+
+	@Test
+	public void testReadBigEndianMswLsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new FloatDoublewordElement(0), //
+				FLOAT);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x44, (byte) 0x9A), //
+				new SimpleRegister((byte) 0x51, (byte) 0xEC) //
+		});
+		assertEquals(1234.56F, (float) sut.channel.getNextValue().get(), 0.001F);
+	}
+
+	@Test
+	public void testReadBigEndianLswMsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new FloatDoublewordElement(0).wordOrder(WordOrder.LSWMSW), //
+				FLOAT);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x51, (byte) 0xEC), //
+				new SimpleRegister((byte) 0x44, (byte) 0x9A) //
+		});
+		assertEquals(1234.56F, (float) sut.channel.getNextValue().get(), 0.001F);
+	}
+
+	@Test
+	public void testReadLittleEndianMswLsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new FloatDoublewordElement(0).byteOrder(LITTLE_ENDIAN), //
+				FLOAT);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0xEC, (byte) 0x51), //
+				new SimpleRegister((byte) 0x9A, (byte) 0x44) //
+		});
+		assertEquals(1234.56F, (float) sut.channel.getNextValue().get(), 0.001F);
+	}
+
+	@Test
+	public void testReadLittleEndianlswMsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new FloatDoublewordElement(0).byteOrder(LITTLE_ENDIAN).wordOrder(WordOrder.LSWMSW), //
+				FLOAT);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x9A, (byte) 0x44), //
+				new SimpleRegister((byte) 0xEC, (byte) 0x51) //
+		});
+		assertEquals(1234.56F, (float) sut.channel.getNextValue().get(), 0.001F);
+	}
+
+	@Test
+	public void testWrite() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC16WriteRegisters<>(//
+				new FloatDoublewordElement(0), //
+				FLOAT);
+		sut.channel.setNextWriteValueFromObject(1234.56F);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0x44, (byte) 0x9A }, registers[0].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x51, (byte) 0xEC }, registers[1].toBytes());
+	}
+
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/FloatQuadruplewordElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/FloatQuadruplewordElementTest.java
@@ -1,0 +1,88 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import static io.openems.common.types.OpenemsType.DOUBLE;
+import static io.openems.common.types.OpenemsType.LONG;
+import static io.openems.edge.bridge.modbus.api.element.WordOrder.LSWMSW;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ghgande.j2mod.modbus.procimg.Register;
+import com.ghgande.j2mod.modbus.procimg.SimpleRegister;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+
+public class FloatQuadruplewordElementTest {
+
+	@Test
+	public void testReadBigEndianMswLsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new FloatQuadruplewordElement(0), //
+				DOUBLE);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x40, (byte) 0x93), //
+				new SimpleRegister((byte) 0x4A, (byte) 0x3D), //
+				new SimpleRegister((byte) 0x70, (byte) 0xA3), //
+				new SimpleRegister((byte) 0xD7, (byte) 0x0A) //
+		});
+		assertEquals(1234.56, (double) sut.channel.getNextValue().get(), 0.001);
+	}
+
+	@Test
+	public void testReadBigEndianLswMsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new FloatQuadruplewordElement(0).wordOrder(WordOrder.LSWMSW), //
+				DOUBLE);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0xD7, (byte) 0x0A), //
+				new SimpleRegister((byte) 0x70, (byte) 0xA3), //
+				new SimpleRegister((byte) 0x4A, (byte) 0x3D), //
+				new SimpleRegister((byte) 0x40, (byte) 0x93) //
+		});
+		assertEquals(1234.56, (double) sut.channel.getNextValue().get(), 0.001);
+	}
+
+	@Test
+	public void testReadLittleEndianMswLsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new FloatQuadruplewordElement(0).byteOrder(LITTLE_ENDIAN), //
+				DOUBLE);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x0A, (byte) 0xD7), //
+				new SimpleRegister((byte) 0xA3, (byte) 0x70), //
+				new SimpleRegister((byte) 0x3D, (byte) 0x4A), //
+				new SimpleRegister((byte) 0x93, (byte) 0x40) //
+		});
+		assertEquals(1234.56F, (double) sut.channel.getNextValue().get(), 0.001);
+	}
+
+	@Test
+	public void testReadLittleEndianLswMsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new FloatQuadruplewordElement(0).wordOrder(WordOrder.LSWMSW).byteOrder(LITTLE_ENDIAN), //
+				DOUBLE);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x93, (byte) 0x40), //
+				new SimpleRegister((byte) 0x3D, (byte) 0x4A), //
+				new SimpleRegister((byte) 0xA3, (byte) 0x70), //
+				new SimpleRegister((byte) 0x0A, (byte) 0xD7) //
+		});
+		assertEquals(1234.56F, (double) sut.channel.getNextValue().get(), 0.001);
+	}
+
+	@Test
+	public void testWriteLittleEndianLswMsw() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC16WriteRegisters<>(//
+				new FloatQuadruplewordElement(0).wordOrder(LSWMSW).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.channel.setNextWriteValueFromObject(1234.56F);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0x93, (byte) 0x40 }, registers[0].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x00, (byte) 0x48 }, registers[1].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x00, (byte) 0x00 }, registers[2].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x00, (byte) 0x00 }, registers[3].toBytes());
+	}
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/ModbusTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/ModbusTest.java
@@ -1,0 +1,88 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import java.util.function.BiFunction;
+
+import io.openems.common.channel.AccessMode;
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.types.OpenemsType;
+import io.openems.edge.bridge.modbus.DummyModbusComponent;
+import io.openems.edge.bridge.modbus.api.task.AbstractTask;
+import io.openems.edge.bridge.modbus.api.task.FC16WriteRegistersTask;
+import io.openems.edge.bridge.modbus.api.task.FC1ReadCoilsTask;
+import io.openems.edge.bridge.modbus.api.task.FC3ReadRegistersTask;
+import io.openems.edge.bridge.modbus.api.task.FC5WriteCoilTask;
+import io.openems.edge.bridge.modbus.api.task.FC6WriteRegisterTask;
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.channel.ChannelId.ChannelIdImpl;
+import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.WriteChannel;
+import io.openems.edge.common.channel.internal.AbstractReadChannel;
+import io.openems.edge.common.taskmanager.Priority;
+
+public class ModbusTest<TASK extends AbstractTask, ELEMENT extends AbstractModbusElement<?>, CHANNEL extends Channel<?>>
+		extends DummyModbusComponent {
+
+	private static final String CHANNEL_ID = "CHANNEL";
+
+	public final CHANNEL channel;
+	public final ELEMENT element;
+	public final TASK task;
+
+	@SuppressWarnings("unchecked")
+	private ModbusTest(ELEMENT element, BiFunction<Integer, Priority, TASK> taskFactory, AccessMode accessMode,
+			OpenemsType openemsType) throws OpenemsException {
+		super();
+		var channelId = new ChannelIdImpl(CHANNEL_ID, Doc.of(openemsType).accessMode(accessMode));
+		this.channel = (CHANNEL) this.addChannel(channelId);
+		this.element = this.m(this.channel.channelId(), element);
+		this.task = taskFactory.apply(0, Priority.LOW);
+		this.getModbusProtocol().addTask(this.task);
+	}
+
+	public static class FC1ReadCoils<ELEMENT extends AbstractModbusElement<?>, CHANNEL extends AbstractReadChannel<?, ?>>
+			extends ModbusTest<FC1ReadCoilsTask, ELEMENT, CHANNEL> {
+		public FC1ReadCoils(ELEMENT element, OpenemsType openemsType) throws OpenemsException {
+			super(element, //
+					(startAddress, priority) -> new FC1ReadCoilsTask(startAddress, priority, element), //
+					AccessMode.READ_ONLY, openemsType);
+		}
+	}
+
+	public static class FC5WriteCoil<ELEMENT extends AbstractModbusElement<?>, CHANNEL extends WriteChannel<?>>
+			extends ModbusTest<FC5WriteCoilTask, ELEMENT, CHANNEL> {
+		@SuppressWarnings("unchecked")
+		public FC5WriteCoil(ModbusCoilElement element, OpenemsType openemsType) throws OpenemsException {
+			super((ELEMENT) element, //
+					(startAddress, priority) -> new FC5WriteCoilTask(startAddress, element), //
+					AccessMode.READ_WRITE, openemsType);
+		}
+	}
+
+	public static class FC3ReadRegisters<ELEMENT extends AbstractModbusElement<?>, CHANNEL extends AbstractReadChannel<?, ?>>
+			extends ModbusTest<FC3ReadRegistersTask, ELEMENT, CHANNEL> {
+		public FC3ReadRegisters(ELEMENT element, OpenemsType openemsType) throws OpenemsException {
+			super(element, //
+					(startAddress, priority) -> new FC3ReadRegistersTask(startAddress, priority, element), //
+					AccessMode.READ_ONLY, openemsType);
+		}
+	}
+
+	public static class FC6WriteRegister<ELEMENT extends AbstractModbusElement<?>, CHANNEL extends WriteChannel<?>>
+			extends ModbusTest<FC6WriteRegisterTask, ELEMENT, CHANNEL> {
+		public FC6WriteRegister(ELEMENT element, OpenemsType openemsType) throws OpenemsException {
+			super(element, //
+					(startAddress, priority) -> new FC6WriteRegisterTask(startAddress, element), //
+					AccessMode.READ_WRITE, openemsType);
+		}
+	}
+
+	public static class FC16WriteRegisters<ELEMENT extends AbstractModbusElement<?>, CHANNEL extends WriteChannel<?>>
+			extends ModbusTest<FC16WriteRegistersTask, ELEMENT, CHANNEL> {
+		public FC16WriteRegisters(ELEMENT element, OpenemsType openemsType) throws OpenemsException {
+			super(element, //
+					(startAddress, priority) -> new FC16WriteRegistersTask(startAddress, element), //
+					AccessMode.READ_WRITE, openemsType);
+		}
+	}
+
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/SignedDoublewordElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/SignedDoublewordElementTest.java
@@ -1,0 +1,79 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import static io.openems.common.types.OpenemsType.LONG;
+import static io.openems.edge.bridge.modbus.api.element.WordOrder.LSWMSW;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ghgande.j2mod.modbus.procimg.Register;
+import com.ghgande.j2mod.modbus.procimg.SimpleRegister;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+
+public class SignedDoublewordElementTest {
+
+	@Test
+	public void testReadBigEndianMswLsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new SignedDoublewordElement(0), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0xAB, (byte) 0xCD), //
+				new SimpleRegister((byte) 0x12, (byte) 0x34) //
+		});
+		assertEquals(0xFFFF_FFFF_ABCD_1234L, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadBigEndianLswMsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new SignedDoublewordElement(0).wordOrder(LSWMSW), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0xAB, (byte) 0xCD), //
+				new SimpleRegister((byte) 0x12, (byte) 0x34) //
+		});
+		System.out.println(sut.channel.getNextValue().get());
+		assertEquals(0x1234_ABCDL, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadLittleEndianMswLsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new SignedDoublewordElement(0).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0xAB, (byte) 0xCD), //
+				new SimpleRegister((byte) 0x12, (byte) 0x34) //
+		});
+		assertEquals(0x3412_CDABL, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadLittleEndianlswMsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new SignedDoublewordElement(0).byteOrder(LITTLE_ENDIAN).wordOrder(LSWMSW), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0xAB, (byte) 0xCD), //
+				new SimpleRegister((byte) 0x12, (byte) 0x34) //
+		});
+		assertEquals(0xFFFF_FFFF_CDAB_3412L, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testWrite() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC16WriteRegisters<>(//
+				new SignedDoublewordElement(0), //
+				LONG);
+		sut.channel.setNextWriteValueFromObject(0x1234_ABCDL);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0x12, (byte) 0x34 }, registers[0].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0xAB, (byte) 0xCD }, registers[1].toBytes());
+	}
+
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/SignedQuadruplewordElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/SignedQuadruplewordElementTest.java
@@ -1,0 +1,100 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import static io.openems.common.types.OpenemsType.LONG;
+import static io.openems.edge.bridge.modbus.api.element.WordOrder.LSWMSW;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ghgande.j2mod.modbus.procimg.Register;
+import com.ghgande.j2mod.modbus.procimg.SimpleRegister;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+
+public class SignedQuadruplewordElementTest {
+
+	@Test
+	public void testReadBigEndianMswLsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new SignedQuadruplewordElement(0), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x01, (byte) 0x23), //
+				new SimpleRegister((byte) 0x45, (byte) 0x67), //
+				new SimpleRegister((byte) 0x89, (byte) 0xAB), //
+				new SimpleRegister((byte) 0xCD, (byte) 0xEF), //
+		});
+		assertEquals(0x0123_4567_89AB_CDEFL, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadBigEndianLswMsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new SignedQuadruplewordElement(0).wordOrder(LSWMSW), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x01, (byte) 0x23), //
+				new SimpleRegister((byte) 0x45, (byte) 0x67), //
+				new SimpleRegister((byte) 0x89, (byte) 0xAB), //
+				new SimpleRegister((byte) 0xCD, (byte) 0xEF), //
+		});
+		assertEquals(0xCDEF_89AB_4567_0123L, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadLittleEndianMswLsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new SignedQuadruplewordElement(0).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x01, (byte) 0x23), //
+				new SimpleRegister((byte) 0x45, (byte) 0x67), //
+				new SimpleRegister((byte) 0x89, (byte) 0xAB), //
+				new SimpleRegister((byte) 0xCD, (byte) 0xEF), //
+		});
+		assertEquals(0xEFCD_AB89_6745_2301L, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadLittleEndianLswMsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new SignedQuadruplewordElement(0).wordOrder(LSWMSW).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x01, (byte) 0x23), //
+				new SimpleRegister((byte) 0x45, (byte) 0x67), //
+				new SimpleRegister((byte) 0x89, (byte) 0xAB), //
+				new SimpleRegister((byte) 0xCD, (byte) 0xEF), //
+		});
+		assertEquals(0x2301_6745_AB89_EFCDL, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testWriteLittleEndianMswLsw() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC16WriteRegisters<>(//
+				new SignedQuadruplewordElement(0).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.channel.setNextWriteValueFromObject(0x2301_6745_AB89_EFCDL);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0xCD, (byte) 0xEF }, registers[0].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x89, (byte) 0xAB }, registers[1].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x45, (byte) 0x67 }, registers[2].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x01, (byte) 0x23 }, registers[3].toBytes());
+	}
+
+	@Test
+	public void testWriteLittleEndianLswMsw() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC16WriteRegisters<>(//
+				new SignedQuadruplewordElement(0).wordOrder(LSWMSW).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.channel.setNextWriteValueFromObject(0x2301_6745_AB89_EFCDL);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0x01, (byte) 0x23 }, registers[0].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x45, (byte) 0x67 }, registers[1].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x89, (byte) 0xAB }, registers[2].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0xCD, (byte) 0xEF }, registers[3].toBytes());
+	}
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/SignedWordElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/SignedWordElementTest.java
@@ -1,0 +1,47 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import static io.openems.common.types.OpenemsType.SHORT;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ghgande.j2mod.modbus.procimg.Register;
+import com.ghgande.j2mod.modbus.procimg.SimpleRegister;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+
+public class SignedWordElementTest {
+
+	@Test
+	public void testReadBigEndian() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(new SignedWordElement(0), SHORT);
+		sut.element.setInputRegisters(new Register[] { new SimpleRegister((byte) 0xAB, (byte) 0xCD) });
+		assertEquals((short) 0xABCD, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadLittleEndian() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(new SignedWordElement(0).byteOrder(LITTLE_ENDIAN), SHORT);
+		sut.element.setInputRegisters(new Register[] { new SimpleRegister((byte) 0xAB, (byte) 0xCD) });
+		assertEquals((short) 0xCDAB, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testWriteBigEndian() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC6WriteRegister<>(new SignedWordElement(0), SHORT);
+		sut.channel.setNextWriteValueFromObject(0x1234);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0x12, (byte) 0x34 }, registers[0].toBytes());
+	}
+
+	@Test
+	public void testWriteLittleEndian() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC6WriteRegister<>(new SignedWordElement(0).byteOrder(LITTLE_ENDIAN), SHORT);
+		sut.channel.setNextWriteValueFromObject(0x1234);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0x34, (byte) 0x12 }, registers[0].toBytes());
+	}
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/StringWordElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/StringWordElementTest.java
@@ -1,0 +1,54 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import static io.openems.common.types.OpenemsType.STRING;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ghgande.j2mod.modbus.procimg.Register;
+import com.ghgande.j2mod.modbus.procimg.SimpleRegister;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+
+public class StringWordElementTest {
+
+	@Test
+	public void testReadBigEndian() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new StringWordElement(0, 4), STRING);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x4F, (byte) 0x70), //
+				new SimpleRegister((byte) 0x65, (byte) 0x6E), //
+				new SimpleRegister((byte) 0x45, (byte) 0x4D), //
+				new SimpleRegister((byte) 0x53, (byte) 0x00) //
+		});
+		assertEquals("OpenEMS", sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadLittleEndian() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				// TODO byteOrder is not applied
+				new StringWordElement(0, 4).byteOrder(LITTLE_ENDIAN), STRING);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x4F, (byte) 0x70), //
+				new SimpleRegister((byte) 0x65, (byte) 0x6E), //
+				new SimpleRegister((byte) 0x45, (byte) 0x4D), //
+				new SimpleRegister((byte) 0x53, (byte) 0x00) //
+		});
+		assertEquals("OpenEMS", sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testWriteBigEndian() throws IllegalArgumentException, OpenemsNamedException {
+		// TODO StringWordElement._setNextWriteValue is non-functional
+		// var sut = new ModbusTest.FC6WriteRegister<>(new StringWordElement(0, 10),
+		// STRING);
+		// sut.channel.setNextWriteValueFromObject("OpenEMS ");
+		// var registers = sut.element.getNextWriteValueAndReset().get();
+		// assertArrayEquals(new byte[] { (byte) 0x4F, (byte) 0x70 },
+		// registers[0].toBytes());
+	}
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/UnsignedDoublewordElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/UnsignedDoublewordElementTest.java
@@ -1,0 +1,110 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import static io.openems.common.types.OpenemsType.LONG;
+import static io.openems.edge.bridge.modbus.api.element.WordOrder.LSWMSW;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ghgande.j2mod.modbus.procimg.Register;
+import com.ghgande.j2mod.modbus.procimg.SimpleRegister;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+
+public class UnsignedDoublewordElementTest {
+
+	@Test
+	public void testReadBigEndianMswLsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new UnsignedDoublewordElement(0), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0xAB, (byte) 0xCD), //
+				new SimpleRegister((byte) 0x12, (byte) 0x34) //
+		});
+		assertEquals(0xABCD_1234L, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadBigEndianLswMsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new UnsignedDoublewordElement(0).wordOrder(LSWMSW), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0xAB, (byte) 0xCD), //
+				new SimpleRegister((byte) 0x12, (byte) 0x34) //
+		});
+		assertEquals(0x1234_ABCDL, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadLittleEndianMswLsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new UnsignedDoublewordElement(0).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0xAB, (byte) 0xCD), //
+				new SimpleRegister((byte) 0x12, (byte) 0x34) //
+		});
+		assertEquals(0x3412_CDABL, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadLittleEndianLswMsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new UnsignedDoublewordElement(0).wordOrder(LSWMSW).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0xAB, (byte) 0xCD), //
+				new SimpleRegister((byte) 0x12, (byte) 0x34) //
+		});
+		assertEquals(0xCDAB_3412L, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testWriteBigEndianMswLsw() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC16WriteRegisters<>(//
+				new UnsignedDoublewordElement(0), //
+				LONG);
+		sut.channel.setNextWriteValueFromObject(0xABCD1234L);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0xAB, (byte) 0xCD }, registers[0].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x12, (byte) 0x34 }, registers[1].toBytes());
+	}
+
+	@Test
+	public void testWriteBigEndianLswMsw() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC16WriteRegisters<>(//
+				new UnsignedDoublewordElement(0).wordOrder(LSWMSW), //
+				LONG);
+		sut.channel.setNextWriteValueFromObject(0xABCD1234L);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0x12, (byte) 0x34 }, registers[0].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0xAB, (byte) 0xCD }, registers[1].toBytes());
+	}
+
+	@Test
+	public void testWriteLittleEndianMswLsw() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC16WriteRegisters<>(//
+				new UnsignedDoublewordElement(0).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.channel.setNextWriteValueFromObject(0xABCD1234L);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0x34, (byte) 0x12 }, registers[0].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0xCD, (byte) 0xAB }, registers[1].toBytes());
+	}
+
+	@Test
+	public void testWriteLittleEndianLswMsw() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC16WriteRegisters<>(//
+				new UnsignedDoublewordElement(0).wordOrder(LSWMSW).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.channel.setNextWriteValueFromObject(0xABCD1234L);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0xCD, (byte) 0xAB }, registers[0].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x34, (byte) 0x12 }, registers[1].toBytes());
+	}
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/UnsignedQuadruplewordElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/UnsignedQuadruplewordElementTest.java
@@ -1,0 +1,101 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import static io.openems.common.types.OpenemsType.LONG;
+import static io.openems.edge.bridge.modbus.api.element.WordOrder.LSWMSW;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ghgande.j2mod.modbus.procimg.Register;
+import com.ghgande.j2mod.modbus.procimg.SimpleRegister;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+
+public class UnsignedQuadruplewordElementTest {
+
+	@Test
+	public void testReadBigEndianMswLsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new UnsignedQuadruplewordElement(0), //
+				LONG);
+		sut.element.debug();
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x01, (byte) 0x23), //
+				new SimpleRegister((byte) 0x45, (byte) 0x67), //
+				new SimpleRegister((byte) 0x89, (byte) 0xAB), //
+				new SimpleRegister((byte) 0xCD, (byte) 0xEF), //
+		});
+		assertEquals(0x0123_4567_89AB_CDEFL, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadBigEndianLswMsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new UnsignedQuadruplewordElement(0).wordOrder(LSWMSW), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x01, (byte) 0x23), //
+				new SimpleRegister((byte) 0x45, (byte) 0x67), //
+				new SimpleRegister((byte) 0x89, (byte) 0xAB), //
+				new SimpleRegister((byte) 0xCD, (byte) 0xEF), //
+		});
+		assertEquals(0xCDEF_89AB_4567_0123L, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadLittleEndianMswLsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new UnsignedQuadruplewordElement(0).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x01, (byte) 0x23), //
+				new SimpleRegister((byte) 0x45, (byte) 0x67), //
+				new SimpleRegister((byte) 0x89, (byte) 0xAB), //
+				new SimpleRegister((byte) 0xCD, (byte) 0xEF), //
+		});
+		assertEquals(0xEFCD_AB89_6745_2301L, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadLittleEndianLswMsw() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(//
+				new UnsignedQuadruplewordElement(0).wordOrder(LSWMSW).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.element.setInputRegisters(new Register[] { //
+				new SimpleRegister((byte) 0x01, (byte) 0x23), //
+				new SimpleRegister((byte) 0x45, (byte) 0x67), //
+				new SimpleRegister((byte) 0x89, (byte) 0xAB), //
+				new SimpleRegister((byte) 0xCD, (byte) 0xEF), //
+		});
+		assertEquals(0x2301_6745_AB89_EFCDL, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testWriteLittleEndianMswLsw() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC16WriteRegisters<>(//
+				new UnsignedQuadruplewordElement(0).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.channel.setNextWriteValueFromObject(0x2301_6745_AB89_EFCDL);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0xCD, (byte) 0xEF }, registers[0].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x89, (byte) 0xAB }, registers[1].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x45, (byte) 0x67 }, registers[2].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x01, (byte) 0x23 }, registers[3].toBytes());
+	}
+
+	@Test
+	public void testWriteLittleEndianLswMsw() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC16WriteRegisters<>(//
+				new UnsignedQuadruplewordElement(0).wordOrder(LSWMSW).byteOrder(LITTLE_ENDIAN), //
+				LONG);
+		sut.channel.setNextWriteValueFromObject(0x2301_6745_AB89_EFCDL);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0x01, (byte) 0x23 }, registers[0].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x45, (byte) 0x67 }, registers[1].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0x89, (byte) 0xAB }, registers[2].toBytes());
+		assertArrayEquals(new byte[] { (byte) 0xCD, (byte) 0xEF }, registers[3].toBytes());
+	}
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/UnsignedWordElementTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/api/element/UnsignedWordElementTest.java
@@ -1,0 +1,83 @@
+package io.openems.edge.bridge.modbus.api.element;
+
+import static io.openems.common.types.OpenemsType.INTEGER;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import com.ghgande.j2mod.modbus.procimg.InputRegister;
+import com.ghgande.j2mod.modbus.procimg.Register;
+import com.ghgande.j2mod.modbus.procimg.SimpleRegister;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.edge.bridge.modbus.api.AbstractModbusBridge;
+
+public class UnsignedWordElementTest {
+
+	@Test
+	public void testReadBigEndian() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(new UnsignedWordElement(0), INTEGER);
+		sut.element.setInputRegisters(new Register[] { new SimpleRegister((byte) 0xAB, (byte) 0xCD) });
+		assertEquals(0xABCD, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testReadLittleEndian() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(new UnsignedWordElement(0).byteOrder(LITTLE_ENDIAN), INTEGER);
+		sut.element.setInputRegisters(new Register[] { new SimpleRegister((byte) 0xAB, (byte) 0xCD) });
+		assertEquals(0xCDAB, sut.channel.getNextValue().get());
+	}
+
+	@Test
+	public void testWriteBigEndian() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC6WriteRegister<>(new UnsignedWordElement(0), INTEGER);
+		sut.channel.setNextWriteValueFromObject(0xBCDE);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0xBC, (byte) 0xDE }, registers[0].toBytes());
+	}
+
+	@Test
+	public void testWriteLittleEndian() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC6WriteRegister<>(new UnsignedWordElement(0).byteOrder(LITTLE_ENDIAN), INTEGER);
+		sut.channel.setNextWriteValueFromObject(0xBCDE);
+		var registers = sut.element.getNextWriteValueAndReset().get();
+		assertArrayEquals(new byte[] { (byte) 0xDE, (byte) 0xBC }, registers[0].toBytes());
+	}
+
+	@Test
+	public void testInvalidate() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(new UnsignedWordElement(0), INTEGER);
+		var bridge = (AbstractModbusBridge) sut.getBridgeModbus();
+		sut.element._setInputRegisters(new Register[] { new SimpleRegister((byte) 0xAB, (byte) 0xCD) });
+		assertEquals(0xABCD, sut.channel.getNextValue().get());
+		sut.element.invalidate(bridge); // invalidValueCounter = 1
+		assertEquals(0xABCD, sut.channel.getNextValue().get());
+		sut.element.invalidate(bridge); // invalidValueCounter = 2
+		assertNull(sut.channel.getNextValue().get());
+	}
+
+	@Test(expected = OpenemsException.class)
+	public void testReadWrongLength() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(new UnsignedWordElement(0), INTEGER);
+		sut.element.setInputRegisters(new Register[3]);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testInputValueNull() throws OpenemsException {
+		var sut = new ModbusTest.FC3ReadRegisters<>(new UnsignedWordElement(0), INTEGER);
+		sut.element.setInputRegisters((InputRegister[]) null);
+		// TODO this should not throw a NPE
+	}
+
+	@Test
+	public void testWriteNone() throws IllegalArgumentException, OpenemsNamedException {
+		var sut = new ModbusTest.FC6WriteRegister<>(new UnsignedWordElement(0), INTEGER);
+		assertEquals(Optional.empty(), sut.element.getNextWriteValueAndReset());
+	}
+}

--- a/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/sunspec/DefaultSunSpecModelTest.java
+++ b/io.openems.edge.bridge.modbus/test/io/openems/edge/bridge/modbus/sunspec/DefaultSunSpecModelTest.java
@@ -1,0 +1,16 @@
+package io.openems.edge.bridge.modbus.sunspec;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class DefaultSunSpecModelTest {
+
+	@Test
+	public void test() {
+		// This is just to test initialization of the enum
+		var e = DefaultSunSpecModel.S_1;
+		assertEquals("Common", e.label);
+	}
+
+}


### PR DESCRIPTION
This PR adds JUnit tests for all Modbus Elements (BitsWordElement, FloatQuadruplewordElement, etc.)