### PR TITLE
Backend: UI-Websocket: get user.globalRole instead of default guest role on AlertingConfigs

### DIFF
--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/OnRequest.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/OnRequest.java
@@ -425,7 +425,7 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 	/**
 	 * Handles a {@link GetUserAlertingConfigsRequest}.
 	 *
-	 * @param user    {@User} who called the request
+	 * @param user    {@link User} who called the request
 	 * @param request the {@link SetUserAlertingConfigsRequest}
 	 * @return the JSON-RPC Success Response Future
 	 * @throws OpenemsException on error
@@ -435,7 +435,7 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 		var edgeId = request.getEdgeId();
 		List<AlertingSetting> users;
 
-		if (user.getRole(edgeId).orElse(user.getGlobalRole()).isLessThan(Role.ADMIN)) {
+		if (userIsAdmin(user, edgeId)) {
 			users = List.of(this.parent.metadata.getUserAlertingSettings(edgeId, user.getId()));
 		} else {
 			users = this.parent.metadata.getUserAlertingSettings(edgeId);
@@ -448,7 +448,7 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 	/**
 	 * Handles a {@link SetUserAlertingConfigsRequest}.
 	 *
-	 * @param user    {@User} who called the request
+	 * @param user    {@link User} who called the request
 	 * @param request the {@link SetUserAlertingConfigsRequest}
 	 * @return the JSON-RPC Success Response Future
 	 * @throws OpenemsException      on error
@@ -457,14 +457,13 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 	private CompletableFuture<? extends JsonrpcResponseSuccess> handleSetUserAlertingConfigsRequest(User user,
 			SetUserAlertingConfigsRequest request) throws OpenemsException {
 		var edgeId = request.getEdgeId();
-		var role = user.getRole(edgeId).orElse(user.getGlobalRole());
 		var userId = user.getId();
 		var userSettings = request.getUserSettings();
 
 		var containsOtherUsersSettings = userSettings.stream() //
 				.anyMatch(u -> !Objects.equals(u.getUserId(), userId));
 
-		if (containsOtherUsersSettings && role.isLessThan(Role.ADMIN)) {
+		if (containsOtherUsersSettings && userIsAdmin(user, edgeId)) {
 			throw new OpenemsException(
 					"Not allowed to update/set alerting information for other users as user [" + userId + "]");
 		}
@@ -472,6 +471,10 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 		this.parent.metadata.setUserAlertingSettings(user, edgeId, request.getUserSettings());
 
 		return CompletableFuture.completedFuture(new GenericJsonrpcResponseSuccess(request.getId()));
+	}
+
+	private static Boolean userIsAdmin(User user, String edgeId) {
+		return user.getRole(edgeId).map(role -> role.isAtLeast(Role.ADMIN)).orElse(false);
 	}
 
 	/**
@@ -510,5 +513,4 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 		return CompletableFuture //
 				.completedFuture(new GetEdgeResponse(request.getId(), edgeMetadata));
 	}
-
 }

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/OnRequest.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/OnRequest.java
@@ -435,7 +435,7 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 		var edgeId = request.getEdgeId();
 		List<AlertingSetting> users;
 
-		if (user.getRole(edgeId).orElse(Role.GUEST).isLessThan(Role.ADMIN)) {
+		if (user.getRole(edgeId).orElse(user.getGlobalRole()).isLessThan(Role.ADMIN)) {
 			users = List.of(this.parent.metadata.getUserAlertingSettings(edgeId, user.getId()));
 		} else {
 			users = this.parent.metadata.getUserAlertingSettings(edgeId);
@@ -457,7 +457,7 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 	private CompletableFuture<? extends JsonrpcResponseSuccess> handleSetUserAlertingConfigsRequest(User user,
 			SetUserAlertingConfigsRequest request) throws OpenemsException {
 		var edgeId = request.getEdgeId();
-		var role = user.getRole(edgeId).orElse(Role.GUEST);
+		var role = user.getRole(edgeId).orElse(user.getGlobalRole());
 		var userId = user.getId();
 		var userSettings = request.getUserSettings();
 

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/OnRequest.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/OnRequest.java
@@ -473,7 +473,7 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 		return CompletableFuture.completedFuture(new GenericJsonrpcResponseSuccess(request.getId()));
 	}
 
-	private static Boolean userIsAdmin(User user, String edgeId) {
+	private static boolean userIsAdmin(User user, String edgeId) {
 		return user.getRole(edgeId).map(role -> role.isAtLeast(Role.ADMIN)).orElse(false);
 	}
 

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/OnRequest.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/OnRequest.java
@@ -436,9 +436,9 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 		List<AlertingSetting> users;
 
 		if (userIsAdmin(user, edgeId)) {
-			users = List.of(this.parent.metadata.getUserAlertingSettings(edgeId, user.getId()));
-		} else {
 			users = this.parent.metadata.getUserAlertingSettings(edgeId);
+		} else {
+			users = List.of(this.parent.metadata.getUserAlertingSettings(edgeId, user.getId()));
 		}
 
 		return CompletableFuture.completedFuture(//
@@ -463,7 +463,7 @@ public class OnRequest implements io.openems.common.websocket.OnRequest {
 		var containsOtherUsersSettings = userSettings.stream() //
 				.anyMatch(u -> !Objects.equals(u.getUserId(), userId));
 
-		if (containsOtherUsersSettings && userIsAdmin(user, edgeId)) {
+		if (containsOtherUsersSettings && !userIsAdmin(user, edgeId)) {
 			throw new OpenemsException(
 					"Not allowed to update/set alerting information for other users as user [" + userId + "]");
 		}


### PR DESCRIPTION
This commit is one of many prepare PRs / commits for a bigger PR: SumStateAlert #2260
By separating the big #2260 into smaller commits we would like to make the review easier.

Co-authored-by: Kai Jeschek [99220919+da-Kai@users.noreply.github.com](mailto:99220919+da-Kai@users.noreply.github.com)