### PR TITLE
Generic-Ess: fix debugLog for max charge power

### DIFF
--- a/io.openems.edge.battery.api/src/io/openems/edge/battery/test/DummyBattery.java
+++ b/io.openems.edge.battery.api/src/io/openems/edge/battery/test/DummyBattery.java
@@ -37,6 +37,30 @@ public class DummyBattery extends AbstractOpenemsComponent implements Battery, O
 	}
 
 	/**
+	 * Sets and applies the {@link StartStop.ChannelId#START_STOP}.
+	 *
+	 * @param value the {@link StartStop} state
+	 * @return myself
+	 */
+	public DummyBattery withStartStop(StartStop value) {
+		this._setStartStop(value);
+		this.getStartStopChannel().nextProcessImage();
+		return this;
+	}
+
+	/**
+	 * Sets and applies the {@link Battery.ChannelId#SOC}.
+	 *
+	 * @param value the Soc in [%]
+	 * @return myself
+	 */
+	public DummyBattery withSoc(int value) {
+		this._setSoc(value);
+		this.getSocChannel().nextProcessImage();
+		return this;
+	}
+
+	/**
 	 * Sets and applies the {@link Battery.ChannelId#CAPACITY}.
 	 *
 	 * @param value the Capacity in [Wh]

--- a/io.openems.edge.batteryinverter.api/src/io/openems/edge/batteryinverter/test/DummyManagedSymmetricBatteryInverter.java
+++ b/io.openems.edge.batteryinverter.api/src/io/openems/edge/batteryinverter/test/DummyManagedSymmetricBatteryInverter.java
@@ -60,9 +60,10 @@ public class DummyManagedSymmetricBatteryInverter extends AbstractOpenemsCompone
 	}
 
 	/**
-	 * Sets and applies the {@link Battery.ChannelId#CAPACITY}.
+	 * Sets and applies the
+	 * {@link SymmetricBatteryInverter.ChannelId#MAX_APPARENT_POWER}.
 	 *
-	 * @param value the Capacity in [Wh]
+	 * @param value the MaxApparentPower in [VA]
 	 * @return myself
 	 */
 	public DummyManagedSymmetricBatteryInverter withMaxApparentPower(int value) {

--- a/io.openems.edge.batteryinverter.api/src/io/openems/edge/batteryinverter/test/DummyManagedSymmetricBatteryInverter.java
+++ b/io.openems.edge.batteryinverter.api/src/io/openems/edge/batteryinverter/test/DummyManagedSymmetricBatteryInverter.java
@@ -41,10 +41,34 @@ public class DummyManagedSymmetricBatteryInverter extends AbstractOpenemsCompone
 		this._setStartStop(value);
 	}
 
+	/**
+	 * Sets and applies the {@link StartStop.ChannelId#START_STOP}.
+	 *
+	 * @param value the {@link StartStop} state
+	 * @return myself
+	 */
+	public DummyManagedSymmetricBatteryInverter withStartStop(StartStop value) {
+		this._setStartStop(value);
+		this.getStartStopChannel().nextProcessImage();
+		return this;
+	}
+
 	@Override
 	public void run(Battery battery, int setActivePower, int setReactivePower) throws OpenemsNamedException {
 		this._setActivePower(setActivePower);
 		this._setReactivePower(setReactivePower);
+	}
+
+	/**
+	 * Sets and applies the {@link Battery.ChannelId#CAPACITY}.
+	 *
+	 * @param value the Capacity in [Wh]
+	 * @return myself
+	 */
+	public DummyManagedSymmetricBatteryInverter withMaxApparentPower(int value) {
+		this._setMaxApparentPower(value);
+		this.getMaxApparentPowerChannel().nextProcessImage();
+		return this;
 	}
 
 }

--- a/io.openems.edge.ess.generic/src/io/openems/edge/ess/generic/common/AbstractChannelManager.java
+++ b/io.openems.edge.ess.generic/src/io/openems/edge/ess/generic/common/AbstractChannelManager.java
@@ -9,6 +9,7 @@ import io.openems.edge.common.channel.Channel;
 import io.openems.edge.common.channel.ChannelId;
 import io.openems.edge.common.component.ClockProvider;
 import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.startstop.StartStoppable;
 import io.openems.edge.ess.api.HybridEss;
 import io.openems.edge.ess.api.SymmetricEss;
 
@@ -40,6 +41,7 @@ public class AbstractChannelManager<ESS extends SymmetricEss, BATTERY extends Ba
 			ManagedSymmetricBatteryInverter batteryInverter) {
 		this.addBatteryListener(clockProvider, battery);
 		this.addBatteryInverterListener(batteryInverter);
+		this.addEssListener(clockProvider, battery);
 	}
 
 	private void addBatteryInverterListener(ManagedSymmetricBatteryInverter batteryInverter) {
@@ -107,6 +109,16 @@ public class AbstractChannelManager<ESS extends SymmetricEss, BATTERY extends Ba
 		this.addCopyListener(battery, //
 				Battery.ChannelId.SOC, //
 				SymmetricEss.ChannelId.SOC);
+	}
+
+	private void addEssListener(ClockProvider clockProvider, Battery battery) {
+		/*
+		 * ESS / Parent
+		 */
+		if (this.parent instanceof StartStoppable) {
+			this.addOnChangeListener(this.parent, StartStoppable.ChannelId.START_STOP,
+					(ignored0, ignored1) -> this.allowedChargeDischargeHandler.accept(clockProvider, battery));
+		}
 	}
 
 	/**

--- a/io.openems.edge.ess.generic/src/io/openems/edge/ess/generic/common/AbstractGenericManagedEss.java
+++ b/io.openems.edge.ess.generic/src/io/openems/edge/ess/generic/common/AbstractGenericManagedEss.java
@@ -134,7 +134,7 @@ public abstract class AbstractGenericManagedEss<ESS extends SymmetricEss, BATTER
 		// minimum of MaxAllowedCharge/DischargePower and MaxApparentPower
 		sb //
 				.append("|Allowed:") //
-				.append(TypeUtils.min(//
+				.append(TypeUtils.max(//
 						this.getAllowedChargePower().get(), TypeUtils.multiply(this.getMaxApparentPower().get(), -1)))
 				.append(";") //
 				.append(TypeUtils.min(//


### PR DESCRIPTION
Due to a sign flaw the allowed max charge power was shown wrongly, i.e. if battery says "-56000" and battery-inverter "-92000", it would show "-92000". Fixed and proven with JUnit test

Also: add listener to execute `allowedChargeDischargeHandler` also if ESS StartStop changes.