### PR TITLE
Modbus SunSpec: split modbus tasks with more than 126 registers

### DIFF
--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/AbstractOpenemsSunSpecComponent.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/AbstractOpenemsSunSpecComponent.java
@@ -362,7 +362,7 @@ public abstract class AbstractOpenemsSunSpecComponent extends AbstractOpenemsMod
 	/**
 	 * Splits the task if it is too long and adds the read tasks.
 	 * 
-	 * @param elements	the Deque of {@link AbstractModbusElement}s for one block.
+	 * @param elements	the Deque of {@link ModbusElement}s for one block.
 	 * @param priority	the reading priority
 	 * @throws OpenemsException on error
 	 */

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/AbstractOpenemsSunSpecComponent.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/sunspec/AbstractOpenemsSunSpecComponent.java
@@ -39,8 +39,11 @@ import io.openems.edge.common.taskmanager.Priority;
  * This class provides a generic implementation of SunSpec ModBus protocols.
  */
 public abstract class AbstractOpenemsSunSpecComponent extends AbstractOpenemsModbusComponent {
-	
-	private static final int MAXIMUM_TASK_LENGTH = 126; 
+
+	/**
+	 * Limit of a task length in j2mod.
+	 */
+	private static final int MAXIMUM_TASK_LENGTH = 126;
 
 	private final Logger log = LoggerFactory.getLogger(AbstractOpenemsSunSpecComponent.class);
 


### PR DESCRIPTION
This PR solves issue #2311. Similar to the Edge2Edge-component, if a modbus task is longer than the limit of j2mod (= 126), it is split. 

Note: When adding a JUnit test to see if it is working (I created a Dummy SunSpec Component which uses all default SunSpec models), I found an error in the `AbstractOpenemsSunSpecComponent`, namely that channels with a constant scale factor (e.g. S305_LAT) are not working. I will treat this in a seperate PR, which will also include my small JUnit test.