### PR TITLE
UI: evcscontroller -> automatic mode -> uses sunny-icon again

### DIFF
--- a/ui/src/app/edge/live/Controller/Evcs/modal/modal.html
+++ b/ui/src/app/edge/live/Controller/Evcs/modal/modal.html
@@ -51,7 +51,7 @@
     <oe-modal-buttons *ngIf="formGroup.controls['chargeMode'].value" [formGroup]="formGroup" controlName="chargeMode"
       [component]="component" [buttons]="[
     { name: ('General.on' | translate), value: 'FORCE_CHARGE', icon: {color:'success', name: 'power-outline'}},
-    { name: ('General.automatic' | translate), value: 'EXCESS_POWER', icon: {color:'primary', name: 'power-outline'}},
+    { name: ('General.automatic' | translate), value: 'EXCESS_POWER', icon: {color:'primary', name: 'sunny-outline'}},
     { name: ('General.off' | translate), value: 'OFF', icon: {color:'primary', name: 'power-outline'}}]">
     </oe-modal-buttons>
 


### PR DESCRIPTION
In the past automatic mode used the sunny-outline icon.
This is missing here (idk if it was intentional).