### PR TITLE
UI: Change color of storage icon in evcs modal

### DIFF
--- a/ui/src/app/edge/live/Controller/Evcs/modal/modal.html
+++ b/ui/src/app/edge/live/Controller/Evcs/modal/modal.html
@@ -114,7 +114,7 @@
           [component]="component"
           [buttons]="[
     { name: ('Edge.Index.Widgets.EVCS.OptimizedChargeMode.ChargingPriority.car' | translate), value: 'CAR', icon: {color:'success', name: 'oe-evcs'}},
-    { name: ('Edge.Index.Widgets.EVCS.OptimizedChargeMode.ChargingPriority.storage' | translate), value: 'STORAGE', icon: {color:'primary', name: 'oe-storage'}}]">
+    { name: ('Edge.Index.Widgets.EVCS.OptimizedChargeMode.ChargingPriority.storage' | translate), value: 'STORAGE', icon: {color:'success', name: 'oe-storage'}}]">
         </oe-modal-buttons>
 
         <oe-modal-horizontal-line></oe-modal-horizontal-line>

--- a/ui/src/app/shared/service/utils.ts
+++ b/ui/src/app/shared/service/utils.ts
@@ -277,7 +277,7 @@ export class Utils {
    * @returns converted value
    */
   public static CONVERT_TO_KILO_WATTHOURS = (value: any): string => {
-    return formatNumber(value / 1000, 'de', '1.0-1') + ' kWh';
+    return formatNumber(Utils.divideSafely(value, 1000), 'de', '1.0-1') + ' kWh';
   };
 
   /**


### PR DESCRIPTION
### Changes
* Correcting color in storage icon of evcs modal from ```primary``` to ```success```
* Avoiding infinity sign in production history flat widget