### PR TITLE
RefuStore88k: add method to get cabin temperature (#729)

### DIFF
--- a/io.openems.edge.batteryinverter.refu88k/src/io/openems/edge/batteryinverter/refu88k/BatteryInverterRefuStore88k.java
+++ b/io.openems.edge.batteryinverter.refu88k/src/io/openems/edge/batteryinverter/refu88k/BatteryInverterRefuStore88k.java
@@ -20,6 +20,7 @@ import io.openems.edge.batteryinverter.refu88k.statemachine.StateMachine.State;
 import io.openems.edge.common.channel.Channel;
 import io.openems.edge.common.channel.Doc;
 import io.openems.edge.common.channel.EnumWriteChannel;
+import io.openems.edge.common.channel.IntegerReadChannel;
 import io.openems.edge.common.channel.StateChannel;
 import io.openems.edge.common.channel.value.Value;
 import io.openems.edge.common.component.OpenemsComponent;
@@ -379,4 +380,21 @@ public interface BatteryInverterRefuStore88k
 		return this.channel(BatteryInverterRefuStore88k.ChannelId.ST).value().asEnum();
 	}
 
+	/**
+	 * Gets the Channel for {@link ChannelId#TMP_CAB}.
+	 *
+	 * @return the {@link Channel}
+	 */
+	public default IntegerReadChannel getInverterTemperatureChannel() {
+		return this.channel(ChannelId.TMP_CAB);
+	}
+
+	/**
+	 * Gets the Inverter Cabin temperature. See {@link ChannelId#TMP_CAB}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Integer> getInverterTemperature() {
+		return this.getInverterTemperatureChannel().value();
+	}
 }

--- a/io.openems.edge.batteryinverter.refu88k/src/io/openems/edge/batteryinverter/refu88k/enums/package-info.java
+++ b/io.openems.edge.batteryinverter.refu88k/src/io/openems/edge/batteryinverter/refu88k/enums/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package io.openems.edge.batteryinverter.refu88k.enums;

--- a/io.openems.edge.batteryinverter.refu88k/src/io/openems/edge/batteryinverter/refu88k/package-info.java
+++ b/io.openems.edge.batteryinverter.refu88k/src/io/openems/edge/batteryinverter/refu88k/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package io.openems.edge.batteryinverter.refu88k;


### PR DESCRIPTION
- Getting the Cabin inverter Temperature from the channel.
- Also includes the package-info.java files.