### PR TITLE
Backend: UIWebsocketImpl does not open WebsocketServer on missed AFTER_IS_INITIALIZED Event

### DIFF
--- a/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/EdgeWebsocketImpl.java
+++ b/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/EdgeWebsocketImpl.java
@@ -108,6 +108,7 @@ public class EdgeWebsocketImpl extends AbstractOpenemsBackendComponent implement
 		}, 10, 10, TimeUnit.SECONDS);
 
 		if (this.metadata.isInitialized()) {
+			// Option A: Metadata is already initialized. We will not get an Metadata.Events.AFTER_IS_INITIALIZED later.
 			this.startServer();
 		}
 	}
@@ -278,6 +279,7 @@ public class EdgeWebsocketImpl extends AbstractOpenemsBackendComponent implement
 	public void handleEvent(Event event) {
 		switch (event.getTopic()) {
 		case Metadata.Events.AFTER_IS_INITIALIZED:
+			// Option B: Metadata initializes too late. We are already activated().
 			this.startServer();
 			break;
 		}

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/UiWebsocketImpl.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/UiWebsocketImpl.java
@@ -89,6 +89,10 @@ public class UiWebsocketImpl extends AbstractOpenemsBackendComponent implements 
 					new JsonPrimitive(this.server != null ? this.server.getConnections().size() : 0));
 			this.timedataManager.write(EDGE_ID, new TimestampedDataNotification(data));
 		}, 10, 10, TimeUnit.SECONDS);
+		if (this.metadata.isInitialized()) {
+			// Option A: Metadata is already initialized. We will not get an Metadata.Events.AFTER_IS_INITIALIZED later.
+			this.startServer(this.config.port(), this.config.poolSize(), this.config.debugMode());
+		}
 	}
 
 	@Deactivate
@@ -224,6 +228,7 @@ public class UiWebsocketImpl extends AbstractOpenemsBackendComponent implements 
 	public void handleEvent(Event event) {
 		switch (event.getTopic()) {
 		case Metadata.Events.AFTER_IS_INITIALIZED:
+			// Option B: Metadata initializes too late. We are already activated().
 			this.startServer(this.config.port(), this.config.poolSize(), this.config.debugMode());
 			break;
 		}


### PR DESCRIPTION
The UI Websocketserver will not call "startServer" on a missed AFTER_IS_INITIALIZED Event, resulting in a 

```
java.lang.NullPointerException: Cannot invoke "io.openems.backend.uiwebsocket.impl.WebsocketServer.getConnections()" because "this.server" is null
```

This happens, when Metadata is initialized, before the WebsocketServer gets configured. (This can happen on restart of the backend too).

Therefore the activate Method in UI Websocket has to check the metadata if it is initialized and start the Server.

This should fix the Isuue #2258 