### PR TITLE
AbstractChannelListenerManager: clean up unused listeners after deactivate()

### DIFF
--- a/io.openems.edge.common/src/io/openems/edge/common/channel/AbstractChannelListenerManager.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/AbstractChannelListenerManager.java
@@ -54,10 +54,12 @@ public abstract class AbstractChannelListenerManager {
 			Channel<?> channel = listener.component.channel(listener.channelId);
 			channel.removeOnSetNextValueCallback(listener.callback);
 		}
+		this.onSetNextValueListeners.clear();
 		for (OnChangeListener<?> listener : this.onChangeListeners) {
 			Channel<?> channel = listener.component.channel(listener.channelId);
 			channel.removeOnChangeCallback(listener.callback);
 		}
+		this.onChangeListeners.clear();
 	}
 
 	/**


### PR DESCRIPTION
As discussed in issue: https://github.com/OpenEMS/openems/issues/2302