### PR TITLE
ElectricityMeter: Use correct channels and avoid null pointer.

### DIFF
--- a/io.openems.edge.meter.api/src/io/openems/edge/meter/api/ElectricityMeter.java
+++ b/io.openems.edge.meter.api/src/io/openems/edge/meter/api/ElectricityMeter.java
@@ -1678,9 +1678,9 @@ public interface ElectricityMeter extends OpenemsComponent {
 	public static void calculateSumActiveProductionEnergyFromPhases(ElectricityMeter meter) {
 		final Consumer<Value<Long>> calculate = ignore -> {
 			meter._setActiveProductionEnergy(TypeUtils.sum(//
-					meter.getActivePowerL1Channel().getNextValue().get(), //
-					meter.getActivePowerL2Channel().getNextValue().get(), //
-					meter.getActivePowerL3Channel().getNextValue().get())); //
+					meter.getActiveProductionEnergyL1Channel().getNextValue().get(), //
+					meter.getActiveProductionEnergyL2Channel().getNextValue().get(), //
+					meter.getActiveProductionEnergyL3Channel().getNextValue().get())); //
 		};
 		meter.getActiveProductionEnergyL1Channel().onSetNextValue(calculate);
 		meter.getActiveProductionEnergyL2Channel().onSetNextValue(calculate);


### PR DESCRIPTION
In calculateSumActiveProductionEnergyFromPhases() wrong channels were used.
Additionally it caused a null pointer, when the result would have been null, because it was internally trying to call intValue() to parse it into a long.

