### PR TITLE
UI: Add redirection for 'OpenEMS Edge' as backend

### DIFF
--- a/ui/src/app/index/index.component.ts
+++ b/ui/src/app/index/index.component.ts
@@ -132,7 +132,7 @@ export class IndexComponent implements OnInit, OnDestroy {
           let edgeIds = Object.keys(metadata.edges);
           this.onlyOneEdgeAvailable = edgeIds.length <= 1;
           this.noEdges = edgeIds.length === 0;
-          this.loggedInUserCanInstall = Role.isAtLeast(metadata.user.globalRole, "installer");
+          this.loggedInUserCanInstall = environment.backend === 'OpenEMS Backend' && Role.isAtLeast(metadata.user.globalRole, "installer");
 
           // Forward directly to device page, if
           // - Direct local access to Edge


### PR DESCRIPTION
- Adds a check for OpenEMS Edge as backend, to be getting redirected to live-view

Solves this community Issue: https://community.openems.io/t/2023-8-ui-bleibt-nach-login-hangen/1837/4