### PR TITLE
Backend: Common + Metadata: Added additional AlertingSettings and Metadata methods

### DIFF
--- a/io.openems.backend.common/src/io/openems/backend/common/alerting/OfflineEdgeAlertingSetting.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/alerting/OfflineEdgeAlertingSetting.java
@@ -1,0 +1,7 @@
+package io.openems.backend.common.alerting;
+
+import java.time.ZonedDateTime;
+
+public record OfflineEdgeAlertingSetting(String edgeId, String userLogin, int delay, ZonedDateTime lastNotification) {
+
+}

--- a/io.openems.backend.common/src/io/openems/backend/common/alerting/SumStateAlertingSetting.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/alerting/SumStateAlertingSetting.java
@@ -1,0 +1,25 @@
+package io.openems.backend.common.alerting;
+
+import java.time.ZonedDateTime;
+
+import io.openems.common.channel.Level;
+
+public record SumStateAlertingSetting(String edgeId, String userLogin, int faultDelay, int warningDelay,
+		ZonedDateTime lastNotification) {
+	/**
+	 * Get the appropriate delay for the given SumState level .
+	 * 
+	 * @param state to get delay for
+	 * @return delay as int
+	 */
+	public int getDelay(Level state) {
+		return switch (state) {
+		case FAULT:
+			yield this.faultDelay;
+		case WARNING:
+			yield this.warningDelay;
+		default:
+			yield -1;
+		};
+	}
+}

--- a/io.openems.backend.common/src/io/openems/backend/common/alerting/UserAlertingSettings.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/alerting/UserAlertingSettings.java
@@ -1,0 +1,13 @@
+package io.openems.backend.common.alerting;
+
+import java.time.ZonedDateTime;
+
+import io.openems.common.session.Role;
+
+public record UserAlertingSettings(String deviceId, String userLogin, Role userRole, //
+		int edgeOfflineDelay, int edgeFaultDelay, int edgeWarningDelay, //
+		ZonedDateTime lastEdgeOfflineNotification, ZonedDateTime lastSumStateNotification) {
+	public UserAlertingSettings(String userLogin, int offlineEdgeDelay, int faultStateDelay, int warningStateDelay) {
+		this(null, userLogin, null, offlineEdgeDelay, faultStateDelay, warningStateDelay, null, null);
+	}
+}

--- a/io.openems.backend.common/src/io/openems/backend/common/alerting/package-info.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/alerting/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package io.openems.backend.common.alerting;

--- a/io.openems.backend.common/src/io/openems/backend/common/metadata/Metadata.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/metadata/Metadata.java
@@ -8,6 +8,8 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import io.openems.backend.common.alerting.OfflineEdgeAlertingSetting;
+import io.openems.backend.common.alerting.SumStateAlertingSetting;
 import org.osgi.annotation.versioning.ProviderType;
 import org.osgi.service.event.EventAdmin;
 
@@ -321,6 +323,25 @@ public interface Metadata {
 	public void setUserAlertingSettings(User user, String edgeId, List<AlertingSetting> users) throws OpenemsException;
 
 	/**
+	 * Gets all the offline-edge-alerting settings for given edge id.
+	 *
+	 * @param edgeId the Edge ID
+	 * @return List of {@link OfflineEdgeAlertingSetting}
+	 * @throws OpenemsException on error
+	 */
+	public List<OfflineEdgeAlertingSetting> getEdgeOfflineAlertingSettings(String edgeId) throws OpenemsException;
+
+	/**
+	 * Gets all the sumState-alerting settings for given edge id.
+	 *
+	 * @param edgeId the Edge ID
+	 * @return List of {@link SumStateAlertingSetting}
+	 * @throws OpenemsException on error
+	 */
+	public List<SumStateAlertingSetting> getSumStateAlertingSettings(String edgeId) throws OpenemsException;
+
+
+	/**
 	 * Returns an EventAdmin, used by Edge objects.
 	 *
 	 * @return {@link EventAdmin}
@@ -364,5 +385,13 @@ public interface Metadata {
 	 * @throws OpenemsNamedException on error
 	 */
 	public EdgeMetadata getEdgeMetadataForUser(User user, String edgeId) throws OpenemsNamedException;
+
+	/**
+	 * Get the SumState of the edge with the given edgeId.
+	 *
+	 * @param edgeId to search for
+	 * @return sumState as {@link Optional} of {@link Level}
+	 */
+	public Optional<Level> getSumState(String edgeId);
 
 }

--- a/io.openems.backend.common/src/io/openems/backend/common/test/DummyMetadata.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/test/DummyMetadata.java
@@ -9,12 +9,15 @@ import org.osgi.service.event.EventAdmin;
 
 import com.google.gson.JsonObject;
 
+import io.openems.backend.common.alerting.OfflineEdgeAlertingSetting;
+import io.openems.backend.common.alerting.SumStateAlertingSetting;
 import io.openems.backend.common.metadata.AlertingSetting;
 import io.openems.backend.common.metadata.Edge;
 import io.openems.backend.common.metadata.EdgeHandler;
 import io.openems.backend.common.metadata.Metadata;
 import io.openems.backend.common.metadata.User;
 import io.openems.common.OpenemsOEM;
+import io.openems.common.channel.Level;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.jsonrpc.request.GetEdgesRequest.PaginationOptions;
@@ -49,6 +52,16 @@ public class DummyMetadata implements Metadata {
 
 	@Override
 	public void setUserAlertingSettings(User user, String edgeId, List<AlertingSetting> users) {
+		throw new UnsupportedOperationException("Unsupported by Dummy Class");
+	}
+
+	@Override
+	public List<OfflineEdgeAlertingSetting> getEdgeOfflineAlertingSettings(String edgeId) throws OpenemsException {
+		throw new UnsupportedOperationException("Unsupported by Dummy Class");
+	}
+
+	@Override
+	public List<SumStateAlertingSetting> getSumStateAlertingSettings(String edgeId) throws OpenemsException {
 		throw new UnsupportedOperationException("Unsupported by Dummy Class");
 	}
 
@@ -145,6 +158,11 @@ public class DummyMetadata implements Metadata {
 
 	@Override
 	public EdgeMetadata getEdgeMetadataForUser(User user, String edgeId) throws OpenemsNamedException {
+		throw new UnsupportedOperationException("Unsupported by Dummy Class");
+	}
+
+	@Override
+	public Optional<Level> getSumState(String edgeId) {
 		throw new UnsupportedOperationException("Unsupported by Dummy Class");
 	}
 

--- a/io.openems.backend.metadata.dummy/src/io/openems/backend/metadata/dummy/MetadataDummy.java
+++ b/io.openems.backend.metadata.dummy/src/io/openems/backend/metadata/dummy/MetadataDummy.java
@@ -28,6 +28,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.JsonObject;
 
+import io.openems.backend.common.alerting.OfflineEdgeAlertingSetting;
+import io.openems.backend.common.alerting.SumStateAlertingSetting;
 import io.openems.backend.common.metadata.AbstractMetadata;
 import io.openems.backend.common.metadata.AlertingSetting;
 import io.openems.backend.common.metadata.Edge;
@@ -286,6 +288,16 @@ public class MetadataDummy extends AbstractMetadata implements Metadata, EventHa
 	}
 
 	@Override
+	public List<OfflineEdgeAlertingSetting> getEdgeOfflineAlertingSettings(String edgeId) throws OpenemsException {
+		throw new UnsupportedOperationException("DummyMetadata.getEdgeOfflineAlertingSettings() is not implemented");
+	}
+
+	@Override
+	public List<SumStateAlertingSetting> getSumStateAlertingSettings(String edgeId) throws OpenemsException {
+		throw new UnsupportedOperationException("DummyMetadata.getSumStateAlertingSettings() is not implemented");
+	}
+
+	@Override
 	public List<EdgeMetadata> getPageDevice(User user, PaginationOptions paginationOptions)
 			throws OpenemsNamedException {
 		var pagesStream = this.edges.values().stream();
@@ -346,6 +358,11 @@ public class MetadataDummy extends AbstractMetadata implements Metadata, EventHa
 				null, //
 				Level.OK //
 		);
+	}
+
+	@Override
+	public Optional<Level> getSumState(String edgeId) {
+		throw new UnsupportedOperationException("DummyMetadata.getSumState() is not implemented");
 	}
 
 }

--- a/io.openems.backend.metadata.file/src/io/openems/backend/metadata/file/MetadataFile.java
+++ b/io.openems.backend.metadata.file/src/io/openems/backend/metadata/file/MetadataFile.java
@@ -30,6 +30,8 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import io.openems.backend.common.alerting.OfflineEdgeAlertingSetting;
+import io.openems.backend.common.alerting.SumStateAlertingSetting;
 import io.openems.backend.common.metadata.AbstractMetadata;
 import io.openems.backend.common.metadata.AlertingSetting;
 import io.openems.backend.common.metadata.Edge;
@@ -303,13 +305,23 @@ public class MetadataFile extends AbstractMetadata implements Metadata, EventHan
 	}
 
 	@Override
+	public AlertingSetting getUserAlertingSettings(String edgeId, String userId) throws OpenemsException {
+		throw new UnsupportedOperationException("FileMetadata.getUserAlertingSettings() is not implemented");
+	}
+
+	@Override
 	public List<AlertingSetting> getUserAlertingSettings(String edgeId) {
 		throw new UnsupportedOperationException("FileMetadata.getUserAlertingSettings() is not implemented");
 	}
 
 	@Override
-	public AlertingSetting getUserAlertingSettings(String edgeId, String userId) throws OpenemsException {
-		throw new UnsupportedOperationException("FileMetadata.getUserAlertingSettings() is not implemented");
+	public List<OfflineEdgeAlertingSetting> getEdgeOfflineAlertingSettings(String edgeId) throws OpenemsException {
+		throw new UnsupportedOperationException("FileMetadata.getEdgeOfflineAlertingSettings() is not implemented");
+	}
+
+	@Override
+	public List<SumStateAlertingSetting> getSumStateAlertingSettings(String edgeId) throws OpenemsException {
+		throw new UnsupportedOperationException("FileMetadata.getSumStateAlertingSettings() is not implemented");
 	}
 
 	@Override
@@ -377,6 +389,11 @@ public class MetadataFile extends AbstractMetadata implements Metadata, EventHan
 				null, //
 				Level.OK //
 		);
+	}
+
+	@Override
+	public Optional<Level> getSumState(String edgeId) {
+		throw new UnsupportedOperationException("FileMetadata.getSumState() is not implemented");
 	}
 
 }

--- a/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/MetadataOdoo.java
+++ b/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/MetadataOdoo.java
@@ -34,6 +34,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import io.openems.backend.common.alerting.OfflineEdgeAlertingSetting;
+import io.openems.backend.common.alerting.SumStateAlertingSetting;
 import io.openems.backend.common.metadata.AbstractMetadata;
 import io.openems.backend.common.metadata.AlertingSetting;
 import io.openems.backend.common.metadata.AppCenterMetadata;
@@ -500,6 +502,16 @@ public class MetadataOdoo extends AbstractMetadata implements AppCenterMetadata,
 	}
 
 	@Override
+	public List<OfflineEdgeAlertingSetting> getEdgeOfflineAlertingSettings(String edgeId) throws OpenemsException {
+		throw new UnsupportedOperationException("MetadataOdoo.getEdgeOfflineAlertingSettings() is not implemented");
+	}
+
+	@Override
+	public List<SumStateAlertingSetting> getSumStateAlertingSettings(String edgeId) throws OpenemsException {
+		throw new UnsupportedOperationException("MetadataOdoo.getSumStateAlertingSettings() is not implemented");
+	}
+
+	@Override
 	public List<EdgeMetadata> getPageDevice(//
 			final User user, //
 			final PaginationOptions paginationOptions //
@@ -516,6 +528,16 @@ public class MetadataOdoo extends AbstractMetadata implements AppCenterMetadata,
 	@Override
 	public EdgeMetadata getEdgeMetadataForUser(User user, String edgeId) throws OpenemsNamedException {
 		return this.convertToEdgeMetadata(user, this.odooHandler.getEdgeWithRole(user, edgeId));
+	}
+
+	@Override
+	public Optional<Level> getSumState(String edgeId) {
+		try {
+			return Optional.of(this.odooHandler.getSumState(edgeId));
+		} catch (Exception e) {
+			this.log.warn(e.getMessage());
+			return Optional.empty();
+		}
 	}
 
 	private EdgeMetadata convertToEdgeMetadata(User user, JsonElement jDevice) throws OpenemsNamedException {

--- a/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/odoo/OdooHandler.java
+++ b/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/odoo/OdooHandler.java
@@ -36,6 +36,7 @@ import io.openems.backend.metadata.odoo.MyUser;
 import io.openems.backend.metadata.odoo.odoo.Domain.Operator;
 import io.openems.backend.metadata.odoo.odoo.OdooUtils.SuccessResponseAndHeaders;
 import io.openems.common.OpenemsOEM;
+import io.openems.common.channel.Level;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.jsonrpc.request.GetEdgesRequest.PaginationOptions;
@@ -1273,6 +1274,16 @@ public class OdooHandler {
 		return JsonUtils.getAsJsonObject(
 				OdooUtils.sendJsonrpcRequest(this.credentials.getUrl() + "/openems_backend/get_edge_with_role",
 						"session_id=" + user.getToken(), request).result);
+	}
+
+	/**
+	 * Get the SumState of the edge with the given edgeId, via a ODOO-Request.
+	 *
+	 * @param edgeId to search for
+	 * @return sumState as {@link Level}
+	 */
+	public Level getSumState(String edgeId) throws OpenemsException {
+		throw new UnsupportedOperationException("OdooHandler.getSumState() is not implemented");
 	}
 
 }


### PR DESCRIPTION
This introduces more AlertingSettings, that will be used in the SumStateAlert  #2260.
Therefore the methods also introduced in #2260 are added here, but do not provide the functionality yet.

This commit is one of many prepare PRs / commits for a bigger PR: SumStateAlert #2260
By separating the big #2260 into smaller commits we would like to make the review easier.

Co-authored-by: Kai Jeschek [99220919+da-Kai@users.noreply.github.com](mailto:99220919+da-Kai@users.noreply.github.com)