### PR TITLE
fix: use tailing comma to always-multiline

### DIFF
--- a/ui/.eslintrc.json
+++ b/ui/.eslintrc.json
@@ -59,7 +59,7 @@
         "curly": "error",
         "comma-dangle": [
           "error",
-          "never"
+          "always-multiline"
         ],
         "eol-last": [
           "error",

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -68,13 +68,13 @@ const routes: Routes = [
       {
         path: 'live', data: { navbarTitle: environment.uiTitle }, providers: [{
           useClass: LiveDataService,
-          provide: DataService
-        }], component: EdgeLiveComponent
+          provide: DataService,
+        }], component: EdgeLiveComponent,
       },
       {
         path: 'history', providers: [{
           useClass: HistoryDataService,
-          provide: DataService
+          provide: DataService,
         }], component: HistoryParentComponent, children: [
           { path: '', component: EdgeHistoryComponent },
           // History Chart Pages
@@ -94,8 +94,8 @@ const routes: Routes = [
           { path: 'gridchart', component: GridChartOverviewComponent },
           { path: 'productionchart', component: ProductionChartOverviewComponent },
           { path: 'selfconsumptionchart', component: SelfconsumptionChartOverviewComponent },
-          { path: 'storagechart', component: StorageChartOverviewComponent }
-        ]
+          { path: 'storagechart', component: StorageChartOverviewComponent },
+        ],
       },
 
       { path: 'settings', data: { navbarTitleToBeTranslated: 'Menu.edgeSettings' }, component: EdgeSettingsComponent },
@@ -114,21 +114,21 @@ const routes: Routes = [
       { path: 'settings/app/install/:appId', component: EdgeSettingsAppInstall },
       { path: 'settings/app/update/:appId', component: EdgeSettingsAppUpdate },
       { path: 'settings/app/single/:appId', component: EdgeSettingsAppSingle },
-      { path: 'settings/alerting', component: EdgeSettingsAlerting }
-    ]
+      { path: 'settings/alerting', component: EdgeSettingsAlerting },
+    ],
   },
 
   { path: 'demo', component: LoginComponent },
   // Fallback
-  { path: '**', pathMatch: 'full', redirectTo: 'login' }
+  { path: '**', pathMatch: 'full', redirectTo: 'login' },
 ];
 
 export const appRoutingProviders: any[] = [];
 
 @NgModule({
   imports: [
-    RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules })
+    RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules }),
   ],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
 export class AppRoutingModule { }

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -13,7 +13,7 @@ import { Language } from './shared/type/language';
 
 @Component({
   selector: 'app-root',
-  templateUrl: 'app.component.html'
+  templateUrl: 'app.component.html',
 })
 export class AppComponent implements OnInit, OnDestroy {
 
@@ -35,7 +35,7 @@ export class AppComponent implements OnInit, OnDestroy {
     public websocket: Websocket,
     private globalRouteChangeHandler: GlobalRouteChangeHandler,
     private titleService: Title,
-    private meta: Meta
+    private meta: Meta,
   ) {
     service.setLang(Language.getByKey(localStorage.LANGUAGE) ?? Language.getByBrowserLang(navigator.language));
 
@@ -60,9 +60,9 @@ export class AppComponent implements OnInit, OnDestroy {
         buttons: [
           {
             text: 'Ok',
-            role: 'cancel'
-          }
-        ]
+            role: 'cancel',
+          },
+        ],
       });
       toast.present();
     });
@@ -72,7 +72,7 @@ export class AppComponent implements OnInit, OnDestroy {
       // OEM colors exist only after ionic is initialized, so the notch color has to be set here
       const notchColor = getComputedStyle(document.documentElement).getPropertyValue('--ion-color-background');
       this.meta.updateTag(
-        { name: 'theme-color', content: notchColor }
+        { name: 'theme-color', content: notchColor },
       );
       this.service.deviceHeight = this.platform.height();
       this.service.deviceWidth = this.platform.width();

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -36,11 +36,11 @@ import { UserModule } from './user/user.module';
     ChartOptionsPopoverComponent,
     PickDatePopoverComponent,
     StatusSingleComponent,
-    SystemLogComponent
+    SystemLogComponent,
   ],
   entryComponents: [
     ChartOptionsPopoverComponent,
-    PickDatePopoverComponent
+    PickDatePopoverComponent,
   ],
   imports: [
     AngularMyDatePickerModule,
@@ -56,7 +56,7 @@ import { UserModule } from './user/user.module';
     SharedModule,
     TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: MyTranslateLoader } }),
     UserModule,
-    RegistrationModule
+    RegistrationModule,
   ],
   providers: [
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
@@ -66,9 +66,9 @@ import { UserModule } from './user/user.module';
     // Use factory for formly. This allows us to use translations in validationMessages.
     { provide: FORMLY_CONFIG, multi: true, useFactory: registerTranslateExtension, deps: [TranslateService] },
     Pagination,
-    CheckForUpdateService
+    CheckForUpdateService,
   ],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
 export class AppModule {
   constructor() {

--- a/ui/src/app/appupdateservice.ts
+++ b/ui/src/app/appupdateservice.ts
@@ -4,12 +4,12 @@ import { SwUpdate } from "@angular/service-worker";
 import { Service } from "./shared/shared";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class CheckForUpdateService {
 
   constructor(private update: SwUpdate,
-    private service: Service
+    private service: Service,
   ) { }
 
   init() {

--- a/ui/src/app/changelog/changelog.module.ts
+++ b/ui/src/app/changelog/changelog.module.ts
@@ -5,15 +5,15 @@ import { ChangelogViewComponent } from './view/view';
 
 @NgModule({
   imports: [
-    SharedModule
+    SharedModule,
   ],
   declarations: [
     ChangelogComponent,
-    ChangelogViewComponent
+    ChangelogViewComponent,
   ],
   exports: [
     ChangelogComponent,
-    ChangelogViewComponent
-  ]
+    ChangelogViewComponent,
+  ],
 })
 export class ChangelogModule { }

--- a/ui/src/app/changelog/view/component/changelog.component.ts
+++ b/ui/src/app/changelog/view/component/changelog.component.ts
@@ -8,7 +8,7 @@ import { Changelog } from './changelog.constants';
 
 @Component({
   selector: 'changelog',
-  templateUrl: './changelog.component.html'
+  templateUrl: './changelog.component.html',
 })
 export class ChangelogComponent implements OnInit {
 
@@ -19,7 +19,7 @@ export class ChangelogComponent implements OnInit {
   constructor(
     public translate: TranslateService,
     public service: Service,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) { }
 
   ngOnInit() {
@@ -39,9 +39,9 @@ export class ChangelogComponent implements OnInit {
       {
         version: 'x.y.z',
         changes: [
-          Changelog.link("OpenEMS Releases", 'https://github.com/OpenEMS/openems/releases')
-        ]
-      }
+          Changelog.link("OpenEMS Releases", 'https://github.com/OpenEMS/openems/releases'),
+        ],
+      },
     ];
 
 }

--- a/ui/src/app/changelog/view/view.ts
+++ b/ui/src/app/changelog/view/view.ts
@@ -2,6 +2,6 @@ import { Component } from "@angular/core";
 
 @Component({
   selector: 'changelogViewComponent',
-  templateUrl: './view.html'
+  templateUrl: './view.html',
 })
 export class ChangelogViewComponent { }

--- a/ui/src/app/edge/edge.component.ts
+++ b/ui/src/app/edge/edge.component.ts
@@ -9,7 +9,7 @@ import { ChannelAddress, Edge, Service, Websocket } from "src/app/shared/shared"
     template: `
     <ion-content></ion-content>
          <ion-router-outlet id="content"></ion-router-outlet>
-    `
+    `,
 })
 export class EdgeComponent implements OnInit, OnDestroy {
 
@@ -19,7 +19,7 @@ export class EdgeComponent implements OnInit, OnDestroy {
         private router: Router,
         private activatedRoute: ActivatedRoute,
         private service: Service,
-        private websocket: Websocket
+        private websocket: Websocket,
     ) { }
 
     public ngOnInit(): void {
@@ -34,7 +34,7 @@ export class EdgeComponent implements OnInit, OnDestroy {
 
                         // Subscribe on these channels for the state in HeaderComponent
                         edge.subscribeChannels(this.websocket, '', [
-                            new ChannelAddress('_sum', 'State')
+                            new ChannelAddress('_sum', 'State'),
                         ]);
                     });
             }).catch(() => {

--- a/ui/src/app/edge/edge.module.ts
+++ b/ui/src/app/edge/edge.module.ts
@@ -6,15 +6,15 @@ import { EdgeComponent } from './edge.component';
 
 @NgModule({
   declarations: [
-    EdgeComponent
+    EdgeComponent,
   ],
   imports: [
     HistoryModule,
     LiveModule,
-    SharedModule
+    SharedModule,
   ],
   exports: [
-    EdgeComponent
-  ]
+    EdgeComponent,
+  ],
 })
 export class EdgeModule { }

--- a/ui/src/app/edge/history/abstracthistorychart.ts
+++ b/ui/src/app/edge/history/abstracthistorychart.ts
@@ -38,21 +38,21 @@ export abstract class AbstractHistoryChart {
     // Colors for Phase 1-3
     protected phase1Color = {
         backgroundColor: 'rgba(255,127,80,0.05)',
-        borderColor: 'rgba(255,127,80,1)'
+        borderColor: 'rgba(255,127,80,1)',
     };
     protected phase2Color = {
         backgroundColor: 'rgba(0,0,255,0.1)',
-        borderColor: 'rgba(0,0,255,1)'
+        borderColor: 'rgba(0,0,255,1)',
     };
     protected phase3Color = {
         backgroundColor: 'rgba(128,128,0,0.1)',
-        borderColor: 'rgba(128,128,0,1)'
+        borderColor: 'rgba(128,128,0,1)',
     };
 
     constructor(
         public readonly spinnerId: string,
         protected service: Service,
-        protected translate: TranslateService
+        protected translate: TranslateService,
     ) {
     }
 
@@ -92,7 +92,7 @@ export abstract class AbstractHistoryChart {
                         }).catch(error => {
                             this.errorResponse = error;
                             resolve(new QueryHistoricTimeseriesDataResponse(error.id, {
-                                timestamps: [null], data: { null: null }
+                                timestamps: [null], data: { null: null },
                             }));
                         });
                     });
@@ -129,12 +129,12 @@ export abstract class AbstractHistoryChart {
                 this.service.getConfig().then(config => {
                     edge.sendRequest(this.service.websocket, new QueryHistoricTimeseriesEnergyPerPeriodRequest(DateUtils.maxDate(fromDate, this.edge?.firstSetupProtocol), toDate, channelAddresses, resolution)).then(response => {
                         resolve(response as QueryHistoricTimeseriesEnergyPerPeriodResponse ?? new QueryHistoricTimeseriesEnergyPerPeriodResponse(response.id, {
-                            timestamps: [null], data: { null: null }
+                            timestamps: [null], data: { null: null },
                         }));
                     }).catch((response) => {
                         this.errorResponse = response;
                         resolve(new QueryHistoricTimeseriesDataResponse("0", {
-                            timestamps: [null], data: { null: null }
+                            timestamps: [null], data: { null: null },
                         }));
                     });
                 });

--- a/ui/src/app/edge/history/abstracthistorywidget.ts
+++ b/ui/src/app/edge/history/abstracthistorywidget.ts
@@ -14,7 +14,7 @@ export abstract class AbstractHistoryWidget {
     // private ngUnsubscribe: Subject<void> = new Subject<void>();
 
     constructor(
-        protected service: Service
+        protected service: Service,
     ) { }
 
     /**

--- a/ui/src/app/edge/history/channelthreshold/channelthresholdchartoverview/channelthresholdchartoverview.component.ts
+++ b/ui/src/app/edge/history/channelthreshold/channelthresholdchartoverview/channelthresholdchartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service, Utils } from '../../../../shared/shared';
 
 @Component({
     selector: ChannelthresholdChartOverviewComponent.SELECTOR,
-    templateUrl: './channelthresholdchartoverview.component.html'
+    templateUrl: './channelthresholdchartoverview.component.html',
 })
 export class ChannelthresholdChartOverviewComponent implements OnInit {
 
@@ -23,7 +23,7 @@ export class ChannelthresholdChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/channelthreshold/singlechart.component.ts
+++ b/ui/src/app/edge/history/channelthreshold/singlechart.component.ts
@@ -11,7 +11,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
   selector: 'channelthresholdSingleChart',
-  templateUrl: '../abstracthistorychart.html'
+  templateUrl: '../abstracthistorychart.html',
 })
 export class ChannelthresholdSingleChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -25,7 +25,7 @@ export class ChannelthresholdSingleChartComponent extends AbstractHistoryChart i
   constructor(
     protected override service: Service,
     protected override translate: TranslateService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) {
     super("channelthreshold-single-chart", service, translate);
   }
@@ -66,11 +66,11 @@ export class ChannelthresholdSingleChartComponent extends AbstractHistoryChart i
         });
         datasets.push({
           label: address.channelId,
-          data: data
+          data: data,
         });
         this.colors.push({
           backgroundColor: 'rgba(0,191,255,0.05)',
-          borderColor: 'rgba(0,191,255,1)'
+          borderColor: 'rgba(0,191,255,1)',
         });
       }
       this.datasets = datasets;

--- a/ui/src/app/edge/history/channelthreshold/totalchart.component.ts
+++ b/ui/src/app/edge/history/channelthreshold/totalchart.component.ts
@@ -11,7 +11,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
   selector: 'channelthresholdTotalChart',
-  templateUrl: '../abstracthistorychart.html'
+  templateUrl: '../abstracthistorychart.html',
 })
 export class ChannelthresholdTotalChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class ChannelthresholdTotalChartComponent extends AbstractHistoryChart im
   constructor(
     protected override service: Service,
     protected override translate: TranslateService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) {
     super("channelthreshold-total-chart", service, translate);
   }
@@ -69,21 +69,21 @@ export class ChannelthresholdTotalChartComponent extends AbstractHistoryChart im
           case 0:
             datasets.push({
               label: address.channelId,
-              data: data
+              data: data,
             });
             this.colors.push({
               backgroundColor: 'rgba(0,191,255,0.05)',
-              borderColor: 'rgba(0,191,255,1)'
+              borderColor: 'rgba(0,191,255,1)',
             });
             break;
           case 1:
             datasets.push({
               label: address.channelId,
-              data: data
+              data: data,
             });
             this.colors.push({
               backgroundColor: 'rgba(0,0,139,0.05)',
-              borderColor: 'rgba(0,0,139,1)'
+              borderColor: 'rgba(0,0,139,1)',
             });
             break;
         }

--- a/ui/src/app/edge/history/channelthreshold/widget.component.ts
+++ b/ui/src/app/edge/history/channelthreshold/widget.component.ts
@@ -9,7 +9,7 @@ import { calculateActiveTimeOverPeriod } from '../shared';
 
 @Component({
     selector: ChannelthresholdWidgetComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class ChannelthresholdWidgetComponent extends AbstractHistoryWidget implements OnInit, OnChanges, OnDestroy {
 
@@ -25,7 +25,7 @@ export class ChannelthresholdWidgetComponent extends AbstractHistoryWidget imple
 
     constructor(
         public override service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super(service);
     }

--- a/ui/src/app/edge/history/chpsoc/chart.component.ts
+++ b/ui/src/app/edge/history/chpsoc/chart.component.ts
@@ -10,7 +10,7 @@ import { Data, TooltipItem } from './../shared';
 
 @Component({
     selector: 'chpsocchart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class ChpSocChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class ChpSocChartComponent extends AbstractHistoryChart implements OnInit
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("chpsoc-chart", service, translate);
     }
@@ -74,11 +74,11 @@ export class ChpSocChartComponent extends AbstractHistoryChart implements OnInit
                             });
                             datasets.push({
                                 label: address.channelId,
-                                data: data
+                                data: data,
                             });
                             this.colors.push({
                                 backgroundColor: 'rgba(0,191,255,0.05)',
-                                borderColor: 'rgba(0,191,255,1)'
+                                borderColor: 'rgba(0,191,255,1)',
                             });
                         } else {
                             let data = result.data[channel].map(value => {
@@ -93,33 +93,33 @@ export class ChpSocChartComponent extends AbstractHistoryChart implements OnInit
                             if (channel == inputChannel) {
                                 datasets.push({
                                     label: this.translate.instant('General.soc'),
-                                    data: data
+                                    data: data,
                                 });
                                 this.colors.push({
                                     backgroundColor: 'rgba(0,0,0,0)',
-                                    borderColor: 'rgba(0,223,0,1)'
+                                    borderColor: 'rgba(0,223,0,1)',
                                 });
                             }
                             if (channel == lowThreshold) {
                                 datasets.push({
                                     label: this.translate.instant('Edge.Index.Widgets.CHP.lowThreshold'),
                                     data: data,
-                                    borderDash: [3, 3]
+                                    borderDash: [3, 3],
                                 });
                                 this.colors.push({
                                     backgroundColor: 'rgba(0,0,0,0)',
-                                    borderColor: 'rgba(0,191,255,1)'
+                                    borderColor: 'rgba(0,191,255,1)',
                                 });
                             }
                             if (channel == highThreshold) {
                                 datasets.push({
                                     label: this.translate.instant('Edge.Index.Widgets.CHP.highThreshold'),
                                     data: data,
-                                    borderDash: [3, 3]
+                                    borderDash: [3, 3],
                                 });
                                 this.colors.push({
                                     backgroundColor: 'rgba(0,0,0,0)',
-                                    borderColor: 'rgba(0,191,255,1)'
+                                    borderColor: 'rgba(0,191,255,1)',
                                 });
                             }
                         }
@@ -152,7 +152,7 @@ export class ChpSocChartComponent extends AbstractHistoryChart implements OnInit
                 outputChannel,
                 inputChannel,
                 new ChannelAddress(this.componentId, '_PropertyHighThreshold'),
-                new ChannelAddress(this.componentId, '_PropertyLowThreshold')
+                new ChannelAddress(this.componentId, '_PropertyLowThreshold'),
             ];
             resolve(result);
         });

--- a/ui/src/app/edge/history/chpsoc/chpsocchartoverview/chpsocchartoverview.component.ts
+++ b/ui/src/app/edge/history/chpsoc/chpsocchartoverview/chpsocchartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
 
 @Component({
     selector: ChpSocChartOverviewComponent.SELECTOR,
-    templateUrl: './chpsocchartoverview.component.html'
+    templateUrl: './chpsocchartoverview.component.html',
 })
 export class ChpSocChartOverviewComponent implements OnInit {
 
@@ -17,7 +17,7 @@ export class ChpSocChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/chpsoc/widget.component.ts
+++ b/ui/src/app/edge/history/chpsoc/widget.component.ts
@@ -9,7 +9,7 @@ import { calculateActiveTimeOverPeriod } from '../shared';
 
 @Component({
     selector: ChpSocWidgetComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class ChpSocWidgetComponent extends AbstractHistoryWidget implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class ChpSocWidgetComponent extends AbstractHistoryWidget implements OnIn
 
     constructor(
         public override service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super(service);
     }

--- a/ui/src/app/edge/history/common/autarchy/Autarchy.ts
+++ b/ui/src/app/edge/history/common/autarchy/Autarchy.ts
@@ -8,20 +8,20 @@ import { OverviewComponent } from './overview/overview';
 @NgModule({
   imports: [
     BrowserModule,
-    SharedModule
+    SharedModule,
   ],
   entryComponents: [
-    FlatComponent
+    FlatComponent,
   ],
   declarations: [
     FlatComponent,
     ChartComponent,
-    OverviewComponent
+    OverviewComponent,
   ],
   exports: [
     FlatComponent,
     ChartComponent,
-    OverviewComponent
-  ]
+    OverviewComponent,
+  ],
 })
 export class Common_Autarchy { }

--- a/ui/src/app/edge/history/common/autarchy/chart/chart.ts
+++ b/ui/src/app/edge/history/common/autarchy/chart/chart.ts
@@ -6,7 +6,7 @@ import { ChannelAddress, Utils } from 'src/app/shared/shared';
 
 @Component({
   selector: 'autarchychart',
-  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html'
+  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html',
 })
 export class ChartComponent extends AbstractHistoryChart {
 
@@ -17,13 +17,13 @@ export class ChartComponent extends AbstractHistoryChart {
         [{
           name: 'Consumption',
           powerChannel: ChannelAddress.fromString('_sum/ConsumptionActivePower'),
-          energyChannel: ChannelAddress.fromString('_sum/ConsumptionActiveEnergy')
+          energyChannel: ChannelAddress.fromString('_sum/ConsumptionActiveEnergy'),
         },
         {
           name: 'GridBuy',
           powerChannel: ChannelAddress.fromString('_sum/GridActivePower'),
           energyChannel: ChannelAddress.fromString('_sum/GridBuyActiveEnergy'),
-          converter: HistoryUtils.ValueConverter.NON_NULL_OR_NEGATIVE
+          converter: HistoryUtils.ValueConverter.NON_NULL_OR_NEGATIVE,
         }],
       output: (data: HistoryUtils.ChannelData) => {
         return [{
@@ -34,20 +34,20 @@ export class ChartComponent extends AbstractHistoryChart {
           converter: () => {
             return data['Consumption']
               ?.map((value, index) =>
-                Utils.calculateAutarchy(data['GridBuy'][index], value)
+                Utils.calculateAutarchy(data['GridBuy'][index], value),
               );
           },
-          color: 'rgb(0,152,204)'
+          color: 'rgb(0,152,204)',
         }];
       },
       tooltip: {
-        formatNumber: '1.0-0'
+        formatNumber: '1.0-0',
       },
       yAxes: [{
         unit: YAxisTitle.PERCENTAGE,
         position: 'left',
-        yAxisId: ChartAxis.LEFT
-      }]
+        yAxisId: ChartAxis.LEFT,
+      }],
     };
   }
 }

--- a/ui/src/app/edge/history/common/autarchy/flat/flat.ts
+++ b/ui/src/app/edge/history/common/autarchy/flat/flat.ts
@@ -4,7 +4,7 @@ import { ChannelAddress, CurrentData, Utils } from '../../../../../shared/shared
 
 @Component({
     selector: 'autarchyWidget',
-    templateUrl: './flat.html'
+    templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 
@@ -20,7 +20,7 @@ export class FlatComponent extends AbstractFlatWidget {
     protected override getChannelAddresses(): ChannelAddress[] {
         return [
             new ChannelAddress('_sum', 'GridBuyActiveEnergy'),
-            new ChannelAddress('_sum', 'ConsumptionActiveEnergy')
+            new ChannelAddress('_sum', 'ConsumptionActiveEnergy'),
         ];
     }
 }

--- a/ui/src/app/edge/history/common/autarchy/overview/overview.ts
+++ b/ui/src/app/edge/history/common/autarchy/overview/overview.ts
@@ -2,6 +2,6 @@ import { Component } from '@angular/core';
 import { AbstractHistoryChartOverview } from 'src/app/shared/genericComponents/chart/abstractHistoryChartOverview';
 
 @Component({
-    templateUrl: './overview.html'
+    templateUrl: './overview.html',
 })
 export class OverviewComponent extends AbstractHistoryChartOverview { }  

--- a/ui/src/app/edge/history/common/common.ts
+++ b/ui/src/app/edge/history/common/common.ts
@@ -12,14 +12,14 @@ import { Common_Selfconsumption } from './selfconsumption/SelfConsumption';
     CommonEnergyMonitor,
     Common_Grid,
     Common_Production,
-    Common_Selfconsumption
+    Common_Selfconsumption,
   ],
   exports: [
     Common_Autarchy,
     CommonEnergyMonitor,
     Common_Grid,
     Common_Production,
-    Common_Selfconsumption
-  ]
+    Common_Selfconsumption,
+  ],
 })
 export class Common { }

--- a/ui/src/app/edge/history/common/energy/chart/channels.spec.ts
+++ b/ui/src/app/edge/history/common/energy/chart/channels.spec.ts
@@ -13,25 +13,25 @@ export namespace History {
       "maintainAspectRatio": false,
       "legend": {
         "labels": {},
-        "position": "bottom"
+        "position": "bottom",
       },
       "elements": {
         "point": {
           "radius": 0,
           "hitRadius": 0,
-          "hoverRadius": 0
+          "hoverRadius": 0,
         },
         "line": {
           "borderWidth": 2,
-          "tension": 0.1
+          "tension": 0.1,
         },
         "rectangle": {
-          "borderWidth": 2
-        }
+          "borderWidth": 2,
+        },
       },
       "hover": {
         "mode": "point",
-        "intersect": true
+        "intersect": true,
       },
       "scales": {
         "yAxes": [
@@ -42,14 +42,14 @@ export namespace History {
               "display": true,
               "labelString": "kW",
               "padding": 5,
-              "fontSize": 11
+              "fontSize": 11,
             },
             "gridLines": {
-              "display": true
+              "display": true,
             },
             "ticks": {
-              "beginAtZero": false
-            }
+              "beginAtZero": false,
+            },
           },
           {
             "id": "right",
@@ -57,18 +57,18 @@ export namespace History {
             "scaleLabel": {
               "display": true,
               "labelString": "%",
-              "padding": 10
+              "padding": 10,
             },
             "gridLines": {
-              "display": false
+              "display": false,
             },
             "ticks": {
               "beginAtZero": true,
               "max": 100,
               "padding": 5,
-              "stepSize": 20
-            }
-          }
+              "stepSize": 20,
+            },
+          },
         ],
         "xAxes": [
           {
@@ -86,22 +86,22 @@ export namespace History {
                 "week": "ll",
                 "month": "MM",
                 "quarter": "[Q]Q - YYYY",
-                "year": "YYYY"
+                "year": "YYYY",
               },
-              "unit": period as TimeUnit
+              "unit": period as TimeUnit,
             },
-            "bounds": "ticks"
-          }
-        ]
+            "bounds": "ticks",
+          },
+        ],
       },
       "tooltips": {
         "mode": "index",
         "intersect": false,
         "axis": "x",
-        "callbacks": {}
+        "callbacks": {},
       },
-      "responsive": true
-    }
+      "responsive": true,
+    },
   });
   export const BAR_CHART_OPTIONS = (period: string): OeChartTester.Dataset.Option => ({
     type: 'option',
@@ -109,25 +109,25 @@ export namespace History {
       "maintainAspectRatio": false,
       "legend": {
         "labels": {},
-        "position": "bottom"
+        "position": "bottom",
       },
       "elements": {
         "point": {
           "radius": 0,
           "hitRadius": 0,
-          "hoverRadius": 0
+          "hoverRadius": 0,
         },
         "line": {
           "borderWidth": 2,
-          "tension": 0.1
+          "tension": 0.1,
         },
         "rectangle": {
-          "borderWidth": 2
-        }
+          "borderWidth": 2,
+        },
       },
       "hover": {
         "mode": "point",
-        "intersect": true
+        "intersect": true,
       },
       "scales": {
         "yAxes": [
@@ -138,22 +138,22 @@ export namespace History {
               "display": true,
               "labelString": "kWh",
               "padding": 5,
-              "fontSize": 11
+              "fontSize": 11,
             },
             "gridLines": {
-              "display": true
+              "display": true,
             },
             "ticks": {
-              "beginAtZero": false
+              "beginAtZero": false,
             },
-            "stacked": true
-          }
+            "stacked": true,
+          },
         ],
         "xAxes": [
           {
             "ticks": {
               "maxTicksLimit": 12,
-              "source": "data"
+              "source": "data",
             },
             "stacked": true,
             "type": "time",
@@ -168,23 +168,23 @@ export namespace History {
                 "week": "ll",
                 "month": "MM",
                 "quarter": "[Q]Q - YYYY",
-                "year": "YYYY"
+                "year": "YYYY",
               },
-              "unit": period as TimeUnit
+              "unit": period as TimeUnit,
             },
             "offset": true,
-            "bounds": "ticks"
-          }
-        ]
+            "bounds": "ticks",
+          },
+        ],
       },
       "tooltips": {
         "mode": "x",
         "intersect": false,
         "axis": "x",
-        "callbacks": {}
+        "callbacks": {},
       },
-      "responsive": true
-    }
+      "responsive": true,
+    },
   });
 
   /** 
@@ -200,8 +200,8 @@ export namespace History {
         '_sum/EssDcChargeEnergy': 15766,
         '_sum/EssDcDischargeEnergy': 7209,
         '_sum/GridSellActiveEnergy': 15615,
-        '_sum/ProductionActiveEnergy': 47597
-      }
+        '_sum/ProductionActiveEnergy': 47597,
+      },
     }),
     dataChannelWithValues: new QueryHistoricTimeseriesDataResponse("0", {
       data: {
@@ -1646,7 +1646,7 @@ export namespace History {
           null,
           null,
           null,
-          null]
+          null],
       },
       timestamps: [
         "2023-07-02T22:00:00Z",
@@ -1936,9 +1936,9 @@ export namespace History {
         "2023-07-03T21:40:00Z",
         "2023-07-03T21:45:00Z",
         "2023-07-03T21:50:00Z",
-        "2023-07-03T21:55:00Z"
-      ]
-    })
+        "2023-07-03T21:55:00Z",
+      ],
+    }),
   });
 
   /** 
@@ -1952,8 +1952,8 @@ export namespace History {
         '_sum/EssDcChargeEnergy': 38671,
         '_sum/EssDcDischargeEnergy': 31809,
         '_sum/GridSellActiveEnergy': 119692,
-        '_sum/ProductionActiveEnergy': 200875
-      }
+        '_sum/ProductionActiveEnergy': 200875,
+      },
     }),
     dataChannelWithValues: new QueryHistoricTimeseriesDataResponse("0", {
       data: {
@@ -2965,7 +2965,7 @@ export namespace History {
           156.1,
           61.5,
           0.6,
-          0]
+          0],
       },
       timestamps: [
         "2023-06-25T22:00:00Z",
@@ -3135,9 +3135,9 @@ export namespace History {
         "2023-07-02T18:00:00Z",
         "2023-07-02T19:00:00Z",
         "2023-07-02T20:00:00Z",
-        "2023-07-02T21:00:00Z"
-      ]
-    })
+        "2023-07-02T21:00:00Z",
+      ],
+    }),
   };
 
   /** 
@@ -3150,8 +3150,8 @@ export namespace History {
         '_sum/EssDcChargeEnergy': 3944328,
         '_sum/EssDcDischargeEnergy': 3394430,
         '_sum/GridSellActiveEnergy': 12738000,
-        '_sum/ProductionActiveEnergy': 22491000
-      }
+        '_sum/ProductionActiveEnergy': 22491000,
+      },
     }),
     energyPerPeriodChannelWithValues:
       new QueryHistoricTimeseriesEnergyPerPeriodResponse("0", {
@@ -3216,7 +3216,7 @@ export namespace History {
             247673,
             157410,
             104249,
-            null
+            null,
           ],
           "_sum/EssDcDischargeEnergy": [
             112818,
@@ -3248,7 +3248,7 @@ export namespace History {
             242102,
             130546,
             59571,
-            null
+            null,
           ],
           "_sum/GridBuyActiveEnergy": [
             16000,
@@ -3280,7 +3280,7 @@ export namespace History {
             72000,
             28000,
             84000,
-            null
+            null,
           ],
           "_sum/GridSellActiveEnergy": [
             603000,
@@ -3312,7 +3312,7 @@ export namespace History {
             776000,
             425000,
             574000,
-            null
+            null,
           ],
           "_sum/ProductionActiveEnergy": [
             908000,
@@ -3344,8 +3344,8 @@ export namespace History {
             1466000,
             808000,
             906000,
-            null
-          ]
+            null,
+          ],
         },
         timestamps: [
           "2023-05-31T22:00:00Z",
@@ -3377,9 +3377,9 @@ export namespace History {
           "2023-06-26T22:00:00Z",
           "2023-06-27T22:00:00Z",
           "2023-06-28T22:00:00Z",
-          "2023-06-29T22:00:00Z"
-        ]
-      })
+          "2023-06-29T22:00:00Z",
+        ],
+      }),
   };
 
   /** 
@@ -3392,8 +3392,8 @@ export namespace History {
         '_sum/EssDcChargeEnergy': 15296815,
         '_sum/EssDcDischargeEnergy': 12898209,
         '_sum/GridSellActiveEnergy': 30703000,
-        '_sum/ProductionActiveEnergy': 68466000
-      }
+        '_sum/ProductionActiveEnergy': 68466000,
+      },
     }),
     energyPerPeriodChannelWithValues:
       new QueryHistoricTimeseriesEnergyPerPeriodResponse("0", {
@@ -3422,7 +3422,7 @@ export namespace History {
             null,
             null,
             null,
-            null
+            null,
           ],
           "_sum/EssDcDischargeEnergy": [
             208491,
@@ -3436,7 +3436,7 @@ export namespace History {
             null,
             null,
             null,
-            null
+            null,
           ],
           "_sum/GridBuyActiveEnergy": [9829000,
             4812000,
@@ -3473,7 +3473,7 @@ export namespace History {
             null,
             null,
             null,
-            null]
+            null],
         },
         timestamps: [
           "2022-12-31T23:00:00Z",
@@ -3487,8 +3487,8 @@ export namespace History {
           "2023-08-31T22:00:00Z",
           "2023-09-30T22:00:00Z",
           "2023-10-31T23:00:00Z",
-          "2023-11-30T23:00:00Z"
-        ]
-      })
+          "2023-11-30T23:00:00Z",
+        ],
+      }),
   };
 }

--- a/ui/src/app/edge/history/common/energy/chart/chart.constants.spec.ts
+++ b/ui/src/app/edge/history/common/energy/chart/chart.constants.spec.ts
@@ -16,18 +16,18 @@ export function expectView(config: EdgeConfig, testContext: TestContext, chartTy
 export const DATASET = (data: OeChartTester.Dataset.Data, labels: OeChartTester.Dataset.LegendLabel, options: OeChartTester.Dataset.Option) => ({
   data: data,
   labels: labels,
-  options: options
+  options: options,
 });
 
 export const DATA = (name: string, value: number[]): OeChartTester.Dataset.Data => ({
   type: "data",
   label: name,
-  value: value
+  value: value,
 });
 
 export const LABELS = (timestamps: string[]): OeChartTester.Dataset.LegendLabel => ({
   type: "label",
-  timestamps: timestamps.map(element => new Date(element))
+  timestamps: timestamps.map(element => new Date(element)),
 });
 
 export const OPTIONS = (options: OeChartTester.Dataset.Option): OeChartTester.Dataset.Option => options;

--- a/ui/src/app/edge/history/common/energy/chart/chart.spec.ts
+++ b/ui/src/app/edge/history/common/energy/chart/chart.spec.ts
@@ -8,12 +8,12 @@ describe('History EnergyMonitor', () => {
   const defaultEMS = DummyConfig.from(
     SOCOMEC_GRID_METER("meter0", "Netzzähler"),
     ESS_GENERIC_MANAGEDSYMMETRIC("ess0"),
-    SOLAR_EDGE_PV_INVERTER("meter1", "Pv inverter")
+    SOLAR_EDGE_PV_INVERTER("meter1", "Pv inverter"),
   );
 
   let TEST_CONTEXT: TestContext;
   beforeEach(() =>
-    TEST_CONTEXT = sharedSetup()
+    TEST_CONTEXT = sharedSetup(),
   );
 
   it('getChartData()', () => {
@@ -29,11 +29,11 @@ describe('History EnergyMonitor', () => {
               DATA('Einspeisung: 15,6 kWh', [null, null, null, 0, 0, 0.006, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.004, 0, 0, 0, 0.004, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.005, 0, 0, 0, 0, 0, 0.001, 0.002, null, null, null, null, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.001, 0.004, 0, 0.004, 0, 0, 0, 0, 0.005, 0.013, 0.006, 0.004, 0.017, 0.015, 0.017, 0.011, 0, 0, 0, 0, 0.029, 0.015, 0.013, 0.019, 0.014, 0.007, 0.016, 0, 0.018, 0.022, 0, 0.012, 0.011, 0.007, 0, 0.033, 0.007, 0.003, 0.004, 0.011, 0, 0.038, 0, 0, 0.019, 0, 0.016, 0.014, 0.018, 0, 1.119, 3.453, 3.608, 3.941, 4.392, 3.786, 4.805, 4.688, 3.095, 2.32, 2.851, 3.058, 4.044, 5.011, 2.789, 6.53, 5.029, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null]),
               DATA('Bezug: 0,9 kWh', [null, null, null, 0.031, 0.018, 0, 0.02, 0.016, 0.015, 0.014, 0.009, 0.02, 0.025, 0.025, 0.025, 0.021, 0.012, 0.009, 0.01, 0.011, 0.005, 0.003, 0, 0.015, 0.018, 0.023, 0, 0, 0, 0.002, 0.002, 0.003, 0.015, 0.008, 0.022, 0.027, 0.016, 0.003, 0.002, 0, 0.028, 0.027, 0.017, 0.001, 0, 0, 0, null, null, null, null, 0.011, 0.01, 0.004, 0.006, 0.007, 0.018, 0.008, 0.012, 0.009, 0.004, 0.013, 0.015, 0.012, 0, 0, 0, 0.002, 0, 0.005, 0.001, 0.03, 0.062, 0, 0, 0, 0, 0, 0, 0, 0, 0.015, 0.005, 0.004, 0.007, 0, 0, 0, 0, 0, 0, 0, 0.005, 0, 0, 0, 0, 0, 0, 0.021, 0, 0, 0, 0, 0, 0.003, 0, 0.004, 0, 0, 0.032, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null]),
               DATA('Verbrauch: 24,4 kWh', [null, null, null, 0.112, 0.262, 0.392, 0.24, 0.23, 0.229, 0.227, 0.317, 0.224, 0.133, 0.135, 0.133, 0.192, 0.209, 0.09, 0.095, 0.096, 0.164, 0.297, 0.184, 0.182, 0.183, 0.198, 0.333, 0.183, 0.093, 0.097, 0.098, 0.197, 0.266, 0.177, 0.144, 0.14, 0.173, 0.304, 0.305, 0.237, 0.232, 0.227, 0.283, 0.344, 0.135, 0.096, 0.095, null, null, null, null, 0.102, 0.129, 0.14, 0.301, 0.248, 0.267, 0.319, 0.31, 0.452, 0.451, 0.28, 0.234, 0.226, 0.249, 0.39, 0.242, 0.199, 0.179, 0.166, 0.28, 0.239, 0.192, 0.187, 0.187, 0.19, 0.303, 0.146, 0.062, 0.062, 0.064, 0.887, 1.119, 1.07, 1.057, 0.596, 0.138, 0.233, 0.152, 0.209, 0.192, 0.202, 0.308, 0.254, 0.175, 0.122, 0.108, 0.137, 0.216, 0.947, 0.599, 0.203, 0.232, 0.328, 0.299, 0.52, 1.213, 0.641, 1.03, 0.442, 0.374, 1.758, 0.249, 0.26, 0.346, 1.879, 0.23, 0.484, 1.26, 1.317, 1.488, 1.451, 1.892, 1.466, 1.332, 0.523, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null]),
-              DATA('Ladezustand', History.DAY.dataChannelWithValues.result.data['_sum/EssSoc'])
+              DATA('Ladezustand', History.DAY.dataChannelWithValues.result.data['_sum/EssSoc']),
             ],
             labels: LABELS(History.DAY.dataChannelWithValues.result.timestamps),
-            options: History.LINE_CHART_OPTIONS('hour')
-          }
+            options: History.LINE_CHART_OPTIONS('hour'),
+          },
 
         });
 
@@ -51,11 +51,11 @@ describe('History EnergyMonitor', () => {
               DATA('Einspeisung: 119,7 kWh', [0.0023333333333333335, 0, 0, 0, 0, 0, 0, 0.014166666666666666, 0.02808333333333333, 0.9546666666666667, 4.150583333333333, 6.431333333333333, 5.737583333333333, 5.6714166666666666, 5.873333333333333, 5.049083333333333, 3.122, 1.0374166666666667, 0.22808333333333333, 0.02, 0, 0, 0, 0.008333333333333333, 0.0030833333333333333, 0.008333333333333333, 0, 0.007727272727272728, 0, 0, 0.00275, 0.013833333333333335, 0.017416666666666667, 0.006083333333333333, 0.5646666666666667, 2.2251666666666665, 2.03375, 3.99725, 4.990083333333333, 3.0128333333333335, 2.4844166666666667, 1.378, 0.65975, 0, 0.001, 0.006916666666666667, 0.008166666666666666, 0, 0, 0, 0, 0, 0, 0, 0.004083333333333333, 0.010583333333333333, 0.011166666666666667, 1.261, 5.308833333333333, 6.604, 6.321166666666667, 6.488333333333333, 6.78425, 6.052083333333333, 2.5839166666666666, 0.529, 0.01616666666666667, 0.0055, 0, 0.0006666666666666666, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0024166666666666664, 0.0125, 0.7065, 5.835416666666667, 4.77025, 6.03925, 6.8445833333333335, 5.370333333333333, 4.490166666666667, 2.3506666666666667, 0.7650833333333333, 0.08583333333333333, 0.011454545454545455, 0, 0, 0.005666666666666667, 0, 0, 0, 0, 0, 0, 0, 0.0033333333333333335, 0.004083333333333333, 0.02033333333333333, 0.02316666666666667, 1.4106666666666667, 0.8588333333333333, 0.0015833333333333333, 0.006583333333333333, 0.010083333333333335, 0.3410833333333333, 2.9290833333333337, 1.1175833333333332, 0.48583333333333334, 0, 0, 0, 0.0006666666666666666, 0.017916666666666668, 0.004, 0, 0, 0.001, 0, 0, 0, 0.02358333333333333, 0.006416666666666667, 0.008166666666666666, 0.0031666666666666666, 0.009916666666666666, 2.7254166666666664, 1.83725, 2.63225, 2.2170833333333335, 0.529, 0, 0, 0, 0, 0, 0.0003333333333333333, 0, 0, 0.011416666666666665, 0.011083333333333334, 0, 0, 0, 0, 0.008333333333333333, 0.008818181818181819, 0.015333333333333334, 0.018857142857142857, 0.024833333333333332, 0.010888888888888889, 2.2174, 3.9214166666666666, 1.6248181818181817, 1.937, 1.789, 0.0195, 0.0143, 0, 0, 0.009, 0.018875]),
               DATA('Bezug: 2,4 kWh', [0, 0.011916666666666666, 0.01633333333333333, 0.00609090909090909, 0.015333333333333334, 0.011666666666666665, 0.0024166666666666664, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.02425, 0.004416666666666667, 0.0035833333333333333, 0, 0, 0, 0.04441666666666667, 0, 0.013111111111111112, 0.001, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0011666666666666668, 0, 0, 0, 0.0015833333333333333, 0.013333333333333334, 0.020416666666666666, 0.01125, 0.019727272727272725, 0.012444444444444445, 0.009583333333333334, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.007666666666666667, 0, 0.0023333333333333335, 0.0125, 0.01609090909090909, 0.02016666666666667, 0.014083333333333333, 0.006363636363636363, 0.01955555555555556, 0.04841666666666666, 0.011166666666666667, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.014222222222222221, 0.00225, 0, 0.0036666666666666666, 0.032916666666666664, 0.014666666666666666, 0.0135, 0.017363636363636362, 0.013333333333333334, 0.022083333333333333, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0009166666666666666, 0, 0.0021666666666666666, 0, 0, 0, 0.0005, 0.04841666666666666, 0, 0.005555555555555556, 0.02716666666666667, 0.017333333333333333, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0023333333333333335, 0.008333333333333333, 0.003, 0.015916666666666666, 0.00325, 0, 0.004333333333333333, 0.001, 0, 0, 0.019545454545454546, 0.0017777777777777776, 0.006416666666666667, 0.017666666666666667, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0058, 0.005625, 0, 0]),
               DATA('Verbrauch: 76,7 kWh', [0.16022222222222224, 0.16516666666666666, 0.14991666666666667, 0.24245454545454548, 0.24866666666666665, 0.2679166666666667, 0.19658333333333333, 0.15775, 0.5408333333333334, 0.7640833333333333, 1.9163333333333332, 0.6645833333333334, 2.0044166666666667, 2.1950833333333333, 1.63125, 0.7880833333333334, 0.24116666666666667, 0.1095, 0.3621666666666667, 0.14041666666666666, 0.9824166666666666, 0.4598333333333333, 0.31808333333333333, 0.8699166666666667, 0.157, 0.14616666666666667, 0.17258333333333334, 0.12590909090909091, 0.19444444444444445, 0.22383333333333336, 0.37725, 0.7250833333333334, 0.385, 1.39075, 0.26275, 0.19433333333333333, 0.10516666666666667, 0.201, 0.30775, 0.19716666666666666, 0.20083333333333334, 0.4910833333333333, 0.398, 0.42825, 0.75675, 0.3935, 0.16933333333333334, 0.24841666666666665, 0.3354166666666667, 0.22233333333333336, 0.1825, 0.1720909090909091, 0.179, 0.2568333333333333, 0.3364166666666667, 0.8403333333333334, 0.4155, 0.6171666666666666, 0.7785, 0.5746666666666667, 1.53875, 0.6193333333333334, 0.99225, 0.43191666666666667, 0.92975, 1.0189166666666667, 0.22433333333333333, 0.6004166666666666, 0.4410833333333333, 0.8973333333333333, 0.5895, 0.24541666666666664, 0.13836363636363638, 0.21366666666666664, 0.18075, 0.16654545454545452, 0.2578888888888889, 0.2514166666666667, 0.5236666666666666, 1.2431666666666668, 0.7379166666666667, 0.9735833333333334, 0.35125, 2.5838333333333336, 1.7480833333333332, 1.2421666666666666, 2.35675, 1.5921666666666667, 1.19375, 0.17808333333333334, 0.24683333333333335, 0.6248181818181818, 0.47044444444444444, 0.9619166666666666, 0.20433333333333334, 0.6376666666666666, 0.14958333333333335, 0.19125, 0.14783333333333334, 0.208, 0.22866666666666666, 0.24891666666666665, 0.1505, 0.6745, 0.7685, 0.5545833333333333, 0.50325, 0.5148333333333334, 1.9893333333333332, 1.2161666666666668, 0.6651666666666667, 0.15025, 0.12625, 0.05316666666666667, 0.4963333333333333, 2.54575, 1.3246666666666667, 2.115, 0.6698333333333334, 0.15458333333333335, 0.15975, 0.13916666666666666, 0.12266666666666667, 0.2029090909090909, 0.23122222222222222, 0.533, 0.15675, 0.13625, 2.067, 0.7903333333333333, 0.9883333333333334, 0.44608333333333333, 0.2790833333333333, 1.8005, 0.8198333333333334, 2.60525, 1.83225, 2.1533333333333333, 1.072, 1.2043333333333333, 0.6051666666666666, 1.13675, 0.3330833333333333, 0.3438333333333333, 0.6486666666666666, 0.48025, 0.17116666666666666, 0.15381818181818183, 0.19722222222222222, 0.22858333333333333, 0.22016666666666665, 0.16758333333333333, 1.3263636363636362, 0.9056666666666666, 0.5432857142857144, 0.8975, 2.457222222222222, 1.1668, 1.3920833333333333, 3.111909090909091, 0.6785, 0.451, 1.089, 0.1713, 0.6919, 0.444625, 0.5696, 0.1315]),
-              DATA('Ladezustand', History.WEEK.dataChannelWithValues.result.data['_sum/EssSoc'])
+              DATA('Ladezustand', History.WEEK.dataChannelWithValues.result.data['_sum/EssSoc']),
             ],
             labels: LABELS(History.WEEK.dataChannelWithValues.result.timestamps),
-            options: History.LINE_CHART_OPTIONS('day')
-          }
+            options: History.LINE_CHART_OPTIONS('day'),
+          },
         });
     }
     {
@@ -74,11 +74,11 @@ describe('History EnergyMonitor', () => {
               DATA('Entladung: 3.394,4 kWh', [112.818, 126.532, 139.622, 133.212, 169.24, 98.705, 109.367, null, 204.267, 118.504, 121.261, 74.97, 144.175, 89.897, 141.582, 111.261, 122.274, 106.232, 139.405, 132.225, 143.86, null, 235.044, 63.914, 123.844, null, 242.102, 130.546, 59.571, null]),
               DATA('Einspeisung: 12.738 kWh', [603, 590, 551, 572, 69, 236, 626, null, 1003, 261, 518, 698, 640, 388, 471, 373, 373, 677, 286, 406, 249, null, 446, 369, 558, null, 776, 425, 574, null]),
               DATA('Bezug: 773 kWh', [16, 6, 3, 3, 5, 48, 4, null, 5, 26, 17, 62, 8, 66, 13, 21, 4, 3, 18, 27, 29, null, 118, 85, 2, null, 72, 28, 84, null]),
-              DATA('Verbrauch: 9.976,1 kWh', [320.342, 346.615, 341.433, 333.054, 358.458, 347.872, 289.283, null, 556.51, 311.366, 314.722, 355.556, 381.671, 384.558, 366.19, 349.336, 303.696, 288.727, 357.434, 388.659, 402.625, null, 713.771, 320.238, 332.099, null, 756.429, 384.136, 371.322, null])
+              DATA('Verbrauch: 9.976,1 kWh', [320.342, 346.615, 341.433, 333.054, 358.458, 347.872, 289.283, null, 556.51, 311.366, 314.722, 355.556, 381.671, 384.558, 366.19, 349.336, 303.696, 288.727, 357.434, 388.659, 402.625, null, 713.771, 320.238, 332.099, null, 756.429, 384.136, 371.322, null]),
             ],
             labels: LABELS(History.MONTH.energyPerPeriodChannelWithValues.result.timestamps),
-            options: History.BAR_CHART_OPTIONS('day')
-          }
+            options: History.BAR_CHART_OPTIONS('day'),
+          },
         });
     }
     {
@@ -97,11 +97,11 @@ describe('History EnergyMonitor', () => {
               DATA('Entladung: 12.898,2 kWh', [208.491, 1339.036, 2911.126, 2555.138, 2123.751, 3394.43, 335.402, null, null, null, null, null]),
               DATA('Einspeisung: 30.703 kWh', [20, 86, 677, 3657, 12839, 12738, 627, null, null, null, null, null]),
               DATA('Bezug: 23.209 kWh', [9829, 4812, 2915, 2036, 2712, 773, 94, null, null, null, null, null]),
-              DATA('Verbrauch: 58.573,4 kWh', [11634.885, 8207.927, 8976.354, 8311.835, 10341.804, 9976.102, 975.807, null, null, null, null, null])
+              DATA('Verbrauch: 58.573,4 kWh', [11634.885, 8207.927, 8976.354, 8311.835, 10341.804, 9976.102, 975.807, null, null, null, null, null]),
             ],
             labels: LABELS(History.YEAR.energyPerPeriodChannelWithValues.result.timestamps),
-            options: History.BAR_CHART_OPTIONS('month')
-          }
+            options: History.BAR_CHART_OPTIONS('month'),
+          },
         });
     }
     {
@@ -112,15 +112,15 @@ describe('History EnergyMonitor', () => {
           datasets: {
             data: [],
             labels: LABELS(History.YEAR.energyPerPeriodChannelWithValues.result.timestamps),
-            options: History.BAR_CHART_OPTIONS('month')
-          }
+            options: History.BAR_CHART_OPTIONS('month'),
+          },
         });
     }
     {
       // Bar-Chart: no productionMeter
       const EMS = DummyConfig.from(
         SOCOMEC_GRID_METER("meter0", "Netzzähler"),
-        ESS_GENERIC_MANAGEDSYMMETRIC("ess0")
+        ESS_GENERIC_MANAGEDSYMMETRIC("ess0"),
       );
 
       expectView(EMS, TEST_CONTEXT, 'bar', History.YEAR,
@@ -132,18 +132,18 @@ describe('History EnergyMonitor', () => {
               DATA('Entladung: 12.898,2 kWh', [208.491, 1339.036, 2911.126, 2555.138, 2123.751, 3394.43, 335.402, null, null, null, null, null]),
               DATA('Einspeisung: 30.703 kWh', [20, 86, 677, 3657, 12839, 12738, 627, null, null, null, null, null]),
               DATA('Bezug: 23.209 kWh', [9829, 4812, 2915, 2036, 2712, 773, 94, null, null, null, null, null]),
-              DATA('Verbrauch: 58.573,4 kWh', [11634.885, 8207.927, 8976.354, 8311.835, 10341.804, 9976.102, 975.807, null, null, null, null, null])
+              DATA('Verbrauch: 58.573,4 kWh', [11634.885, 8207.927, 8976.354, 8311.835, 10341.804, 9976.102, 975.807, null, null, null, null, null]),
             ],
             labels: LABELS(History.YEAR.energyPerPeriodChannelWithValues.result.timestamps),
-            options: History.BAR_CHART_OPTIONS('month')
-          }
+            options: History.BAR_CHART_OPTIONS('month'),
+          },
         });
     }
     {
       // Bar-Chart: only gridMeter
 
       const EMS = DummyConfig.from(
-        SOCOMEC_GRID_METER("meter0", "Netzzähler")
+        SOCOMEC_GRID_METER("meter0", "Netzzähler"),
       );
 
       expectView(EMS, TEST_CONTEXT, 'bar', History.YEAR,
@@ -152,18 +152,18 @@ describe('History EnergyMonitor', () => {
             data: [
               DATA('Einspeisung: 30.703 kWh', [20, 86, 677, 3657, 12839, 12738, 627, null, null, null, null, null]),
               DATA('Bezug: 23.209 kWh', [9829, 4812, 2915, 2036, 2712, 773, 94, null, null, null, null, null]),
-              DATA('Verbrauch: 58.573,4 kWh', [11634.885, 8207.927, 8976.354, 8311.835, 10341.804, 9976.102, 975.807, null, null, null, null, null])
+              DATA('Verbrauch: 58.573,4 kWh', [11634.885, 8207.927, 8976.354, 8311.835, 10341.804, 9976.102, 975.807, null, null, null, null, null]),
             ],
             labels: LABELS(History.YEAR.energyPerPeriodChannelWithValues.result.timestamps),
-            options: History.BAR_CHART_OPTIONS('month')
-          }
+            options: History.BAR_CHART_OPTIONS('month'),
+          },
         });
     }
     {
       // Bar-Chart: only ess
 
       const EMS = DummyConfig.from(
-        ESS_GENERIC_MANAGEDSYMMETRIC("ess0")
+        ESS_GENERIC_MANAGEDSYMMETRIC("ess0"),
       );
 
       expectView(EMS, TEST_CONTEXT, 'bar', History.YEAR,
@@ -172,11 +172,11 @@ describe('History EnergyMonitor', () => {
             data: [
               DATA('Beladung: 15.296,8 kWh', [294.606, 1673.109, 3337.772, 3074.303, 2495.947, 3944.328, 372.595, null, null, null, null, null]),
               DATA('Entladung: 12.898,2 kWh', [208.491, 1339.036, 2911.126, 2555.138, 2123.751, 3394.43, 335.402, null, null, null, null, null]),
-              DATA('Verbrauch: 58.573,4 kWh', [11634.885, 8207.927, 8976.354, 8311.835, 10341.804, 9976.102, 975.807, null, null, null, null, null])
+              DATA('Verbrauch: 58.573,4 kWh', [11634.885, 8207.927, 8976.354, 8311.835, 10341.804, 9976.102, 975.807, null, null, null, null, null]),
             ],
             labels: LABELS(History.YEAR.energyPerPeriodChannelWithValues.result.timestamps),
-            options: History.BAR_CHART_OPTIONS('month')
-          }
+            options: History.BAR_CHART_OPTIONS('month'),
+          },
         });
     }
   });

--- a/ui/src/app/edge/history/common/energy/chart/chart.ts
+++ b/ui/src/app/edge/history/common/energy/chart/chart.ts
@@ -7,7 +7,7 @@ import { ChannelAddress, EdgeConfig, Utils } from 'src/app/shared/shared';
 
 @Component({
   selector: 'energychart',
-  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html'
+  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html',
 })
 export class ChartComponent extends AbstractHistoryChart {
 
@@ -26,7 +26,7 @@ export class ChartComponent extends AbstractHistoryChart {
             newObj.push({
               name: 'Consumption',
               powerChannel: new ChannelAddress('_sum', 'ConsumptionActivePower'),
-              energyChannel: new ChannelAddress('_sum', 'ConsumptionActiveEnergy')
+              energyChannel: new ChannelAddress('_sum', 'ConsumptionActiveEnergy'),
             });
             break;
           case 'Common_Autarchy':
@@ -35,26 +35,26 @@ export class ChartComponent extends AbstractHistoryChart {
               name: 'GridBuy',
               powerChannel: new ChannelAddress('_sum', 'GridActivePower'),
               energyChannel: new ChannelAddress('_sum', 'GridBuyActiveEnergy'),
-              ...(chartType === 'line' && { converter: HistoryUtils.ValueConverter.NEGATIVE_AS_ZERO })
+              ...(chartType === 'line' && { converter: HistoryUtils.ValueConverter.NEGATIVE_AS_ZERO }),
             }, {
               name: 'GridSell',
               powerChannel: new ChannelAddress('_sum', 'GridActivePower'),
               energyChannel: new ChannelAddress('_sum', 'GridSellActiveEnergy'),
-              ...(chartType === 'line' && { converter: HistoryUtils.ValueConverter.POSITIVE_AS_ZERO_AND_INVERT_NEGATIVE })
+              ...(chartType === 'line' && { converter: HistoryUtils.ValueConverter.POSITIVE_AS_ZERO_AND_INVERT_NEGATIVE }),
             });
             break;
           case 'Storage':
             newObj.push({
               name: 'EssSoc',
-              powerChannel: new ChannelAddress('_sum', 'EssSoc')
+              powerChannel: new ChannelAddress('_sum', 'EssSoc'),
             }, {
               name: 'EssCharge',
               powerChannel: new ChannelAddress('_sum', 'EssActivePower'),
-              energyChannel: new ChannelAddress('_sum', 'EssDcChargeEnergy')
+              energyChannel: new ChannelAddress('_sum', 'EssDcChargeEnergy'),
             }, {
               name: 'EssDischarge',
               powerChannel: new ChannelAddress('_sum', 'EssActivePower'),
-              energyChannel: new ChannelAddress('_sum', 'EssDcDischargeEnergy')
+              energyChannel: new ChannelAddress('_sum', 'EssDcDischargeEnergy'),
             });
             break;
           case 'Common_Selfconsumption':
@@ -62,11 +62,11 @@ export class ChartComponent extends AbstractHistoryChart {
             newObj.push({
               name: 'ProductionActivePower',
               powerChannel: new ChannelAddress('_sum', 'ProductionActivePower'),
-              energyChannel: new ChannelAddress('_sum', 'ProductionActiveEnergy')
+              energyChannel: new ChannelAddress('_sum', 'ProductionActiveEnergy'),
             }, {
               name: 'ProductionDcActual',
               powerChannel: new ChannelAddress('_sum', 'ProductionDcActualPower'),
-              energyChannel: new ChannelAddress('_sum', 'ProductionActiveEnergy')
+              energyChannel: new ChannelAddress('_sum', 'ProductionActiveEnergy'),
             });
             break;
         }
@@ -90,7 +90,7 @@ export class ChartComponent extends AbstractHistoryChart {
             color: 'rgb(45,143,171)',
             stack: 0,
             hiddenOnInit: chartType == 'line' ? false : true,
-            order: 1
+            order: 1,
           },
 
           // DirectConsumption, displayed in stack 1 & 2, only one legenItem
@@ -104,7 +104,7 @@ export class ChartComponent extends AbstractHistoryChart {
                 ?.map(value => HistoryUtils.ValueConverter.NEGATIVE_AS_ZERO(value)),
             color: 'rgb(244,164,96)',
             stack: [1, 2],
-            order: 2
+            order: 2,
           }],
 
           // Charge Power
@@ -121,7 +121,7 @@ export class ChartComponent extends AbstractHistoryChart {
             },
             color: 'rgb(0,223,0)',
             stack: 1,
-            ...(chartType === 'line' && { order: 6 })
+            ...(chartType === 'line' && { order: 6 }),
           },
 
           // Discharge Power
@@ -138,7 +138,7 @@ export class ChartComponent extends AbstractHistoryChart {
             },
             color: 'rgb(200,0,0)',
             stack: 2,
-            ...(chartType === 'line' && { order: 5 })
+            ...(chartType === 'line' && { order: 5 }),
           },
 
           // Sell to grid
@@ -152,7 +152,7 @@ export class ChartComponent extends AbstractHistoryChart {
             },
             color: 'rgb(0,0,200)',
             stack: 1,
-            ...(chartType === 'line' && { order: 4 })
+            ...(chartType === 'line' && { order: 4 }),
           },
 
           // Buy from Grid
@@ -166,7 +166,7 @@ export class ChartComponent extends AbstractHistoryChart {
             },
             color: 'rgb(0,0,0)',
             stack: 2,
-            ...(chartType === 'line' && { order: 2 })
+            ...(chartType === 'line' && { order: 2 }),
           },
 
           // Consumption
@@ -181,7 +181,7 @@ export class ChartComponent extends AbstractHistoryChart {
             color: 'rgb(253,197,7)',
             stack: 3,
             hiddenOnInit: chartType == 'line' ? false : true,
-            ...(chartType === 'line' && { order: 0 })
+            ...(chartType === 'line' && { order: 0 }),
           },
           ...[chartType === 'line' &&
           {
@@ -193,8 +193,8 @@ export class ChartComponent extends AbstractHistoryChart {
             borderDash: [10, 10],
             yAxisId: ChartAxis.RIGHT,
             stack: 1,
-            customUnit: YAxisTitle.PERCENTAGE
-          }]
+            customUnit: YAxisTitle.PERCENTAGE,
+          }],
         ];
       },
       tooltip: {
@@ -206,7 +206,7 @@ export class ChartComponent extends AbstractHistoryChart {
             return translate.instant('General.consumption');
           }
           return null;
-        }
+        },
       },
       yAxes: [
 
@@ -214,7 +214,7 @@ export class ChartComponent extends AbstractHistoryChart {
         {
           unit: YAxisTitle.ENERGY,
           position: 'left',
-          yAxisId: ChartAxis.LEFT
+          yAxisId: ChartAxis.LEFT,
         },
 
         // Right Yaxis, only shown for line-chart
@@ -223,9 +223,9 @@ export class ChartComponent extends AbstractHistoryChart {
           customTitle: '%',
           position: 'right',
           yAxisId: ChartAxis.RIGHT,
-          displayGrid: false
-        })
-      ]
+          displayGrid: false,
+        }),
+      ],
     };
   }
 

--- a/ui/src/app/edge/history/common/energy/energy.ts
+++ b/ui/src/app/edge/history/common/energy/energy.ts
@@ -8,18 +8,18 @@ import { FlatComponent } from './flat/flat';
 @NgModule({
   imports: [
     BrowserModule,
-    SharedModule
+    SharedModule,
   ],
   entryComponents: [
     FlatComponent,
-    ChartComponent
+    ChartComponent,
   ],
   declarations: [
     FlatComponent,
-    ChartComponent
+    ChartComponent,
   ],
   exports: [
-    FlatComponent
-  ]
+    FlatComponent,
+  ],
 })
 export class CommonEnergyMonitor { }

--- a/ui/src/app/edge/history/common/energy/flat/flat.ts
+++ b/ui/src/app/edge/history/common/energy/flat/flat.ts
@@ -8,7 +8,7 @@ import { saveAs } from 'file-saver-es';
 
 @Component({
     selector: 'energy',
-    templateUrl: './flat.html'
+    templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 
@@ -27,7 +27,7 @@ export class FlatComponent extends AbstractFlatWidget {
     protected override getChannelAddresses(): ChannelAddress[] {
         return [
             new ChannelAddress('_sum', 'GridBuyActiveEnergy'),
-            new ChannelAddress('_sum', 'ConsumptionActiveEnergy')
+            new ChannelAddress('_sum', 'ConsumptionActiveEnergy'),
         ];
     }
 
@@ -50,7 +50,7 @@ export class FlatComponent extends AbstractFlatWidget {
                     view[i] = binary.charCodeAt(i);
                 }
                 const data: Blob = new Blob([view], {
-                    type: FlatComponent.EXCEL_TYPE
+                    type: FlatComponent.EXCEL_TYPE,
                 });
 
                 let fileName = "Export-" + edge.id + "-";

--- a/ui/src/app/edge/history/common/grid/chart/chart.spec.ts
+++ b/ui/src/app/edge/history/common/grid/chart/chart.spec.ts
@@ -8,12 +8,12 @@ import { expectView } from "./chart.constants.spec";
 
 describe('History Grid', () => {
   const defaultEMS = DummyConfig.from(
-    SOCOMEC_GRID_METER("meter0", "Netzzähler")
+    SOCOMEC_GRID_METER("meter0", "Netzzähler"),
   );
 
   let TEST_CONTEXT: TestContext;
   beforeEach(() =>
-    TEST_CONTEXT = sharedSetup()
+    TEST_CONTEXT = sharedSetup(),
   );
 
   it('#getChartData()', () => {
@@ -24,11 +24,11 @@ describe('History Grid', () => {
           datasets: {
             data: [
               DATA('Einspeisung: 15,6 kWh', [null, null, null, 0, 0, 0.006, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.004, 0, 0, 0, 0.004, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.005, 0, 0, 0, 0, 0, 0.001, 0.002, null, null, null, null, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.001, 0.004, 0, 0.004, 0, 0, 0, 0, 0.005, 0.013, 0.006, 0.004, 0.017, 0.015, 0.017, 0.011, 0, 0, 0, 0, 0.029, 0.015, 0.013, 0.019, 0.014, 0.007, 0.016, 0, 0.018, 0.022, 0, 0.012, 0.011, 0.007, 0, 0.033, 0.007, 0.003, 0.004, 0.011, 0, 0.038, 0, 0, 0.019, 0, 0.016, 0.014, 0.018, 0, 1.119, 3.453, 3.608, 3.941, 4.392, 3.786, 4.805, 4.688, 3.095, 2.32, 2.851, 3.058, 4.044, 5.011, 2.789, 6.53, 5.029, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null]),
-              DATA('Bezug: 0,9 kWh', [null, null, null, 0.031, 0.018, 0, 0.02, 0.016, 0.015, 0.014, 0.009, 0.02, 0.025, 0.025, 0.025, 0.021, 0.012, 0.009, 0.01, 0.011, 0.005, 0.003, 0, 0.015, 0.018, 0.023, 0, 0, 0, 0.002, 0.002, 0.003, 0.015, 0.008, 0.022, 0.027, 0.016, 0.003, 0.002, 0, 0.028, 0.027, 0.017, 0.001, 0, 0, 0, null, null, null, null, 0.011, 0.01, 0.004, 0.006, 0.007, 0.018, 0.008, 0.012, 0.009, 0.004, 0.013, 0.015, 0.012, 0, 0, 0, 0.002, 0, 0.005, 0.001, 0.03, 0.062, 0, 0, 0, 0, 0, 0, 0, 0, 0.015, 0.005, 0.004, 0.007, 0, 0, 0, 0, 0, 0, 0, 0.005, 0, 0, 0, 0, 0, 0, 0.021, 0, 0, 0, 0, 0, 0.003, 0, 0.004, 0, 0, 0.032, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null])
+              DATA('Bezug: 0,9 kWh', [null, null, null, 0.031, 0.018, 0, 0.02, 0.016, 0.015, 0.014, 0.009, 0.02, 0.025, 0.025, 0.025, 0.021, 0.012, 0.009, 0.01, 0.011, 0.005, 0.003, 0, 0.015, 0.018, 0.023, 0, 0, 0, 0.002, 0.002, 0.003, 0.015, 0.008, 0.022, 0.027, 0.016, 0.003, 0.002, 0, 0.028, 0.027, 0.017, 0.001, 0, 0, 0, null, null, null, null, 0.011, 0.01, 0.004, 0.006, 0.007, 0.018, 0.008, 0.012, 0.009, 0.004, 0.013, 0.015, 0.012, 0, 0, 0, 0.002, 0, 0.005, 0.001, 0.03, 0.062, 0, 0, 0, 0, 0, 0, 0, 0, 0.015, 0.005, 0.004, 0.007, 0, 0, 0, 0, 0, 0, 0, 0.005, 0, 0, 0, 0, 0, 0, 0.021, 0, 0, 0, 0, 0, 0.003, 0, 0.004, 0, 0, 0.032, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null]),
             ],
             labels: LABELS(History.DAY.dataChannelWithValues.result.timestamps),
-            options: OeTester.ChartOptions.LINE_CHART_OPTIONS('hour')
-          }
+            options: OeTester.ChartOptions.LINE_CHART_OPTIONS('hour'),
+          },
         }, false);
     }
     {
@@ -38,11 +38,11 @@ describe('History Grid', () => {
           datasets: {
             data: [
               DATA('Einspeisung: 119,7 kWh', [0.0023333333333333335, 0, 0, 0, 0, 0, 0, 0.014166666666666666, 0.02808333333333333, 0.9546666666666667, 4.150583333333333, 6.431333333333333, 5.737583333333333, 5.6714166666666666, 5.873333333333333, 5.049083333333333, 3.122, 1.0374166666666667, 0.22808333333333333, 0.02, 0, 0, 0, 0.008333333333333333, 0.0030833333333333333, 0.008333333333333333, 0, 0.007727272727272728, 0, 0, 0.00275, 0.013833333333333335, 0.017416666666666667, 0.006083333333333333, 0.5646666666666667, 2.2251666666666665, 2.03375, 3.99725, 4.990083333333333, 3.0128333333333335, 2.4844166666666667, 1.378, 0.65975, 0, 0.001, 0.006916666666666667, 0.008166666666666666, 0, 0, 0, 0, 0, 0, 0, 0.004083333333333333, 0.010583333333333333, 0.011166666666666667, 1.261, 5.308833333333333, 6.604, 6.321166666666667, 6.488333333333333, 6.78425, 6.052083333333333, 2.5839166666666666, 0.529, 0.01616666666666667, 0.0055, 0, 0.0006666666666666666, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0024166666666666664, 0.0125, 0.7065, 5.835416666666667, 4.77025, 6.03925, 6.8445833333333335, 5.370333333333333, 4.490166666666667, 2.3506666666666667, 0.7650833333333333, 0.08583333333333333, 0.011454545454545455, 0, 0, 0.005666666666666667, 0, 0, 0, 0, 0, 0, 0, 0.0033333333333333335, 0.004083333333333333, 0.02033333333333333, 0.02316666666666667, 1.4106666666666667, 0.8588333333333333, 0.0015833333333333333, 0.006583333333333333, 0.010083333333333335, 0.3410833333333333, 2.9290833333333337, 1.1175833333333332, 0.48583333333333334, 0, 0, 0, 0.0006666666666666666, 0.017916666666666668, 0.004, 0, 0, 0.001, 0, 0, 0, 0.02358333333333333, 0.006416666666666667, 0.008166666666666666, 0.0031666666666666666, 0.009916666666666666, 2.7254166666666664, 1.83725, 2.63225, 2.2170833333333335, 0.529, 0, 0, 0, 0, 0, 0.0003333333333333333, 0, 0, 0.011416666666666665, 0.011083333333333334, 0, 0, 0, 0, 0.008333333333333333, 0.008818181818181819, 0.015333333333333334, 0.018857142857142857, 0.024833333333333332, 0.010888888888888889, 2.2174, 3.9214166666666666, 1.6248181818181817, 1.937, 1.789, 0.0195, 0.0143, 0, 0, 0.009, 0.018875]),
-              DATA('Bezug: 2,4 kWh', [0, 0.011916666666666666, 0.01633333333333333, 0.00609090909090909, 0.015333333333333334, 0.011666666666666665, 0.0024166666666666664, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.02425, 0.004416666666666667, 0.0035833333333333333, 0, 0, 0, 0.04441666666666667, 0, 0.013111111111111112, 0.001, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0011666666666666668, 0, 0, 0, 0.0015833333333333333, 0.013333333333333334, 0.020416666666666666, 0.01125, 0.019727272727272725, 0.012444444444444445, 0.009583333333333334, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.007666666666666667, 0, 0.0023333333333333335, 0.0125, 0.01609090909090909, 0.02016666666666667, 0.014083333333333333, 0.006363636363636363, 0.01955555555555556, 0.04841666666666666, 0.011166666666666667, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.014222222222222221, 0.00225, 0, 0.0036666666666666666, 0.032916666666666664, 0.014666666666666666, 0.0135, 0.017363636363636362, 0.013333333333333334, 0.022083333333333333, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0009166666666666666, 0, 0.0021666666666666666, 0, 0, 0, 0.0005, 0.04841666666666666, 0, 0.005555555555555556, 0.02716666666666667, 0.017333333333333333, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0023333333333333335, 0.008333333333333333, 0.003, 0.015916666666666666, 0.00325, 0, 0.004333333333333333, 0.001, 0, 0, 0.019545454545454546, 0.0017777777777777776, 0.006416666666666667, 0.017666666666666667, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0058, 0.005625, 0, 0])
+              DATA('Bezug: 2,4 kWh', [0, 0.011916666666666666, 0.01633333333333333, 0.00609090909090909, 0.015333333333333334, 0.011666666666666665, 0.0024166666666666664, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.02425, 0.004416666666666667, 0.0035833333333333333, 0, 0, 0, 0.04441666666666667, 0, 0.013111111111111112, 0.001, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0011666666666666668, 0, 0, 0, 0.0015833333333333333, 0.013333333333333334, 0.020416666666666666, 0.01125, 0.019727272727272725, 0.012444444444444445, 0.009583333333333334, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.007666666666666667, 0, 0.0023333333333333335, 0.0125, 0.01609090909090909, 0.02016666666666667, 0.014083333333333333, 0.006363636363636363, 0.01955555555555556, 0.04841666666666666, 0.011166666666666667, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.014222222222222221, 0.00225, 0, 0.0036666666666666666, 0.032916666666666664, 0.014666666666666666, 0.0135, 0.017363636363636362, 0.013333333333333334, 0.022083333333333333, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0009166666666666666, 0, 0.0021666666666666666, 0, 0, 0, 0.0005, 0.04841666666666666, 0, 0.005555555555555556, 0.02716666666666667, 0.017333333333333333, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0023333333333333335, 0.008333333333333333, 0.003, 0.015916666666666666, 0.00325, 0, 0.004333333333333333, 0.001, 0, 0, 0.019545454545454546, 0.0017777777777777776, 0.006416666666666667, 0.017666666666666667, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0058, 0.005625, 0, 0]),
             ],
             labels: LABELS(History.WEEK.dataChannelWithValues.result.timestamps),
-            options: OeTester.ChartOptions.LINE_CHART_OPTIONS('day')
-          }
+            options: OeTester.ChartOptions.LINE_CHART_OPTIONS('day'),
+          },
 
         }, false);
     }
@@ -53,11 +53,11 @@ describe('History Grid', () => {
           datasets: {
             data: [
               DATA('Einspeisung: 12.738 kWh', [603, 590, 551, 572, 69, 236, 626, null, 1003, 261, 518, 698, 640, 388, 471, 373, 373, 677, 286, 406, 249, null, 446, 369, 558, null, 776, 425, 574, null]),
-              DATA('Bezug: 773 kWh', [16, 6, 3, 3, 5, 48, 4, null, 5, 26, 17, 62, 8, 66, 13, 21, 4, 3, 18, 27, 29, null, 118, 85, 2, null, 72, 28, 84, null])
+              DATA('Bezug: 773 kWh', [16, 6, 3, 3, 5, 48, 4, null, 5, 26, 17, 62, 8, 66, 13, 21, 4, 3, 18, 27, 29, null, 118, 85, 2, null, 72, 28, 84, null]),
             ],
             labels: LABELS(History.MONTH.energyPerPeriodChannelWithValues.result.timestamps),
-            options: OeTester.ChartOptions.BAR_CHART_OPTIONS('day')
-          }
+            options: OeTester.ChartOptions.BAR_CHART_OPTIONS('day'),
+          },
 
         }, false);
     }
@@ -68,11 +68,11 @@ describe('History Grid', () => {
           datasets: {
             data: [
               DATA('Einspeisung: 30.703 kWh', [20, 86, 677, 3657, 12839, 12738, 627, null, null, null, null, null]),
-              DATA('Bezug: 23.209 kWh', [9829, 4812, 2915, 2036, 2712, 773, 94, null, null, null, null, null])
+              DATA('Bezug: 23.209 kWh', [9829, 4812, 2915, 2036, 2712, 773, 94, null, null, null, null, null]),
             ],
             labels: LABELS(History.YEAR.energyPerPeriodChannelWithValues.result.timestamps),
-            options: OeTester.ChartOptions.BAR_CHART_OPTIONS('month')
-          }
+            options: OeTester.ChartOptions.BAR_CHART_OPTIONS('month'),
+          },
         }, false);
     }
   });

--- a/ui/src/app/edge/history/common/grid/chart/chart.ts
+++ b/ui/src/app/edge/history/common/grid/chart/chart.ts
@@ -8,7 +8,7 @@ import { ChannelAddress, EdgeConfig } from 'src/app/shared/shared';
 
 @Component({
   selector: 'gridchart',
-  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html'
+  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html',
 })
 export class ChartComponent extends AbstractHistoryChart {
 
@@ -23,21 +23,21 @@ export class ChartComponent extends AbstractHistoryChart {
         name: 'GridSell',
         powerChannel: ChannelAddress.fromString('_sum/GridActivePower'),
         energyChannel: ChannelAddress.fromString('_sum/GridSellActiveEnergy'),
-        ...(chartType === 'line' && { converter: HistoryUtils.ValueConverter.ONLY_NEGATIVE_AND_NEGATIVE_AS_POSITIVE })
+        ...(chartType === 'line' && { converter: HistoryUtils.ValueConverter.ONLY_NEGATIVE_AND_NEGATIVE_AS_POSITIVE }),
       },
       {
         name: 'GridBuy',
         powerChannel: ChannelAddress.fromString('_sum/GridActivePower'),
         energyChannel: ChannelAddress.fromString('_sum/GridBuyActiveEnergy'),
-        converter: HistoryUtils.ValueConverter.NEGATIVE_AS_ZERO
-      }
+        converter: HistoryUtils.ValueConverter.NEGATIVE_AS_ZERO,
+      },
     ];
 
     if (showPhases) {
       ['L1', 'L2', 'L3'].forEach(phase => {
         input.push({
           name: 'GridActivePower' + phase,
-          powerChannel: ChannelAddress.fromString('_sum/GridActivePower' + phase)
+          powerChannel: ChannelAddress.fromString('_sum/GridActivePower' + phase),
         });
       });
     }
@@ -57,7 +57,7 @@ export class ChartComponent extends AbstractHistoryChart {
             },
             // TODO create Color class
             color: 'rgba(0,0,200)',
-            stack: 1
+            stack: 1,
           },
 
           {
@@ -69,7 +69,7 @@ export class ChartComponent extends AbstractHistoryChart {
               return data['GridBuy'];
             },
             color: 'rgb(0,0,0)',
-            stack: 0
+            stack: 0,
           }];
 
 
@@ -87,20 +87,20 @@ export class ChartComponent extends AbstractHistoryChart {
               return data['GridActivePower' + phase] ?? null;
             },
             color: AbstractHistoryChart.phaseColors[index],
-            stack: 3
+            stack: 3,
           });
         });
 
         return datasets;
       },
       tooltip: {
-        formatNumber: '1.0-2'
+        formatNumber: '1.0-2',
       },
       yAxes: [{
         unit: YAxisTitle.ENERGY,
         position: 'left',
-        yAxisId: ChartAxis.LEFT
-      }]
+        yAxisId: ChartAxis.LEFT,
+      }],
     };
   }
 }

--- a/ui/src/app/edge/history/common/grid/flat/flat.ts
+++ b/ui/src/app/edge/history/common/grid/flat/flat.ts
@@ -3,6 +3,6 @@ import { AbstractFlatWidget } from 'src/app/shared/genericComponents/flat/abstra
 
 @Component({
   selector: 'gridWidget',
-  templateUrl: './flat.html'
+  templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget { }

--- a/ui/src/app/edge/history/common/grid/grid.ts
+++ b/ui/src/app/edge/history/common/grid/grid.ts
@@ -9,20 +9,20 @@ import { OverviewComponent } from './overview/overview';
 @NgModule({
   imports: [
     BrowserModule,
-    SharedModule
+    SharedModule,
   ],
   entryComponents: [
-    FlatComponent
+    FlatComponent,
   ],
   declarations: [
     FlatComponent,
     ChartComponent,
-    OverviewComponent
+    OverviewComponent,
   ],
   exports: [
     FlatComponent,
     ChartComponent,
-    OverviewComponent
-  ]
+    OverviewComponent,
+  ],
 })
 export class Common_Grid { }

--- a/ui/src/app/edge/history/common/grid/overview/overview.ts
+++ b/ui/src/app/edge/history/common/grid/overview/overview.ts
@@ -2,6 +2,6 @@ import { Component } from '@angular/core';
 import { AbstractHistoryChartOverview } from 'src/app/shared/genericComponents/chart/abstractHistoryChartOverview';
 
 @Component({
-    templateUrl: './overview.html'
+    templateUrl: './overview.html',
 })
 export class OverviewComponent extends AbstractHistoryChartOverview { }  

--- a/ui/src/app/edge/history/common/production/chart/chargerChart.ts
+++ b/ui/src/app/edge/history/common/production/chart/chargerChart.ts
@@ -7,7 +7,7 @@ import { ChannelAddress } from '../../../../../shared/shared';
 
 @Component({
   selector: 'productionChargerChart',
-  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html'
+  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html',
 })
 export class ChargerChartComponent extends AbstractHistoryChart {
 
@@ -17,7 +17,7 @@ export class ChargerChartComponent extends AbstractHistoryChart {
         name: 'ActualPower',
         powerChannel: ChannelAddress.fromString(this.component.id + '/ActualPower'),
         energyChannel: ChannelAddress.fromString(this.component.id + '/ActualEnergy'),
-        converter: (data) => data != null ? data : null
+        converter: (data) => data != null ? data : null,
       }],
       output: (data: HistoryUtils.ChannelData) => {
         return [
@@ -27,18 +27,18 @@ export class ChargerChartComponent extends AbstractHistoryChart {
             nameSuffix: (energyResponse: QueryHistoricTimeseriesEnergyResponse) => {
               return energyResponse.result.data[this.component.id + '/ActualEnergy'];
             },
-            color: 'rgb(0,152,204)'
-          }
+            color: 'rgb(0,152,204)',
+          },
         ];
       },
       tooltip: {
-        formatNumber: '1.1-2'
+        formatNumber: '1.1-2',
       },
       yAxes: [{
         unit: YAxisTitle.ENERGY,
         position: 'left',
-        yAxisId: ChartAxis.LEFT
-      }]
+        yAxisId: ChartAxis.LEFT,
+      }],
     };
   }
 }

--- a/ui/src/app/edge/history/common/production/chart/productionMeterChart.ts
+++ b/ui/src/app/edge/history/common/production/chart/productionMeterChart.ts
@@ -8,7 +8,7 @@ import { ChannelAddress } from '../../../../../shared/shared';
 /** Will be used in the Future again */
 @Component({
   selector: 'productionMeterchart',
-  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html'
+  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html',
 })
 export class ProductionMeterChartComponent extends AbstractHistoryChart {
 
@@ -17,8 +17,8 @@ export class ProductionMeterChartComponent extends AbstractHistoryChart {
       name: 'ActivePower',
       powerChannel: ChannelAddress.fromString(this.component.id + '/ActivePower'),
       energyChannel: ChannelAddress.fromString(this.component.id + '/ActiveProductionEnergy'),
-      converter: (data) => data != null ? data : null
-    }
+      converter: (data) => data != null ? data : null,
+    },
     ];
 
     // Phase 1 to 3
@@ -26,7 +26,7 @@ export class ProductionMeterChartComponent extends AbstractHistoryChart {
       channels.push({
         name: 'ActivePowerL' + i,
         powerChannel: ChannelAddress.fromString(this.component.id + '/ActivePowerL' + i),
-        energyChannel: ChannelAddress.fromString(this.component.id + '/ActiveProductionEnergyL' + i)
+        energyChannel: ChannelAddress.fromString(this.component.id + '/ActiveProductionEnergyL' + i),
       });
     }
     return {
@@ -41,7 +41,7 @@ export class ProductionMeterChartComponent extends AbstractHistoryChart {
           converter: () => {
             return data['ActivePower'];
           },
-          color: 'rgb(0,152,204)'
+          color: 'rgb(0,152,204)',
         });
         if (this.showPhases) {
 
@@ -52,20 +52,20 @@ export class ProductionMeterChartComponent extends AbstractHistoryChart {
               converter: () => {
                 return data['ActivePowerL' + i] ?? null;
               },
-              color: AbstractHistoryChart.phaseColors[i - 1]
+              color: AbstractHistoryChart.phaseColors[i - 1],
             });
           }
         }
         return datasets;
       },
       tooltip: {
-        formatNumber: '1.1-2'
+        formatNumber: '1.1-2',
       },
       yAxes: [{
         unit: YAxisTitle.ENERGY,
         position: 'left',
-        yAxisId: ChartAxis.LEFT
-      }]
+        yAxisId: ChartAxis.LEFT,
+      }],
     };
   }
 }

--- a/ui/src/app/edge/history/common/production/chart/totalAcChart.ts
+++ b/ui/src/app/edge/history/common/production/chart/totalAcChart.ts
@@ -7,7 +7,7 @@ import { ChannelAddress } from '../../../../../shared/shared';
 
 @Component({
   selector: 'productionTotalAcChart',
-  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html'
+  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html',
 })
 export class TotalAcChartComponent extends AbstractHistoryChart {
 
@@ -18,20 +18,20 @@ export class TotalAcChartComponent extends AbstractHistoryChart {
           {
             name: 'ProductionAcActivePower',
             powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePower'),
-            energyChannel: ChannelAddress.fromString('_sum/ProductionAcActiveEnergy')
+            energyChannel: ChannelAddress.fromString('_sum/ProductionAcActiveEnergy'),
           },
           {
             name: 'ProductionAcActivePowerL1',
-            powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePowerL1')
+            powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePowerL1'),
           },
           {
             name: 'ProductionAcActivePowerL2',
-            powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePowerL2')
+            powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePowerL2'),
           },
           {
             name: 'ProductionAcActivePowerL3',
-            powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePowerL3')
-          }
+            powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePowerL3'),
+          },
         ],
       output: (data: HistoryUtils.ChannelData) => {
         let datasets: HistoryUtils.DisplayValues[] = [];
@@ -45,7 +45,7 @@ export class TotalAcChartComponent extends AbstractHistoryChart {
             return data['ProductionAcActivePower'];
           },
           color: "rgb(0,152,204)",
-          stack: 0
+          stack: 0,
         });
 
         for (let i = 1; i < 4; i++) {
@@ -57,20 +57,20 @@ export class TotalAcChartComponent extends AbstractHistoryChart {
               }
               return data['ProductionAcActivePowerL' + i] ?? null;
             },
-            color: 'rgb(' + AbstractHistoryChart.phaseColors[i - 1] + ')'
+            color: 'rgb(' + AbstractHistoryChart.phaseColors[i - 1] + ')',
           });
         }
 
         return datasets;
       },
       tooltip: {
-        formatNumber: '1.1-2'
+        formatNumber: '1.1-2',
       },
       yAxes: [{
         unit: YAxisTitle.ENERGY,
         position: 'left',
-        yAxisId: ChartAxis.LEFT
-      }]
+        yAxisId: ChartAxis.LEFT,
+      }],
     };
   }
 }

--- a/ui/src/app/edge/history/common/production/chart/totalChart.ts
+++ b/ui/src/app/edge/history/common/production/chart/totalChart.ts
@@ -7,7 +7,7 @@ import { ChannelAddress } from '../../../../../shared/shared';
 
 @Component({
   selector: 'productionTotalChart',
-  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html'
+  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html',
 })
 export class TotalChartComponent extends AbstractHistoryChart {
 
@@ -19,7 +19,7 @@ export class TotalChartComponent extends AbstractHistoryChart {
     let channels: HistoryUtils.InputChannel[] = [{
       name: 'ProductionActivePower',
       powerChannel: ChannelAddress.fromString('_sum/ProductionActivePower'),
-      energyChannel: ChannelAddress.fromString('_sum/ProductionActiveEnergy')
+      energyChannel: ChannelAddress.fromString('_sum/ProductionActiveEnergy'),
     }];
 
     // If at least one charger
@@ -27,7 +27,7 @@ export class TotalChartComponent extends AbstractHistoryChart {
       channels.push({
         name: 'ProductionDcActualPower',
         powerChannel: ChannelAddress.fromString('_sum/ProductionDcActualPower'),
-        energyChannel: ChannelAddress.fromString('_sum/ProductionDcActiveEnergy')
+        energyChannel: ChannelAddress.fromString('_sum/ProductionDcActiveEnergy'),
       });
     }
 
@@ -36,15 +36,15 @@ export class TotalChartComponent extends AbstractHistoryChart {
       channels.push(
         {
           name: 'ProductionAcActivePowerL1',
-          powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePowerL1')
+          powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePowerL1'),
         },
         {
           name: 'ProductionAcActivePowerL2',
-          powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePowerL2')
+          powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePowerL2'),
         },
         {
           name: 'ProductionAcActivePowerL3',
-          powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePowerL3')
+          powerChannel: ChannelAddress.fromString('_sum/ProductionAcActivePowerL3'),
         });
     }
 
@@ -52,7 +52,7 @@ export class TotalChartComponent extends AbstractHistoryChart {
       channels.push({
         name: component.id,
         powerChannel: ChannelAddress.fromString(component.id + '/ActivePower'),
-        energyChannel: ChannelAddress.fromString(component.id + '/ActiveProductionEnergy')
+        energyChannel: ChannelAddress.fromString(component.id + '/ActiveProductionEnergy'),
       });
 
     }
@@ -60,7 +60,7 @@ export class TotalChartComponent extends AbstractHistoryChart {
       channels.push({
         name: component.id,
         powerChannel: ChannelAddress.fromString(component.id + '/ActualPower'),
-        energyChannel: ChannelAddress.fromString(component.id + '/ActualEnergy')
+        energyChannel: ChannelAddress.fromString(component.id + '/ActualEnergy'),
       });
     }
 
@@ -78,7 +78,7 @@ export class TotalChartComponent extends AbstractHistoryChart {
           },
           color: 'rgb(0,152,204)',
           hiddenOnInit: true,
-          stack: 2
+          stack: 2,
         });
 
         if (!this.showTotal) {
@@ -108,7 +108,7 @@ export class TotalChartComponent extends AbstractHistoryChart {
               return effectiveProduction;
             },
             color: 'rgb(' + AbstractHistoryChart.phaseColors[i - 1] + ')',
-            stack: 3
+            stack: 3,
           });
         }
 
@@ -125,7 +125,7 @@ export class TotalChartComponent extends AbstractHistoryChart {
               return data[component.id] ?? null;
             },
             color: productionMeterColors[Math.min(i, (productionMeterColors.length - 1))],
-            stack: 1
+            stack: 1,
           });
         }
 
@@ -142,20 +142,20 @@ export class TotalChartComponent extends AbstractHistoryChart {
               return data[component.id] ?? null;
             },
             color: chargerColors[Math.min(i, (chargerColors.length - 1))],
-            stack: 1
+            stack: 1,
           });
         }
         return datasets;
       },
       tooltip: {
         formatNumber: '1.1-2',
-        afterTitle: this.translate.instant('General.TOTAL')
+        afterTitle: this.translate.instant('General.TOTAL'),
       },
       yAxes: [{
         unit: YAxisTitle.ENERGY,
         position: 'left',
-        yAxisId: ChartAxis.LEFT
-      }]
+        yAxisId: ChartAxis.LEFT,
+      }],
     };
 
     return chartObject;

--- a/ui/src/app/edge/history/common/production/chart/totalDcChart.ts
+++ b/ui/src/app/edge/history/common/production/chart/totalDcChart.ts
@@ -7,7 +7,7 @@ import { ChannelAddress } from '../../../../../shared/shared';
 
 @Component({
   selector: 'totalDcChart',
-  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html'
+  templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html',
 })
 export class TotalDcChartComponent extends AbstractHistoryChart {
 
@@ -19,8 +19,8 @@ export class TotalDcChartComponent extends AbstractHistoryChart {
             name: 'ProductionDcActual',
             powerChannel: ChannelAddress.fromString('_sum/ProductionDcActualPower'),
             energyChannel: ChannelAddress.fromString('_sum/ProductionDcActiveEnergy'),
-            converter: (data) => data != null ? data : null
-          }
+            converter: (data) => data != null ? data : null,
+          },
         ],
       output: (data: HistoryUtils.ChannelData) => {
         return [{
@@ -32,17 +32,17 @@ export class TotalDcChartComponent extends AbstractHistoryChart {
             return data['ProductionDcActual'] ?? null;
           },
           strokeThroughHiddingStyle: false,
-          color: 'rgb(0,152,204)'
+          color: 'rgb(0,152,204)',
         }];
       },
       tooltip: {
-        formatNumber: '1.1-2'
+        formatNumber: '1.1-2',
       },
       yAxes: [{
         unit: YAxisTitle.ENERGY,
         position: 'left',
-        yAxisId: ChartAxis.LEFT
-      }]
+        yAxisId: ChartAxis.LEFT,
+      }],
     };
   }
 }

--- a/ui/src/app/edge/history/common/production/flat/flat.ts
+++ b/ui/src/app/edge/history/common/production/flat/flat.ts
@@ -5,7 +5,7 @@ import { ChannelAddress, EdgeConfig, Utils } from '../../../../../shared/shared'
 
 @Component({
   selector: 'productionWidget',
-  templateUrl: './flat.html'
+  templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 

--- a/ui/src/app/edge/history/common/production/overview/overview.ts
+++ b/ui/src/app/edge/history/common/production/overview/overview.ts
@@ -3,7 +3,7 @@ import { AbstractHistoryChartOverview } from '../../../../../shared/genericCompo
 import { ChannelAddress, EdgeConfig } from '../../../../../shared/shared';
 
 @Component({
-  templateUrl: './overview.html'
+  templateUrl: './overview.html',
 })
 export class OverviewComponent extends AbstractHistoryChartOverview {
   protected chargerComponents: EdgeConfig.Component[] = [];

--- a/ui/src/app/edge/history/common/production/production.ts
+++ b/ui/src/app/edge/history/common/production/production.ts
@@ -13,7 +13,7 @@ import { OverviewComponent } from './overview/overview';
 @NgModule({
   imports: [
     BrowserModule,
-    SharedModule
+    SharedModule,
   ],
   entryComponents: [
     FlatComponent,
@@ -22,7 +22,7 @@ import { OverviewComponent } from './overview/overview';
     TotalDcChartComponent,
     TotalAcChartComponent,
     TotalChartComponent,
-    ChargerChartComponent
+    ChargerChartComponent,
   ],
   declarations: [
     FlatComponent,
@@ -31,7 +31,7 @@ import { OverviewComponent } from './overview/overview';
     TotalDcChartComponent,
     TotalAcChartComponent,
     TotalChartComponent,
-    ChargerChartComponent
+    ChargerChartComponent,
   ],
   exports: [
     FlatComponent,
@@ -40,7 +40,7 @@ import { OverviewComponent } from './overview/overview';
     TotalDcChartComponent,
     TotalAcChartComponent,
     TotalChartComponent,
-    ChargerChartComponent
-  ]
+    ChargerChartComponent,
+  ],
 })
 export class Common_Production { }

--- a/ui/src/app/edge/history/common/selfconsumption/SelfConsumption.ts
+++ b/ui/src/app/edge/history/common/selfconsumption/SelfConsumption.ts
@@ -8,20 +8,20 @@ import { OverviewComponent } from "./overview/overview";
 @NgModule({
     imports: [
         BrowserModule,
-        SharedModule
+        SharedModule,
     ],
     entryComponents: [
-        FlatComponent
+        FlatComponent,
     ],
     declarations: [
         FlatComponent,
         ChartComponent,
-        OverviewComponent
+        OverviewComponent,
     ],
     exports: [
         FlatComponent,
         ChartComponent,
-        OverviewComponent
-    ]
+        OverviewComponent,
+    ],
 })
 export class Common_Selfconsumption { }

--- a/ui/src/app/edge/history/common/selfconsumption/chart/chart.component.ts
+++ b/ui/src/app/edge/history/common/selfconsumption/chart/chart.component.ts
@@ -6,7 +6,7 @@ import { ChannelAddress } from 'src/app/shared/shared';
 
 @Component({
     selector: 'selfconsumptionChart',
-    templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html'
+    templateUrl: '../../../../../shared/genericComponents/chart/abstracthistorychart.html',
 })
 export class ChartComponent extends AbstractHistoryChart {
 
@@ -18,12 +18,12 @@ export class ChartComponent extends AbstractHistoryChart {
                     name: 'GridSell',
                     powerChannel: ChannelAddress.fromString('_sum/GridActivePower'),
                     energyChannel: ChannelAddress.fromString('_sum/GridSellActiveEnergy'),
-                    ...(this.chartType === 'line' && { converter: HistoryUtils.ValueConverter.POSITIVE_AS_ZERO_AND_INVERT_NEGATIVE })
+                    ...(this.chartType === 'line' && { converter: HistoryUtils.ValueConverter.POSITIVE_AS_ZERO_AND_INVERT_NEGATIVE }),
                 },
                 {
                     name: 'ProductionActivePower',
                     powerChannel: ChannelAddress.fromString('_sum/ProductionActivePower'),
-                    energyChannel: ChannelAddress.fromString('_sum/ProductionActiveEnergy')
+                    energyChannel: ChannelAddress.fromString('_sum/ProductionActiveEnergy'),
                 }],
             output: (data: HistoryUtils.ChannelData) => {
                 return [{
@@ -34,20 +34,20 @@ export class ChartComponent extends AbstractHistoryChart {
                     converter: () => {
                         return data['GridSell']
                             ?.map((value, index) =>
-                                Utils.calculateSelfConsumption(value, data['ProductionActivePower'][index])
+                                Utils.calculateSelfConsumption(value, data['ProductionActivePower'][index]),
                             );
                     },
-                    color: 'rgb(253,197,7)'
+                    color: 'rgb(253,197,7)',
                 }];
             },
             tooltip: {
-                formatNumber: '1.0-0'
+                formatNumber: '1.0-0',
             },
             yAxes: [{
                 unit: YAxisTitle.PERCENTAGE,
                 position: 'left',
-                yAxisId: ChartAxis.LEFT
-            }]
+                yAxisId: ChartAxis.LEFT,
+            }],
         };
     }
 }

--- a/ui/src/app/edge/history/common/selfconsumption/flat/flat.ts
+++ b/ui/src/app/edge/history/common/selfconsumption/flat/flat.ts
@@ -4,7 +4,7 @@ import { CurrentData, Utils, ChannelAddress } from 'src/app/shared/shared';
 
 @Component({
     selector: 'selfconsumptionWidget',
-    templateUrl: './flat.html'
+    templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 
@@ -13,14 +13,14 @@ export class FlatComponent extends AbstractFlatWidget {
     protected override onCurrentData(currentData: CurrentData) {
         this.selfconsumptionValue = Utils.calculateSelfConsumption(
             currentData.allComponents['_sum/GridSellActiveEnergy'],
-            currentData.allComponents['_sum/ProductionActiveEnergy']
+            currentData.allComponents['_sum/ProductionActiveEnergy'],
         );
     }
 
     protected override getChannelAddresses(): ChannelAddress[] {
         return [
             new ChannelAddress('_sum', 'GridSellActiveEnergy'),
-            new ChannelAddress('_sum', 'ProductionActiveEnergy')
+            new ChannelAddress('_sum', 'ProductionActiveEnergy'),
         ];
     }
 }

--- a/ui/src/app/edge/history/common/selfconsumption/overview/overview.ts
+++ b/ui/src/app/edge/history/common/selfconsumption/overview/overview.ts
@@ -2,6 +2,6 @@ import { Component } from '@angular/core';
 import { AbstractHistoryChartOverview } from 'src/app/shared/genericComponents/chart/abstractHistoryChartOverview';
 
 @Component({
-    templateUrl: './overview.html'
+    templateUrl: './overview.html',
 })
 export class OverviewComponent extends AbstractHistoryChartOverview { }  

--- a/ui/src/app/edge/history/consumption/consumptionchartoverview/consumptionchartoverview.component.ts
+++ b/ui/src/app/edge/history/consumption/consumptionchartoverview/consumptionchartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
 
 @Component({
     selector: ConsumptionChartOverviewComponent.SELECTOR,
-    templateUrl: './consumptionchartoverview.component.html'
+    templateUrl: './consumptionchartoverview.component.html',
 })
 export class ConsumptionChartOverviewComponent implements OnInit {
 
@@ -20,7 +20,7 @@ export class ConsumptionChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/consumption/evcschart.component.ts
+++ b/ui/src/app/edge/history/consumption/evcschart.component.ts
@@ -11,7 +11,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
     selector: 'consumptionEvcsChart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class ConsumptionEvcsChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -25,7 +25,7 @@ export class ConsumptionEvcsChartComponent extends AbstractHistoryChart implemen
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("consumption-evcs-chart", service, translate);
     }
@@ -71,11 +71,11 @@ export class ConsumptionEvcsChartComponent extends AbstractHistoryChart implemen
                     datasets.push({
                         label: this.translate.instant('General.consumption'),
                         data: chargeData,
-                        hidden: false
+                        hidden: false,
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(253,197,7,0.05)',
-                        borderColor: 'rgba(253,197,7,1)'
+                        borderColor: 'rgba(253,197,7,1)',
                     });
                 }
             });
@@ -93,7 +93,7 @@ export class ConsumptionEvcsChartComponent extends AbstractHistoryChart implemen
     protected getChannelAddresses(): Promise<ChannelAddress[]> {
         return new Promise((resolve) => {
             let result: ChannelAddress[] = [
-                new ChannelAddress(this.componentId, 'ChargePower')
+                new ChannelAddress(this.componentId, 'ChargePower'),
             ];
             resolve(result);
         });

--- a/ui/src/app/edge/history/consumption/meterchart.component.ts
+++ b/ui/src/app/edge/history/consumption/meterchart.component.ts
@@ -11,7 +11,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
     selector: 'consumptionMeterChart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class ConsumptionMeterChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -25,7 +25,7 @@ export class ConsumptionMeterChartComponent extends AbstractHistoryChart impleme
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("consumption-meter-chart", service, translate);
     }
@@ -70,11 +70,11 @@ export class ConsumptionMeterChartComponent extends AbstractHistoryChart impleme
                     datasets.push({
                         label: this.translate.instant('General.consumption'),
                         data: activePowerData,
-                        hidden: false
+                        hidden: false,
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(253,197,7,0.05)',
-                        borderColor: 'rgba(253,197,7,1)'
+                        borderColor: 'rgba(253,197,7,1)',
                     });
                 }
             });
@@ -92,7 +92,7 @@ export class ConsumptionMeterChartComponent extends AbstractHistoryChart impleme
     protected getChannelAddresses(edge: Edge, config: EdgeConfig): Promise<ChannelAddress[]> {
         return new Promise((resolve) => {
             let result: ChannelAddress[] = [
-                new ChannelAddress(this.componentId, 'ActivePower')
+                new ChannelAddress(this.componentId, 'ActivePower'),
             ];
             let consumptionMeters = config.getComponentsImplementingNature("io.openems.edge.meter.api.ElectricityMeter")
                 .filter(component => component.isEnabled && config.isTypeConsumptionMetered(component));

--- a/ui/src/app/edge/history/consumption/otherchart.component.ts
+++ b/ui/src/app/edge/history/consumption/otherchart.component.ts
@@ -11,7 +11,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
     selector: 'consumptionOtherChart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class ConsumptionOtherChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class ConsumptionOtherChartComponent extends AbstractHistoryChart impleme
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("consumption-other-chart", service, translate);
     }
@@ -62,7 +62,7 @@ export class ConsumptionOtherChartComponent extends AbstractHistoryChart impleme
                     .filter(component => !(
                         component.factoryId == 'Evcs.Cluster' ||
                         component.factoryId == 'Evcs.Cluster.PeakShaving' ||
-                        component.factoryId == 'Evcs.Cluster.SelfConsumption')
+                        component.factoryId == 'Evcs.Cluster.SelfConsumption'),
                     ).forEach(component => {
                         if (result.data[component.id + '/ChargePower']) {
                             totalEvcsConsumption = result.data[component.id + '/ChargePower'].map((value, index) => {
@@ -96,11 +96,11 @@ export class ConsumptionOtherChartComponent extends AbstractHistoryChart impleme
                     datasets.push({
                         label: this.translate.instant('General.consumption'),
                         data: otherConsumption,
-                        hidden: false
+                        hidden: false,
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(253,197,7,0.05)',
-                        borderColor: 'rgba(253,197,7,1)'
+                        borderColor: 'rgba(253,197,7,1)',
                     });
                 }
                 this.datasets = datasets;
@@ -121,7 +121,7 @@ export class ConsumptionOtherChartComponent extends AbstractHistoryChart impleme
     protected getChannelAddresses(edge: Edge, config: EdgeConfig): Promise<ChannelAddress[]> {
         return new Promise((resolve) => {
             let result: ChannelAddress[] = [
-                new ChannelAddress('_sum', 'ConsumptionActivePower')
+                new ChannelAddress('_sum', 'ConsumptionActivePower'),
             ];
             config.getComponentsImplementingNature("io.openems.edge.evcs.api.Evcs").filter(component => !(component.factoryId == 'Evcs.Cluster')).forEach(component => {
                 result.push(new ChannelAddress(component.id, 'ChargePower'));

--- a/ui/src/app/edge/history/consumption/singlechart.component.ts
+++ b/ui/src/app/edge/history/consumption/singlechart.component.ts
@@ -11,7 +11,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
     selector: 'consumptionSingleChart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class ConsumptionSingleChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -26,7 +26,7 @@ export class ConsumptionSingleChartComponent extends AbstractHistoryChart implem
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("consumption-single-chart", service, translate);
     }
@@ -79,11 +79,11 @@ export class ConsumptionSingleChartComponent extends AbstractHistoryChart implem
                                     datasets.push({
                                         label: this.translate.instant('General.consumption'),
                                         data: data,
-                                        hidden: false
+                                        hidden: false,
                                     });
                                     this.colors.push({
                                         backgroundColor: 'rgba(253,197,7,0.05)',
-                                        borderColor: 'rgba(253,197,7,1)'
+                                        borderColor: 'rgba(253,197,7,1)',
                                     });
                                 }
 
@@ -91,11 +91,11 @@ export class ConsumptionSingleChartComponent extends AbstractHistoryChart implem
                                 if (channelAddress.channelId == 'ActivePower') {
                                     datasets.push({
                                         label: component.alias,
-                                        data: data
+                                        data: data,
                                     });
                                     this.colors.push({
                                         backgroundColor: 'rgba(255,64,64,0.1)',
-                                        borderColor: 'rgba(255,64,64,1)'
+                                        borderColor: 'rgba(255,64,64,1)',
                                     });
                                 }
 
@@ -103,21 +103,21 @@ export class ConsumptionSingleChartComponent extends AbstractHistoryChart implem
                                     if (channelAddress.channelId == 'ConsumptionActivePowerL1') {
                                         datasets.push({
                                             label: this.translate.instant('General.phase') + ' ' + 'L1',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push(this.phase1Color);
                                     }
                                     if (channelAddress.channelId == 'ConsumptionActivePowerL2') {
                                         datasets.push({
                                             label: this.translate.instant('General.phase') + ' ' + 'L2',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push(this.phase2Color);
                                     }
                                     if (channelAddress.channelId == 'ConsumptionActivePowerL3') {
                                         datasets.push({
                                             label: this.translate.instant('General.phase') + ' ' + 'L3',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push(this.phase3Color);
                                     }
@@ -126,31 +126,31 @@ export class ConsumptionSingleChartComponent extends AbstractHistoryChart implem
                                     if (channelAddress.channelId == 'ActivePowerL1') {
                                         datasets.push({
                                             label: component.alias + ' Phase ' + 'L1',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push({
                                             backgroundColor: 'rgba(255,193,193,0.1)',
-                                            borderColor: 'rgba(139,35,35,1)'
+                                            borderColor: 'rgba(139,35,35,1)',
                                         });
                                     }
                                     if (channelAddress.channelId == 'ActivePowerL2') {
                                         datasets.push({
                                             label: component.alias + ' Phase ' + 'L2',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push({
                                             backgroundColor: 'rgba(198,226,255,0.1)',
-                                            borderColor: 'rgba(198,226,255,1)'
+                                            borderColor: 'rgba(198,226,255,1)',
                                         });
                                     }
                                     if (channelAddress.channelId == 'ActivePowerL3') {
                                         datasets.push({
                                             label: component.alias + ' Phase ' + 'L3',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push({
                                             backgroundColor: 'rgba(121,205,205,0.1)',
-                                            borderColor: 'rgba(121,205,205,1)'
+                                            borderColor: 'rgba(121,205,205,1)',
                                         });
                                     }
                                 }
@@ -186,7 +186,7 @@ export class ConsumptionSingleChartComponent extends AbstractHistoryChart implem
                 new ChannelAddress('_sum', 'ConsumptionActivePower'),
                 new ChannelAddress('_sum', 'ConsumptionActivePowerL1'),
                 new ChannelAddress('_sum', 'ConsumptionActivePowerL2'),
-                new ChannelAddress('_sum', 'ConsumptionActivePowerL3')
+                new ChannelAddress('_sum', 'ConsumptionActivePowerL3'),
             ];
 
             let consumptionMeters = config.getComponentsImplementingNature("io.openems.edge.meter.api.ElectricityMeter")

--- a/ui/src/app/edge/history/consumption/totalchart.component.ts
+++ b/ui/src/app/edge/history/consumption/totalchart.component.ts
@@ -11,7 +11,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
     selector: 'consumptionTotalChart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class ConsumptionTotalChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -28,7 +28,7 @@ export class ConsumptionTotalChartComponent extends AbstractHistoryChart impleme
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("consumption-total-chart", service, translate);
     }
@@ -133,11 +133,11 @@ export class ConsumptionTotalChartComponent extends AbstractHistoryChart impleme
                                     datasets.push({
                                         label: this.translate.instant('General.TOTAL'),
                                         data: data,
-                                        hidden: false
+                                        hidden: false,
                                     });
                                     this.colors.push({
                                         backgroundColor: 'rgba(253,197,7,0.05)',
-                                        borderColor: 'rgba(253,197,7,1)'
+                                        borderColor: 'rgba(253,197,7,1)',
                                     });
                                 }
 
@@ -146,21 +146,21 @@ export class ConsumptionTotalChartComponent extends AbstractHistoryChart impleme
                                     if (channelAddress.channelId == 'ConsumptionActivePowerL1') {
                                         datasets.push({
                                             label: this.translate.instant('General.phase') + ' ' + 'L1',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push(this.phase1Color);
                                     }
                                     if (channelAddress.channelId == 'ConsumptionActivePowerL2') {
                                         datasets.push({
                                             label: this.translate.instant('General.phase') + ' ' + 'L2',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push(this.phase2Color);
                                     }
                                     if (channelAddress.channelId == 'ConsumptionActivePowerL3') {
                                         datasets.push({
                                             label: this.translate.instant('General.phase') + ' ' + 'L3',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push(this.phase3Color);
                                     }
@@ -169,31 +169,31 @@ export class ConsumptionTotalChartComponent extends AbstractHistoryChart impleme
                                     if (channelAddress.channelId == 'ActivePowerL1') {
                                         datasets.push({
                                             label: component.alias + ' Phase ' + 'L1',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push({
                                             backgroundColor: 'rgba(255,193,193,0.1)',
-                                            borderColor: 'rgba(139,35,35,1)'
+                                            borderColor: 'rgba(139,35,35,1)',
                                         });
                                     }
                                     if (channelAddress.channelId == 'ActivePowerL2') {
                                         datasets.push({
                                             label: component.alias + ' Phase ' + 'L2',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push({
                                             backgroundColor: 'rgba(198,226,255,0.1)',
-                                            borderColor: 'rgba(198,226,255,1)'
+                                            borderColor: 'rgba(198,226,255,1)',
                                         });
                                     }
                                     if (channelAddress.channelId == 'ActivePowerL3') {
                                         datasets.push({
                                             label: component.alias + ' Phase ' + 'L3',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push({
                                             backgroundColor: 'rgba(121,205,205,0.1)',
-                                            borderColor: 'rgba(121,205,205,1)'
+                                            borderColor: 'rgba(121,205,205,1)',
                                         });
                                     }
                                 }
@@ -203,11 +203,11 @@ export class ConsumptionTotalChartComponent extends AbstractHistoryChart impleme
                                         datasets.push({
                                             label: this.translate.instant('Edge.Index.Widgets.EVCS.chargingStation') + ' (' + this.translate.instant('General.TOTAL') + ')',
                                             data: totalEvcsConsumption,
-                                            hidden: false
+                                            hidden: false,
                                         });
                                         this.colors.push({
                                             backgroundColor: 'rgba(45,143,171,0.05)',
-                                            borderColor: 'rgba(45,143,171,1)'
+                                            borderColor: 'rgba(45,143,171,1)',
                                         });
                                     }
                                     if (channelAddress.channelId == "ChargePower") {
@@ -228,11 +228,11 @@ export class ConsumptionTotalChartComponent extends AbstractHistoryChart impleme
                                         datasets.push({
                                             label: component.alias,
                                             data: data,
-                                            hidden: false
+                                            hidden: false,
                                         });
                                         this.colors.push({
                                             backgroundColor: 'rgba(' + evcsRedColor.toString() + ',' + evcsGreenColor.toString() + ',' + evcsBlueColor.toString() + ',0.05)',
-                                            borderColor: 'rgba(' + evcsRedColor.toString() + ',' + evcsGreenColor.toString() + ',' + evcsBlueColor.toString() + ',1)'
+                                            borderColor: 'rgba(' + evcsRedColor.toString() + ',' + evcsGreenColor.toString() + ',' + evcsBlueColor.toString() + ',1)',
                                         });
                                     }
                                 } else if (regularEvcsComponents.length == 1) {
@@ -240,11 +240,11 @@ export class ConsumptionTotalChartComponent extends AbstractHistoryChart impleme
                                         datasets.push({
                                             label: (component.id == component.alias ? component.id : component.alias),
                                             data: data,
-                                            hidden: false
+                                            hidden: false,
                                         });
                                         this.colors.push({
                                             backgroundColor: 'rgba(45,143,171,0.05)',
-                                            borderColor: 'rgba(45,143,171,1)'
+                                            borderColor: 'rgba(45,143,171,1)',
                                         });
                                     }
                                 }
@@ -254,11 +254,11 @@ export class ConsumptionTotalChartComponent extends AbstractHistoryChart impleme
                                         datasets.push({
                                             label: (component.id == component.alias ? component.id : component.alias),
                                             data: data,
-                                            hidden: false
+                                            hidden: false,
                                         });
                                         this.colors.push({
                                             backgroundColor: 'rgba(220,20,60,0.05)',
-                                            borderColor: 'rgba(220,20,60,1)'
+                                            borderColor: 'rgba(220,20,60,1)',
                                         });
                                     }
                                 }
@@ -279,17 +279,17 @@ export class ConsumptionTotalChartComponent extends AbstractHistoryChart impleme
                                     config.getComponentsImplementingNature("io.openems.edge.meter.api.ElectricityMeter")
                                         .filter(component =>
                                             component.isEnabled &&
-                                            config.isTypeConsumptionMetered(component)
+                                            config.isTypeConsumptionMetered(component),
                                         ).length > 0
                                 )) {
                                     datasets.push({
                                         label: this.translate.instant('General.otherConsumption'),
                                         data: otherConsumption,
-                                        hidden: false
+                                        hidden: false,
                                     });
                                     this.colors.push({
                                         backgroundColor: 'rgba(0,223,0,0.00)',
-                                        borderColor: 'rgba(0,223,0,05)'
+                                        borderColor: 'rgba(0,223,0,05)',
                                     });
                                 }
                             }
@@ -325,7 +325,7 @@ export class ConsumptionTotalChartComponent extends AbstractHistoryChart impleme
                 new ChannelAddress('_sum', 'ConsumptionActivePower'),
                 new ChannelAddress('_sum', 'ConsumptionActivePowerL1'),
                 new ChannelAddress('_sum', 'ConsumptionActivePowerL2'),
-                new ChannelAddress('_sum', 'ConsumptionActivePowerL3')
+                new ChannelAddress('_sum', 'ConsumptionActivePowerL3'),
             ];
             config.getComponentsImplementingNature("io.openems.edge.evcs.api.Evcs")
                 .filter(component => !(

--- a/ui/src/app/edge/history/consumption/widget.component.ts
+++ b/ui/src/app/edge/history/consumption/widget.component.ts
@@ -8,7 +8,7 @@ import { AbstractHistoryWidget } from '../abstracthistorywidget';
 
 @Component({
     selector: ConsumptionComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class ConsumptionComponent extends AbstractHistoryWidget implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class ConsumptionComponent extends AbstractHistoryWidget implements OnIni
 
     constructor(
         public override service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super(service);
     }
@@ -69,7 +69,7 @@ export class ConsumptionComponent extends AbstractHistoryWidget implements OnIni
         return new Promise((resolve) => {
 
             let channels: ChannelAddress[] = [
-                new ChannelAddress('_sum', 'ConsumptionActiveEnergy')
+                new ChannelAddress('_sum', 'ConsumptionActiveEnergy'),
             ];
 
             this.evcsComponents = config.getComponentsImplementingNature("io.openems.edge.evcs.api.Evcs")
@@ -79,7 +79,7 @@ export class ConsumptionComponent extends AbstractHistoryWidget implements OnIni
                     !component.isEnabled == false);
             for (let component of this.evcsComponents) {
                 channels.push(
-                    new ChannelAddress(component.id, 'ActiveConsumptionEnergy')
+                    new ChannelAddress(component.id, 'ActiveConsumptionEnergy'),
                 );
             }
 
@@ -87,7 +87,7 @@ export class ConsumptionComponent extends AbstractHistoryWidget implements OnIni
                 .filter(component => component.isEnabled && config.isTypeConsumptionMetered(component));
             for (let component of this.consumptionMeterComponents) {
                 channels.push(
-                    new ChannelAddress(component.id, 'ActiveProductionEnergy')
+                    new ChannelAddress(component.id, 'ActiveProductionEnergy'),
                 );
             }
             resolve(channels);

--- a/ui/src/app/edge/history/delayedselltogrid/chart.component.ts
+++ b/ui/src/app/edge/history/delayedselltogrid/chart.component.ts
@@ -10,7 +10,7 @@ import { Data, TooltipItem } from './../shared';
 
 @Component({
     selector: 'delayedselltogridgchart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class DelayedSellToGridChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class DelayedSellToGridChartComponent extends AbstractHistoryChart implem
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("delayedsellTogrid-chart", service, translate);
     }
@@ -72,11 +72,11 @@ export class DelayedSellToGridChartComponent extends AbstractHistoryChart implem
                     datasets.push({
                         label: this.translate.instant('General.gridSell'),
                         data: data,
-                        hidden: false
+                        hidden: false,
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,0,0,0.05)',
-                        borderColor: 'rgba(0,0,0,1)'
+                        borderColor: 'rgba(0,0,0,1)',
                     });
                 }
                 if (sellToGridPowerLimit in result.data) {
@@ -93,11 +93,11 @@ export class DelayedSellToGridChartComponent extends AbstractHistoryChart implem
                         label: this.translate.instant('Edge.Index.Widgets.DelayedSellToGrid.sellToGridPowerLimit'),
                         data: data,
                         hidden: false,
-                        borderDash: [3, 3]
+                        borderDash: [3, 3],
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,0,0,0)',
-                        borderColor: 'rgba(0,223,0,1)'
+                        borderColor: 'rgba(0,223,0,1)',
                     });
                 }
                 if (continuousSellToGridPower in result.data) {
@@ -114,11 +114,11 @@ export class DelayedSellToGridChartComponent extends AbstractHistoryChart implem
                         label: this.translate.instant('Edge.Index.Widgets.DelayedSellToGrid.continuousSellToGridPower'),
                         data: data,
                         hidden: false,
-                        borderDash: [3, 3]
+                        borderDash: [3, 3],
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,0,0,0)',
-                        borderColor: 'rgba(200,0,0,1)'
+                        borderColor: 'rgba(200,0,0,1)',
                     });
                 }
                 if ('_sum/EssActivePower' in result.data) {
@@ -145,11 +145,11 @@ export class DelayedSellToGridChartComponent extends AbstractHistoryChart implem
                     datasets.push({
                         label: this.translate.instant('General.chargePower'),
                         data: chargeData,
-                        borderDash: [10, 10]
+                        borderDash: [10, 10],
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,223,0,0.05)',
-                        borderColor: 'rgba(0,223,0,1)'
+                        borderColor: 'rgba(0,223,0,1)',
                     });
                     /*
                      * Storage Discharge
@@ -166,11 +166,11 @@ export class DelayedSellToGridChartComponent extends AbstractHistoryChart implem
                     datasets.push({
                         label: this.translate.instant('General.dischargePower'),
                         data: dischargeData,
-                        borderDash: [10, 10]
+                        borderDash: [10, 10],
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(200,0,0,0.05)',
-                        borderColor: 'rgba(200,0,0,1)'
+                        borderColor: 'rgba(200,0,0,1)',
                     });
                 }
                 this.datasets = datasets;
@@ -197,7 +197,7 @@ export class DelayedSellToGridChartComponent extends AbstractHistoryChart implem
                 new ChannelAddress(this.componentId, '_PropertyContinuousSellToGridPower'),
                 new ChannelAddress(config.getComponent(this.componentId).properties['meter.id'], 'ActivePower'),
                 new ChannelAddress('_sum', 'ProductionDcActualPower'),
-                new ChannelAddress('_sum', 'EssActivePower')
+                new ChannelAddress('_sum', 'EssActivePower'),
             ];
             resolve(result);
         });

--- a/ui/src/app/edge/history/delayedselltogrid/symmetricpeakshavingchartoverview/delayedselltogridchartoverview.component.ts
+++ b/ui/src/app/edge/history/delayedselltogrid/symmetricpeakshavingchartoverview/delayedselltogridchartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
 
 @Component({
     selector: DelayedSellToGridChartOverviewComponent.SELECTOR,
-    templateUrl: './delayedselltogridchartoverview.component.html'
+    templateUrl: './delayedselltogridchartoverview.component.html',
 })
 export class DelayedSellToGridChartOverviewComponent implements OnInit {
 
@@ -15,7 +15,7 @@ export class DelayedSellToGridChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/delayedselltogrid/widget.component.ts
+++ b/ui/src/app/edge/history/delayedselltogrid/widget.component.ts
@@ -5,7 +5,7 @@ import { Edge, Service, EdgeConfig } from 'src/app/shared/shared';
 
 @Component({
     selector: DelayedSellToGridWidgetComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class DelayedSellToGridWidgetComponent implements OnInit {
 
@@ -19,7 +19,7 @@ export class DelayedSellToGridWidgetComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/fixdigitaloutput/fixdigitaloutputchartoverview/fixdigitaloutputchartoverview.component.ts
+++ b/ui/src/app/edge/history/fixdigitaloutput/fixdigitaloutputchartoverview/fixdigitaloutputchartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service, Utils } from '../../../../shared/shared';
 
 @Component({
     selector: FixDigitalOutputChartOverviewComponent.SELECTOR,
-    templateUrl: './fixdigitaloutputchartoverview.component.html'
+    templateUrl: './fixdigitaloutputchartoverview.component.html',
 })
 export class FixDigitalOutputChartOverviewComponent implements OnInit {
 
@@ -21,7 +21,7 @@ export class FixDigitalOutputChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/fixdigitaloutput/singlechart.component.ts
+++ b/ui/src/app/edge/history/fixdigitaloutput/singlechart.component.ts
@@ -11,7 +11,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
   selector: 'fixDigitalOutputSingleChart',
-  templateUrl: '../abstracthistorychart.html'
+  templateUrl: '../abstracthistorychart.html',
 })
 export class FixDigitalOutputSingleChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -25,7 +25,7 @@ export class FixDigitalOutputSingleChartComponent extends AbstractHistoryChart i
   constructor(
     protected override service: Service,
     protected override translate: TranslateService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) {
     super("fixdigitaloutput-single-chart", service, translate);
   }
@@ -66,11 +66,11 @@ export class FixDigitalOutputSingleChartComponent extends AbstractHistoryChart i
         });
         datasets.push({
           label: address.channelId,
-          data: data
+          data: data,
         });
         this.colors.push({
           backgroundColor: 'rgba(0,191,255,0.05)',
-          borderColor: 'rgba(0,191,255,1)'
+          borderColor: 'rgba(0,191,255,1)',
         });
       }
       this.datasets = datasets;

--- a/ui/src/app/edge/history/fixdigitaloutput/totalchart.component.ts
+++ b/ui/src/app/edge/history/fixdigitaloutput/totalchart.component.ts
@@ -11,7 +11,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
   selector: 'fixDigitalOutputTotalChart',
-  templateUrl: '../abstracthistorychart.html'
+  templateUrl: '../abstracthistorychart.html',
 })
 export class FixDigitalOutputTotalChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class FixDigitalOutputTotalChartComponent extends AbstractHistoryChart im
   constructor(
     protected override service: Service,
     protected override translate: TranslateService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) {
     super("fixdigitaloutput-total-chart", service, translate);
   }
@@ -68,21 +68,21 @@ export class FixDigitalOutputTotalChartComponent extends AbstractHistoryChart im
           case 0:
             datasets.push({
               label: address.channelId,
-              data: data
+              data: data,
             });
             this.colors.push({
               backgroundColor: 'rgba(0,191,255,0.05)',
-              borderColor: 'rgba(0,191,255,1)'
+              borderColor: 'rgba(0,191,255,1)',
             });
             break;
           case 1:
             datasets.push({
               label: address.channelId,
-              data: data
+              data: data,
             });
             this.colors.push({
               backgroundColor: 'rgba(0,0,139,0.05)',
-              borderColor: 'rgba(0,0,139,1)'
+              borderColor: 'rgba(0,0,139,1)',
             });
             break;
         }

--- a/ui/src/app/edge/history/fixdigitaloutput/widget.component.ts
+++ b/ui/src/app/edge/history/fixdigitaloutput/widget.component.ts
@@ -9,7 +9,7 @@ import { calculateActiveTimeOverPeriod } from '../shared';
 
 @Component({
     selector: FixDigitalOutputWidgetComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class FixDigitalOutputWidgetComponent extends AbstractHistoryWidget implements OnInit, OnChanges, OnDestroy {
 
@@ -25,7 +25,7 @@ export class FixDigitalOutputWidgetComponent extends AbstractHistoryWidget imple
 
     constructor(
         public override service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super(service);
     }

--- a/ui/src/app/edge/history/grid/chart.component.ts
+++ b/ui/src/app/edge/history/grid/chart.component.ts
@@ -10,7 +10,7 @@ import { Data, TooltipItem } from './../shared';
 
 @Component({
     selector: 'gridChart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class GridChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class GridChartComponent extends AbstractHistoryChart implements OnInit, 
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("grid-chart", service, translate);
     }
@@ -70,11 +70,11 @@ export class GridChartComponent extends AbstractHistoryChart implements OnInit, 
                 datasets.push({
                     label: this.translate.instant('General.grid'),
                     data: gridData,
-                    hidden: false
+                    hidden: false,
                 });
                 this.colors.push({
                     backgroundColor: 'rgba(0,0,0,0.05)',
-                    borderColor: 'rgba(0,0,0,1)'
+                    borderColor: 'rgba(0,0,0,1)',
                 });
             }
 
@@ -95,7 +95,7 @@ export class GridChartComponent extends AbstractHistoryChart implements OnInit, 
                     datasets.push({
                         label: this.translate.instant('General.phase') + ' ' + 'L1',
                         data: gridData,
-                        hidden: false
+                        hidden: false,
                     });
                     this.colors.push(this.phase1Color);
                 }
@@ -115,7 +115,7 @@ export class GridChartComponent extends AbstractHistoryChart implements OnInit, 
                     datasets.push({
                         label: this.translate.instant('General.phase') + ' ' + 'L2',
                         data: gridData,
-                        hidden: false
+                        hidden: false,
                     });
                     this.colors.push(this.phase2Color);
                 }
@@ -135,7 +135,7 @@ export class GridChartComponent extends AbstractHistoryChart implements OnInit, 
                     datasets.push({
                         label: this.translate.instant('General.phase') + ' ' + 'L3',
                         data: gridData,
-                        hidden: false
+                        hidden: false,
                     });
                     this.colors.push(this.phase3Color);
                 }
@@ -157,7 +157,7 @@ export class GridChartComponent extends AbstractHistoryChart implements OnInit, 
                 new ChannelAddress('_sum', 'GridActivePower'),
                 new ChannelAddress('_sum', 'GridActivePowerL1'),
                 new ChannelAddress('_sum', 'GridActivePowerL2'),
-                new ChannelAddress('_sum', 'GridActivePowerL3')
+                new ChannelAddress('_sum', 'GridActivePowerL3'),
             ];
             resolve(result);
         });

--- a/ui/src/app/edge/history/gridoptimizedcharge/chart.component.ts
+++ b/ui/src/app/edge/history/gridoptimizedcharge/chart.component.ts
@@ -12,7 +12,7 @@ import { ChartOptions, Data, DEFAULT_TIME_CHART_OPTIONS, TooltipItem } from '../
 
 @Component({
   selector: 'gridOptimizedChargeChart',
-  templateUrl: '../abstracthistorychart.html'
+  templateUrl: '../abstracthistorychart.html',
 })
 export class GridOptimizedChargeChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -26,7 +26,7 @@ export class GridOptimizedChargeChartComponent extends AbstractHistoryChart impl
   constructor(
     protected override service: Service,
     protected override translate: TranslateService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) {
     super("gridOptimizedCharge-chart", service, translate);
   }
@@ -76,11 +76,11 @@ export class GridOptimizedChargeChartComponent extends AbstractHistoryChart impl
             label: this.translate.instant('Edge.Index.Widgets.GridOptimizedCharge.maximumCharge'),
             data: delayChargeData,
             hidden: false,
-            borderDash: [3, 3]
+            borderDash: [3, 3],
           });
           this.colors.push({
             backgroundColor: 'rgba(253,197,7,0.05)',
-            borderColor: 'rgba(253,197,7,1)'
+            borderColor: 'rgba(253,197,7,1)',
           });
         }
 
@@ -101,11 +101,11 @@ export class GridOptimizedChargeChartComponent extends AbstractHistoryChart impl
             label: this.translate.instant('Edge.Index.Widgets.GridOptimizedCharge.minimumCharge'),
             data: sellToGridLimitData,
             hidden: false,
-            borderDash: [3, 3]
+            borderDash: [3, 3],
           });
           this.colors.push({
             backgroundColor: 'rgba(200,0,0,0.05)',
-            borderColor: 'rgba(200,0,0,1)'
+            borderColor: 'rgba(200,0,0,1)',
           });
         }
 
@@ -137,11 +137,11 @@ export class GridOptimizedChargeChartComponent extends AbstractHistoryChart impl
             data: chargeData,
             hidden: false,
             yAxisID: 'yAxis1',
-            position: 'left'
+            position: 'left',
           });
           this.colors.push({
             backgroundColor: 'rgba(0,223,0,0.05)',
-            borderColor: 'rgba(0,223,0,1)'
+            borderColor: 'rgba(0,223,0,1)',
           });
 
           // State of charge data
@@ -161,11 +161,11 @@ export class GridOptimizedChargeChartComponent extends AbstractHistoryChart impl
               hidden: false,
               yAxisID: 'yAxis2',
               position: 'right',
-              borderDash: [10, 10]
+              borderDash: [10, 10],
             });
             this.colors.push({
               backgroundColor: 'rgba(189, 195, 199,0.05)',
-              borderColor: 'rgba(189, 195, 199,1)'
+              borderColor: 'rgba(189, 195, 199,1)',
             });
           }
         }
@@ -192,7 +192,7 @@ export class GridOptimizedChargeChartComponent extends AbstractHistoryChart impl
       let result: ChannelAddress[] = [
         new ChannelAddress('_sum', 'EssActivePower'),
         new ChannelAddress('_sum', 'ProductionDcActualPower'),
-        new ChannelAddress('_sum', 'EssSoc')
+        new ChannelAddress('_sum', 'EssSoc'),
       ];
       if (this.component != null && this.component.id) {
         result.push(new ChannelAddress(this.component.id, 'DelayChargeMaximumChargeLimit'));
@@ -213,25 +213,25 @@ export class GridOptimizedChargeChartComponent extends AbstractHistoryChart impl
         display: true,
         labelString: "%",
         padding: -2,
-        fontSize: 11
+        fontSize: 11,
       },
       gridLines: {
-        display: false
+        display: false,
       },
       ticks: {
         beginAtZero: true,
         max: 100,
         padding: -5,
-        stepSize: 20
-      }
+        stepSize: 20,
+      },
     });
     options.layout = {
       padding: {
         left: 2,
         right: 2,
         top: 0,
-        bottom: 0
-      }
+        bottom: 0,
+      },
     };
     //x-axis
     if (differenceInDays(this.service.historyPeriod.value.to, this.service.historyPeriod.value.from) >= 5) {

--- a/ui/src/app/edge/history/gridoptimizedcharge/gridoptimizedchargechartoverview/gridoptimizedchargechartoverview.component.ts
+++ b/ui/src/app/edge/history/gridoptimizedcharge/gridoptimizedchargechartoverview/gridoptimizedchargechartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
 
 @Component({
     selector: GridOptimizedChargeChartOverviewComponent.SELECTOR,
-    templateUrl: './gridoptimizedchargechartoverview.component.html'
+    templateUrl: './gridoptimizedchargechartoverview.component.html',
 })
 export class GridOptimizedChargeChartOverviewComponent implements OnInit {
 
@@ -15,7 +15,7 @@ export class GridOptimizedChargeChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/gridoptimizedcharge/sellToGridLimitChart.component.ts
+++ b/ui/src/app/edge/history/gridoptimizedcharge/sellToGridLimitChart.component.ts
@@ -11,7 +11,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
   selector: 'sellToGridLimitChart',
-  templateUrl: '../abstracthistorychart.html'
+  templateUrl: '../abstracthistorychart.html',
 })
 export class SellToGridLimitChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -28,7 +28,7 @@ export class SellToGridLimitChartComponent extends AbstractHistoryChart implemen
   constructor(
     protected override service: Service,
     protected override translate: TranslateService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) {
     super("gridOptimizedCharge-chart", service, translate);
   }
@@ -79,11 +79,11 @@ export class SellToGridLimitChartComponent extends AbstractHistoryChart implemen
           datasets.push({
             label: this.translate.instant('General.gridSell'),
             data: sellToGridData,
-            hidden: false
+            hidden: false,
           });
           this.colors.push({
             backgroundColor: 'rgba(0,0,200,0.05)',
-            borderColor: 'rgba(0,0,200,1)'
+            borderColor: 'rgba(0,0,200,1)',
           });
         }
 
@@ -106,11 +106,11 @@ export class SellToGridLimitChartComponent extends AbstractHistoryChart implemen
             label: this.translate.instant('Edge.Index.Widgets.GridOptimizedCharge.maximumGridFeedIn'),
             data: sellToGridLimitData,
             hidden: false,
-            borderDash: [3, 3]
+            borderDash: [3, 3],
           });
           this.colors.push({
             backgroundColor: 'rgba(0,0,0,0.05)',
-            borderColor: 'rgba(0,0,0,1)'
+            borderColor: 'rgba(0,0,0,1)',
           });
 
           let batterySellToGridLimitData = result.data[this.component.id + '/_PropertyMaximumSellToGridPower'].map(value => {
@@ -129,11 +129,11 @@ export class SellToGridLimitChartComponent extends AbstractHistoryChart implemen
             label: "Maximale Netzeinspeisung durch Batteriebeladung",
             data: batterySellToGridLimitData,
             hidden: false,
-            borderDash: [3, 3]
+            borderDash: [3, 3],
           });
           this.colors.push({
             backgroundColor: 'rgba(200,0,0,0.05)',
-            borderColor: 'rgba(200,0,0,1)'
+            borderColor: 'rgba(200,0,0,1)',
           });
         }
 
@@ -152,11 +152,11 @@ export class SellToGridLimitChartComponent extends AbstractHistoryChart implemen
           datasets.push({
             label: this.translate.instant('General.production'),
             data: productionData,
-            hidden: false
+            hidden: false,
           });
           this.colors.push({
             backgroundColor: 'rgba(45,143,171,0.05)',
-            borderColor: 'rgba(45,143,171,1)'
+            borderColor: 'rgba(45,143,171,1)',
           });
         }
         this.datasets = datasets;

--- a/ui/src/app/edge/history/gridoptimizedcharge/widget.component.ts
+++ b/ui/src/app/edge/history/gridoptimizedcharge/widget.component.ts
@@ -7,7 +7,7 @@ import { AbstractHistoryWidget } from '../abstracthistorywidget';
 
 @Component({
     selector: GridOptimizedChargeWidgetComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class GridOptimizedChargeWidgetComponent extends AbstractHistoryWidget implements OnInit, OnChanges, OnDestroy {
 
@@ -27,7 +27,7 @@ export class GridOptimizedChargeWidgetComponent extends AbstractHistoryWidget im
 
     constructor(
         public override service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super(service);
     }
@@ -79,7 +79,7 @@ export class GridOptimizedChargeWidgetComponent extends AbstractHistoryWidget im
                 new ChannelAddress(this.componentId, 'DelayChargeTime'),
                 new ChannelAddress(this.componentId, 'SellToGridLimitTime'),
                 new ChannelAddress(this.componentId, 'AvoidLowChargingTime'),
-                new ChannelAddress(this.componentId, 'NoLimitationTime')
+                new ChannelAddress(this.componentId, 'NoLimitationTime'),
             ];
             resolve(channeladdresses);
         });

--- a/ui/src/app/edge/history/heatingelement/chart.component.ts
+++ b/ui/src/app/edge/history/heatingelement/chart.component.ts
@@ -11,7 +11,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
   selector: 'heatingelementChart',
-  templateUrl: '../abstracthistorychart.html'
+  templateUrl: '../abstracthistorychart.html',
 })
 export class HeatingelementChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -25,7 +25,7 @@ export class HeatingelementChartComponent extends AbstractHistoryChart implement
   constructor(
     protected override service: Service,
     protected override translate: TranslateService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) {
     super("heatingelement-chart", service, translate);
   }
@@ -69,11 +69,11 @@ export class HeatingelementChartComponent extends AbstractHistoryChart implement
           });
           datasets.push({
             label: 'Level',
-            data: levelData
+            data: levelData,
           });
           this.colors.push({
             backgroundColor: 'rgba(200,0,0,0.05)',
-            borderColor: 'rgba(200,0,0,1)'
+            borderColor: 'rgba(200,0,0,1)',
           });
         }
         this.datasets = datasets;

--- a/ui/src/app/edge/history/heatingelement/heatingelementchartoverview/heatingelementchartoverview.component.ts
+++ b/ui/src/app/edge/history/heatingelement/heatingelementchartoverview/heatingelementchartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
 
 @Component({
     selector: HeatingelementChartOverviewComponent.SELECTOR,
-    templateUrl: './heatingelementchartoverview.component.html'
+    templateUrl: './heatingelementchartoverview.component.html',
 })
 export class HeatingelementChartOverviewComponent implements OnInit {
 
@@ -15,7 +15,7 @@ export class HeatingelementChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/heatingelement/widget.component.ts
+++ b/ui/src/app/edge/history/heatingelement/widget.component.ts
@@ -8,7 +8,7 @@ import { AbstractHistoryWidget } from '../abstracthistorywidget';
 
 @Component({
     selector: HeatingelementWidgetComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class HeatingelementWidgetComponent extends AbstractHistoryWidget implements OnInit, OnChanges, OnDestroy {
 
@@ -27,7 +27,7 @@ export class HeatingelementWidgetComponent extends AbstractHistoryWidget impleme
 
     constructor(
         public override service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super(service);
     }
@@ -69,7 +69,7 @@ export class HeatingelementWidgetComponent extends AbstractHistoryWidget impleme
             let channeladdresses = [
                 new ChannelAddress(this.componentId, 'Level1CumulatedTime'),
                 new ChannelAddress(this.componentId, 'Level2CumulatedTime'),
-                new ChannelAddress(this.componentId, 'Level3CumulatedTime')
+                new ChannelAddress(this.componentId, 'Level3CumulatedTime'),
             ];
             resolve(channeladdresses);
         });

--- a/ui/src/app/edge/history/heatpump/chart.component.ts
+++ b/ui/src/app/edge/history/heatpump/chart.component.ts
@@ -9,7 +9,7 @@ import { Data, TooltipItem } from './../shared';
 
 @Component({
     selector: 'heatpumpchart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class HeatPumpChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -23,7 +23,7 @@ export class HeatPumpChartComponent extends AbstractHistoryChart implements OnIn
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("heatpump-chart", service, translate);
     }
@@ -67,11 +67,11 @@ export class HeatPumpChartComponent extends AbstractHistoryChart implements OnIn
                 datasets.push({
                     label: this.translate.instant('General.state'),
                     data: stateTimeData,
-                    hidden: false
+                    hidden: false,
                 });
                 this.colors.push({
                     backgroundColor: 'rgba(200,0,0,0.05)',
-                    borderColor: 'rgba(200,0,0,1)'
+                    borderColor: 'rgba(200,0,0,1)',
                 });
             }
             this.datasets = datasets;

--- a/ui/src/app/edge/history/heatpump/heatpumpchartoverview/heatpumpchartoverview.component.ts
+++ b/ui/src/app/edge/history/heatpump/heatpumpchartoverview/heatpumpchartoverview.component.ts
@@ -5,7 +5,7 @@ import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
 
 @Component({
     selector: HeatPumpChartOverviewComponent.SELECTOR,
-    templateUrl: './heatpumpchartoverview.component.html'
+    templateUrl: './heatpumpchartoverview.component.html',
 })
 export class HeatPumpChartOverviewComponent implements OnInit {
 
@@ -17,7 +17,7 @@ export class HeatPumpChartOverviewComponent implements OnInit {
     constructor(
         public service: Service,
         public modalCtrl: ModalController,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/heatpump/widget.component.ts
+++ b/ui/src/app/edge/history/heatpump/widget.component.ts
@@ -8,7 +8,7 @@ import { AbstractHistoryWidget } from '../abstracthistorywidget';
 
 @Component({
     selector: HeatpumpWidgetComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class HeatpumpWidgetComponent extends AbstractHistoryWidget implements OnInit, OnChanges, OnDestroy {
 
@@ -29,7 +29,7 @@ export class HeatpumpWidgetComponent extends AbstractHistoryWidget implements On
     constructor(
         public override service: Service,
         private route: ActivatedRoute,
-        public modalCtrl: ModalController
+        public modalCtrl: ModalController,
     ) {
         super(service);
     }
@@ -79,7 +79,7 @@ export class HeatpumpWidgetComponent extends AbstractHistoryWidget implements On
                 new ChannelAddress(this.componentId, 'ForceOnStateTime'),
                 new ChannelAddress(this.componentId, 'RegularStateTime'),
                 new ChannelAddress(this.componentId, 'RecommendationStateTime'),
-                new ChannelAddress(this.componentId, 'LockStateTime')
+                new ChannelAddress(this.componentId, 'LockStateTime'),
             ];
             resolve(channels);
         });

--- a/ui/src/app/edge/history/history.component.ts
+++ b/ui/src/app/edge/history/history.component.ts
@@ -8,7 +8,7 @@ import { environment } from 'src/environments';
 
 @Component({
   selector: 'history',
-  templateUrl: './history.component.html'
+  templateUrl: './history.component.html',
 })
 export class HistoryComponent implements OnInit {
 
@@ -36,7 +36,7 @@ export class HistoryComponent implements OnInit {
   constructor(
     public service: Service,
     public translate: TranslateService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) { }
 
   ngOnInit() {
@@ -77,11 +77,11 @@ export class HistoryComponent implements OnInit {
       /* handle grid breakpoints */(window.innerWidth < 768 ? window.innerWidth - 150 : window.innerWidth - 400));
     this.socChartHeight =
       /* minimum size */ Math.max(150,
-      /* maximium size */ Math.min(200, ref)
+      /* maximium size */ Math.min(200, ref),
     ) + "px";
     this.energyChartHeight =
       /* minimum size */ Math.max(300,
-      /* maximium size */ Math.min(600, ref)
+      /* maximium size */ Math.min(600, ref),
     ) + "px";
   }
 }

--- a/ui/src/app/edge/history/history.module.ts
+++ b/ui/src/app/edge/history/history.module.ts
@@ -61,7 +61,7 @@ import { TimeOfUseTariffDischargeWidgetComponent } from './timeofusetariffdischa
 @NgModule({
   imports: [
     SharedModule,
-    Common
+    Common,
   ],
   declarations: [
     AsymmetricPeakshavingChartComponent,
@@ -118,7 +118,7 @@ import { TimeOfUseTariffDischargeWidgetComponent } from './timeofusetariffdischa
     TimeslotPeakshavingChartComponent,
     TimeslotPeakshavingChartOverviewComponent,
     TimeslotPeakshavingWidgetComponent,
-    HistoryParentComponent
-  ]
+    HistoryParentComponent,
+  ],
 })
 export class HistoryModule { }

--- a/ui/src/app/edge/history/historydataservice.ts
+++ b/ui/src/app/edge/history/historydataservice.ts
@@ -14,7 +14,7 @@ export class HistoryDataService extends DataService {
 
   constructor(
     @Inject(Websocket) protected websocket: Websocket,
-    @Inject(Service) protected service: Service
+    @Inject(Service) protected service: Service,
   ) {
     super();
   }

--- a/ui/src/app/edge/history/historyparent.component.ts
+++ b/ui/src/app/edge/history/historyparent.component.ts
@@ -6,6 +6,6 @@ import { Component } from "@angular/core";
     template: `
     <ion-router-outlet>
 </ion-router-outlet>
-    `
+    `,
 })
 export class HistoryParentComponent { }

--- a/ui/src/app/edge/history/peakshaving/asymmetric/asymmetricpeakshavingchartoverview/asymmetricpeakshavingchartoverview.component.ts
+++ b/ui/src/app/edge/history/peakshaving/asymmetric/asymmetricpeakshavingchartoverview/asymmetricpeakshavingchartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service } from '../../../../../shared/shared';
 
 @Component({
     selector: AsymmetricPeakshavingChartOverviewComponent.SELECTOR,
-    templateUrl: './asymmetricpeakshavingchartoverview.component.html'
+    templateUrl: './asymmetricpeakshavingchartoverview.component.html',
 })
 export class AsymmetricPeakshavingChartOverviewComponent implements OnInit {
 
@@ -15,7 +15,7 @@ export class AsymmetricPeakshavingChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/peakshaving/asymmetric/chart.component.ts
+++ b/ui/src/app/edge/history/peakshaving/asymmetric/chart.component.ts
@@ -10,7 +10,7 @@ import { Data, TooltipItem } from './../../shared';
 
 @Component({
     selector: 'asymmetricpeakshavingchart',
-    templateUrl: '../../abstracthistorychart.html'
+    templateUrl: '../../abstracthistorychart.html',
 })
 export class AsymmetricPeakshavingChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class AsymmetricPeakshavingChartComponent extends AbstractHistoryChart im
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("asymmetricpeakshaving-chart", service, translate);
     }
@@ -73,7 +73,7 @@ export class AsymmetricPeakshavingChartComponent extends AbstractHistoryChart im
                 datasets.push({
                     label: this.translate.instant('General.phase') + ' ' + 'L1',
                     data: data,
-                    hidden: false
+                    hidden: false,
                 });
                 this.colors.push(this.phase1Color);
             }
@@ -90,7 +90,7 @@ export class AsymmetricPeakshavingChartComponent extends AbstractHistoryChart im
                 datasets.push({
                     label: this.translate.instant('General.phase') + ' ' + 'L2',
                     data: data,
-                    hidden: false
+                    hidden: false,
                 });
                 this.colors.push(this.phase2Color);
             }
@@ -107,7 +107,7 @@ export class AsymmetricPeakshavingChartComponent extends AbstractHistoryChart im
                 datasets.push({
                     label: this.translate.instant('General.phase') + ' ' + 'L3',
                     data: data,
-                    hidden: false
+                    hidden: false,
                 });
                 this.colors.push(this.phase3Color);
             }
@@ -125,11 +125,11 @@ export class AsymmetricPeakshavingChartComponent extends AbstractHistoryChart im
                     label: this.translate.instant('Edge.Index.Widgets.Peakshaving.rechargePower'),
                     data: data,
                     hidden: false,
-                    borderDash: [3, 3]
+                    borderDash: [3, 3],
                 });
                 this.colors.push({
                     backgroundColor: 'rgba(0,0,0,0)',
-                    borderColor: 'rgba(0,223,0,1)'
+                    borderColor: 'rgba(0,223,0,1)',
                 });
             }
             if (peakshavingPower in result.data) {
@@ -146,11 +146,11 @@ export class AsymmetricPeakshavingChartComponent extends AbstractHistoryChart im
                     label: this.translate.instant('Edge.Index.Widgets.Peakshaving.peakshavingPower'),
                     data: data,
                     hidden: false,
-                    borderDash: [3, 3]
+                    borderDash: [3, 3],
                 });
                 this.colors.push({
                     backgroundColor: 'rgba(0,0,0,0)',
-                    borderColor: 'rgba(200,0,0,1)'
+                    borderColor: 'rgba(200,0,0,1)',
                 });
             }
             if ('_sum/EssActivePower' in result.data) {
@@ -176,11 +176,11 @@ export class AsymmetricPeakshavingChartComponent extends AbstractHistoryChart im
                 });
                 datasets.push({
                     label: this.translate.instant('General.chargePower'),
-                    data: chargeData
+                    data: chargeData,
                 });
                 this.colors.push({
                     backgroundColor: 'rgba(0,223,0,0.05)',
-                    borderColor: 'rgba(0,223,0,1)'
+                    borderColor: 'rgba(0,223,0,1)',
                 });
                 /*
                  * Storage Discharge
@@ -196,11 +196,11 @@ export class AsymmetricPeakshavingChartComponent extends AbstractHistoryChart im
                 });
                 datasets.push({
                     label: this.translate.instant('General.dischargePower'),
-                    data: dischargeData
+                    data: dischargeData,
                 });
                 this.colors.push({
                     backgroundColor: 'rgba(200,0,0,0.05)',
-                    borderColor: 'rgba(200,0,0,1)'
+                    borderColor: 'rgba(200,0,0,1)',
                 });
             }
             this.datasets = datasets;
@@ -223,7 +223,7 @@ export class AsymmetricPeakshavingChartComponent extends AbstractHistoryChart im
                 new ChannelAddress(this.component.properties['meter.id'], 'ActivePowerL2'),
                 new ChannelAddress(this.component.properties['meter.id'], 'ActivePowerL3'),
                 new ChannelAddress('_sum', 'ProductionDcActualPower'),
-                new ChannelAddress('_sum', 'EssActivePower')
+                new ChannelAddress('_sum', 'EssActivePower'),
             ];
             resolve(result);
         });

--- a/ui/src/app/edge/history/peakshaving/asymmetric/widget.component.ts
+++ b/ui/src/app/edge/history/peakshaving/asymmetric/widget.component.ts
@@ -5,7 +5,7 @@ import { Edge, Service, EdgeConfig } from 'src/app/shared/shared';
 
 @Component({
     selector: AsymmetricPeakshavingWidgetComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class AsymmetricPeakshavingWidgetComponent implements OnInit {
 
@@ -19,7 +19,7 @@ export class AsymmetricPeakshavingWidgetComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/peakshaving/symmetric/chart.component.ts
+++ b/ui/src/app/edge/history/peakshaving/symmetric/chart.component.ts
@@ -10,7 +10,7 @@ import { Data, TooltipItem } from './../../shared';
 
 @Component({
     selector: 'symmetricpeakshavingchart',
-    templateUrl: '../../abstracthistorychart.html'
+    templateUrl: '../../abstracthistorychart.html',
 })
 export class SymmetricPeakshavingChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class SymmetricPeakshavingChartComponent extends AbstractHistoryChart imp
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("symmetricpeakshaving-chart", service, translate);
     }
@@ -72,11 +72,11 @@ export class SymmetricPeakshavingChartComponent extends AbstractHistoryChart imp
                     datasets.push({
                         label: this.translate.instant('General.measuredValue'),
                         data: data,
-                        hidden: false
+                        hidden: false,
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,0,0,0.05)',
-                        borderColor: 'rgba(0,0,0,1)'
+                        borderColor: 'rgba(0,0,0,1)',
                     });
                 }
                 if (rechargePower in result.data) {
@@ -93,11 +93,11 @@ export class SymmetricPeakshavingChartComponent extends AbstractHistoryChart imp
                         label: this.translate.instant('Edge.Index.Widgets.Peakshaving.rechargePower'),
                         data: data,
                         hidden: false,
-                        borderDash: [3, 3]
+                        borderDash: [3, 3],
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,0,0,0)',
-                        borderColor: 'rgba(0,223,0,1)'
+                        borderColor: 'rgba(0,223,0,1)',
                     });
                 }
                 if (peakshavingPower in result.data) {
@@ -114,11 +114,11 @@ export class SymmetricPeakshavingChartComponent extends AbstractHistoryChart imp
                         label: this.translate.instant('Edge.Index.Widgets.Peakshaving.peakshavingPower'),
                         data: data,
                         hidden: false,
-                        borderDash: [3, 3]
+                        borderDash: [3, 3],
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,0,0,0)',
-                        borderColor: 'rgba(200,0,0,1)'
+                        borderColor: 'rgba(200,0,0,1)',
                     });
                 }
                 if ('_sum/EssActivePower' in result.data) {
@@ -145,11 +145,11 @@ export class SymmetricPeakshavingChartComponent extends AbstractHistoryChart imp
                     datasets.push({
                         label: this.translate.instant('General.chargePower'),
                         data: chargeData,
-                        borderDash: [10, 10]
+                        borderDash: [10, 10],
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,223,0,0.05)',
-                        borderColor: 'rgba(0,223,0,1)'
+                        borderColor: 'rgba(0,223,0,1)',
                     });
                     /*
                      * Storage Discharge
@@ -166,11 +166,11 @@ export class SymmetricPeakshavingChartComponent extends AbstractHistoryChart imp
                     datasets.push({
                         label: this.translate.instant('General.dischargePower'),
                         data: dischargeData,
-                        borderDash: [10, 10]
+                        borderDash: [10, 10],
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(200,0,0,0.05)',
-                        borderColor: 'rgba(200,0,0,1)'
+                        borderColor: 'rgba(200,0,0,1)',
                     });
                 }
                 this.datasets = datasets;
@@ -197,7 +197,7 @@ export class SymmetricPeakshavingChartComponent extends AbstractHistoryChart imp
                 new ChannelAddress(this.componentId, '_PropertyPeakShavingPower'),
                 new ChannelAddress(config.getComponent(this.componentId).properties['meter.id'], 'ActivePower'),
                 new ChannelAddress('_sum', 'ProductionDcActualPower'),
-                new ChannelAddress('_sum', 'EssActivePower')
+                new ChannelAddress('_sum', 'EssActivePower'),
             ];
             resolve(result);
         });

--- a/ui/src/app/edge/history/peakshaving/symmetric/symmetricpeakshavingchartoverview/symmetricpeakshavingchartoverview.component.ts
+++ b/ui/src/app/edge/history/peakshaving/symmetric/symmetricpeakshavingchartoverview/symmetricpeakshavingchartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service } from '../../../../../shared/shared';
 
 @Component({
     selector: SymmetricPeakshavingChartOverviewComponent.SELECTOR,
-    templateUrl: './symmetricpeakshavingchartoverview.component.html'
+    templateUrl: './symmetricpeakshavingchartoverview.component.html',
 })
 export class SymmetricPeakshavingChartOverviewComponent implements OnInit {
 
@@ -15,7 +15,7 @@ export class SymmetricPeakshavingChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/peakshaving/symmetric/widget.component.ts
+++ b/ui/src/app/edge/history/peakshaving/symmetric/widget.component.ts
@@ -5,7 +5,7 @@ import { Edge, EdgeConfig, Service } from 'src/app/shared/shared';
 
 @Component({
     selector: SymmetricPeakshavingWidgetComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class SymmetricPeakshavingWidgetComponent implements OnInit {
 
@@ -19,7 +19,7 @@ export class SymmetricPeakshavingWidgetComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/peakshaving/timeslot/chart.component.ts
+++ b/ui/src/app/edge/history/peakshaving/timeslot/chart.component.ts
@@ -10,7 +10,7 @@ import { Data, TooltipItem } from './../../shared';
 
 @Component({
     selector: 'timeslotpeakshavingchart',
-    templateUrl: '../../abstracthistorychart.html'
+    templateUrl: '../../abstracthistorychart.html',
 })
 export class TimeslotPeakshavingChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class TimeslotPeakshavingChartComponent extends AbstractHistoryChart impl
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("timeslotpeakshaving-chart", service, translate);
     }
@@ -85,11 +85,11 @@ export class TimeslotPeakshavingChartComponent extends AbstractHistoryChart impl
                     datasets.push({
                         label: this.translate.instant('General.measuredValue'),
                         data: data,
-                        hidden: false
+                        hidden: false,
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,0,0,0.05)',
-                        borderColor: 'rgba(0,0,0,1)'
+                        borderColor: 'rgba(0,0,0,1)',
                     });
                 }
                 if (rechargePower in result.data) {
@@ -106,11 +106,11 @@ export class TimeslotPeakshavingChartComponent extends AbstractHistoryChart impl
                         label: this.translate.instant('Edge.Index.Widgets.Peakshaving.rechargePower'),
                         data: data,
                         hidden: false,
-                        borderDash: [3, 3]
+                        borderDash: [3, 3],
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,0,0,0)',
-                        borderColor: 'rgba(0,223,0,1)'
+                        borderColor: 'rgba(0,223,0,1)',
                     });
                 }
                 if (peakshavingPower in result.data) {
@@ -127,11 +127,11 @@ export class TimeslotPeakshavingChartComponent extends AbstractHistoryChart impl
                         label: this.translate.instant('Edge.Index.Widgets.Peakshaving.peakshavingPower'),
                         data: data,
                         hidden: false,
-                        borderDash: [3, 3]
+                        borderDash: [3, 3],
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,0,0,0)',
-                        borderColor: 'rgba(200,0,0,1)'
+                        borderColor: 'rgba(200,0,0,1)',
                     });
                 }
                 if ('_sum/EssActivePower' in result.data) {
@@ -158,11 +158,11 @@ export class TimeslotPeakshavingChartComponent extends AbstractHistoryChart impl
                     datasets.push({
                         label: this.translate.instant('General.chargePower'),
                         data: chargeData,
-                        borderDash: [10, 10]
+                        borderDash: [10, 10],
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,223,0,0.05)',
-                        borderColor: 'rgba(0,223,0,1)'
+                        borderColor: 'rgba(0,223,0,1)',
                     });
                     /*
                      * Storage Discharge
@@ -179,11 +179,11 @@ export class TimeslotPeakshavingChartComponent extends AbstractHistoryChart impl
                     datasets.push({
                         label: this.translate.instant('General.dischargePower'),
                         data: dischargeData,
-                        borderDash: [10, 10]
+                        borderDash: [10, 10],
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(200,0,0,0.05)',
-                        borderColor: 'rgba(200,0,0,1)'
+                        borderColor: 'rgba(200,0,0,1)',
                     });
                 }
                 this.datasets = datasets;
@@ -211,7 +211,7 @@ export class TimeslotPeakshavingChartComponent extends AbstractHistoryChart impl
                 new ChannelAddress(this.componentId, 'StateMachine'),
                 new ChannelAddress(config.getComponent(this.componentId).properties['meter.id'], 'ActivePower'),
                 new ChannelAddress('_sum', 'ProductionDcActualPower'),
-                new ChannelAddress('_sum', 'EssActivePower')
+                new ChannelAddress('_sum', 'EssActivePower'),
             ];
             resolve(result);
         });

--- a/ui/src/app/edge/history/peakshaving/timeslot/timeslotpeakshavingchartoverview/timeslotpeakshavingchartoverview.component.ts
+++ b/ui/src/app/edge/history/peakshaving/timeslot/timeslotpeakshavingchartoverview/timeslotpeakshavingchartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service } from '../../../../../shared/shared';
 
 @Component({
     selector: TimeslotPeakshavingChartOverviewComponent.SELECTOR,
-    templateUrl: './timeslotpeakshavingchartoverview.component.html'
+    templateUrl: './timeslotpeakshavingchartoverview.component.html',
 })
 export class TimeslotPeakshavingChartOverviewComponent implements OnInit {
 
@@ -15,7 +15,7 @@ export class TimeslotPeakshavingChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/peakshaving/timeslot/widget.component.ts
+++ b/ui/src/app/edge/history/peakshaving/timeslot/widget.component.ts
@@ -5,7 +5,7 @@ import { Edge, EdgeConfig, Service } from 'src/app/shared/shared';
 
 @Component({
     selector: TimeslotPeakshavingWidgetComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class TimeslotPeakshavingWidgetComponent implements OnInit {
 
@@ -19,7 +19,7 @@ export class TimeslotPeakshavingWidgetComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/shared.ts
+++ b/ui/src/app/edge/history/shared.ts
@@ -12,7 +12,7 @@ export interface Dataset {
 export const EMPTY_DATASET = [{
     label: "no Data available",
     data: [],
-    hidden: false
+    hidden: false,
 }];
 
 export type Data = {
@@ -144,36 +144,36 @@ export const DEFAULT_TIME_CHART_OPTIONS: ChartOptions = {
     maintainAspectRatio: false,
     legend: {
         labels: {},
-        position: 'bottom'
+        position: 'bottom',
     },
     elements: {
         point: {
             radius: 0,
             hitRadius: 0,
-            hoverRadius: 0
+            hoverRadius: 0,
         },
         line: {
             borderWidth: 2,
-            tension: 0.1
+            tension: 0.1,
         },
         rectangle: {
-            borderWidth: 2
-        }
+            borderWidth: 2,
+        },
     },
     hover: {
         mode: 'point',
-        intersect: true
+        intersect: true,
     },
     scales: {
         yAxes: [{
             position: 'left',
             scaleLabel: {
                 display: true,
-                labelString: ""
+                labelString: "",
             },
             ticks: {
-                beginAtZero: true
-            }
+                beginAtZero: true,
+            },
         }],
         xAxes: [{
             ticks: {},
@@ -190,10 +190,10 @@ export const DEFAULT_TIME_CHART_OPTIONS: ChartOptions = {
                     week: 'll', // Week 46, or maybe "[W]WW - YYYY" ?
                     month: 'MM', // September
                     quarter: '[Q]Q - YYYY', // Q3 - 2015
-                    year: 'YYYY' // 2015,
-                }
-            }
-        }]
+                    year: 'YYYY', // 2015,
+                },
+            },
+        }],
     },
     tooltips: {
         mode: 'index',
@@ -203,34 +203,34 @@ export const DEFAULT_TIME_CHART_OPTIONS: ChartOptions = {
             title(tooltipItems: TooltipItem[], data: Data): string {
                 let date = new Date(tooltipItems[0].xLabel);
                 return date.toLocaleDateString() + " " + date.toLocaleTimeString();
-            }
-        }
-    }
+            },
+        },
+    },
 };
 
 export const DEFAULT_TIME_CHART_OPTIONS_WITHOUT_PREDEFINED_Y_AXIS: ChartOptions = {
     maintainAspectRatio: false,
     legend: {
         labels: {},
-        position: 'bottom'
+        position: 'bottom',
     },
     elements: {
         point: {
             radius: 0,
             hitRadius: 0,
-            hoverRadius: 0
+            hoverRadius: 0,
         },
         line: {
             borderWidth: 2,
-            tension: 0.1
+            tension: 0.1,
         },
         rectangle: {
-            borderWidth: 2
-        }
+            borderWidth: 2,
+        },
     },
     hover: {
         mode: 'point',
-        intersect: true
+        intersect: true,
     },
     scales: {
         yAxes: [],
@@ -249,10 +249,10 @@ export const DEFAULT_TIME_CHART_OPTIONS_WITHOUT_PREDEFINED_Y_AXIS: ChartOptions 
                     week: 'll', // Week 46, or maybe "[W]WW - YYYY" ?
                     month: 'MM', // September
                     quarter: '[Q]Q - YYYY', // Q3 - 2015
-                    year: 'YYYY' // 2015,
-                }
-            }
-        }]
+                    year: 'YYYY', // 2015,
+                },
+            },
+        }],
     },
     tooltips: {
         mode: 'index',
@@ -262,9 +262,9 @@ export const DEFAULT_TIME_CHART_OPTIONS_WITHOUT_PREDEFINED_Y_AXIS: ChartOptions 
             title(tooltipItems: TooltipItem[], data: Data): string {
                 let date = new Date(tooltipItems[0].xLabel);
                 return date.toLocaleDateString() + " " + date.toLocaleTimeString();
-            }
-        }
-    }
+            },
+        },
+    },
 };
 
 export function calculateActiveTimeOverPeriod(channel: ChannelAddress, queryResult: QueryHistoricTimeseriesDataResponse['result']) {

--- a/ui/src/app/edge/history/singlethreshold/chart.component.ts
+++ b/ui/src/app/edge/history/singlethreshold/chart.component.ts
@@ -11,7 +11,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
   selector: 'singlethresholdChart',
-  templateUrl: '../abstracthistorychart.html'
+  templateUrl: '../abstracthistorychart.html',
 })
 export class SinglethresholdChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -25,7 +25,7 @@ export class SinglethresholdChartComponent extends AbstractHistoryChart implemen
   constructor(
     protected override service: Service,
     protected override translate: TranslateService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) {
     super("singlethreshold-chart", service, translate);
   }
@@ -84,11 +84,11 @@ export class SinglethresholdChartComponent extends AbstractHistoryChart implemen
               data: data,
               hidden: false,
               yAxisID: yAxisID,
-              position: 'right'
+              position: 'right',
             });
             this.colors.push({
               backgroundColor: 'rgba(0,191,255,0.05)',
-              borderColor: 'rgba(0,191,255,1)'
+              borderColor: 'rgba(0,191,255,1)',
             });
           }
           if (channel == inputChannel) {
@@ -142,12 +142,12 @@ export class SinglethresholdChartComponent extends AbstractHistoryChart implemen
                 data: data,
                 hidden: false,
                 yAxisID: yAxisID,
-                position: 'right'
+                position: 'right',
               });
 
               this.colors.push({
                 backgroundColor: 'rgba(189, 195, 199,0.05)',
-                borderColor: 'rgba(189, 195, 199,1)'
+                borderColor: 'rgba(189, 195, 199,1)',
               });
             } else {
               datasets.push({
@@ -155,12 +155,12 @@ export class SinglethresholdChartComponent extends AbstractHistoryChart implemen
                 data: data,
                 hidden: false,
                 yAxisID: 'yAxis1',
-                position: 'left'
+                position: 'left',
               });
 
               this.colors.push({
                 backgroundColor: 'rgba(0,0,0,0.05)',
-                borderColor: 'rgba(0,0,0,1)'
+                borderColor: 'rgba(0,0,0,1)',
               });
             }
           }
@@ -230,17 +230,17 @@ export class SinglethresholdChartComponent extends AbstractHistoryChart implemen
         position: 'right',
         scaleLabel: {
           display: true,
-          labelString: "%"
+          labelString: "%",
         },
         gridLines: {
-          display: false
+          display: false,
         },
         ticks: {
           beginAtZero: true,
           max: 100,
           padding: -5,
-          stepSize: 20
-        }
+          stepSize: 20,
+        },
       });
     }
     options.tooltips.callbacks.label = function (tooltipItem: TooltipItem, data: Data) {

--- a/ui/src/app/edge/history/singlethreshold/singlethresholdchartoverview/singlethresholdchartoverview.component.ts
+++ b/ui/src/app/edge/history/singlethreshold/singlethresholdchartoverview/singlethresholdchartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service, Utils } from '../../../../shared/shared';
 
 @Component({
     selector: SinglethresholdChartOverviewComponent.SELECTOR,
-    templateUrl: './singlethresholdchartoverview.component.html'
+    templateUrl: './singlethresholdchartoverview.component.html',
 })
 export class SinglethresholdChartOverviewComponent implements OnInit {
 
@@ -20,7 +20,7 @@ export class SinglethresholdChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/singlethreshold/widget.component.ts
+++ b/ui/src/app/edge/history/singlethreshold/widget.component.ts
@@ -9,7 +9,7 @@ import { calculateActiveTimeOverPeriod } from '../shared';
 
 @Component({
     selector: SinglethresholdWidgetComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class SinglethresholdWidgetComponent extends AbstractHistoryWidget implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class SinglethresholdWidgetComponent extends AbstractHistoryWidget implem
 
     constructor(
         public override service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super(service);
     }

--- a/ui/src/app/edge/history/storage/chargerchart.component.ts
+++ b/ui/src/app/edge/history/storage/chargerchart.component.ts
@@ -10,7 +10,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
     selector: 'storageChargerChart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class StorageChargerChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -26,7 +26,7 @@ export class StorageChargerChartComponent extends AbstractHistoryChart implement
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("storage-charger-chart", service, translate);
     }
@@ -70,11 +70,11 @@ export class StorageChargerChartComponent extends AbstractHistoryChart implement
                     datasets.push({
                         label: this.translate.instant('General.chargePower'),
                         data: chargerData,
-                        hidden: false
+                        hidden: false,
                     });
                     this.colors.push({
                         backgroundColor: 'rgba(0,223,0,0.05)',
-                        borderColor: 'rgba(0,223,0,1)'
+                        borderColor: 'rgba(0,223,0,1)',
                     });
                 }
             });
@@ -92,7 +92,7 @@ export class StorageChargerChartComponent extends AbstractHistoryChart implement
     protected getChannelAddresses(edge: Edge, config: EdgeConfig): Promise<ChannelAddress[]> {
         return new Promise((resolve) => {
             let result: ChannelAddress[] = [
-                new ChannelAddress(this.componentId, 'ActualPower')
+                new ChannelAddress(this.componentId, 'ActualPower'),
             ];
             resolve(result);
         });

--- a/ui/src/app/edge/history/storage/esschart.component.ts
+++ b/ui/src/app/edge/history/storage/esschart.component.ts
@@ -10,7 +10,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
     selector: 'storageESSChart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class StorageESSChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -28,7 +28,7 @@ export class StorageESSChartComponent extends AbstractHistoryChart implements On
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("storage-ess-chart", service, translate);
     }
@@ -77,32 +77,32 @@ export class StorageESSChartComponent extends AbstractHistoryChart implements On
                                     datasets.push({
                                         label: this.translate.instant('General.chargeDischarge'),
                                         data: data,
-                                        hidden: false
+                                        hidden: false,
                                     });
                                     this.colors.push({
                                         backgroundColor: 'rgba(0,223,0,0.05)',
-                                        borderColor: 'rgba(0,223,0,1)'
+                                        borderColor: 'rgba(0,223,0,1)',
                                     });
                                 }
                                 if (this.componentId + '/ActivePowerL1' && this.componentId + '/ActivePowerL2' && this.componentId + '/ActivePowerL3' in result.data && this.showPhases == true) {
                                     if (channelAddress.channelId == 'ActivePowerL1') {
                                         datasets.push({
                                             label: this.translate.instant('General.phase') + ' ' + 'L1',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push(this.phase1Color);
                                     }
                                     if (channelAddress.channelId == 'ActivePowerL2') {
                                         datasets.push({
                                             label: this.translate.instant('General.phase') + ' ' + 'L2',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push(this.phase2Color);
                                     }
                                     if (channelAddress.channelId == 'ActivePowerL3') {
                                         datasets.push({
                                             label: this.translate.instant('General.phase') + ' ' + 'L3',
-                                            data: data
+                                            data: data,
                                         });
                                         this.colors.push(this.phase3Color);
                                     }
@@ -139,13 +139,13 @@ export class StorageESSChartComponent extends AbstractHistoryChart implements On
         let factory = config.factories[factoryID];
         return new Promise((resolve, reject) => {
             let result: ChannelAddress[] = [
-                new ChannelAddress(this.componentId, 'ActivePower')
+                new ChannelAddress(this.componentId, 'ActivePower'),
             ];
             if ((factory.natureIds.includes("io.openems.edge.ess.api.AsymmetricEss"))) {
                 result.push(
                     new ChannelAddress(component.id, 'ActivePowerL1'),
                     new ChannelAddress(component.id, 'ActivePowerL2'),
-                    new ChannelAddress(component.id, 'ActivePowerL3')
+                    new ChannelAddress(component.id, 'ActivePowerL3'),
                 );
             }
             resolve(result);

--- a/ui/src/app/edge/history/storage/singlechart.component.ts
+++ b/ui/src/app/edge/history/storage/singlechart.component.ts
@@ -10,7 +10,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
     selector: 'storageSingleChart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class StorageSingleChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class StorageSingleChartComponent extends AbstractHistoryChart implements
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("storage-single-chart", service, translate);
     }
@@ -126,30 +126,30 @@ export class StorageSingleChartComponent extends AbstractHistoryChart implements
                                 if (channelAddress.channelId == "EssActivePower") {
                                     datasets.push({
                                         label: this.translate.instant('General.chargeDischarge'),
-                                        data: totalData
+                                        data: totalData,
                                     });
                                     this.colors.push({
                                         backgroundColor: 'rgba(0,223,0,0.05)',
-                                        borderColor: 'rgba(0,223,0,1)'
+                                        borderColor: 'rgba(0,223,0,1)',
                                     });
                                 }
                                 if ('_sum/EssActivePowerL1' && '_sum/EssActivePowerL2' && '_sum/EssActivePowerL3' in result.data && this.showPhases == true) {
                                     if (channelAddress.channelId == 'EssActivePowerL1') {
                                         datasets.push({
                                             label: this.translate.instant('General.phase') + ' ' + 'L1',
-                                            data: totalDataL1
+                                            data: totalDataL1,
                                         });
                                         this.colors.push(this.phase1Color);
                                     } if (channelAddress.channelId == 'EssActivePowerL2') {
                                         datasets.push({
                                             label: this.translate.instant('General.phase') + ' ' + 'L2',
-                                            data: totalDataL2
+                                            data: totalDataL2,
                                         });
                                         this.colors.push(this.phase2Color);
                                     } if (channelAddress.channelId == 'EssActivePowerL3') {
                                         datasets.push({
                                             label: this.translate.instant('General.phase') + ' ' + 'L3',
-                                            data: totalDataL3
+                                            data: totalDataL3,
                                         });
                                         this.colors.push(this.phase3Color);
                                     }
@@ -187,7 +187,7 @@ export class StorageSingleChartComponent extends AbstractHistoryChart implements
                 new ChannelAddress('_sum', 'ProductionDcActualPower'),
                 new ChannelAddress('_sum', 'EssActivePowerL1'),
                 new ChannelAddress('_sum', 'EssActivePowerL2'),
-                new ChannelAddress('_sum', 'EssActivePowerL3')
+                new ChannelAddress('_sum', 'EssActivePowerL3'),
             ];
             resolve(result);
         });

--- a/ui/src/app/edge/history/storage/socchart.component.ts
+++ b/ui/src/app/edge/history/storage/socchart.component.ts
@@ -10,7 +10,7 @@ import { Data, TooltipItem } from './../shared';
 
 @Component({
     selector: 'socStorageChart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class SocStorageChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class SocStorageChartComponent extends AbstractHistoryChart implements On
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("storage-single-chart", service, translate);
     }
@@ -75,21 +75,21 @@ export class SocStorageChartComponent extends AbstractHistoryChart implements On
                                 if (channelAddress.channelId === 'EssSoc') {
                                     datasets.push({
                                         label: (moreThanOneESS ? this.translate.instant('General.TOTAL') : this.translate.instant('General.soc')),
-                                        data: data
+                                        data: data,
                                     });
                                     this.colors.push({
                                         backgroundColor: 'rgba(0,223,0,0.05)',
-                                        borderColor: 'rgba(0,223,0,1)'
+                                        borderColor: 'rgba(0,223,0,1)',
                                     });
                                 }
                                 if (channelAddress.channelId === 'Soc' && moreThanOneESS) {
                                     datasets.push({
                                         label: (channelAddress.componentId == component.alias ? component.id : component.alias),
-                                        data: data
+                                        data: data,
                                     });
                                     this.colors.push({
                                         backgroundColor: 'rgba(128,128,128,0.05)',
-                                        borderColor: 'rgba(128,128,128,1)'
+                                        borderColor: 'rgba(128,128,128,1)',
                                     });
                                 }
                             }
@@ -98,11 +98,11 @@ export class SocStorageChartComponent extends AbstractHistoryChart implements On
                                     label:
                                         this.emergencyCapacityReserveComponents.length > 1 ? component.alias : this.translate.instant("Edge.Index.EmergencyReserve.emergencyReserve"),
                                     data: data,
-                                    borderDash: [3, 3]
+                                    borderDash: [3, 3],
                                 });
                                 this.colors.push({
                                     backgroundColor: 'rgba(1, 1, 1,0)',
-                                    borderColor: 'rgba(1, 1, 1,1)'
+                                    borderColor: 'rgba(1, 1, 1,1)',
                                 });
                             }
                         });
@@ -140,7 +140,7 @@ export class SocStorageChartComponent extends AbstractHistoryChart implements On
 
             this.emergencyCapacityReserveComponents
                 .forEach(component =>
-                    channeladdresses.push(new ChannelAddress(component.id, 'ActualReserveSoc'))
+                    channeladdresses.push(new ChannelAddress(component.id, 'ActualReserveSoc')),
                 );
 
             const ess = config.getComponentsImplementingNature("io.openems.edge.ess.api.SymmetricEss");

--- a/ui/src/app/edge/history/storage/storagechartoverview/storagechartoverview.component.ts
+++ b/ui/src/app/edge/history/storage/storagechartoverview/storagechartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service, Utils } from '../../../../shared/shared';
 
 @Component({
     selector: StorageChartOverviewComponent.SELECTOR,
-    templateUrl: './storagechartoverview.component.html'
+    templateUrl: './storagechartoverview.component.html',
 })
 export class StorageChartOverviewComponent implements OnInit {
 
@@ -24,7 +24,7 @@ export class StorageChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/storage/totalchart.component.ts
+++ b/ui/src/app/edge/history/storage/totalchart.component.ts
@@ -10,7 +10,7 @@ import { Data, TooltipItem } from '../shared';
 
 @Component({
     selector: 'storageTotalChart',
-    templateUrl: '../abstracthistorychart.html'
+    templateUrl: '../abstracthistorychart.html',
 })
 export class StorageTotalChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
     @Input() public period: DefaultTypes.HistoryPeriod;
@@ -23,7 +23,7 @@ export class StorageTotalChartComponent extends AbstractHistoryChart implements 
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("storage-total-chart", service, translate);
     }
@@ -98,29 +98,29 @@ export class StorageTotalChartComponent extends AbstractHistoryChart implements 
                             if (channelAddress.channelId == "EssActivePower") {
                                 datasets.push({
                                     label: this.translate.instant('General.TOTAL'),
-                                    data: totalData
+                                    data: totalData,
                                 });
                                 this.colors.push({
                                     backgroundColor: 'rgba(0,223,0,0.05)',
-                                    borderColor: 'rgba(0,223,0,1)'
+                                    borderColor: 'rgba(0,223,0,1)',
                                 });
                             } if ('_sum/EssActivePowerL1' && '_sum/EssActivePowerL2' && '_sum/EssActivePowerL3' in result.data && this.showPhases == true) {
                                 if (channelAddress.channelId == 'EssActivePowerL1') {
                                     datasets.push({
                                         label: this.translate.instant('General.phase') + ' ' + 'L1',
-                                        data: data
+                                        data: data,
                                     });
                                     this.colors.push(this.phase1Color);
                                 } if (channelAddress.channelId == 'EssActivePowerL2') {
                                     datasets.push({
                                         label: this.translate.instant('General.phase') + ' ' + 'L2',
-                                        data: data
+                                        data: data,
                                     });
                                     this.colors.push(this.phase2Color);
                                 } if (channelAddress.channelId == 'EssActivePowerL3') {
                                     datasets.push({
                                         label: this.translate.instant('General.phase') + ' ' + 'L3',
-                                        data: data
+                                        data: data,
                                     });
                                     this.colors.push(this.phase3Color);
                                 }
@@ -129,32 +129,32 @@ export class StorageTotalChartComponent extends AbstractHistoryChart implements 
                                 datasets.push({
                                     label: (channelAddress.componentId == component.alias ? component.id : component.alias),
                                     data: data,
-                                    hidden: false
+                                    hidden: false,
                                 });
                                 this.colors.push({
                                     backgroundColor: 'rgba(45,143,171,0.05)',
-                                    borderColor: 'rgba(45,143,171,1)'
+                                    borderColor: 'rgba(45,143,171,1)',
                                 });
                             }
                             if (component.id + '/ActivePowerL1' && component.id + '/ActivePowerL2' && component.id + '/ActivePowerL3' in result.data && this.showPhases == true) {
                                 if (channelAddress.channelId == 'ActivePowerL1') {
                                     datasets.push({
                                         label: (channelAddress.componentId == component.alias ? ' (' + component.id + ')' : ' (' + component.alias + ')') + ' ' + this.translate.instant('General.phase') + ' ' + 'L1',
-                                        data: data
+                                        data: data,
                                     });
                                     this.colors.push(this.phase1Color);
                                 }
                                 if (channelAddress.channelId == 'ActivePowerL2') {
                                     datasets.push({
                                         label: (channelAddress.componentId == component.alias ? ' (' + component.id + ')' : ' (' + component.alias + ')') + ' ' + this.translate.instant('General.phase') + ' ' + 'L2',
-                                        data: data
+                                        data: data,
                                     });
                                     this.colors.push(this.phase2Color);
                                 }
                                 if (channelAddress.channelId == 'ActivePowerL3') {
                                     datasets.push({
                                         label: (channelAddress.componentId == component.alias ? ' (' + component.id + ')' : ' (' + component.alias + ')') + ' ' + this.translate.instant('General.phase') + ' ' + 'L3',
-                                        data: data
+                                        data: data,
                                     });
                                     this.colors.push(this.phase3Color);
                                 }
@@ -163,11 +163,11 @@ export class StorageTotalChartComponent extends AbstractHistoryChart implements 
                                 datasets.push({
                                     label: (channelAddress.componentId == component.alias ? component.id : component.alias),
                                     data: chargerData,
-                                    hidden: false
+                                    hidden: false,
                                 });
                                 this.colors.push({
                                     backgroundColor: 'rgba(255,215,0,0.05)',
-                                    borderColor: 'rgba(255,215,0,1)'
+                                    borderColor: 'rgba(255,215,0,1)',
                                 });
                             }
                         });
@@ -202,7 +202,7 @@ export class StorageTotalChartComponent extends AbstractHistoryChart implements 
                 new ChannelAddress('_sum', 'ProductionDcActualPower'),
                 new ChannelAddress('_sum', 'EssActivePowerL1'),
                 new ChannelAddress('_sum', 'EssActivePowerL2'),
-                new ChannelAddress('_sum', 'EssActivePowerL3')
+                new ChannelAddress('_sum', 'EssActivePowerL3'),
             ];
             config.getComponentsImplementingNature("io.openems.edge.ess.api.SymmetricEss")
                 .filter(component => !component.factoryId.includes("Ess.Cluster"))
@@ -214,7 +214,7 @@ export class StorageTotalChartComponent extends AbstractHistoryChart implements 
                         result.push(
                             new ChannelAddress(component.id, 'ActivePowerL1'),
                             new ChannelAddress(component.id, 'ActivePowerL2'),
-                            new ChannelAddress(component.id, 'ActivePowerL3')
+                            new ChannelAddress(component.id, 'ActivePowerL3'),
                         );
                     }
                 });

--- a/ui/src/app/edge/history/storage/widget.component.ts
+++ b/ui/src/app/edge/history/storage/widget.component.ts
@@ -7,7 +7,7 @@ import { AbstractHistoryWidget } from '../abstracthistorywidget';
 
 @Component({
     selector: StorageComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class StorageComponent extends AbstractHistoryWidget implements OnInit, OnChanges, OnDestroy {
 
@@ -24,7 +24,7 @@ export class StorageComponent extends AbstractHistoryWidget implements OnInit, O
 
     constructor(
         public override service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
 
     ) {
         super(service);
@@ -61,7 +61,7 @@ export class StorageComponent extends AbstractHistoryWidget implements OnInit, O
             let channels: ChannelAddress[] = [];
             channels.push(
                 new ChannelAddress('_sum', 'EssDcChargeEnergy'),
-                new ChannelAddress('_sum', 'EssDcDischargeEnergy')
+                new ChannelAddress('_sum', 'EssDcDischargeEnergy'),
             );
             resolve(channels);
         });

--- a/ui/src/app/edge/history/timeofusetariffdischarge/chart.component.ts
+++ b/ui/src/app/edge/history/timeofusetariffdischarge/chart.component.ts
@@ -12,7 +12,7 @@ import { Data, TooltipItem, Unit } from '../shared';
 
 @Component({
   selector: 'timeOfUseTariffDischargeChart',
-  templateUrl: '../abstracthistorychart.html'
+  templateUrl: '../abstracthistorychart.html',
 })
 export class TimeOfUseTariffDischargeChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -31,7 +31,7 @@ export class TimeOfUseTariffDischargeChartComponent extends AbstractHistoryChart
   constructor(
     protected override service: Service,
     protected override translate: TranslateService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) {
     super("timeOfUseTariffDischarge-chart", service, translate);
   }
@@ -117,12 +117,12 @@ export class TimeOfUseTariffDischargeChartComponent extends AbstractHistoryChart
             type: 'bar',
             label: this.translate.instant('Edge.Index.Energymonitor.storageDischarge'),
             data: quarterlyPricesNightData,
-            order: 3
+            order: 3,
           });
           this.colors.push({
             // Dark Green
             backgroundColor: 'rgba(51,102,0,0.8)',
-            borderColor: 'rgba(51,102,0,1)'
+            borderColor: 'rgba(51,102,0,1)',
           });
 
           // Set dataset for Quarterly Prices outside zone
@@ -130,12 +130,12 @@ export class TimeOfUseTariffDischargeChartComponent extends AbstractHistoryChart
             type: 'bar',
             label: this.translate.instant('Edge.Index.Widgets.TimeOfUseTariff.State.standby'),
             data: quarterlyPricesStandbyModeData,
-            order: 3
+            order: 3,
           });
           this.colors.push({
             // Dark Blue
             backgroundColor: 'rgba(0,0,200,0.7)',
-            borderColor: 'rgba(0,0,200,0.9)'
+            borderColor: 'rgba(0,0,200,0.9)',
           });
 
           // Show charge data only for the new controller.
@@ -145,12 +145,12 @@ export class TimeOfUseTariffDischargeChartComponent extends AbstractHistoryChart
               type: 'bar',
               label: this.translate.instant('Edge.Index.Widgets.TimeOfUseTariff.State.CHARGING'),
               data: quarterlyPricesChargedData,
-              order: 3
+              order: 3,
             });
             this.colors.push({
               // Sky blue
               backgroundColor: 'rgba(0, 204, 204,0.5)',
-              borderColor: 'rgba(0, 204, 204,0.7)'
+              borderColor: 'rgba(0, 204, 204,0.7)',
             });
           } else {
             // Set dataset for buy from grid
@@ -158,12 +158,12 @@ export class TimeOfUseTariffDischargeChartComponent extends AbstractHistoryChart
               type: 'bar',
               label: this.translate.instant('General.gridBuy'),
               data: quarterlyPricesDelayedDischargeData,
-              order: 4
+              order: 4,
             });
             this.colors.push({
               // Black
               backgroundColor: 'rgba(0,0,0,0.8)',
-              borderColor: 'rgba(0,0,0,0.9)'
+              borderColor: 'rgba(0,0,0,0.9)',
             });
 
           }
@@ -212,11 +212,11 @@ export class TimeOfUseTariffDischargeChartComponent extends AbstractHistoryChart
             yAxisID: 'yAxis2',
             position: 'right',
             borderDash: [10, 10],
-            order: 1
+            order: 1,
           });
           this.colors.push({
             backgroundColor: 'rgba(189, 195, 199,0.2)',
-            borderColor: 'rgba(189, 195, 199,1)'
+            borderColor: 'rgba(189, 195, 199,1)',
           });
         }
 
@@ -259,7 +259,7 @@ export class TimeOfUseTariffDischargeChartComponent extends AbstractHistoryChart
       let channels: ChannelAddress[] = [
         new ChannelAddress(this.componentId, 'QuarterlyPrices'),
         new ChannelAddress(this.componentId, 'StateMachine'),
-        new ChannelAddress('_sum', 'EssSoc')
+        new ChannelAddress('_sum', 'EssSoc'),
         // new ChannelAddress(this.componentId, 'PredictedSocWithoutLogic'),
       ];
 
@@ -283,25 +283,25 @@ export class TimeOfUseTariffDischargeChartComponent extends AbstractHistoryChart
         display: true,
         labelString: "%",
         padding: -2,
-        fontSize: 11
+        fontSize: 11,
       },
       gridLines: {
-        display: false
+        display: false,
       },
       ticks: {
         beginAtZero: true,
         max: 100,
         padding: -5,
-        stepSize: 20
-      }
+        stepSize: 20,
+      },
     });
     options.layout = {
       padding: {
         left: 2,
         right: 2,
         top: 0,
-        bottom: 0
-      }
+        bottom: 0,
+      },
     };
 
     options.scales.xAxes[0].stacked = true;

--- a/ui/src/app/edge/history/timeofusetariffdischarge/timeofusetariffdischargeoverview/timeofusetariffdischargechartoverview.component.ts
+++ b/ui/src/app/edge/history/timeofusetariffdischarge/timeofusetariffdischargeoverview/timeofusetariffdischargechartoverview.component.ts
@@ -4,7 +4,7 @@ import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
 
 @Component({
     selector: TimeOfUseTariffDischargeChartOverviewComponent.SELECTOR,
-    templateUrl: './timeofusetariffdischargechartoverview.component.html'
+    templateUrl: './timeofusetariffdischargechartoverview.component.html',
 })
 export class TimeOfUseTariffDischargeChartOverviewComponent implements OnInit {
 
@@ -16,7 +16,7 @@ export class TimeOfUseTariffDischargeChartOverviewComponent implements OnInit {
 
     constructor(
         public service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/history/timeofusetariffdischarge/widget.component.ts
+++ b/ui/src/app/edge/history/timeofusetariffdischarge/widget.component.ts
@@ -7,7 +7,7 @@ import { AbstractHistoryWidget } from '../abstracthistorywidget';
 
 @Component({
     selector: TimeOfUseTariffDischargeWidgetComponent.SELECTOR,
-    templateUrl: './widget.component.html'
+    templateUrl: './widget.component.html',
 })
 export class TimeOfUseTariffDischargeWidgetComponent extends AbstractHistoryWidget implements OnInit, OnChanges, OnDestroy {
 
@@ -23,7 +23,7 @@ export class TimeOfUseTariffDischargeWidgetComponent extends AbstractHistoryWidg
 
     constructor(
         public override service: Service,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super(service);
     }

--- a/ui/src/app/edge/live/Controller/Channelthreshold/Channelthreshold.ts
+++ b/ui/src/app/edge/live/Controller/Channelthreshold/Channelthreshold.ts
@@ -6,7 +6,7 @@ import { ChannelAddress, CurrentData } from '../../../../shared/shared';
 
 @Component({
   selector: 'Controller_Channelthreshold',
-  templateUrl: './Channelthreshold.html'
+  templateUrl: './Channelthreshold.html',
 })
 export class Controller_ChannelthresholdComponent extends AbstractFlatWidget {
 
@@ -14,7 +14,7 @@ export class Controller_ChannelthresholdComponent extends AbstractFlatWidget {
   public icon: Icon = {
     name: '',
     size: 'large',
-    color: 'dark'
+    color: 'dark',
   };
   public state: string = '?';
 

--- a/ui/src/app/edge/live/Controller/ChpSoc/ChpSoc.ts
+++ b/ui/src/app/edge/live/Controller/ChpSoc/ChpSoc.ts
@@ -7,7 +7,7 @@ import { Controller_ChpSocModalComponent } from './modal/modal.component';
 
 @Component({
     selector: 'Controller_ChpSocComponent',
-    templateUrl: './ChpSoc.html'
+    templateUrl: './ChpSoc.html',
 })
 export class Controller_ChpSocComponent extends AbstractFlatWidget {
 
@@ -23,7 +23,7 @@ export class Controller_ChpSocComponent extends AbstractFlatWidget {
     public icon: Icon = {
         name: '',
         size: 'large',
-        color: 'primary'
+        color: 'primary',
     };
     private static PROPERTY_MODE: string = '_PropertyMode';
 
@@ -38,7 +38,7 @@ export class Controller_ChpSocComponent extends AbstractFlatWidget {
             this.inputChannel,
             this.propertyModeChannel,
             new ChannelAddress(this.component.id, '_PropertyHighThreshold'),
-            new ChannelAddress(this.component.id, '_PropertyLowThreshold')
+            new ChannelAddress(this.component.id, '_PropertyLowThreshold'),
         ];
     }
 
@@ -81,8 +81,8 @@ export class Controller_ChpSocComponent extends AbstractFlatWidget {
                 component: this.component,
                 edge: this.edge,
                 outputChannel: this.outputChannel,
-                inputChannel: this.inputChannel
-            }
+                inputChannel: this.inputChannel,
+            },
         });
         return await modal.present();
     }

--- a/ui/src/app/edge/live/Controller/ChpSoc/modal/modal.component.ts
+++ b/ui/src/app/edge/live/Controller/ChpSoc/modal/modal.component.ts
@@ -10,7 +10,7 @@ type mode = 'MANUAL_ON' | 'MANUAL_OFF' | 'AUTOMATIC';
 
 @Component({
     selector: Controller_ChpSocModalComponent.SELECTOR,
-    templateUrl: './modal.component.html'
+    templateUrl: './modal.component.html',
 })
 export class Controller_ChpSocModalComponent implements OnInit {
 
@@ -23,7 +23,7 @@ export class Controller_ChpSocModalComponent implements OnInit {
 
     public thresholds: RangeValue = {
         lower: null,
-        upper: null
+        upper: null,
     };
 
     constructor(
@@ -31,7 +31,7 @@ export class Controller_ChpSocModalComponent implements OnInit {
         public websocket: Websocket,
         public router: Router,
         protected translate: TranslateService,
-        public modalCtrl: ModalController
+        public modalCtrl: ModalController,
     ) { }
 
     ngOnInit() {
@@ -62,7 +62,7 @@ export class Controller_ChpSocModalComponent implements OnInit {
 
         if (this.edge != null) {
             this.edge.updateComponentConfig(this.websocket, this.component.id, [
-                { name: 'mode', value: newMode }
+                { name: 'mode', value: newMode },
             ]).then(() => {
                 this.component.properties.mode = newMode;
                 this.service.toast(this.translate.instant('General.changeAccepted'), 'success');
@@ -90,7 +90,7 @@ export class Controller_ChpSocModalComponent implements OnInit {
         if (this.edge != null && (oldLowerThreshold != newLowerThreshold || oldUpperThreshold != newUpperThreshold)) {
             this.edge.updateComponentConfig(this.websocket, this.component.id, [
                 { name: 'lowThreshold', value: newLowerThreshold },
-                { name: 'highThreshold', value: newUpperThreshold }
+                { name: 'highThreshold', value: newUpperThreshold },
             ]).then(() => {
                 this.component.properties['lowThreshold'] = newLowerThreshold;
                 this.component.properties['highThreshold'] = newUpperThreshold;

--- a/ui/src/app/edge/live/Controller/Ess/FixActivePower/Ess_FixActivePower.ts
+++ b/ui/src/app/edge/live/Controller/Ess/FixActivePower/Ess_FixActivePower.ts
@@ -7,18 +7,18 @@ import { ModalComponent } from './modal/modal';
 @NgModule({
   imports: [
     BrowserModule,
-    SharedModule
+    SharedModule,
   ],
   entryComponents: [
     FlatComponent,
-    ModalComponent
+    ModalComponent,
   ],
   declarations: [
     FlatComponent,
-    ModalComponent
+    ModalComponent,
   ],
   exports: [
-    FlatComponent
-  ]
+    FlatComponent,
+  ],
 })
 export class Controller_Ess_FixActivePower { }

--- a/ui/src/app/edge/live/Controller/Ess/FixActivePower/flat/flat.ts
+++ b/ui/src/app/edge/live/Controller/Ess/FixActivePower/flat/flat.ts
@@ -7,7 +7,7 @@ import { ModalComponent } from '../modal/modal';
 
 @Component({
   selector: 'Controller_Ess_FixActivePower',
-  templateUrl: './flat.html'
+  templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 
@@ -20,7 +20,7 @@ export class FlatComponent extends AbstractFlatWidget {
   protected override getChannelAddresses(): ChannelAddress[] {
     return [
       new ChannelAddress(this.component.id, "_PropertyPower"),
-      new ChannelAddress(this.component.id, "_PropertyMode")
+      new ChannelAddress(this.component.id, "_PropertyMode"),
     ];
   }
 
@@ -36,8 +36,8 @@ export class FlatComponent extends AbstractFlatWidget {
     const modal = await this.modalController.create({
       component: ModalComponent,
       componentProps: {
-        component: this.component
-      }
+        component: this.component,
+      },
     });
     return await modal.present();
   }

--- a/ui/src/app/edge/live/Controller/Ess/FixActivePower/modal/modal.ts
+++ b/ui/src/app/edge/live/Controller/Ess/FixActivePower/modal/modal.ts
@@ -4,7 +4,7 @@ import { AbstractModal } from 'src/app/shared/genericComponents/modal/abstractMo
 import { ChannelAddress, CurrentData, Utils } from 'src/app/shared/shared';
 
 @Component({
-  templateUrl: './modal.html'
+  templateUrl: './modal.html',
 })
 export class ModalComponent extends AbstractModal {
 
@@ -15,7 +15,7 @@ export class ModalComponent extends AbstractModal {
 
   protected override getChannelAddresses(): ChannelAddress[] {
     return [
-      new ChannelAddress(this.component.id, "_PropertyPower")
+      new ChannelAddress(this.component.id, "_PropertyPower"),
     ];
   }
 
@@ -26,7 +26,7 @@ export class ModalComponent extends AbstractModal {
   protected override getFormGroup(): FormGroup {
     return this.formBuilder.group({
       mode: new FormControl(this.component.properties.mode),
-      power: new FormControl(this.component.properties.power)
+      power: new FormControl(this.component.properties.power),
     });
   }
 }

--- a/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/Ess_GridOptimizedCharge.ts
+++ b/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/Ess_GridOptimizedCharge.ts
@@ -8,20 +8,20 @@ import { PredictionChartComponent } from './modal/predictionChart';
 @NgModule({
     imports: [
         BrowserModule,
-        SharedModule
+        SharedModule,
     ],
     entryComponents: [
         FlatComponent,
         ModalComponent,
-        PredictionChartComponent
+        PredictionChartComponent,
     ],
     declarations: [
         FlatComponent,
         ModalComponent,
-        PredictionChartComponent
+        PredictionChartComponent,
     ],
     exports: [
-        FlatComponent
-    ]
+        FlatComponent,
+    ],
 })
 export class Controller_Ess_GridOptimizedCharge { }

--- a/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/flat/flat.ts
+++ b/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/flat/flat.ts
@@ -6,7 +6,7 @@ import { ModalComponent } from '../modal/modal';
 
 @Component({
     selector: 'Controller_Ess_GridOptimizedCharge',
-    templateUrl: './flat.html'
+    templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 
@@ -25,7 +25,7 @@ export class FlatComponent extends AbstractFlatWidget {
             new ChannelAddress(this.componentId, "SellToGridLimitState"),
             new ChannelAddress(this.componentId, "DelayChargeMaximumChargeLimit"),
             new ChannelAddress(this.componentId, "SellToGridLimitMinimumChargeLimit"),
-            new ChannelAddress(this.componentId, "_PropertyMode")
+            new ChannelAddress(this.componentId, "_PropertyMode"),
         ];
     }
     protected override onCurrentData(currentData: CurrentData) {
@@ -75,8 +75,8 @@ export class FlatComponent extends AbstractFlatWidget {
         const modal = await this.modalController.create({
             component: ModalComponent,
             componentProps: {
-                component: this.component
-            }
+                component: this.component,
+            },
         });
         return await modal.present();
     }

--- a/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/modal/modal.ts
+++ b/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/modal/modal.ts
@@ -6,7 +6,7 @@ import { Role } from 'src/app/shared/type/role';
 
 @Component({
     templateUrl: './modal.html',
-    changeDetection: ChangeDetectionStrategy.OnPush
+    changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ModalComponent extends AbstractModal {
 
@@ -34,7 +34,7 @@ export class ModalComponent extends AbstractModal {
             this.isAtLeastAdmin = true;
             if ('ess.id' in this.component.properties) {
                 channels.push(
-                    new ChannelAddress(this.component.properties['ess.id'], "Capacity")
+                    new ChannelAddress(this.component.properties['ess.id'], "Capacity"),
                 );
             }
         }
@@ -47,7 +47,7 @@ export class ModalComponent extends AbstractModal {
             new ChannelAddress(this.component.id, "TargetEpochSeconds"),
             new ChannelAddress(this.component.id, "TargetMinute"),
             new ChannelAddress(this.component.id, "DelayChargeMaximumChargeLimit"),
-            new ChannelAddress(this.component.id, "PredictedChargeStartEpochSeconds")
+            new ChannelAddress(this.component.id, "PredictedChargeStartEpochSeconds"),
         );
         return channels;
     }
@@ -61,7 +61,7 @@ export class ModalComponent extends AbstractModal {
                 currentData.allComponents[this.component.id + '/SellToGridLimitMinimumChargeLimit'] > 0)) {
             this.chargeLimit = {
                 name: this.translate.instant('Edge.Index.Widgets.GridOptimizedCharge.minimumCharge'),
-                value: currentData.allComponents[this.component.id + '/SellToGridLimitMinimumChargeLimit']
+                value: currentData.allComponents[this.component.id + '/SellToGridLimitMinimumChargeLimit'],
             };
             this.state = this.translate.instant('Edge.Index.Widgets.GridOptimizedCharge.State.gridFeedInLimitationIsAvoided');
 
@@ -95,7 +95,7 @@ export class ModalComponent extends AbstractModal {
             if (currentData.allComponents[this.component.id + '/DelayChargeMaximumChargeLimit'] != null) {
                 this.chargeLimit = {
                     name: this.translate.instant('Edge.Index.Widgets.GridOptimizedCharge.maximumCharge'),
-                    value: currentData.allComponents[this.component.id + '/DelayChargeMaximumChargeLimit']
+                    value: currentData.allComponents[this.component.id + '/DelayChargeMaximumChargeLimit'],
                 };
             }
         }
@@ -119,10 +119,10 @@ export class ModalComponent extends AbstractModal {
             sellToGridLimitEnabled: new FormControl(this.component.properties.sellToGridLimitEnabled),
             maximumSellToGridPower: new FormControl(this.component.properties.maximumSellToGridPower, Validators.compose([
                 Validators.pattern('^(?:[1-9][0-9]*|0)$'),
-                Validators.required
+                Validators.required,
             ])),
             delayChargeRiskLevel: new FormControl(this.component.properties.delayChargeRiskLevel),
-            manualTargetTime: new FormControl(this.component.properties.manualTargetTime)
+            manualTargetTime: new FormControl(this.component.properties.manualTargetTime),
         });
     }
 }

--- a/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/modal/predictionChart.ts
+++ b/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/modal/predictionChart.ts
@@ -9,7 +9,7 @@ import { ChannelAddress, Edge, EdgeConfig, Service, Utils } from 'src/app/shared
 
 @Component({
     selector: 'predictionChart',
-    templateUrl: '../../../../../history/abstracthistorychart.html'
+    templateUrl: '../../../../../history/abstracthistorychart.html',
 })
 export class PredictionChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
 
@@ -28,7 +28,7 @@ export class PredictionChartComponent extends AbstractHistoryChart implements On
     constructor(
         protected override service: Service,
         protected override translate: TranslateService,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) {
         super("prediction-chart", service, translate);
     }
@@ -173,22 +173,22 @@ export class PredictionChartComponent extends AbstractHistoryChart implements On
                     data: socData,
                     hidden: false,
                     yAxisID: 'yAxis2',
-                    position: 'right'
+                    position: 'right',
                 }, {
                     label: this.translate.instant('Edge.Index.Widgets.GridOptimizedCharge.expectedSoc'),
                     data: predictedSocData,
                     hidden: false,
                     yAxisID: 'yAxis2',
-                    position: 'right'
+                    position: 'right',
                 });
 
                 // Push the depending colors 
                 this.colors.push({
                     backgroundColor: 'rgba(189, 195, 199,0.05)',
-                    borderColor: 'rgba(189, 195, 199,1)'
+                    borderColor: 'rgba(189, 195, 199,1)',
                 }, {
                     backgroundColor: 'rgba(0,223,0,0)',
-                    borderColor: 'rgba(0,223,0,1)'
+                    borderColor: 'rgba(0,223,0,1)',
                 });
             }
 
@@ -207,7 +207,7 @@ export class PredictionChartComponent extends AbstractHistoryChart implements On
 
         return new Promise((resolve) => {
             let result: ChannelAddress[] = [
-                new ChannelAddress('_sum', 'EssSoc')
+                new ChannelAddress('_sum', 'EssSoc'),
             ];
             if (this.component != null && this.component.id) {
                 result.push(new ChannelAddress(this.component.id, 'DelayChargeMaximumChargeLimit'));
@@ -236,17 +236,17 @@ export class PredictionChartComponent extends AbstractHistoryChart implements On
                     display: true,
                     labelString: "%",
                     padding: -2,
-                    fontSize: 11
+                    fontSize: 11,
                 },
                 gridLines: {
-                    display: true
+                    display: true,
                 },
                 ticks: {
                     beginAtZero: true,
                     max: 100,
                     padding: -5,
-                    stepSize: 20
-                }
+                    stepSize: 20,
+                },
             });
 
         options.layout = {
@@ -254,8 +254,8 @@ export class PredictionChartComponent extends AbstractHistoryChart implements On
                 left: 2,
                 right: 2,
                 top: 0,
-                bottom: 0
-            }
+                bottom: 0,
+            },
         };
         //x-axis
         options.scales.xAxes[0].time.unit = "hour";

--- a/ui/src/app/edge/live/Controller/Ess/TimeOfUseTariffDischarge/Ess_TimeOfUseTariff_Discharge.ts
+++ b/ui/src/app/edge/live/Controller/Ess/TimeOfUseTariffDischarge/Ess_TimeOfUseTariff_Discharge.ts
@@ -7,18 +7,18 @@ import { ModalComponent } from "./modal/modal";
 @NgModule({
     imports: [
         BrowserModule,
-        SharedModule
+        SharedModule,
     ],
     entryComponents: [
         FlatComponent,
-        ModalComponent
+        ModalComponent,
     ],
     declarations: [
         FlatComponent,
-        ModalComponent
+        ModalComponent,
     ],
     exports: [
-        FlatComponent
-    ]
+        FlatComponent,
+    ],
 })
 export class Controller_Ess_TimeOfUseTariff_Discharge { }

--- a/ui/src/app/edge/live/Controller/Ess/TimeOfUseTariffDischarge/flat/flat.ts
+++ b/ui/src/app/edge/live/Controller/Ess/TimeOfUseTariffDischarge/flat/flat.ts
@@ -6,7 +6,7 @@ import { ModalComponent } from '../modal/modal';
 
 @Component({
     selector: 'Controller_Ess_TimeOfUseTariff_Discharge',
-    templateUrl: './flat.html'
+    templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget implements OnInit {
 
@@ -19,15 +19,15 @@ export class FlatComponent extends AbstractFlatWidget implements OnInit {
         const modal = await this.modalController.create({
             component: ModalComponent,
             componentProps: {
-                component: this.component
-            }
+                component: this.component,
+            },
         });
         return await modal.present();
     }
 
     protected override getChannelAddresses(): ChannelAddress[] {
         return [
-            new ChannelAddress(this.component.id, 'QuarterlyPrices')
+            new ChannelAddress(this.component.id, 'QuarterlyPrices'),
         ];
     }
 

--- a/ui/src/app/edge/live/Controller/Ess/TimeOfUseTariffDischarge/modal/modal.ts
+++ b/ui/src/app/edge/live/Controller/Ess/TimeOfUseTariffDischarge/modal/modal.ts
@@ -4,7 +4,7 @@ import { AbstractModal } from 'src/app/shared/genericComponents/modal/abstractMo
 import { ChannelAddress, Currency, CurrentData } from 'src/app/shared/shared';
 
 @Component({
-    templateUrl: './modal.html'
+    templateUrl: './modal.html',
 })
 export class ModalComponent extends AbstractModal {
 
@@ -14,13 +14,13 @@ export class ModalComponent extends AbstractModal {
 
     protected override getFormGroup(): FormGroup {
         return this.formBuilder.group({
-            mode: new FormControl(this.component.properties.mode)
+            mode: new FormControl(this.component.properties.mode),
         });
     }
 
     protected override getChannelAddresses(): ChannelAddress[] {
         return [
-            new ChannelAddress(this.component.id, 'QuarterlyPrices')
+            new ChannelAddress(this.component.id, 'QuarterlyPrices'),
         ];
     }
 

--- a/ui/src/app/edge/live/Controller/Evcs/Evcs.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/Evcs.ts
@@ -8,21 +8,21 @@ import { PopoverComponent } from './popover/popover';
 @NgModule({
   imports: [
     BrowserModule,
-    SharedModule
+    SharedModule,
   ],
   entryComponents: [
     FlatComponent,
     ModalComponent,
-    PopoverComponent
+    PopoverComponent,
   ],
   declarations: [
     FlatComponent,
     ModalComponent,
-    PopoverComponent
+    PopoverComponent,
   ],
   exports: [
-    FlatComponent
-  ]
+    FlatComponent,
+  ],
 })
 export class Controller_Evcs { }
 

--- a/ui/src/app/edge/live/Controller/Evcs/administration/administration.component.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/administration/administration.component.ts
@@ -6,7 +6,7 @@ import { Edge, EdgeConfig, Service, Websocket } from '../../../../../shared/shar
 
 @Component({
   selector: AdministrationComponent.SELECTOR,
-  templateUrl: './administration.component.html'
+  templateUrl: './administration.component.html',
 })
 export class AdministrationComponent implements OnInit {
 
@@ -23,7 +23,7 @@ export class AdministrationComponent implements OnInit {
     public modalCtrl: ModalController,
     public service: Service,
     private websocket: Websocket,
-    public translate: TranslateService
+    public translate: TranslateService,
   ) { }
 
   ngOnInit() {
@@ -46,7 +46,7 @@ export class AdministrationComponent implements OnInit {
 
     if (this.edge != null && oldValue != newValue) {
       this.edge.updateComponentConfig(this.websocket, this.evcsComponent.id, [
-        { name: 'minHwCurrent', value: newValue }
+        { name: 'minHwCurrent', value: newValue },
       ]).then(() => {
         this.evcsComponent.properties.minHwCurrent = newValue;
         this.service.toast(this.translate.instant('General.changeAccepted'), 'success');

--- a/ui/src/app/edge/live/Controller/Evcs/flat/flat.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/flat/flat.ts
@@ -10,7 +10,7 @@ type ChargeMode = 'FORCE_CHARGE' | 'EXCESS_POWER' | 'OFF';
 
 @Component({
   selector: 'Controller_Evcs',
-  templateUrl: './flat.html'
+  templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 
@@ -54,7 +54,7 @@ export class FlatComponent extends AbstractFlatWidget {
       // channels for modal component, subscribe here for better UX
       new ChannelAddress(this.component.id, 'MinimumHardwarePower'),
       new ChannelAddress(this.component.id, 'MaximumHardwarePower'),
-      new ChannelAddress(this.component.id, 'SetChargePowerLimit')
+      new ChannelAddress(this.component.id, 'SetChargePowerLimit'),
     ];
   }
 
@@ -176,8 +176,8 @@ export class FlatComponent extends AbstractFlatWidget {
     const modal = await this.modalController.create({
       component: ModalComponent,
       componentProps: {
-        component: this.component
-      }
+        component: this.component,
+      },
     });
     return await modal.present();
   }

--- a/ui/src/app/edge/live/Controller/Evcs/modal/modal.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/modal/modal.ts
@@ -11,7 +11,7 @@ import { PopoverComponent } from '../popover/popover';
 
 type ChargeMode = 'FORCE_CHARGE' | 'EXCESS_POWER';
 @Component({
-  templateUrl: './modal.html'
+  templateUrl: './modal.html',
 })
 export class ModalComponent extends AbstractModal {
 
@@ -77,7 +77,7 @@ export class ModalComponent extends AbstractModal {
       new ChannelAddress(this.component.id, 'SetChargePowerLimit'),
       new ChannelAddress(this.controller.id, '_PropertyChargeMode'),
       new ChannelAddress(this.controller.id, '_PropertyEnabledCharging'),
-      new ChannelAddress(this.controller.id, '_PropertyDefaultChargeMinPower')
+      new ChannelAddress(this.controller.id, '_PropertyDefaultChargeMinPower'),
     ];
   }
 
@@ -151,7 +151,7 @@ export class ModalComponent extends AbstractModal {
       energySessionLimit: new FormControl(this.controller.properties.energySessionLimit),
       // EnergySessionLimit as kWh value, for ion-range
       energySessionLimitKwh: new FormControl(Math.round(this.controller.properties.energySessionLimit / 1000)),
-      enabledCharging: new FormControl(this.isChargingEnabled)
+      enabledCharging: new FormControl(this.isChargingEnabled),
     });
   }
 
@@ -180,7 +180,7 @@ export class ModalComponent extends AbstractModal {
         if (this.edge != null) {
           let newMinChargePower = maxAllowedChargePower;
           this.edge.updateComponentConfig(this.websocket, this.controller.id, [
-            { name: 'forceChargeMinPower', value: newMinChargePower }
+            { name: 'forceChargeMinPower', value: newMinChargePower },
           ]).then(() => {
             this.controller.properties.forceChargeMinPower = newMinChargePower;
           }).catch(reason => {
@@ -243,8 +243,8 @@ export class ModalComponent extends AbstractModal {
     const popover = await this.popoverctrl.create({
       component: PopoverComponent,
       componentProps: {
-        chargeMode: this.formGroup.controls['chargeMode'].value
-      }
+        chargeMode: this.formGroup.controls['chargeMode'].value,
+      },
     });
     return await popover.present();
   }
@@ -254,8 +254,8 @@ export class ModalComponent extends AbstractModal {
       component: AdministrationComponent,
       componentProps: {
         evcsComponent: this.evcsComponent,
-        edge: this.edge
-      }
+        edge: this.edge,
+      },
     });
     modal.onDidDismiss().then(() => {
       this.updateRenaultZoeConfig();

--- a/ui/src/app/edge/live/Controller/Evcs/popover/popover.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/popover/popover.ts
@@ -3,7 +3,7 @@ import { AbstractModal } from 'src/app/shared/genericComponents/modal/abstractMo
 
 type ChargeMode = 'FORCE_CHARGE' | 'EXCESS_POWER' | 'OFF';
 @Component({
-    templateUrl: './popover.html'
+    templateUrl: './popover.html',
 })
 
 export class PopoverComponent extends AbstractModal {

--- a/ui/src/app/edge/live/Controller/Io/ChannelSingleThreshold/Io_ChannelSingleThreshold.ts
+++ b/ui/src/app/edge/live/Controller/Io/ChannelSingleThreshold/Io_ChannelSingleThreshold.ts
@@ -7,7 +7,7 @@ import { Controller_Io_ChannelSingleThresholdModalComponent } from './modal/moda
 
 @Component({
   selector: 'Controller_Io_ChannelSingleThresholdComponent',
-  templateUrl: './Io_ChannelSingleThreshold.html'
+  templateUrl: './Io_ChannelSingleThreshold.html',
 })
 export class Controller_Io_ChannelSingleThresholdComponent extends AbstractFlatWidget {
 
@@ -19,7 +19,7 @@ export class Controller_Io_ChannelSingleThresholdComponent extends AbstractFlatW
   public icon: Icon = {
     name: '',
     color: '',
-    size: ''
+    size: '',
   };
   public dependendOn: string;
   public dependendOnValue: any;
@@ -174,8 +174,8 @@ export class Controller_Io_ChannelSingleThresholdComponent extends AbstractFlatW
         config: this.config,
         edge: this.edge,
         outputChannel: this.outputChannel,
-        inputChannel: this.inputChannel
-      }
+        inputChannel: this.inputChannel,
+      },
     });
     return await modal.present();
   }

--- a/ui/src/app/edge/live/Controller/Io/ChannelSingleThreshold/modal/modal.component.ts
+++ b/ui/src/app/edge/live/Controller/Io/ChannelSingleThreshold/modal/modal.component.ts
@@ -9,7 +9,7 @@ type inputMode = 'SOC' | 'GRIDSELL' | 'GRIDBUY' | 'PRODUCTION' | 'OTHER'
 
 @Component({
   selector: 'Io_ChannelSingleThresholdModalComponent',
-  templateUrl: './modal.component.html'
+  templateUrl: './modal.component.html',
 })
 export class Controller_Io_ChannelSingleThresholdModalComponent implements OnInit {
 
@@ -34,7 +34,7 @@ export class Controller_Io_ChannelSingleThresholdModalComponent implements OnIni
     public modalCtrl: ModalController,
     public translate: TranslateService,
     public websocket: Websocket,
-    public formBuilder: FormBuilder
+    public formBuilder: FormBuilder,
   ) {
   }
 
@@ -43,19 +43,19 @@ export class Controller_Io_ChannelSingleThresholdModalComponent implements OnIni
       minimumSwitchingTime: new FormControl(this.component.properties.minimumSwitchingTime, Validators.compose([
         Validators.min(5),
         Validators.pattern('^[1-9][0-9]*$'),
-        Validators.required
+        Validators.required,
       ])),
       switchedLoadPower: new FormControl(this.component.properties.switchedLoadPower, Validators.compose([
         Validators.pattern('^(?:[1-9][0-9]*|0)$'),
-        Validators.required
+        Validators.required,
       ])),
       threshold: new FormControl(this.getInputMode() == 'GRIDSELL' ? this.component.properties.threshold * -1 : this.component.properties.threshold, Validators.compose([
         Validators.min(1),
         Validators.pattern('^[1-9][0-9]*$'),
-        Validators.required
+        Validators.required,
       ])),
       inputMode: new FormControl(this.getInputMode()),
-      invert: new FormControl(this.component.properties.invert, Validators.requiredTrue)
+      invert: new FormControl(this.component.properties.invert, Validators.requiredTrue),
     });
     this.minimumSwitchingTime = this.formGroup.controls['minimumSwitchingTime'];
     this.threshold = this.formGroup.controls['threshold'];
@@ -141,7 +141,7 @@ export class Controller_Io_ChannelSingleThresholdModalComponent implements OnIni
 
     if (this.edge != null) {
       this.edge.updateComponentConfig(this.websocket, this.component.id, [
-        { name: 'mode', value: newMode }
+        { name: 'mode', value: newMode },
       ]).then(() => {
         this.component.properties.mode = newMode;
         this.service.toast(this.translate.instant('General.changeAccepted'), 'success');

--- a/ui/src/app/edge/live/Controller/Io/FixDigitalOutput/Io_FixDigitalOutput.ts
+++ b/ui/src/app/edge/live/Controller/Io/FixDigitalOutput/Io_FixDigitalOutput.ts
@@ -6,7 +6,7 @@ import { Controller_Io_FixDigitalOutputModalComponent } from './modal/modal.comp
 
 @Component({
   selector: 'Controller_Io_FixDigitalOutput',
-  templateUrl: './Io_FixDigitalOutput.html'
+  templateUrl: './Io_FixDigitalOutput.html',
 })
 export class Controller_Io_FixDigitalOutputComponent extends AbstractFlatWidget {
 
@@ -37,8 +37,8 @@ export class Controller_Io_FixDigitalOutputComponent extends AbstractFlatWidget 
       component: Controller_Io_FixDigitalOutputModalComponent,
       componentProps: {
         component: this.component,
-        edge: this.edge
-      }
+        edge: this.edge,
+      },
     });
     return await modal.present();
   }

--- a/ui/src/app/edge/live/Controller/Io/FixDigitalOutput/modal/modal.component.ts
+++ b/ui/src/app/edge/live/Controller/Io/FixDigitalOutput/modal/modal.component.ts
@@ -6,7 +6,7 @@ import { Edge, EdgeConfig, Service, Websocket } from 'src/app/shared/shared';
 
 @Component({
   selector: 'fixdigitaloutput-modal',
-  templateUrl: './modal.component.html'
+  templateUrl: './modal.component.html',
 })
 export class Controller_Io_FixDigitalOutputModalComponent {
 
@@ -18,7 +18,7 @@ export class Controller_Io_FixDigitalOutputModalComponent {
     protected translate: TranslateService,
     public modalCtrl: ModalController,
     public router: Router,
-    public websocket: Websocket
+    public websocket: Websocket,
   ) { }
 
   /**  
@@ -35,7 +35,7 @@ export class Controller_Io_FixDigitalOutputModalComponent {
     let newMode = (event.detail.value.toLowerCase() === 'true');
 
     this.edge.updateComponentConfig(this.websocket, this.component.id, [
-      { name: 'isOn', value: newMode }
+      { name: 'isOn', value: newMode },
     ]).then(() => {
       this.component.properties.isOn = newMode;
       this.service.toast(this.translate.instant('General.changeAccepted'), 'success');

--- a/ui/src/app/edge/live/Controller/Io/HeatingElement/Io_HeatingElement.ts
+++ b/ui/src/app/edge/live/Controller/Io/HeatingElement/Io_HeatingElement.ts
@@ -7,18 +7,18 @@ import { ModalComponent } from "./modal/modal";
 @NgModule({
   imports: [
     BrowserModule,
-    SharedModule
+    SharedModule,
   ],
   entryComponents: [
     FlatComponent,
-    ModalComponent
+    ModalComponent,
   ],
   declarations: [
     FlatComponent,
-    ModalComponent
+    ModalComponent,
   ],
   exports: [
-    FlatComponent
-  ]
+    FlatComponent,
+  ],
 })
 export class Controller_Io_HeatingElement { }

--- a/ui/src/app/edge/live/Controller/Io/HeatingElement/flat/flat.ts
+++ b/ui/src/app/edge/live/Controller/Io/HeatingElement/flat/flat.ts
@@ -8,7 +8,7 @@ import { ModalComponent } from '../modal/modal';
 
 @Component({
     selector: 'Controller_Io_HeatingElement',
-    templateUrl: './flat.html'
+    templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 
@@ -31,7 +31,7 @@ export class FlatComponent extends AbstractFlatWidget {
             ChannelAddress.fromString(
                 this.component.properties['outputChannelPhaseL2']),
             ChannelAddress.fromString(
-                this.component.properties['outputChannelPhaseL3'])
+                this.component.properties['outputChannelPhaseL3']),
         );
 
         let channelAddresses: ChannelAddress[] = [
@@ -39,7 +39,7 @@ export class FlatComponent extends AbstractFlatWidget {
             ...this.outputChannelArray,
             new ChannelAddress(this.component.id, 'Status'),
             new ChannelAddress(this.component.id, FlatComponent.PROPERTY_MODE),
-            new ChannelAddress(this.component.id, '_PropertyWorkMode')
+            new ChannelAddress(this.component.id, '_PropertyWorkMode'),
         ];
         return channelAddresses;
     }
@@ -93,8 +93,8 @@ export class FlatComponent extends AbstractFlatWidget {
         const modal = await this.modalController.create({
             component: ModalComponent,
             componentProps: {
-                component: this.component
-            }
+                component: this.component,
+            },
         });
         return await modal.present();
     }

--- a/ui/src/app/edge/live/Controller/Io/HeatingElement/modal/modal.ts
+++ b/ui/src/app/edge/live/Controller/Io/HeatingElement/modal/modal.ts
@@ -7,7 +7,7 @@ import { Mode, WorkMode } from 'src/app/shared/type/general';
 
 @Component({
     selector: 'heatingelement-modal',
-    templateUrl: './modal.html'
+    templateUrl: './modal.html',
 })
 export class ModalComponent extends AbstractModal implements OnInit {
 
@@ -35,7 +35,7 @@ export class ModalComponent extends AbstractModal implements OnInit {
             outputChannelPhaseTwo,
             outputChannelPhaseThree,
             new ChannelAddress(this.component.id, ModalComponent.PROPERTY_MODE),
-            new ChannelAddress(this.component.id, '_PropertyWorkMode')
+            new ChannelAddress(this.component.id, '_PropertyWorkMode'),
         ];
         return channelAddresses;
     }
@@ -68,7 +68,7 @@ export class ModalComponent extends AbstractModal implements OnInit {
             endTime: new FormControl(this.component.properties.endTime),
             workMode: new FormControl(this.component.properties.workMode),
             defaultLevel: new FormControl(this.component.properties.defaultLevel),
-            mode: new FormControl(this.mode)
+            mode: new FormControl(this.mode),
         });
     }
 

--- a/ui/src/app/edge/live/Controller/Io/Heatpump/Io_Heatpump.ts
+++ b/ui/src/app/edge/live/Controller/Io/Heatpump/Io_Heatpump.ts
@@ -7,7 +7,7 @@ import { Controller_Io_HeatpumpModalComponent } from './modal/modal.component';
 
 @Component({
   selector: 'Controller_Io_Heatpump',
-  templateUrl: './Io_Heatpump.html'
+  templateUrl: './Io_Heatpump.html',
 })
 export class Controller_Io_HeatpumpComponent extends AbstractFlatWidget {
 
@@ -23,7 +23,7 @@ export class Controller_Io_HeatpumpComponent extends AbstractFlatWidget {
     return [
       new ChannelAddress(this.component.id, 'Status'),
       new ChannelAddress(this.component.id, 'State'),
-      new ChannelAddress(this.component.id, Controller_Io_HeatpumpComponent.PROPERTY_MODE)
+      new ChannelAddress(this.component.id, Controller_Io_HeatpumpComponent.PROPERTY_MODE),
     ];
   }
 
@@ -67,8 +67,8 @@ export class Controller_Io_HeatpumpComponent extends AbstractFlatWidget {
       componentProps: {
         edge: this.edge,
         component: this.component,
-        status: this.status
-      }
+        status: this.status,
+      },
     });
     modal.onDidDismiss().then(() => {
       this.service.getConfig().then(config => {

--- a/ui/src/app/edge/live/Controller/Io/Heatpump/modal/modal.component.ts
+++ b/ui/src/app/edge/live/Controller/Io/Heatpump/modal/modal.component.ts
@@ -9,7 +9,7 @@ type AutomaticEnableMode = 'automaticRecommendationCtrlEnabled' | 'automaticForc
 
 @Component({
   selector: 'heatpump-modal',
-  templateUrl: './modal.component.html'
+  templateUrl: './modal.component.html',
 })
 export class Controller_Io_HeatpumpModalComponent implements OnInit {
 
@@ -24,7 +24,7 @@ export class Controller_Io_HeatpumpModalComponent implements OnInit {
     protected translate: TranslateService,
     public formBuilder: FormBuilder,
     public modalCtrl: ModalController,
-    public service: Service
+    public service: Service,
   ) { }
 
   ngOnInit() {
@@ -40,7 +40,7 @@ export class Controller_Io_HeatpumpModalComponent implements OnInit {
       automaticLockSoc: new FormControl(this.component.properties.automaticLockSoc),
       automaticRecommendationCtrlEnabled: new FormControl(this.component.properties.automaticRecommendationCtrlEnabled),
       automaticRecommendationSurplusPower: new FormControl(this.component.properties.automaticRecommendationSurplusPower),
-      minimumSwitchingTime: new FormControl(this.component.properties.minimumSwitchingTime)
+      minimumSwitchingTime: new FormControl(this.component.properties.minimumSwitchingTime),
     });
   };
 
@@ -50,7 +50,7 @@ export class Controller_Io_HeatpumpModalComponent implements OnInit {
 
     if (this.edge != null) {
       this.edge.updateComponentConfig(this.websocket, this.component.id, [
-        { name: 'mode', value: newMode }
+        { name: 'mode', value: newMode },
       ]).then(() => {
         this.component.properties.mode = newMode;
         this.formGroup.markAsPristine();

--- a/ui/src/app/edge/live/Controller/PeakShaving/Asymmetric/Asymmetric.ts
+++ b/ui/src/app/edge/live/Controller/PeakShaving/Asymmetric/Asymmetric.ts
@@ -7,7 +7,7 @@ import { Controller_Asymmetric_PeakShavingModalComponent } from './modal/modal.c
 
 @Component({
     selector: 'Controller_Asymmetric_PeakShaving',
-    templateUrl: './Asymmetric.html'
+    templateUrl: './Asymmetric.html',
 })
 export class Controller_Asymmetric_PeakShavingComponent extends AbstractFlatWidget {
 
@@ -23,7 +23,7 @@ export class Controller_Asymmetric_PeakShavingComponent extends AbstractFlatWidg
             new ChannelAddress(this.meterId, 'ActivePower'),
             new ChannelAddress(this.meterId, 'ActivePowerL1'),
             new ChannelAddress(this.meterId, 'ActivePowerL2'),
-            new ChannelAddress(this.meterId, 'ActivePowerL3')
+            new ChannelAddress(this.meterId, 'ActivePowerL3'),
         ];
     }
 
@@ -32,7 +32,7 @@ export class Controller_Asymmetric_PeakShavingComponent extends AbstractFlatWidg
         let activePowerArray: number[] = [
             currentData.allComponents[this.meterId + '/ActivePowerL1'],
             currentData.allComponents[this.meterId + '/ActivePowerL2'],
-            currentData.allComponents[this.meterId + '/ActivePowerL3']
+            currentData.allComponents[this.meterId + '/ActivePowerL3'],
         ];
 
         let name: string[] = ['L1', 'L2', 'L3'];
@@ -41,7 +41,7 @@ export class Controller_Asymmetric_PeakShavingComponent extends AbstractFlatWidg
 
             // Show most stressed Phase
             name: name[activePowerArray.indexOf(Math.max(...activePowerArray))],
-            value: Math.max(...activePowerArray, 0)
+            value: Math.max(...activePowerArray, 0),
         });
 
         this.peakShavingPower = this.component.properties['peakShavingPower'];
@@ -54,8 +54,8 @@ export class Controller_Asymmetric_PeakShavingComponent extends AbstractFlatWidg
             componentProps: {
                 component: this.component,
                 edge: this.edge,
-                mostStressedPhase: this.mostStressedPhase
-            }
+                mostStressedPhase: this.mostStressedPhase,
+            },
         });
         return await modal.present();
     }

--- a/ui/src/app/edge/live/Controller/PeakShaving/Asymmetric/modal/modal.component.ts
+++ b/ui/src/app/edge/live/Controller/PeakShaving/Asymmetric/modal/modal.component.ts
@@ -7,7 +7,7 @@ import { Edge, EdgeConfig, Service, Websocket } from '../../../../../../shared/s
 
 @Component({
     selector: 'asymmetricpeakshaving-modal',
-    templateUrl: './modal.component.html'
+    templateUrl: './modal.component.html',
 })
 export class Controller_Asymmetric_PeakShavingModalComponent implements OnInit {
 
@@ -23,19 +23,19 @@ export class Controller_Asymmetric_PeakShavingModalComponent implements OnInit {
         public translate: TranslateService,
         public modalCtrl: ModalController,
         public formBuilder: FormBuilder,
-        public websocket: Websocket
+        public websocket: Websocket,
     ) { }
 
     ngOnInit() {
         this.formGroup = this.formBuilder.group({
             peakShavingPower: new FormControl(this.component.properties.peakShavingPower, Validators.compose([
                 Validators.pattern('^(?:[1-9][0-9]*|0)$'),
-                Validators.required
+                Validators.required,
             ])),
             rechargePower: new FormControl(this.component.properties.rechargePower, Validators.compose([
                 Validators.pattern('^(?:[1-9][0-9]*|0)$'),
-                Validators.required
-            ]))
+                Validators.required,
+            ])),
         });
     }
 

--- a/ui/src/app/edge/live/Controller/PeakShaving/Symmetric/Symmetric.ts
+++ b/ui/src/app/edge/live/Controller/PeakShaving/Symmetric/Symmetric.ts
@@ -6,7 +6,7 @@ import { Controller_Symmetric_PeakShavingModalComponent } from './modal/modal.co
 
 @Component({
     selector: 'Controller_Symmetric_PeakShaving',
-    templateUrl: './Symmetric.html'
+    templateUrl: './Symmetric.html',
 })
 export class Controller_Symmetric_PeakShavingComponent extends AbstractFlatWidget {
 
@@ -19,7 +19,7 @@ export class Controller_Symmetric_PeakShavingComponent extends AbstractFlatWidge
         return [
             new ChannelAddress(this.component.properties['meter.id'], 'ActivePower'),
             new ChannelAddress(this.componentId, '_PropertyPeakShavingPower'),
-            new ChannelAddress(this.componentId, '_PropertyRechargePower')
+            new ChannelAddress(this.componentId, '_PropertyRechargePower'),
         ];
     }
 
@@ -37,8 +37,8 @@ export class Controller_Symmetric_PeakShavingComponent extends AbstractFlatWidge
             component: Controller_Symmetric_PeakShavingModalComponent,
             componentProps: {
                 component: this.component,
-                edge: this.edge
-            }
+                edge: this.edge,
+            },
         });
         return await modal.present();
     }

--- a/ui/src/app/edge/live/Controller/PeakShaving/Symmetric/modal/modal.component.ts
+++ b/ui/src/app/edge/live/Controller/PeakShaving/Symmetric/modal/modal.component.ts
@@ -6,7 +6,7 @@ import { Edge, EdgeConfig, Service, Websocket } from '../../../../../../shared/s
 
 @Component({
     selector: 'symmetricpeakshaving-modal',
-    templateUrl: './modal.component.html'
+    templateUrl: './modal.component.html',
 })
 export class Controller_Symmetric_PeakShavingModalComponent implements OnInit {
 
@@ -22,19 +22,19 @@ export class Controller_Symmetric_PeakShavingModalComponent implements OnInit {
         public modalCtrl: ModalController,
         public service: Service,
         public translate: TranslateService,
-        public websocket: Websocket
+        public websocket: Websocket,
     ) { }
 
     ngOnInit() {
         this.formGroup = this.formBuilder.group({
             peakShavingPower: new FormControl(this.component.properties.peakShavingPower, Validators.compose([
                 Validators.pattern('^(?:[1-9][0-9]*|0)$'),
-                Validators.required
+                Validators.required,
             ])),
             rechargePower: new FormControl(this.component.properties.rechargePower, Validators.compose([
                 Validators.pattern('^(?:[1-9][0-9]*|0)$'),
-                Validators.required
-            ]))
+                Validators.required,
+            ])),
         });
     }
 

--- a/ui/src/app/edge/live/Controller/PeakShaving/Symmetric_TimeSlot/Symmetric_TimeSlot.ts
+++ b/ui/src/app/edge/live/Controller/PeakShaving/Symmetric_TimeSlot/Symmetric_TimeSlot.ts
@@ -6,7 +6,7 @@ import { Controller_Symmetric_TimeSlot_PeakShavingModalComponent } from './modal
 
 @Component({
     selector: 'Controller_Symmetric_TimeSlot_PeakShaving',
-    templateUrl: './Symmetric_TimeSlot.html'
+    templateUrl: './Symmetric_TimeSlot.html',
 })
 export class Controller_Symmetric_TimeSlot_PeakShavingComponent extends AbstractFlatWidget {
 
@@ -19,7 +19,7 @@ export class Controller_Symmetric_TimeSlot_PeakShavingComponent extends Abstract
         return [
             new ChannelAddress(this.component.properties['meter.id'], 'ActivePower'),
             new ChannelAddress(this.componentId, '_PropertyPeakShavingPower'),
-            new ChannelAddress(this.componentId, '_PropertyRechargePower')
+            new ChannelAddress(this.componentId, '_PropertyRechargePower'),
         ];
     }
     protected override onCurrentData(currentData: CurrentData) {
@@ -35,8 +35,8 @@ export class Controller_Symmetric_TimeSlot_PeakShavingComponent extends Abstract
             component: Controller_Symmetric_TimeSlot_PeakShavingModalComponent,
             componentProps: {
                 component: this.component,
-                edge: this.edge
-            }
+                edge: this.edge,
+            },
         });
         modal.onDidDismiss().then(() => {
             this.service.getConfig().then(config => {

--- a/ui/src/app/edge/live/Controller/PeakShaving/Symmetric_TimeSlot/modal/modal.component.ts
+++ b/ui/src/app/edge/live/Controller/PeakShaving/Symmetric_TimeSlot/modal/modal.component.ts
@@ -6,7 +6,7 @@ import { Edge, EdgeConfig, Service, Websocket } from '../../../../../../shared/s
 
 @Component({
     selector: 'timeslotpeakshaving-modal',
-    templateUrl: './modal.component.html'
+    templateUrl: './modal.component.html',
 })
 export class Controller_Symmetric_TimeSlot_PeakShavingModalComponent implements OnInit {
 
@@ -23,36 +23,36 @@ export class Controller_Symmetric_TimeSlot_PeakShavingModalComponent implements 
         public modalCtrl: ModalController,
         public service: Service,
         public translate: TranslateService,
-        public websocket: Websocket
+        public websocket: Websocket,
     ) { }
 
     ngOnInit() {
         this.formGroup = this.formBuilder.group({
             peakShavingPower: new FormControl(this.component.properties.peakShavingPower, Validators.compose([
                 Validators.pattern('^(?:[1-9][0-9]*|0)$'),
-                Validators.required
+                Validators.required,
             ])),
             rechargePower: new FormControl(this.component.properties.rechargePower, Validators.compose([
                 Validators.pattern('^(?:[1-9][0-9]*|0)$'),
-                Validators.required
+                Validators.required,
             ])),
             slowChargePower: new FormControl((this.component.properties.slowChargePower) * -1),
             slowChargeStartTime: new FormControl(this.component.properties.slowChargeStartTime, Validators.compose([
                 Validators.pattern('^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$'),
-                Validators.required
+                Validators.required,
             ])),
             startDate: new FormControl(this.component.properties.startDate, Validators.compose([
                 Validators.pattern('^(0[1-9]|[12][0-9]|3[01])[.](0[1-9]|1[012])[.](19|20)[0-9]{2}$'),
-                Validators.required
+                Validators.required,
             ])),
             startTime: new FormControl(this.component.properties.startTime, Validators.compose([
                 Validators.pattern('^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$'),
-                Validators.required
+                Validators.required,
             ])),
             endDate: new FormControl(this.component.properties.endDate),
             endTime: new FormControl(this.component.properties.endTime, Validators.compose([
                 Validators.pattern('^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$'),
-                Validators.required
+                Validators.required,
             ])),
             monday: new FormControl(this.component.properties.monday),
             tuesday: new FormControl(this.component.properties.tuesday),
@@ -60,7 +60,7 @@ export class Controller_Symmetric_TimeSlot_PeakShavingModalComponent implements 
             thursday: new FormControl(this.component.properties.thursday),
             friday: new FormControl(this.component.properties.friday),
             saturday: new FormControl(this.component.properties.saturday),
-            sunday: new FormControl(this.component.properties.sunday)
+            sunday: new FormControl(this.component.properties.sunday),
         });
     }
 

--- a/ui/src/app/edge/live/Io/Api_DigitalInput/Io_Api_DigitalInput.ts
+++ b/ui/src/app/edge/live/Io/Api_DigitalInput/Io_Api_DigitalInput.ts
@@ -6,7 +6,7 @@ import { Io_Api_DigitalInput_ModalComponent } from './modal/modal.component';
 
 @Component({
     selector: 'Io_Api_DigitalInput',
-    templateUrl: './Io_Api_DigitalInput.html'
+    templateUrl: './Io_Api_DigitalInput.html',
 })
 
 export class Io_Api_DigitalInputComponent extends AbstractFlatWidget {
@@ -23,7 +23,7 @@ export class Io_Api_DigitalInputComponent extends AbstractFlatWidget {
 
                 for (let channel in component.channels) {
                     channels.push(
-                        new ChannelAddress(component.id, channel)
+                        new ChannelAddress(component.id, channel),
                     );
                 }
             }
@@ -37,8 +37,8 @@ export class Io_Api_DigitalInputComponent extends AbstractFlatWidget {
             component: Io_Api_DigitalInput_ModalComponent,
             componentProps: {
                 edge: this.edge,
-                ioComponents: this.ioComponents
-            }
+                ioComponents: this.ioComponents,
+            },
         });
         return await modal.present();
     }

--- a/ui/src/app/edge/live/Io/Api_DigitalInput/modal/modal.component.ts
+++ b/ui/src/app/edge/live/Io/Api_DigitalInput/modal/modal.component.ts
@@ -4,7 +4,7 @@ import { ModalController } from '@ionic/angular';
 
 @Component({
     selector: 'Io_Api_DigitalInputModal',
-    templateUrl: './modal.component.html'
+    templateUrl: './modal.component.html',
 })
 export class Io_Api_DigitalInput_ModalComponent {
 
@@ -15,6 +15,6 @@ export class Io_Api_DigitalInput_ModalComponent {
 
     constructor(
         public service: Service,
-        public modalCtrl: ModalController
+        public modalCtrl: ModalController,
     ) { }
 }

--- a/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/Evcs_Api_Cluster.ts
+++ b/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/Evcs_Api_Cluster.ts
@@ -6,7 +6,7 @@ import { Evcs_Api_ClusterModalComponent } from './modal/evcsCluster-modal.page';
 
 @Component({
   selector: 'Evcs_Api_Cluster',
-  templateUrl: './Evcs_Api_Cluster.html'
+  templateUrl: './Evcs_Api_Cluster.html',
 })
 export class Evcs_Api_ClusterComponent extends AbstractFlatWidget {
 
@@ -38,7 +38,7 @@ export class Evcs_Api_ClusterComponent extends AbstractFlatWidget {
       new ChannelAddress(this.componentId, 'State'),
       new ChannelAddress(this.componentId, 'EnergySession'),
       new ChannelAddress(this.componentId, 'MinimumHardwarePower'),
-      new ChannelAddress(this.componentId, 'MaximumHardwarePower')
+      new ChannelAddress(this.componentId, 'MaximumHardwarePower'),
     );
     return this.channelAddresses;
   }
@@ -76,7 +76,7 @@ export class Evcs_Api_ClusterComponent extends AbstractFlatWidget {
       new ChannelAddress(componentId, 'Status'),
       new ChannelAddress(componentId, 'State'),
       new ChannelAddress(componentId, 'EnergySession'),
-      new ChannelAddress(componentId, 'Alias')
+      new ChannelAddress(componentId, 'Alias'),
     );
   }
 
@@ -87,8 +87,8 @@ export class Evcs_Api_ClusterComponent extends AbstractFlatWidget {
         config: this.component,
         edge: this.edge,
         componentId: this.componentId,
-        evcsMap: this.evcsMap
-      }
+        evcsMap: this.evcsMap,
+      },
     });
     return await modal.present();
   }

--- a/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/modal/evcs-chart/evcs.chart.ts
+++ b/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/modal/evcs-chart/evcs.chart.ts
@@ -10,7 +10,7 @@ import * as Chart from 'chart.js';
 
 @Component({
   selector: EvcsChartComponent.SELECTOR,
-  templateUrl: './evcs.chart.html'
+  templateUrl: './evcs.chart.html',
 })
 export class EvcsChartComponent implements OnInit, OnChanges {
 
@@ -30,7 +30,7 @@ export class EvcsChartComponent implements OnInit, OnChanges {
 
   constructor(
     protected translate: TranslateService,
-    public modalController: ModalController
+    public modalController: ModalController,
   ) { }
 
   ngOnInit() {
@@ -39,7 +39,7 @@ export class EvcsChartComponent implements OnInit, OnChanges {
     this.options.scales.yAxes[0].ticks.max = this.getMaxPower();
     this.labels = ['Ladeleistung'];
     this.datasets = [
-      { data: [], label: '' }
+      { data: [], label: '' },
     ];
 
   }
@@ -63,7 +63,7 @@ export class EvcsChartComponent implements OnInit, OnChanges {
       if (this.datasets[index] == null) {
         this.datasets.push({
           label: alias,
-          data: [chargePowerKW != null ? chargePowerKW : 0]
+          data: [chargePowerKW != null ? chargePowerKW : 0],
         });
       } else if (alias == "") { //this.datasets[index].label
         this.datasets[index].label = evcsId;
@@ -92,38 +92,38 @@ export class EvcsChartComponent implements OnInit, OnChanges {
 export const DEFAULT_BAR_CHART_OPTIONS: BarChartOptions = {
   maintainAspectRatio: false,
   legend: {
-    position: 'bottom'
+    position: 'bottom',
   },
   elements: {
     point: {
       radius: 0,
       hitRadius: 0,
-      hoverRadius: 0
+      hoverRadius: 0,
     },
     line: {
       borderWidth: 2,
-      tension: 0.1
-    }
+      tension: 0.1,
+    },
   },
   hover: {
     mode: 'point',
-    intersect: true
+    intersect: true,
   },
   scales: {
     xAxes: [{
-      stacked: true
+      stacked: true,
     }],
     yAxes: [{
       scaleLabel: {
         display: true,
-        labelString: ""
+        labelString: "",
       },
       ticks: {
         beginAtZero: true,
-        max: 50
+        max: 50,
       },
-      stacked: true
-    }]
+      stacked: true,
+    }],
   },
   tooltips: {
     mode: 'index',
@@ -136,8 +136,8 @@ export const DEFAULT_BAR_CHART_OPTIONS: BarChartOptions = {
         value = parseFloat(value.toFixed(2));
         let label = data.datasets[tooltipItems.datasetIndex].label;
         return label + ": " + value.toLocaleString('de-DE') + " kW";
-      }
-    }
+      },
+    },
   },
   annotation: {
     annotations: [{
@@ -149,10 +149,10 @@ export const DEFAULT_BAR_CHART_OPTIONS: BarChartOptions = {
       borderWidth: 4,
       label: {
         enabled: true,
-        content: 'Test label'
-      }
-    }]
-  }
+        content: 'Test label',
+      },
+    }],
+  },
 };
 
 export type BarChartOptions = {

--- a/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/modal/evcsCluster-modal.page.ts
+++ b/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/modal/evcsCluster-modal.page.ts
@@ -9,7 +9,7 @@ type Priority = 'CAR' | 'STORAGE';
 
 @Component({
     selector: 'Evcs_Api_Cluster-modal',
-    templateUrl: './evcsCluster-modal.page.html'
+    templateUrl: './evcsCluster-modal.page.html',
 })
 export class Evcs_Api_ClusterModalComponent implements OnInit {
 
@@ -30,7 +30,7 @@ export class Evcs_Api_ClusterModalComponent implements OnInit {
         noSwipingClass: 'swiper-no-swiping',
         //noSwipingSelector: 'ion-range, ion-toggle',
         initialSlide: 0,
-        speed: 1000
+        speed: 1000,
     };
     public firstEvcs: string;
     public lastEvcs: string;
@@ -43,7 +43,7 @@ export class Evcs_Api_ClusterModalComponent implements OnInit {
         public router: Router,
         private route: ActivatedRoute,
         protected translate: TranslateService,
-        private modalCtrl: ModalController
+        private modalCtrl: ModalController,
     ) {
     }
 
@@ -70,7 +70,7 @@ export class Evcs_Api_ClusterModalComponent implements OnInit {
 
         if (this.edge != null) {
             this.edge.updateComponentConfig(this.websocket, this.config.id, [
-                { name: 'evcs.ids', value: newListOrder }
+                { name: 'evcs.ids', value: newListOrder },
             ]).then(response => {
                 this.config.properties.chargeMode = newListOrder;
                 this.service.toast(this.translate.instant('General.changeAccepted'), 'success');
@@ -106,7 +106,7 @@ export class Evcs_Api_ClusterModalComponent implements OnInit {
 
         if (this.edge != null) {
             this.edge.updateComponentConfig(this.websocket, currentController.id, [
-                { name: 'chargeMode', value: newChargeMode }
+                { name: 'chargeMode', value: newChargeMode },
             ]).then(response => {
                 currentController.properties.chargeMode = newChargeMode;
                 this.service.toast(this.translate.instant('General.changeAccepted'), 'success');
@@ -135,7 +135,7 @@ export class Evcs_Api_ClusterModalComponent implements OnInit {
 
         if (this.edge != null) {
             this.edge.updateComponentConfig(this.websocket, currentController.id, [
-                { name: 'priority', value: newPriority }
+                { name: 'priority', value: newPriority },
             ]).then(response => {
                 currentController.properties.priority = newPriority;
                 this.service.toast(this.translate.instant('General.changeAccepted'), 'success');
@@ -159,7 +159,7 @@ export class Evcs_Api_ClusterModalComponent implements OnInit {
 
         if (this.edge != null) {
             this.edge.updateComponentConfig(this.websocket, currentController.id, [
-                { name: 'forceChargeMinPower', value: newMinChargePower }
+                { name: 'forceChargeMinPower', value: newMinChargePower },
             ]).then(response => {
                 currentController.properties.forceChargeMinPower = newMinChargePower;
                 this.service.toast(this.translate.instant('General.changeAccepted'), 'success');
@@ -182,7 +182,7 @@ export class Evcs_Api_ClusterModalComponent implements OnInit {
 
         if (this.edge != null) {
             this.edge.updateComponentConfig(this.websocket, currentController.id, [
-                { name: 'defaultChargeMinPower', value: newMinChargePower }
+                { name: 'defaultChargeMinPower', value: newMinChargePower },
             ]).then(response => {
                 currentController.properties.defaultChargeMinPower = newMinChargePower;
                 this.service.toast(this.translate.instant('General.changeAccepted'), 'success');
@@ -214,7 +214,7 @@ export class Evcs_Api_ClusterModalComponent implements OnInit {
         }
         if (this.edge != null) {
             this.edge.updateComponentConfig(this.websocket, currentController.id, [
-                { name: 'defaultChargeMinPower', value: newMinChargePower }
+                { name: 'defaultChargeMinPower', value: newMinChargePower },
             ]).then(response => {
                 currentController.properties.defaultChargeMinPower = newMinChargePower;
                 this.service.toast(this.translate.instant('General.changeAccepted'), 'success');
@@ -237,7 +237,7 @@ export class Evcs_Api_ClusterModalComponent implements OnInit {
         let newChargingState = !oldChargingState;
         if (this.edge != null) {
             this.edge.updateComponentConfig(this.websocket, currentController.id, [
-                { name: 'enabledCharging', value: newChargingState }
+                { name: 'enabledCharging', value: newChargingState },
             ]).then(response => {
                 currentController.properties.enabledCharging = newChargingState;
                 this.service.toast(this.translate.instant('General.changeAccepted'), 'success');

--- a/ui/src/app/edge/live/common/autarchy/Common_Autarchy.ts
+++ b/ui/src/app/edge/live/common/autarchy/Common_Autarchy.ts
@@ -7,18 +7,18 @@ import { ModalComponent } from './modal/modal';
 @NgModule({
   imports: [
     BrowserModule,
-    SharedModule
+    SharedModule,
   ],
   entryComponents: [
     FlatComponent,
-    ModalComponent
+    ModalComponent,
   ],
   declarations: [
     FlatComponent,
-    ModalComponent
+    ModalComponent,
   ],
   exports: [
-    FlatComponent
-  ]
+    FlatComponent,
+  ],
 })
 export class Common_Autarchy { }

--- a/ui/src/app/edge/live/common/autarchy/flat/flat.ts
+++ b/ui/src/app/edge/live/common/autarchy/flat/flat.ts
@@ -5,7 +5,7 @@ import { ModalComponent } from '../modal/modal';
 
 @Component({
   selector: 'Common_Autarchy',
-  templateUrl: './flat.html'
+  templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 
@@ -14,20 +14,20 @@ export class FlatComponent extends AbstractFlatWidget {
   protected override getChannelAddresses(): ChannelAddress[] {
     return [
       new ChannelAddress('_sum', 'GridActivePower'),
-      new ChannelAddress('_sum', 'ConsumptionActivePower')
+      new ChannelAddress('_sum', 'ConsumptionActivePower'),
     ];
   }
 
   protected override onCurrentData(currentData: CurrentData) {
     this.percentageValue = Utils.calculateAutarchy(
       currentData.allComponents['_sum/GridActivePower'],
-      currentData.allComponents['_sum/ConsumptionActivePower']
+      currentData.allComponents['_sum/ConsumptionActivePower'],
     );
   }
 
   async presentModal() {
     const modal = await this.modalController.create({
-      component: ModalComponent
+      component: ModalComponent,
     });
     return await modal.present();
   }

--- a/ui/src/app/edge/live/common/autarchy/modal/modal.spec.ts
+++ b/ui/src/app/edge/live/common/autarchy/modal/modal.spec.ts
@@ -22,8 +22,8 @@ describe('Autarchy - Modal', () => {
       expectView(TEST_CONTEXT, VIEW_CONTEXT, {
         title: "Autarkie",
         lines: [
-          LINE_INFO("Die Autarkie gibt an zu wie viel Prozent die aktuell genutzte Leistung durch Erzeugung und Speicherentladung gedeckt wird.")
-        ]
+          LINE_INFO("Die Autarkie gibt an zu wie viel Prozent die aktuell genutzte Leistung durch Erzeugung und Speicherentladung gedeckt wird."),
+        ],
       });
     }
   });

--- a/ui/src/app/edge/live/common/autarchy/modal/modal.ts
+++ b/ui/src/app/edge/live/common/autarchy/modal/modal.ts
@@ -5,7 +5,7 @@ import { EdgeConfig } from 'src/app/shared/shared';
 import { Role } from 'src/app/shared/type/role';
 
 @Component({
-  templateUrl: '../../../../../shared/formly/formly-field-modal/template.html'
+  templateUrl: '../../../../../shared/formly/formly-field-modal/template.html',
 })
 export class ModalComponent extends AbstractFormlyComponent {
   protected override generateView(config: EdgeConfig, role: Role): OeFormlyView {
@@ -17,8 +17,8 @@ export class ModalComponent extends AbstractFormlyComponent {
       title: translate.instant('General.autarchy'),
       lines: [{
         type: 'info-line',
-        name: translate.instant("Edge.Index.Widgets.autarchyInfo")
-      }]
+        name: translate.instant("Edge.Index.Widgets.autarchyInfo"),
+      }],
     };
   }
 }

--- a/ui/src/app/edge/live/common/consumption/Common_Consumption.ts
+++ b/ui/src/app/edge/live/common/consumption/Common_Consumption.ts
@@ -7,18 +7,18 @@ import { ModalComponent } from './modal/modal';
 @NgModule({
   imports: [
     BrowserModule,
-    SharedModule
+    SharedModule,
   ],
   entryComponents: [
     FlatComponent,
-    ModalComponent
+    ModalComponent,
   ],
   declarations: [
     FlatComponent,
-    ModalComponent
+    ModalComponent,
   ],
   exports: [
-    FlatComponent
-  ]
+    FlatComponent,
+  ],
 })
 export class Common_Consumption { }

--- a/ui/src/app/edge/live/common/consumption/flat/flat.ts
+++ b/ui/src/app/edge/live/common/consumption/flat/flat.ts
@@ -5,7 +5,7 @@ import { ModalComponent } from '../modal/modal';
 
 @Component({
   selector: 'consumption',
-  templateUrl: './flat.html'
+  templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 
@@ -24,7 +24,7 @@ export class FlatComponent extends AbstractFlatWidget {
       // TODO should be moved to Modal
       new ChannelAddress('_sum', 'ConsumptionActivePowerL1'),
       new ChannelAddress('_sum', 'ConsumptionActivePowerL2'),
-      new ChannelAddress('_sum', 'ConsumptionActivePowerL3')
+      new ChannelAddress('_sum', 'ConsumptionActivePowerL3'),
     ];
 
     // Get consumptionMeterComponents
@@ -36,7 +36,7 @@ export class FlatComponent extends AbstractFlatWidget {
         new ChannelAddress(component.id, 'ActivePower'),
         new ChannelAddress(component.id, 'ActivePowerL1'),
         new ChannelAddress(component.id, 'ActivePowerL2'),
-        new ChannelAddress(component.id, 'ActivePowerL3')
+        new ChannelAddress(component.id, 'ActivePowerL3'),
       );
     }
 
@@ -47,7 +47,7 @@ export class FlatComponent extends AbstractFlatWidget {
 
     for (let component of this.evcss) {
       channelAddresses.push(
-        new ChannelAddress(component.id, 'ChargePower')
+        new ChannelAddress(component.id, 'ChargePower'),
       );
     }
     return channelAddresses;
@@ -80,7 +80,7 @@ export class FlatComponent extends AbstractFlatWidget {
 
   async presentModal() {
     const modal = await this.modalController.create({
-      component: ModalComponent
+      component: ModalComponent,
     });
     return await modal.present();
   }

--- a/ui/src/app/edge/live/common/consumption/modal/modal.spec.ts
+++ b/ui/src/app/edge/live/common/consumption/modal/modal.spec.ts
@@ -18,7 +18,7 @@ describe('Consumption - Modal', () => {
         '_sum/ConsumptionActivePower': -1000,
         '_sum/ConsumptionActivePowerL1': -1000,
         '_sum/ConsumptionActivePowerL2': 1000,
-        '_sum/ConsumptionActivePowerL3': -1000
+        '_sum/ConsumptionActivePowerL3': -1000,
       };
       const EMS = DummyConfig.from();
 
@@ -31,8 +31,8 @@ describe('Consumption - Modal', () => {
           CHANNEL_LINE("Phase L3", "0 W", TextIndentation.SINGLE),
           LINE_HORIZONTAL,
           VALUE_FROM_CHANNELS_LINE("Sonstiger", "0 W"),
-          LINE_INFO_PHASES_DE
-        ]
+          LINE_INFO_PHASES_DE,
+        ],
       });
     }
 
@@ -43,7 +43,7 @@ describe('Consumption - Modal', () => {
         SOCOMEC_CONSUMPTION_METER("meter1", "Heizung"),
         EVCS_KEBA_KECONTACT("evcs0", "Evcs"),
         EVCS_KEBA_KECONTACT("evcs1", "Evcs 2"),
-        EVCS_KEBA_KECONTACT("evcs2", "Evcs 3")
+        EVCS_KEBA_KECONTACT("evcs2", "Evcs 3"),
       );
       const VIEW_CONTEXT: OeFormlyViewTester.Context = {
         '_sum/ConsumptionActivePower': 1000,
@@ -60,7 +60,7 @@ describe('Consumption - Modal', () => {
         'meter1/ActivePowerL3': null,
         'evcs0/ChargePower': 1000,
         'evcs1/ChargePower': -1000,
-        'evcs2/ChargePower': null
+        'evcs2/ChargePower': null,
       };
 
       expectView(EMS, Role.ADMIN, VIEW_CONTEXT, TEST_CONTEXT, {
@@ -88,22 +88,22 @@ describe('Consumption - Modal', () => {
           CHANNEL_LINE("Phase L3", "-", TextIndentation.SINGLE),
           LINE_HORIZONTAL,
           VALUE_FROM_CHANNELS_LINE("Sonstiger", "0 W"),
-          LINE_INFO_PHASES_DE
-        ]
+          LINE_INFO_PHASES_DE,
+        ],
       });
     }
 
     // No consumptionMeter, one evcs
     {
       const EMS = DummyConfig.from(
-        EVCS_KEBA_KECONTACT("evcs0", "Evcs")
+        EVCS_KEBA_KECONTACT("evcs0", "Evcs"),
       );
       const VIEW_CONTEXT: OeFormlyViewTester.Context = {
         '_sum/ConsumptionActivePower': 1000,
         '_sum/ConsumptionActivePowerL1': 300,
         '_sum/ConsumptionActivePowerL2': 350,
         '_sum/ConsumptionActivePowerL3': 350,
-        'evcs0/ChargePower': 1000
+        'evcs0/ChargePower': 1000,
       };
 
       expectView(EMS, Role.ADMIN, VIEW_CONTEXT, TEST_CONTEXT, {
@@ -117,15 +117,15 @@ describe('Consumption - Modal', () => {
           CHANNEL_LINE("Evcs", "1.000 W"),
           LINE_HORIZONTAL,
           VALUE_FROM_CHANNELS_LINE("Sonstiger", "0 W"),
-          LINE_INFO_PHASES_DE
-        ]
+          LINE_INFO_PHASES_DE,
+        ],
       });
     }
 
     // One consumptionMeter, no evcs
     {
       const EMS = DummyConfig.from(
-        SOCOMEC_CONSUMPTION_METER("meter0", "Waermepumpe")
+        SOCOMEC_CONSUMPTION_METER("meter0", "Waermepumpe"),
       );
       const VIEW_CONTEXT: OeFormlyViewTester.Context = {
         '_sum/ConsumptionActivePower': 1000,
@@ -135,7 +135,7 @@ describe('Consumption - Modal', () => {
         'meter0/ActivePower': 1000,
         'meter0/ActivePowerL1': 1000,
         'meter0/ActivePowerL2': -1000,
-        'meter0/ActivePowerL3': 1000
+        'meter0/ActivePowerL3': 1000,
       };
 
       expectView(EMS, Role.ADMIN, VIEW_CONTEXT, TEST_CONTEXT, {
@@ -152,8 +152,8 @@ describe('Consumption - Modal', () => {
           CHANNEL_LINE("Phase L3", "1.000 W", TextIndentation.SINGLE),
           LINE_HORIZONTAL,
           VALUE_FROM_CHANNELS_LINE("Sonstiger", "0 W"),
-          LINE_INFO_PHASES_DE
-        ]
+          LINE_INFO_PHASES_DE,
+        ],
       });
     }
   });

--- a/ui/src/app/edge/live/common/consumption/modal/modal.ts
+++ b/ui/src/app/edge/live/common/consumption/modal/modal.ts
@@ -10,7 +10,7 @@ import { Role } from 'src/app/shared/type/role';
 import { ChannelAddress, CurrentData, EdgeConfig } from '../../../../../shared/shared';
 
 @Component({
-  templateUrl: '../../../../../shared/formly/formly-field-modal/template.html'
+  templateUrl: '../../../../../shared/formly/formly-field-modal/template.html',
 })
 export class ModalComponent extends AbstractFormlyComponent {
 
@@ -34,7 +34,7 @@ export class ModalComponent extends AbstractFormlyComponent {
       type: 'channel-line',
       name: translate.instant('General.TOTAL'),
       channel: '_sum/ConsumptionActivePower',
-      converter: Converter.ONLY_POSITIVE_POWER_AND_NEGATIVE_AS_ZERO
+      converter: Converter.ONLY_POSITIVE_POWER_AND_NEGATIVE_AS_ZERO,
     });
 
     Phase.THREE_PHASE.forEach(phase => {
@@ -43,13 +43,13 @@ export class ModalComponent extends AbstractFormlyComponent {
         name: translate.instant('General.phase') + ' ' + phase,
         indentation: TextIndentation.SINGLE,
         channel: '_sum/ConsumptionActivePower' + phase,
-        converter: Converter.ONLY_POSITIVE_POWER_AND_NEGATIVE_AS_ZERO
+        converter: Converter.ONLY_POSITIVE_POWER_AND_NEGATIVE_AS_ZERO,
       });
     });
 
     if (evcss.length > 0) {
       lines.push({
-        type: 'horizontal-line'
+        type: 'horizontal-line',
       });
     }
 
@@ -59,7 +59,7 @@ export class ModalComponent extends AbstractFormlyComponent {
         type: 'channel-line',
         name: Name.METER_ALIAS_OR_ID(evcs),
         channel: evcs.id + '/ChargePower',
-        converter: Converter.ONLY_POSITIVE_POWER_AND_NEGATIVE_AS_ZERO
+        converter: Converter.ONLY_POSITIVE_POWER_AND_NEGATIVE_AS_ZERO,
       });
 
       if (index < (evcss.length - 1)) {
@@ -77,7 +77,7 @@ export class ModalComponent extends AbstractFormlyComponent {
         type: 'channel-line',
         name: Name.METER_ALIAS_OR_ID(meter),
         channel: meter.id + '/ActivePower',
-        converter: Converter.ONLY_POSITIVE_POWER_AND_NEGATIVE_AS_ZERO
+        converter: Converter.ONLY_POSITIVE_POWER_AND_NEGATIVE_AS_ZERO,
       });
       Phase.THREE_PHASE.forEach(phase => {
         lines.push({
@@ -85,13 +85,13 @@ export class ModalComponent extends AbstractFormlyComponent {
           name: 'Phase ' + phase,
           channel: meter.id + '/ActivePower' + phase,
           indentation: TextIndentation.SINGLE,
-          converter: Converter.ONLY_POSITIVE_POWER_AND_NEGATIVE_AS_ZERO
+          converter: Converter.ONLY_POSITIVE_POWER_AND_NEGATIVE_AS_ZERO,
         });
       });
 
       if (index < (consumptionMeters.length - 1)) {
         lines.push({
-          type: 'horizontal-line'
+          type: 'horizontal-line',
         });
       }
     });
@@ -110,17 +110,17 @@ export class ModalComponent extends AbstractFormlyComponent {
       type: 'value-from-channels-line',
       name: translate.instant('General.otherConsumption'),
       value: (currentData: CurrentData) => Converter.ONLY_POSITIVE_POWER_AND_NEGATIVE_AS_ZERO(Converter.CALCULATE_CONSUMPTION_OTHER_POWER(evcss, consumptionMeters, currentData)),
-      channelsToSubscribe: channelsToSubscribe
+      channelsToSubscribe: channelsToSubscribe,
     });
 
     lines.push({
       type: 'info-line',
-      name: translate.instant('Edge.Index.Widgets.phasesInfo')
+      name: translate.instant('Edge.Index.Widgets.phasesInfo'),
     });
 
     return {
       title: translate.instant('General.consumption'),
-      lines: lines
+      lines: lines,
     };
   }
 }

--- a/ui/src/app/edge/live/common/grid/Common_Grid.ts
+++ b/ui/src/app/edge/live/common/grid/Common_Grid.ts
@@ -7,18 +7,18 @@ import { ModalComponent } from './modal/modal';
 @NgModule({
     imports: [
         BrowserModule,
-        SharedModule
+        SharedModule,
     ],
     entryComponents: [
         FlatComponent,
-        ModalComponent
+        ModalComponent,
     ],
     declarations: [
         FlatComponent,
-        ModalComponent
+        ModalComponent,
     ],
     exports: [
-        FlatComponent
-    ]
+        FlatComponent,
+    ],
 })
 export class Common_Grid { }

--- a/ui/src/app/edge/live/common/grid/flat/flat.ts
+++ b/ui/src/app/edge/live/common/grid/flat/flat.ts
@@ -5,7 +5,7 @@ import { ModalComponent } from '../modal/modal';
 
 @Component({
   selector: 'grid',
-  templateUrl: './flat.html'
+  templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 
@@ -26,7 +26,7 @@ export class FlatComponent extends AbstractFlatWidget {
       // TODO should be moved to Modal 
       new ChannelAddress('_sum', 'GridActivePowerL1'),
       new ChannelAddress('_sum', 'GridActivePowerL2'),
-      new ChannelAddress('_sum', 'GridActivePowerL3')
+      new ChannelAddress('_sum', 'GridActivePowerL3'),
     ];
     return channelAddresses;
   }
@@ -41,8 +41,8 @@ export class FlatComponent extends AbstractFlatWidget {
     const modal = await this.modalController.create({
       component: ModalComponent,
       componentProps: {
-        edge: this.edge
-      }
+        edge: this.edge,
+      },
     });
     return await modal.present();
   }

--- a/ui/src/app/edge/live/common/grid/modal/modal.spec.ts
+++ b/ui/src/app/edge/live/common/grid/modal/modal.spec.ts
@@ -14,7 +14,7 @@ const VIEW_CONTEXT = (properties?: {}): OeFormlyViewTester.Context => ({
   "meter0/CurrentL1": 2170,
   "meter0/ActivePowerL1": -500,
   "meter0/ActivePowerL2": 1500,
-  ...properties
+  ...properties,
 });
 
 describe('Grid - Modal', () => {
@@ -29,14 +29,14 @@ describe('Grid - Modal', () => {
       expectView(EMS, Role.ADMIN, VIEW_CONTEXT(), TEST_CONTEXT, {
         title: "Netz",
         lines: [
-        ]
+        ],
       });
     }
 
     {
       // Single Meter
       const EMS = DummyConfig.from(
-        SOCOMEC_GRID_METER("meter0", "Netzzähler")
+        SOCOMEC_GRID_METER("meter0", "Netzzähler"),
       );
 
       // Admin and Installer
@@ -49,8 +49,8 @@ describe('Grid - Modal', () => {
           PHASE_ADMIN("Phase L2 Bezug", "-", "-", "1.500 W"),
           PHASE_ADMIN("Phase L3", "-", "-", "-"),
           LINE_HORIZONTAL,
-          LINE_INFO_PHASES_DE
-        ]
+          LINE_INFO_PHASES_DE,
+        ],
       });
 
       // Owner and Guest
@@ -63,8 +63,8 @@ describe('Grid - Modal', () => {
           PHASE_GUEST("Phase L2 Bezug", "1.500 W"),
           PHASE_GUEST("Phase L3", "-"),
           LINE_HORIZONTAL,
-          LINE_INFO_PHASES_DE
-        ]
+          LINE_INFO_PHASES_DE,
+        ],
       });
 
       // Offgrid
@@ -74,7 +74,7 @@ describe('Grid - Modal', () => {
           {
             type: "channel-line",
             name: "Keine Netzverbindung!",
-            value: ""
+            value: "",
           },
           CHANNEL_LINE("Einspeisung", "1.000 W"),
           CHANNEL_LINE("Bezug", "0 W"),
@@ -82,8 +82,8 @@ describe('Grid - Modal', () => {
           PHASE_ADMIN("Phase L2 Bezug", "-", "-", "1.500 W"),
           PHASE_ADMIN("Phase L3", "-", "-", "-"),
           LINE_HORIZONTAL,
-          LINE_INFO_PHASES_DE
-        ]
+          LINE_INFO_PHASES_DE,
+        ],
       });
     }
 
@@ -91,7 +91,7 @@ describe('Grid - Modal', () => {
       // Two Meters
       const EMS = DummyConfig.from(
         SOCOMEC_GRID_METER("meter10"),
-        SOCOMEC_GRID_METER("meter11")
+        SOCOMEC_GRID_METER("meter11"),
       );
 
       // Admin and Installer -> two meters
@@ -111,8 +111,8 @@ describe('Grid - Modal', () => {
           PHASE_ADMIN("Phase L2", "-", "-", "-"),
           PHASE_ADMIN("Phase L3", "-", "-", "-"),
           LINE_HORIZONTAL,
-          LINE_INFO_PHASES_DE
-        ]
+          LINE_INFO_PHASES_DE,
+        ],
       });
 
       // Owner and Guest -> two meters
@@ -132,8 +132,8 @@ describe('Grid - Modal', () => {
           PHASE_GUEST("Phase L2", "-"),
           PHASE_GUEST("Phase L3", "-"),
           LINE_HORIZONTAL,
-          LINE_INFO_PHASES_DE
-        ]
+          LINE_INFO_PHASES_DE,
+        ],
       });
     }
   });

--- a/ui/src/app/edge/live/common/grid/modal/modal.ts
+++ b/ui/src/app/edge/live/common/grid/modal/modal.ts
@@ -9,7 +9,7 @@ import { ChannelAddress, EdgeConfig } from 'src/app/shared/shared';
 import { Role } from 'src/app/shared/type/role';
 
 @Component({
-  templateUrl: '../../../../../shared/formly/formly-field-modal/template.html'
+  templateUrl: '../../../../../shared/formly/formly-field-modal/template.html',
 })
 export class ModalComponent extends AbstractFormlyComponent {
 
@@ -25,7 +25,7 @@ export class ModalComponent extends AbstractFormlyComponent {
       name: translate.instant("General.offGrid"),
       channel: '_sum/GridMode',
       filter: Filter.GRID_MODE_IS_OFF_GRID,
-      converter: Converter.HIDE_VALUE
+      converter: Converter.HIDE_VALUE,
     }];
 
     var gridMeters = Object.values(config.components).filter(component => config?.isTypeGrid(component));
@@ -37,15 +37,15 @@ export class ModalComponent extends AbstractFormlyComponent {
           type: 'channel-line',
           name: translate.instant("General.gridSellAdvanced"),
           channel: '_sum/GridActivePower',
-          converter: Converter.GRID_SELL_POWER_OR_ZERO
+          converter: Converter.GRID_SELL_POWER_OR_ZERO,
         },
         {
           type: 'channel-line',
           name: translate.instant("General.gridBuyAdvanced"),
           channel: '_sum/GridActivePower',
-          converter: Converter.GRID_BUY_POWER_OR_ZERO
+          converter: Converter.GRID_BUY_POWER_OR_ZERO,
         }, {
-        type: 'horizontal-line'
+        type: 'horizontal-line',
       });
     }
 
@@ -58,13 +58,13 @@ export class ModalComponent extends AbstractFormlyComponent {
             type: 'channel-line',
             name: translate.instant("General.gridSellAdvanced"),
             channel: meter.id + '/ActivePower',
-            converter: Converter.GRID_SELL_POWER_OR_ZERO
+            converter: Converter.GRID_SELL_POWER_OR_ZERO,
           },
           {
             type: 'channel-line',
             name: translate.instant("General.gridBuyAdvanced"),
             channel: meter.id + '/ActivePower',
-            converter: Converter.GRID_BUY_POWER_OR_ZERO
+            converter: Converter.GRID_BUY_POWER_OR_ZERO,
           });
 
       } else {
@@ -73,7 +73,7 @@ export class ModalComponent extends AbstractFormlyComponent {
           type: 'channel-line',
           name: Name.SUFFIX_FOR_GRID_SELL_OR_GRID_BUY(translate, meter.alias),
           channel: meter.id + '/ActivePower',
-          converter: Converter.POWER_IN_WATT
+          converter: Converter.POWER_IN_WATT,
         });
       }
 
@@ -81,7 +81,7 @@ export class ModalComponent extends AbstractFormlyComponent {
         // Individual phases: Voltage, Current and Power
         ...ModalComponent.generatePhasesView(meter, translate, role), {
         // Line separator
-        type: 'horizontal-line'
+        type: 'horizontal-line',
       });
     }
 
@@ -89,13 +89,13 @@ export class ModalComponent extends AbstractFormlyComponent {
       // Technical info
       lines.push({
         type: 'info-line',
-        name: translate.instant("Edge.Index.Widgets.phasesInfo")
+        name: translate.instant("Edge.Index.Widgets.phasesInfo"),
       });
     }
 
     return {
       title: translate.instant('General.grid'),
-      lines: lines
+      lines: lines,
     };
   }
 
@@ -105,10 +105,10 @@ export class ModalComponent extends AbstractFormlyComponent {
         type: 'children-line',
         name: {
           channel: ChannelAddress.fromString(component.id + '/ActivePower' + phase),
-          converter: Name.SUFFIX_FOR_GRID_SELL_OR_GRID_BUY(translate, translate.instant('General.phase') + " " + phase)
+          converter: Name.SUFFIX_FOR_GRID_SELL_OR_GRID_BUY(translate, translate.instant('General.phase') + " " + phase),
         },
         indentation: TextIndentation.SINGLE,
-        children: ModalComponent.generatePhasesLineItems(role, phase, component)
+        children: ModalComponent.generatePhasesLineItems(role, phase, component),
       });
   }
 
@@ -118,18 +118,18 @@ export class ModalComponent extends AbstractFormlyComponent {
       children.push({
         type: 'item',
         channel: component.id + '/Voltage' + phase,
-        converter: Converter.VOLTAGE_IN_MILLIVOLT_TO_VOLT
+        converter: Converter.VOLTAGE_IN_MILLIVOLT_TO_VOLT,
       }, {
         type: 'item',
         channel: component.id + '/Current' + phase,
-        converter: Converter.CURRENT_IN_MILLIAMPERE_TO_AMPERE
+        converter: Converter.CURRENT_IN_MILLIAMPERE_TO_AMPERE,
       });
     }
 
     children.push({
       type: 'item',
       channel: component.id + '/ActivePower' + phase,
-      converter: Converter.POSITIVE_POWER
+      converter: Converter.POSITIVE_POWER,
     });
 
     return children;

--- a/ui/src/app/edge/live/common/production/Common_Production.ts
+++ b/ui/src/app/edge/live/common/production/Common_Production.ts
@@ -7,18 +7,18 @@ import { ModalComponent } from './modal/modal';
 @NgModule({
   imports: [
     BrowserModule,
-    SharedModule
+    SharedModule,
   ],
   entryComponents: [
     FlatComponent,
-    ModalComponent
+    ModalComponent,
   ],
   declarations: [
     FlatComponent,
-    ModalComponent
+    ModalComponent,
   ],
   exports: [
-    FlatComponent
-  ]
+    FlatComponent,
+  ],
 })
 export class Common_Production { }

--- a/ui/src/app/edge/live/common/production/flat/flat.ts
+++ b/ui/src/app/edge/live/common/production/flat/flat.ts
@@ -5,7 +5,7 @@ import { ModalComponent } from '../modal/modal';
 
 @Component({
     selector: 'Common_Production',
-    templateUrl: './flat.html'
+    templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 
@@ -29,7 +29,7 @@ export class FlatComponent extends AbstractFlatWidget {
 
     async presentModal() {
         const modal = await this.modalController.create({
-            component: ModalComponent
+            component: ModalComponent,
         });
         return await modal.present();
     }

--- a/ui/src/app/edge/live/common/production/modal/modal.ts
+++ b/ui/src/app/edge/live/common/production/modal/modal.ts
@@ -3,7 +3,7 @@ import { AbstractModal } from 'src/app/shared/genericComponents/modal/abstractMo
 import { ChannelAddress, EdgeConfig, Utils } from 'src/app/shared/shared';
 
 @Component({
-    templateUrl: './modal.html'
+    templateUrl: './modal.html',
 })
 export class ModalComponent extends AbstractModal {
 

--- a/ui/src/app/edge/live/common/selfconsumption/Common_Selfconsumption.ts
+++ b/ui/src/app/edge/live/common/selfconsumption/Common_Selfconsumption.ts
@@ -7,18 +7,18 @@ import { ModalComponent } from './modal/modal';
 @NgModule({
   imports: [
     BrowserModule,
-    SharedModule
+    SharedModule,
   ],
   entryComponents: [
     FlatComponent,
-    ModalComponent
+    ModalComponent,
   ],
   declarations: [
     FlatComponent,
-    ModalComponent
+    ModalComponent,
   ],
   exports: [
-    FlatComponent
-  ]
+    FlatComponent,
+  ],
 })
 export class Common_Selfconsumption { }

--- a/ui/src/app/edge/live/common/selfconsumption/flat/flat.ts
+++ b/ui/src/app/edge/live/common/selfconsumption/flat/flat.ts
@@ -6,7 +6,7 @@ import { ModalComponent } from '../modal/modal';
 
 @Component({
     selector: 'Common_Selfconsumption',
-    templateUrl: './flat.html'
+    templateUrl: './flat.html',
 })
 export class FlatComponent extends AbstractFlatWidget {
 
@@ -15,7 +15,7 @@ export class FlatComponent extends AbstractFlatWidget {
     protected override getChannelAddresses() {
         return [
             new ChannelAddress('_sum', 'GridActivePower'),
-            new ChannelAddress('_sum', 'ProductionActivePower')
+            new ChannelAddress('_sum', 'ProductionActivePower'),
         ];
     }
 
@@ -23,15 +23,15 @@ export class FlatComponent extends AbstractFlatWidget {
         this.calculatedSelfConsumption = Utils.calculateSelfConsumption(
             Utils.multiplySafely(
                 currentData.allComponents['_sum/GridActivePower'],
-                -1
+                -1,
             ),
-            currentData.allComponents['_sum/ProductionActivePower']
+            currentData.allComponents['_sum/ProductionActivePower'],
         );
     }
 
     async presentModal() {
         const modal = await this.modalController.create({
-            component: ModalComponent
+            component: ModalComponent,
         });
         return await modal.present();
     }

--- a/ui/src/app/edge/live/common/selfconsumption/modal/modal.spec.ts
+++ b/ui/src/app/edge/live/common/selfconsumption/modal/modal.spec.ts
@@ -22,8 +22,8 @@ describe('SelfConsumption - Modal', () => {
       expectView(TEST_CONTEXT, VIEW_CONTEXT, {
         title: "Eigenverbrauch",
         lines: [
-          LINE_INFO("Der Eigenverbrauch gibt an zu wie viel Prozent die aktuell erzeugte Leistung durch direkten Verbrauch und durch Speicherbeladung selbst genutzt wird.")
-        ]
+          LINE_INFO("Der Eigenverbrauch gibt an zu wie viel Prozent die aktuell erzeugte Leistung durch direkten Verbrauch und durch Speicherbeladung selbst genutzt wird."),
+        ],
       });
     }
   });

--- a/ui/src/app/edge/live/common/selfconsumption/modal/modal.ts
+++ b/ui/src/app/edge/live/common/selfconsumption/modal/modal.ts
@@ -5,7 +5,7 @@ import { EdgeConfig } from 'src/app/shared/shared';
 import { Role } from 'src/app/shared/type/role';
 
 @Component({
-    templateUrl: '../../../../../shared/formly/formly-field-modal/template.html'
+    templateUrl: '../../../../../shared/formly/formly-field-modal/template.html',
 })
 export class ModalComponent extends AbstractFormlyComponent {
     protected override generateView(config: EdgeConfig, role: Role): OeFormlyView {
@@ -17,8 +17,8 @@ export class ModalComponent extends AbstractFormlyComponent {
             title: translate.instant('General.selfConsumption'),
             lines: [{
                 type: 'info-line',
-                name: translate.instant("Edge.Index.Widgets.selfconsumptionInfo")
-            }]
+                name: translate.instant("Edge.Index.Widgets.selfconsumptionInfo"),
+            }],
         };
     }
 }

--- a/ui/src/app/edge/live/common/storage/modal/modal.component.ts
+++ b/ui/src/app/edge/live/common/storage/modal/modal.component.ts
@@ -8,7 +8,7 @@ import { Role } from 'src/app/shared/type/role';
 
 @Component({
     selector: 'storage-modal',
-    templateUrl: './modal.component.html'
+    templateUrl: './modal.component.html',
 })
 export class StorageModalComponent implements OnInit, OnDestroy {
 
@@ -33,7 +33,7 @@ export class StorageModalComponent implements OnInit, OnDestroy {
         public translate: TranslateService,
         public modalCtrl: ModalController,
         public websocket: Websocket,
-        public formBuilder: FormBuilder
+        public formBuilder: FormBuilder,
     ) { }
 
     ngOnInit() {
@@ -62,7 +62,7 @@ export class StorageModalComponent implements OnInit, OnDestroy {
                 new ChannelAddress(controller.id, "_PropertyTargetTimeSpecified"),
                 new ChannelAddress(controller.id, "_PropertyTargetSoc"),
                 new ChannelAddress(controller.id, "_PropertyTargetTimeBuffer"),
-                new ChannelAddress(controller.id, "ExpectedStartEpochSeconds")
+                new ChannelAddress(controller.id, "ExpectedStartEpochSeconds"),
             );
         }
         this.edge.subscribeChannels(this.websocket, "storage", channelAddresses);
@@ -85,8 +85,8 @@ export class StorageModalComponent implements OnInit, OnDestroy {
                                 this.formBuilder.group({
                                     controllerId: new FormControl(controller['id']),
                                     isReserveSocEnabled: new FormControl(isReserveSocEnabled),
-                                    reserveSoc: new FormControl(reserveSoc)
-                                })
+                                    reserveSoc: new FormControl(reserveSoc),
+                                }),
                             );
                         } else if (controller.factoryId == 'Controller.Ess.PrepareBatteryExtension') {
 
@@ -131,8 +131,8 @@ export class StorageModalComponent implements OnInit, OnDestroy {
                                     targetTimeSpecified: new FormControl(targetTimeSpecified),
                                     targetSoc: new FormControl(targetSoc),
                                     targetTimeBuffer: new FormControl(targetTimeBuffer),
-                                    expectedStartOfPreparation: new FormControl(expectedStartOfPreparation)
-                                })
+                                    expectedStartOfPreparation: new FormControl(expectedStartOfPreparation),
+                                }),
                             );
                         }
                     }
@@ -187,7 +187,7 @@ export class StorageModalComponent implements OnInit, OnDestroy {
                 let value = element.values().next().value;
                 properties.push({
                     name: name,
-                    value: value
+                    value: value,
                 });
             });
 

--- a/ui/src/app/edge/live/common/storage/storage.component.ts
+++ b/ui/src/app/edge/live/common/storage/storage.component.ts
@@ -9,7 +9,7 @@ import { StorageModalComponent } from './modal/modal.component';
 
 @Component({
     selector: 'storage',
-    templateUrl: './storage.component.html'
+    templateUrl: './storage.component.html',
 })
 export class StorageComponent extends AbstractFlatWidget {
 
@@ -34,7 +34,7 @@ export class StorageComponent extends AbstractFlatWidget {
             // TODO should be moved to Modal
             new ChannelAddress('_sum', 'EssActivePowerL1'),
             new ChannelAddress('_sum', 'EssActivePowerL2'),
-            new ChannelAddress('_sum', 'EssActivePowerL3')
+            new ChannelAddress('_sum', 'EssActivePowerL3'),
         ];
 
         this.prepareBatteryExtensionCtrl = this.config.getComponentsByFactory("Controller.Ess.PrepareBatteryExtension")
@@ -42,7 +42,7 @@ export class StorageComponent extends AbstractFlatWidget {
             .reduce((result, component) => {
                 return {
                     ...result,
-                    [component.properties['ess.id']]: component
+                    [component.properties['ess.id']]: component,
                 };
             }, {});
 
@@ -52,7 +52,7 @@ export class StorageComponent extends AbstractFlatWidget {
                 new ChannelAddress(controller.id, "CtrlIsBlockingEss"),
                 new ChannelAddress(controller.id, "CtrlIsChargingEss"),
                 new ChannelAddress(controller.id, "CtrlIsDischargingEss"),
-                new ChannelAddress(controller.id, "_PropertyIsRunning")
+                new ChannelAddress(controller.id, "_PropertyIsRunning"),
             );
         }
 
@@ -63,14 +63,14 @@ export class StorageComponent extends AbstractFlatWidget {
             .reduce((result, component) => {
                 return {
                     ...result,
-                    [component.properties['ess.id']]: component
+                    [component.properties['ess.id']]: component,
                 };
             }, {});
         for (let component of Object.values(this.emergencyReserveComponents)) {
 
             channelAddresses.push(
                 new ChannelAddress(component.id, '_PropertyReserveSoc'),
-                new ChannelAddress(component.id, '_PropertyIsReserveSocEnabled')
+                new ChannelAddress(component.id, '_PropertyIsReserveSocEnabled'),
             );
         }
         // Get Chargers
@@ -80,7 +80,7 @@ export class StorageComponent extends AbstractFlatWidget {
             .filter(component => component.isEnabled);
         for (let component of this.chargerComponents) {
             channelAddresses.push(
-                new ChannelAddress(component.id, 'ActualPower')
+                new ChannelAddress(component.id, 'ActualPower'),
             );
         }
 
@@ -104,13 +104,13 @@ export class StorageComponent extends AbstractFlatWidget {
 
             channelAddresses.push(
                 new ChannelAddress(component.id, 'Soc'),
-                new ChannelAddress(component.id, 'Capacity')
+                new ChannelAddress(component.id, 'Capacity'),
             );
             if (this.config.factories[component.factoryId].natureIds.includes("io.openems.edge.ess.api.AsymmetricEss")) {
                 channelAddresses.push(
                     new ChannelAddress(component.id, 'ActivePowerL1'),
                     new ChannelAddress(component.id, 'ActivePowerL2'),
-                    new ChannelAddress(component.id, 'ActivePowerL3')
+                    new ChannelAddress(component.id, 'ActivePowerL3'),
                 );
             }
         }
@@ -147,7 +147,7 @@ export class StorageComponent extends AbstractFlatWidget {
                     currentData.allComponents[controller.id + '/_PropertyIsRunning'] == 1,
                     currentData.allComponents[controller.id + '/CtrlIsBlockingEss'],
                     currentData.allComponents[controller.id + '/CtrlIsChargingEss'],
-                    currentData.allComponents[controller.id + '/CtrlIsDischargingEss']
+                    currentData.allComponents[controller.id + '/CtrlIsDischargingEss'],
                 ));
         }
 
@@ -217,8 +217,8 @@ export class StorageComponent extends AbstractFlatWidget {
                 component: this.component,
                 essComponents: this.essComponents,
                 chargerComponents: this.chargerComponents,
-                singleComponent: this.component
-            }
+                singleComponent: this.component,
+            },
         });
         return await modal.present();
     }

--- a/ui/src/app/edge/live/delayedselltogrid/delayedselltogrid.component.ts
+++ b/ui/src/app/edge/live/delayedselltogrid/delayedselltogrid.component.ts
@@ -7,7 +7,7 @@ import { DelayedSellToGridModalComponent } from './modal/modal.component';
 
 @Component({
     selector: DelayedSellToGridComponent.SELECTOR,
-    templateUrl: './delayedselltogrid.component.html'
+    templateUrl: './delayedselltogrid.component.html',
 })
 export class DelayedSellToGridComponent implements OnInit, OnDestroy {
 
@@ -24,7 +24,7 @@ export class DelayedSellToGridComponent implements OnInit, OnDestroy {
         private websocket: Websocket,
         protected translate: TranslateService,
         public modalCtrl: ModalController,
-        public service: Service
+        public service: Service,
     ) { }
 
     ngOnInit() {
@@ -45,8 +45,8 @@ export class DelayedSellToGridComponent implements OnInit, OnDestroy {
             component: DelayedSellToGridModalComponent,
             componentProps: {
                 component: this.component,
-                edge: this.edge
-            }
+                edge: this.edge,
+            },
         });
         return await modal.present();
     }

--- a/ui/src/app/edge/live/delayedselltogrid/modal/modal.component.ts
+++ b/ui/src/app/edge/live/delayedselltogrid/modal/modal.component.ts
@@ -6,7 +6,7 @@ import { Edge, EdgeConfig, Service, Websocket } from '../../../../shared/shared'
 
 @Component({
     selector: DelayedSellToGridModalComponent.SELECTOR,
-    templateUrl: './modal.component.html'
+    templateUrl: './modal.component.html',
 })
 export class DelayedSellToGridModalComponent implements OnInit {
 
@@ -23,19 +23,19 @@ export class DelayedSellToGridModalComponent implements OnInit {
         public modalCtrl: ModalController,
         public service: Service,
         public translate: TranslateService,
-        public websocket: Websocket
+        public websocket: Websocket,
     ) { }
 
     ngOnInit() {
         this.formGroup = this.formBuilder.group({
             continuousSellToGridPower: new FormControl(this.component.properties.continuousSellToGridPower, Validators.compose([
                 Validators.pattern('^(?:[1-9][0-9]*|0)$'),
-                Validators.required
+                Validators.required,
             ])),
             sellToGridPowerLimit: new FormControl(this.component.properties.sellToGridPowerLimit, Validators.compose([
                 Validators.pattern('^(?:[1-9][0-9]*|0)$'),
-                Validators.required
-            ]))
+                Validators.required,
+            ])),
         });
     }
 

--- a/ui/src/app/edge/live/energymonitor/chart/chart.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/chart.component.ts
@@ -10,7 +10,7 @@ import { StorageSectionComponent } from './section/storage.component';
 
 @Component({
   selector: 'energymonitor-chart',
-  templateUrl: './chart.component.html'
+  templateUrl: './chart.component.html',
 })
 export class EnergymonitorChartComponent implements OnInit, OnDestroy {
 
@@ -45,7 +45,7 @@ export class EnergymonitorChartComponent implements OnInit, OnDestroy {
   private ngUnsubscribe: Subject<void> = new Subject<void>();
 
   constructor(
-    private service: Service
+    private service: Service,
   ) { }
 
   ngOnInit() {

--- a/ui/src/app/edge/live/energymonitor/chart/section/abstractsection.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/abstractsection.component.ts
@@ -13,7 +13,7 @@ export class SectionValue {
 export class SvgSquarePosition {
     constructor(
         public x: number,
-        public y: number
+        public y: number,
     ) { }
 }
 
@@ -22,7 +22,7 @@ export class SvgSquare {
         public length: number,
         public valueRatio: SvgTextPosition,
         public valueText: SvgTextPosition,
-        public image: SvgImagePosition
+        public image: SvgImagePosition,
     ) { }
 }
 
@@ -31,7 +31,7 @@ export class SvgTextPosition {
         public x: number,
         public y: number,
         public anchor: "start" | "middle" | "end",
-        public fontsize: number
+        public fontsize: number,
     ) { }
 }
 
@@ -40,7 +40,7 @@ export class SvgImagePosition {
         public image: string,
         public x: number,
         public y: number,
-        public length: number
+        public length: number,
     ) { }
 }
 
@@ -66,7 +66,7 @@ export class EnergyFlow {
             y1: string,
             x2: string,
             y2: string
-        }
+        },
     ) { }
 
     public update(energyFlow: SvgEnergyFlow, animationEnergyFlow: SvgEnergyFlow) {
@@ -149,7 +149,7 @@ export abstract class AbstractSection {
         public color: string,
         protected translate: TranslateService,
         service: Service,
-        widgetClass: string
+        widgetClass: string,
     ) {
         this.sectionId = translateName;
         this.name = translate.instant(translateName);
@@ -336,7 +336,7 @@ export abstract class AbstractSection {
             length,
             new SvgTextPosition(xText, yText, "middle", textSize),
             new SvgTextPosition(xText, yNumber, "middle", numberSize),
-            new SvgImagePosition("assets/img/" + this.getImagePath(), (length / 2) - (imageSize / 2), yImage, imageSize)
+            new SvgImagePosition("assets/img/" + this.getImagePath(), (length / 2) - (imageSize / 2), yImage, imageSize),
         );
     }
 

--- a/ui/src/app/edge/live/energymonitor/chart/section/consumption.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/consumption.component.ts
@@ -13,16 +13,16 @@ import { AbstractSection, EnergyFlow, Ratio, SvgEnergyFlow, SvgSquare, SvgSquare
         trigger('Consumption', [
             state('show', style({
                 opacity: 0.1,
-                transform: 'translateX(0%)'
+                transform: 'translateX(0%)',
             })),
             state('hide', style({
                 opacity: 0.6,
-                transform: 'translateX(17%)'
+                transform: 'translateX(17%)',
             })),
             transition('show => hide', animate('650ms ease-out')),
-            transition('hide => show', animate('0ms ease-in'))
-        ])
-    ]
+            transition('hide => show', animate('0ms ease-in')),
+        ]),
+    ],
 })
 export class ConsumptionSectionComponent extends AbstractSection implements OnInit, OnDestroy {
 
@@ -35,7 +35,7 @@ export class ConsumptionSectionComponent extends AbstractSection implements OnIn
     constructor(
         unitpipe: UnitvaluePipe,
         translate: TranslateService,
-        service: Service
+        service: Service,
     ) {
         super('General.consumption', "right", "#FDC507", translate, service, "Consumption");
         this.unitpipe = unitpipe;
@@ -119,7 +119,7 @@ export class ConsumptionSectionComponent extends AbstractSection implements OnIn
             bottomLeft: { x: v, y: v },
             topRight: { x: r, y: v * -1 },
             bottomRight: { x: r, y: v },
-            middleRight: { x: r - v, y: 0 }
+            middleRight: { x: r - v, y: 0 },
         };
         if (ratio > 0) {
             // towards right
@@ -141,7 +141,7 @@ export class ConsumptionSectionComponent extends AbstractSection implements OnIn
             bottomLeft: { x: v, y: v },
             topRight: { x: r, y: v * -1 },
             bottomRight: { x: r, y: v },
-            middleRight: { x: r - v, y: 0 }
+            middleRight: { x: r - v, y: 0 },
         };
         if (ratio > 0) {
             // towards right

--- a/ui/src/app/edge/live/energymonitor/chart/section/grid.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/grid.component.ts
@@ -13,28 +13,28 @@ import { AbstractSection, EnergyFlow, Ratio, SvgEnergyFlow, SvgSquare, SvgSquare
         trigger('GridBuy', [
             state('show', style({
                 opacity: 0.4,
-                transform: 'translateX(0%)'
+                transform: 'translateX(0%)',
             })),
             state('hide', style({
                 opacity: 0.1,
-                transform: 'translateX(17%)'
+                transform: 'translateX(17%)',
             })),
             transition('show => hide', animate('650ms')),
-            transition('hide => show', animate('0ms'))
+            transition('hide => show', animate('0ms')),
         ]),
         trigger('GridSell', [
             state('show', style({
                 opacity: 0.1,
-                transform: 'translateX(0%)'
+                transform: 'translateX(0%)',
             })),
             state('hide', style({
                 opacity: 0.4,
-                transform: 'translateX(-17%)'
+                transform: 'translateX(-17%)',
             })),
             transition('show => hide', animate('650ms ease-out')),
-            transition('hide => show', animate('0ms ease-in'))
-        ])
-    ]
+            transition('hide => show', animate('0ms ease-in')),
+        ]),
+    ],
 })
 export class GridSectionComponent extends AbstractSection implements OnInit, OnDestroy {
 
@@ -49,7 +49,7 @@ export class GridSectionComponent extends AbstractSection implements OnInit, OnD
     constructor(
         translate: TranslateService,
         service: Service,
-        unitpipe: UnitvaluePipe
+        unitpipe: UnitvaluePipe,
     ) {
         super('General.grid', "left", "#1d1d1d", translate, service, "Grid");
         this.unitpipe = unitpipe;
@@ -180,7 +180,7 @@ export class GridSectionComponent extends AbstractSection implements OnInit, OnD
             topRight: { x: v * -1, y: v * -1 },
             topLeft: { x: r * -1, y: v * -1 },
             middleLeft: { x: r * -1 + v, y: 0 },
-            middleRight: { x: 0, y: 0 }
+            middleRight: { x: 0, y: 0 },
         };
         if (ratio > 0) {
             // towards left
@@ -202,7 +202,7 @@ export class GridSectionComponent extends AbstractSection implements OnInit, OnD
             topRight: { x: v * -1, y: v * -1 },
             topLeft: { x: r * -1, y: v * -1 },
             middleLeft: { x: r * -1 + v, y: 0 },
-            middleRight: { x: 0, y: 0 }
+            middleRight: { x: 0, y: 0 },
         };
 
         if (ratio > 0) {

--- a/ui/src/app/edge/live/energymonitor/chart/section/production.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/production.component.ts
@@ -13,16 +13,16 @@ import { AbstractSection, EnergyFlow, Ratio, SvgEnergyFlow, SvgSquare, SvgSquare
         trigger('Production', [
             state('show', style({
                 opacity: 0.4,
-                transform: 'translateY(0)'
+                transform: 'translateY(0)',
             })),
             state('hide', style({
                 opacity: 0.1,
-                transform: 'translateY(17%)'
+                transform: 'translateY(17%)',
             })),
             transition('show => hide', animate('650ms ease-out')),
-            transition('hide => show', animate('0ms ease-in'))
-        ])
-    ]
+            transition('hide => show', animate('0ms ease-in')),
+        ]),
+    ],
 })
 export class ProductionSectionComponent extends AbstractSection implements OnInit, OnDestroy {
 
@@ -35,7 +35,7 @@ export class ProductionSectionComponent extends AbstractSection implements OnIni
     constructor(
         translate: TranslateService,
         service: Service,
-        unitpipe: UnitvaluePipe
+        unitpipe: UnitvaluePipe,
     ) {
         super('General.production', "up", "#36aed1", translate, service, "Common_Production");
         this.unitpipe = unitpipe;
@@ -121,7 +121,7 @@ export class ProductionSectionComponent extends AbstractSection implements OnIni
             topRight: { x: v, y: r * -1 },
             bottomRight: { x: v, y: v * -1 },
             middleBottom: { x: 0, y: 0 },
-            middleTop: { x: 0, y: r * -1 + v }
+            middleTop: { x: 0, y: r * -1 + v },
         };
         if (ratio < 0) {
             // towards top
@@ -142,7 +142,7 @@ export class ProductionSectionComponent extends AbstractSection implements OnIni
             topRight: { x: v, y: r * -1 },
             bottomRight: { x: v, y: v * -1 },
             middleBottom: { x: 0, y: 0 },
-            middleTop: { x: 0, y: r * -1 + v }
+            middleTop: { x: 0, y: r * -1 + v },
         };
         if (ratio > 0) {
             // towards bottom

--- a/ui/src/app/edge/live/energymonitor/chart/section/storage.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/storage.component.ts
@@ -13,28 +13,28 @@ import { AbstractSection, EnergyFlow, Ratio, SvgEnergyFlow, SvgSquare, SvgSquare
         trigger('Discharge', [
             state('show', style({
                 opacity: 0.4,
-                transform: 'translateY(0)'
+                transform: 'translateY(0)',
             })),
             state('hide', style({
                 opacity: 0.1,
-                transform: 'translateY(-17%)'
+                transform: 'translateY(-17%)',
             })),
             transition('show => hide', animate('650ms ease-out')),
-            transition('hide => show', animate('0ms ease-in'))
+            transition('hide => show', animate('0ms ease-in')),
         ]),
         trigger('Charge', [
             state('show', style({
                 opacity: 0.1,
-                transform: 'translateY(0)'
+                transform: 'translateY(0)',
             })),
             state('hide', style({
                 opacity: 0.4,
-                transform: 'translateY(17%)'
+                transform: 'translateY(17%)',
             })),
             transition('show => hide', animate('650ms ease-out')),
-            transition('hide => show', animate('0ms ease-out'))
-        ])
-    ]
+            transition('hide => show', animate('0ms ease-out')),
+        ]),
+    ],
 })
 export class StorageSectionComponent extends AbstractSection implements OnInit, OnDestroy {
 
@@ -51,7 +51,7 @@ export class StorageSectionComponent extends AbstractSection implements OnInit, 
     constructor(
         translate: TranslateService,
         service: Service,
-        unitpipe: UnitvaluePipe
+        unitpipe: UnitvaluePipe,
     ) {
         super('Edge.Index.Energymonitor.storage', "down", "#009846", translate, service, "Storage");
         this.unitpipe = unitpipe;
@@ -176,7 +176,7 @@ export class StorageSectionComponent extends AbstractSection implements OnInit, 
             topRight: { x: v, y: v },
             bottomRight: { x: v, y: r },
             middleBottom: { x: 0, y: r - v },
-            middleTop: { x: 0, y: 0 }
+            middleTop: { x: 0, y: 0 },
         };
         if (ratio > 0) {
             // towards bottom
@@ -198,7 +198,7 @@ export class StorageSectionComponent extends AbstractSection implements OnInit, 
             topRight: { x: v, y: v },
             bottomRight: { x: v, y: r },
             middleBottom: { x: 0, y: r - v },
-            middleTop: { x: 0, y: 0 }
+            middleTop: { x: 0, y: 0 },
         };
         if (ratio < 0) {
             // towards top

--- a/ui/src/app/edge/live/energymonitor/energymonitor.component.ts
+++ b/ui/src/app/edge/live/energymonitor/energymonitor.component.ts
@@ -4,7 +4,7 @@ import { ChannelAddress, Edge, Service, Websocket } from '../../../shared/shared
 
 @Component({
   selector: EnergymonitorComponent.SELECTOR,
-  templateUrl: './energymonitor.component.html'
+  templateUrl: './energymonitor.component.html',
 })
 export class EnergymonitorComponent implements OnInit, OnDestroy {
 
@@ -15,7 +15,7 @@ export class EnergymonitorComponent implements OnInit, OnDestroy {
   constructor(
     private service: Service,
     private websocket: Websocket,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) { }
 
   ngOnInit() {
@@ -29,7 +29,7 @@ export class EnergymonitorComponent implements OnInit, OnDestroy {
         // Production
         new ChannelAddress('_sum', 'ProductionActivePower'), new ChannelAddress('_sum', 'ProductionDcActualPower'), new ChannelAddress('_sum', 'ProductionAcActivePower'), new ChannelAddress('_sum', 'ProductionMaxActivePower'),
         // Consumption
-        new ChannelAddress('_sum', 'ConsumptionActivePower'), new ChannelAddress('_sum', 'ConsumptionMaxActivePower')
+        new ChannelAddress('_sum', 'ConsumptionActivePower'), new ChannelAddress('_sum', 'ConsumptionMaxActivePower'),
       ]);
     });
   }

--- a/ui/src/app/edge/live/energymonitor/energymonitor.module.ts
+++ b/ui/src/app/edge/live/energymonitor/energymonitor.module.ts
@@ -14,7 +14,7 @@ import { StorageSectionComponent } from './chart/section/storage.component';
   imports: [
     BrowserAnimationsModule,
     BrowserModule,
-    SharedModule
+    SharedModule,
   ],
   declarations: [
     ConsumptionSectionComponent,
@@ -22,11 +22,11 @@ import { StorageSectionComponent } from './chart/section/storage.component';
     EnergymonitorComponent,
     GridSectionComponent,
     ProductionSectionComponent,
-    StorageSectionComponent
+    StorageSectionComponent,
   ],
   exports: [
-    EnergymonitorComponent
-  ]
+    EnergymonitorComponent,
+  ],
 })
 export class EnergymonitorModule { }
 

--- a/ui/src/app/edge/live/info/info.component.ts
+++ b/ui/src/app/edge/live/info/info.component.ts
@@ -2,6 +2,6 @@ import { Component } from '@angular/core';
 
 @Component({
     selector: 'info',
-    templateUrl: './info.component.html'
+    templateUrl: './info.component.html',
 })
 export class InfoComponent { }

--- a/ui/src/app/edge/live/live.component.ts
+++ b/ui/src/app/edge/live/live.component.ts
@@ -5,7 +5,7 @@ import { Edge, EdgeConfig, Service, Utils, Websocket, Widgets } from 'src/app/sh
 
 @Component({
   selector: 'live',
-  templateUrl: './live.component.html'
+  templateUrl: './live.component.html',
 })
 export class LiveComponent implements OnInit, OnDestroy {
 
@@ -18,7 +18,7 @@ export class LiveComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     public service: Service,
     protected utils: Utils,
-    protected websocket: Websocket
+    protected websocket: Websocket,
   ) { }
 
   public ngOnInit() {

--- a/ui/src/app/edge/live/live.module.ts
+++ b/ui/src/app/edge/live/live.module.ts
@@ -59,7 +59,7 @@ import { Controller_Evcs } from './Controller/Evcs/Evcs';
     Controller_Io_HeatingElement,
     EnergymonitorModule,
     SharedModule,
-    Controller_Evcs
+    Controller_Evcs,
   ],
   entryComponents: [
     AdministrationComponent,
@@ -77,7 +77,7 @@ import { Controller_Evcs } from './Controller/Evcs/Evcs';
     Evcs_Api_ClusterModalComponent,
     Io_Api_DigitalInput_ModalComponent,
     Io_Api_DigitalInputComponent,
-    StorageModalComponent
+    StorageModalComponent,
   ],
   declarations: [
     AdministrationComponent,
@@ -108,7 +108,7 @@ import { Controller_Evcs } from './Controller/Evcs/Evcs';
     LiveComponent,
     OfflineComponent,
     StorageComponent,
-    StorageModalComponent
-  ]
+    StorageModalComponent,
+  ],
 })
 export class LiveModule { }

--- a/ui/src/app/edge/live/livedataservice.ts
+++ b/ui/src/app/edge/live/livedataservice.ts
@@ -13,7 +13,7 @@ export class LiveDataService extends DataService implements OnDestroy {
 
     constructor(
         @Inject(Websocket) protected websocket: Websocket,
-        @Inject(Service) protected service: Service
+        @Inject(Service) protected service: Service,
     ) {
         super();
     }

--- a/ui/src/app/edge/live/offline/offline.component.ts
+++ b/ui/src/app/edge/live/offline/offline.component.ts
@@ -3,14 +3,14 @@ import { Edge, Service } from 'src/app/shared/shared';
 
 @Component({
     selector: 'offline',
-    templateUrl: './offline.component.html'
+    templateUrl: './offline.component.html',
 })
 export class OfflineComponent implements OnInit {
 
     public edge: Edge | null = null;
 
     constructor(
-        public service: Service
+        public service: Service,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/edge/settings/alerting/alerting.component.ts
+++ b/ui/src/app/edge/settings/alerting/alerting.component.ts
@@ -19,7 +19,7 @@ type RoleUsersSettings = { role: Role, form: FormGroup, settings: UserSettingOpt
 
 @Component({
   selector: AlertingComponent.SELECTOR,
-  templateUrl: './alerting.component.html'
+  templateUrl: './alerting.component.html',
 })
 export class AlertingComponent implements OnInit {
   protected static readonly SELECTOR = "alerting";
@@ -41,7 +41,7 @@ export class AlertingComponent implements OnInit {
     private websocket: Websocket,
     private service: Service,
     private translate: TranslateService,
-    public formBuilder: FormBuilder
+    public formBuilder: FormBuilder,
   ) { }
 
   public ngOnInit(): void {
@@ -90,19 +90,19 @@ export class AlertingComponent implements OnInit {
       formGroup: new FormGroup({}),
       options: {
         formState: {
-          awesomeIsForced: false
-        }
+          awesomeIsForced: false,
+        },
       },
       model: {
         isActivated: userSettings.delayTime > 0,
-        delayTime: userSettings.delayTime
+        delayTime: userSettings.delayTime,
       },
       fields: [{
         key: 'isActivated',
         type: 'checkbox',
         templateOptions: {
-          label: this.translate.instant('Edge.Config.Alerting.activate')
-        }
+          label: this.translate.instant('Edge.Config.Alerting.activate'),
+        },
       },
       {
         key: 'delayTime',
@@ -111,11 +111,11 @@ export class AlertingComponent implements OnInit {
           label: this.translate.instant('Edge.Config.Alerting.delay'),
           type: 'number',
           required: true,
-          options: delays
+          options: delays,
         },
-        hideExpression: model => !model.isActivated
-      }
-      ]
+        hideExpression: model => !model.isActivated,
+      },
+      ],
     };
   }
 
@@ -169,7 +169,7 @@ export class AlertingComponent implements OnInit {
     roleSetting.settings.push({ userId: userSetting.userId, delayTime: userSetting.delayTime, options: this.getDelayOptions(delay) });
     roleSetting.form.addControl(userSetting.userId, this.formBuilder.group({
       isActivated: new FormControl(activated),
-      delayTime: new FormControl(delay)
+      delayTime: new FormControl(delay),
     }));
   }
 
@@ -240,7 +240,7 @@ export class AlertingComponent implements OnInit {
 
       changedUserSettings.push({
         delayTime: this.currentUserForm.formGroup.controls['delayTime']?.value ?? 0,
-        userId: this.currentUserInformation.userId
+        userId: this.currentUserInformation.userId,
       });
     }
 
@@ -257,7 +257,7 @@ export class AlertingComponent implements OnInit {
               let isActivated = control.value['isActivated'];
               changedUserSettings.push({
                 delayTime: isActivated ? delayTime : 0,
-                userId: user.userId
+                userId: user.userId,
               });
               userOptions.push(user);
             }

--- a/ui/src/app/edge/settings/app/app.module.ts
+++ b/ui/src/app/edge/settings/app/app.module.ts
@@ -26,9 +26,9 @@ export function registerTranslateExtension(translate: TranslateService) {
         name: 'key',
         message() {
           return translate.stream('Edge.Config.App.Key.invalidPattern');
-        }
-      }
-    ]
+        },
+      },
+    ],
   };
 }
 
@@ -38,20 +38,20 @@ export function registerTranslateExtension(translate: TranslateService) {
     FormlyModule.forRoot({
       wrappers: [
         { name: "formly-safe-input-wrapper", component: FormlySafeInputWrapperComponent },
-        { name: "input-with-unit", component: FormlyInputWithUnitComponent }
+        { name: "input-with-unit", component: FormlyInputWithUnitComponent },
       ],
       types: [
         { name: "text", component: FormlyTextComponent },
         { name: "formly-option-group-picker", component: FormlyOptionGroupPickerComponent },
-        { name: "reorder-array", component: FormlyReorderArrayComponent }
+        { name: "reorder-array", component: FormlyReorderArrayComponent },
       ],
       validators: [
-        { name: 'key', validation: KeyValidator }
+        { name: 'key', validation: KeyValidator },
       ],
       validationMessages: [
-        { name: 'key', message: "The key doesnt match the pattern!" }
-      ]
-    })
+        { name: 'key', message: "The key doesnt match the pattern!" },
+      ],
+    }),
   ],
   declarations: [
     IndexComponent,
@@ -64,17 +64,17 @@ export function registerTranslateExtension(translate: TranslateService) {
     FormlyTextComponent,
     FormlyInputWithUnitComponent,
     FormlyOptionGroupPickerComponent,
-    FormlyReorderArrayComponent
+    FormlyReorderArrayComponent,
   ],
   exports: [
     IndexComponent,
     InstallAppComponent,
     SingleAppComponent,
-    UpdateAppComponent
+    UpdateAppComponent,
   ],
   providers: [
     // Use factory for formly. This allows us to use translations in validationMessages.
-    { provide: FORMLY_CONFIG, multi: true, useFactory: registerTranslateExtension, deps: [TranslateService] }
-  ]
+    { provide: FORMLY_CONFIG, multi: true, useFactory: registerTranslateExtension, deps: [TranslateService] },
+  ],
 })
 export class AppModule { }

--- a/ui/src/app/edge/settings/app/formly/formly-text.ts
+++ b/ui/src/app/edge/settings/app/formly/formly-text.ts
@@ -9,7 +9,7 @@ import { FieldType, FieldTypeConfig } from "@ngx-formly/core";
         <ion-text [innerHTML]="props.description"></ion-text>
     </ion-item>
     `,
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
 })
 export class FormlyTextComponent extends FieldType<FieldTypeConfig>  {
 

--- a/ui/src/app/edge/settings/app/formly/input-with-unit.ts
+++ b/ui/src/app/edge/settings/app/formly/input-with-unit.ts
@@ -14,6 +14,6 @@ import { FieldWrapper } from '@ngx-formly/core';
             </ion-col>
         </ion-row>
     </ion-grid>
-`
+`,
 })
 export class FormlyInputWithUnitComponent extends FieldWrapper { }

--- a/ui/src/app/edge/settings/app/formly/option-group-picker/formly-option-group-picker.component.ts
+++ b/ui/src/app/edge/settings/app/formly/option-group-picker/formly-option-group-picker.component.ts
@@ -4,7 +4,7 @@ import { OptionGroup, OptionGroupConfig, Option } from "./optionGroupPickerConfi
 
 @Component({
     selector: 'formly-option-group-picker',
-    templateUrl: './formly-option-group-picker.component.html'
+    templateUrl: './formly-option-group-picker.component.html',
 })
 export class FormlyOptionGroupPickerComponent extends FieldType<FieldTypeConfig> implements OnInit {
 
@@ -56,9 +56,9 @@ export class FormlyOptionGroupPickerComponent extends FieldType<FieldTypeConfig>
                         return {
                             value: optionConfig.value,
                             title: optionConfig.expressions?.title?.(field) ?? optionConfig.title ?? optionConfig.value,
-                            disabled: optionConfig.expressions?.disabled?.(field) ?? optionConfig.disabled ?? false
+                            disabled: optionConfig.expressions?.disabled?.(field) ?? optionConfig.disabled ?? false,
                         };
-                    })
+                    }),
             };
         }).filter(group => {
             // Remove empty OptionGroups

--- a/ui/src/app/edge/settings/app/formly/reorder-select/formly-reorder-array.component.ts
+++ b/ui/src/app/edge/settings/app/formly/reorder-select/formly-reorder-array.component.ts
@@ -4,7 +4,7 @@ import { FieldType, FieldTypeConfig, FormlyFieldConfig, FormlyFieldProps } from 
 
 @Component({
     selector: 'reorder-array',
-    templateUrl: './formly-reorder-array.component.html'
+    templateUrl: './formly-reorder-array.component.html',
 })
 export class FormlyReorderArrayComponent extends FieldType<FieldTypeConfig<FormlyFieldProps & {
     allowDuplicates?: boolean,
@@ -101,8 +101,8 @@ export class FormlyReorderArrayComponent extends FieldType<FieldTypeConfig<Forml
                 label: optionConfig.label,
                 value: optionConfig.value,
                 expressions: {
-                    locked: optionConfig.expressions?.locked?.(this.field) ?? false
-                }
+                    locked: optionConfig.expressions?.locked?.(this.field) ?? false,
+                },
             };
         }) ?? [];
     }

--- a/ui/src/app/edge/settings/app/formly/safe-input/formly-safe-input-modal.component.ts
+++ b/ui/src/app/edge/settings/app/formly/safe-input/formly-safe-input-modal.component.ts
@@ -5,7 +5,7 @@ import { FormlyFieldConfig } from "@ngx-formly/core";
 
 @Component({
     selector: 'formly-safe-input-modal',
-    templateUrl: './formly-safe-input-modal.component.html'
+    templateUrl: './formly-safe-input-modal.component.html',
 })
 export class FormlySafeInputModalComponent implements OnInit {
 
@@ -20,7 +20,7 @@ export class FormlySafeInputModalComponent implements OnInit {
     protected myModel: {};
 
     constructor(
-        protected modalCtrl: ModalController
+        protected modalCtrl: ModalController,
     ) { }
 
     ngOnInit(): void {

--- a/ui/src/app/edge/settings/app/formly/safe-input/formly-safe-input.extended.ts
+++ b/ui/src/app/edge/settings/app/formly/safe-input/formly-safe-input.extended.ts
@@ -7,7 +7,7 @@ import { OptionGroupConfig } from "../option-group-picker/optionGroupPickerConfi
 
 @Component({
     selector: 'formly-safe-input-wrapper',
-    templateUrl: './formly-safe-input.extended.html'
+    templateUrl: './formly-safe-input.extended.html',
 })
 export class FormlySafeInputWrapperComponent extends FieldWrapper implements OnInit {
 
@@ -15,7 +15,7 @@ export class FormlySafeInputWrapperComponent extends FieldWrapper implements OnI
     protected displayType: 'string' | 'boolean' | 'number' | 'optionGroup';
 
     constructor(
-        private modalController: ModalController
+        private modalController: ModalController,
     ) {
         super();
     }
@@ -39,9 +39,9 @@ export class FormlySafeInputWrapperComponent extends FieldWrapper implements OnI
             componentProps: {
                 title: this.props.label,
                 fields: this.getFields(),
-                model: this.model
+                model: this.model,
             },
-            cssClass: ['auto-height']
+            cssClass: ['auto-height'],
         });
         modal.onDidDismiss().then(event => {
             if (!event.data) {

--- a/ui/src/app/edge/settings/app/index.component.ts
+++ b/ui/src/app/edge/settings/app/index.component.ts
@@ -21,7 +21,7 @@ import { InstallAppComponent } from './install.component';
 
 @Component({
   selector: IndexComponent.SELECTOR,
-  templateUrl: './index.component.html'
+  templateUrl: './index.component.html',
 })
 export class IndexComponent implements OnInit, OnDestroy {
 
@@ -40,15 +40,15 @@ export class IndexComponent implements OnInit, OnDestroy {
 
   public installedApps: AppList = {
     name: 'Edge.Config.App.installed', appCategories: []
-    , shouldBeShown: () => this.key === null // only show installed apps when the user is not currently selecting an app from a key
+    , shouldBeShown: () => this.key === null, // only show installed apps when the user is not currently selecting an app from a key
   };
   public availableApps: AppList = {
     name: 'Edge.Config.App.available', appCategories: []
-    , shouldBeShown: () => true // always show available apps
+    , shouldBeShown: () => true, // always show available apps
   };
   public incompatibleApps: AppList = {
     name: 'Edge.Config.App.incompatible', appCategories: []
-    , shouldBeShown: () => this.edge.roleIsAtLeast(Role.ADMIN) // only show incompatible apps for admins
+    , shouldBeShown: () => this.edge.roleIsAtLeast(Role.ADMIN), // only show incompatible apps for admins
   };
 
   public appLists: AppList[] = [this.installedApps, this.availableApps, this.incompatibleApps];
@@ -72,7 +72,7 @@ export class IndexComponent implements OnInit, OnDestroy {
     private websocket: Websocket,
     private translate: TranslateService,
     private router: Router,
-    private modalController: ModalController
+    private modalController: ModalController,
   ) {
   }
 
@@ -91,7 +91,7 @@ export class IndexComponent implements OnInit, OnDestroy {
 
     this.service.setCurrentComponent({
       languageKey: 'Edge.Config.App.NAME_WITH_EDGE_NAME',
-      interpolateParams: { edgeShortName: environment.edgeShortName }
+      interpolateParams: { edgeShortName: environment.edgeShortName },
     }, this.route).then(edge => {
       this.edge = edge;
 
@@ -103,7 +103,7 @@ export class IndexComponent implements OnInit, OnDestroy {
       edge.sendRequest(this.websocket,
         new ComponentJsonApiRequest({
           componentId: '_appManager',
-          payload: new GetApps.Request()
+          payload: new GetApps.Request(),
         })).then(response => {
 
           this.service.stopSpinner(this.spinnerId);
@@ -219,9 +219,9 @@ export class IndexComponent implements OnInit, OnDestroy {
       componentProps: {
         edge: this.edge,
         behaviour: KeyValidationBehaviour.SELECT,
-        knownApps: this.apps
+        knownApps: this.apps,
       },
-      cssClass: 'auto-height'
+      cssClass: 'auto-height',
     });
     modal.onDidDismiss().then(data => {
       if (!data.data) {
@@ -238,7 +238,7 @@ export class IndexComponent implements OnInit, OnDestroy {
             .filter(e => !Flags.getByType(e.flags, Flags.SHOW_AFTER_KEY_REDEEM))
             .map<App>(d => {
               return { id: 0, appId: d.appId };
-            })]
+            })],
         };
         this.useMasterKey = true;
         this.updateSelection();
@@ -250,8 +250,8 @@ export class IndexComponent implements OnInit, OnDestroy {
         // load bundles
         this.edge.sendRequest(this.websocket, new AppCenter.Request({
           payload: new AppCenterGetPossibleApps.Request({
-            key: this.key.keyId
-          })
+            key: this.key.keyId,
+          }),
         })).then(response => {
           const result = (response as AppCenterGetPossibleApps.Response).result;
           this.key.bundles = result.bundles;
@@ -287,9 +287,9 @@ export class IndexComponent implements OnInit, OnDestroy {
       component: KeyModalComponent,
       componentProps: {
         edge: this.edge,
-        behaviour: KeyValidationBehaviour.REGISTER
+        behaviour: KeyValidationBehaviour.REGISTER,
       },
-      cssClass: 'auto-height'
+      cssClass: 'auto-height',
     });
 
     return await modal.present();

--- a/ui/src/app/edge/settings/app/install.component.ts
+++ b/ui/src/app/edge/settings/app/install.component.ts
@@ -19,7 +19,7 @@ import { hasPredefinedKey } from './permissions';
 
 @Component({
   selector: InstallAppComponent.SELECTOR,
-  templateUrl: './install.component.html'
+  templateUrl: './install.component.html',
 })
 export class InstallAppComponent implements OnInit, OnDestroy {
 
@@ -49,7 +49,7 @@ export class InstallAppComponent implements OnInit, OnDestroy {
     private service: Service,
     private modalController: ModalController,
     private router: Router,
-    private translate: TranslateService
+    private translate: TranslateService,
   ) {
   }
 
@@ -73,9 +73,9 @@ export class InstallAppComponent implements OnInit, OnDestroy {
       this.edge.sendRequest(this.websocket,
         new AppCenter.Request({
           payload: new AppCenterIsAppFree.Request({
-            appId: this.appId
-          })
-        })
+            appId: this.appId,
+          }),
+        }),
       ).then(response => {
         const result = (response as AppCenterIsAppFree.Response).result;
         this.isAppFree = result.isAppFree;
@@ -91,7 +91,7 @@ export class InstallAppComponent implements OnInit, OnDestroy {
       edge.sendRequest(this.websocket,
         new ComponentJsonApiRequest({
           componentId: '_appManager',
-          payload: new GetAppAssistant.Request({ appId: appId })
+          payload: new GetAppAssistant.Request({ appId: appId }),
         })).then(response => {
           let appAssistant = GetAppAssistant.postprocess((response as GetAppAssistant.Response).result);
 
@@ -134,15 +134,15 @@ export class InstallAppComponent implements OnInit, OnDestroy {
           appId: this.appId,
           alias: alias,
           properties: clonedFields,
-          ...(key && { key: key })
-        })
+          ...(key && { key: key }),
+        }),
       });
       // if key not set send request with supplied key
       if (!key) {
         request = new AppCenter.Request({
           payload: new AppCenterInstallAppWithSuppliedKeyRequest.Request({
-            installRequest: request
-          })
+            installRequest: request,
+          }),
         });
       }
 
@@ -206,9 +206,9 @@ export class InstallAppComponent implements OnInit, OnDestroy {
         edge: this.edge,
         appId: this.appId,
         behaviour: KeyValidationBehaviour.SELECT,
-        appName: this.appName
+        appName: this.appName,
       },
-      cssClass: 'auto-height'
+      cssClass: 'auto-height',
     });
 
     const selectKeyPromise = new Promise<string>((resolve, reject) => {

--- a/ui/src/app/edge/settings/app/jsonrpc/addAppInstance.ts
+++ b/ui/src/app/edge/settings/app/jsonrpc/addAppInstance.ts
@@ -45,7 +45,7 @@ export namespace AddAppInstance {
                 appId: string,
                 alias: string,
                 properties: {}
-            }
+            },
         ) {
             super(METHOD, params);
         }
@@ -59,7 +59,7 @@ export namespace AddAppInstance {
                 instanceId: string,
                 instance: GetAppInstances.AppInstance,
                 warnings: String[]
-            }
+            },
         ) {
             super(id, result);
         }

--- a/ui/src/app/edge/settings/app/jsonrpc/deleteAppInstance.ts
+++ b/ui/src/app/edge/settings/app/jsonrpc/deleteAppInstance.ts
@@ -37,7 +37,7 @@ export namespace DeleteAppInstance {
         public constructor(
             public override readonly params: {
                 instanceId: string
-            }
+            },
         ) {
             super(METHOD, params);
         }

--- a/ui/src/app/edge/settings/app/jsonrpc/getApp.ts
+++ b/ui/src/app/edge/settings/app/jsonrpc/getApp.ts
@@ -49,7 +49,7 @@ export namespace GetApp {
         public constructor(
             public override readonly params: {
                 appId: string
-            }
+            },
         ) {
             super(METHOD, {});
         }
@@ -61,7 +61,7 @@ export namespace GetApp {
             public override readonly id: string,
             public override readonly result: {
                 app: GetApps.App
-            }
+            },
         ) {
             super(id, result);
         }

--- a/ui/src/app/edge/settings/app/jsonrpc/getAppAssistant.spec.ts
+++ b/ui/src/app/edge/settings/app/jsonrpc/getAppAssistant.spec.ts
@@ -10,25 +10,25 @@ describe('GetAppAssistent', () => {
                 key: 'a',
                 type: 'input',
                 props: {
-                    type: 'text'
+                    type: 'text',
                 },
                 fieldGroup: [
                     {
                         key: 'b',
                         type: 'input',
                         props: {
-                            type: 'number'
-                        }
-                    }
-                ]
+                            type: 'number',
+                        },
+                    },
+                ],
             },
             {
                 key: 'c',
                 type: 'input',
                 props: {
-                    type: 'number'
-                }
-            }
+                    type: 'number',
+                },
+            },
         ];
     });
 

--- a/ui/src/app/edge/settings/app/jsonrpc/getAppAssistant.ts
+++ b/ui/src/app/edge/settings/app/jsonrpc/getAppAssistant.ts
@@ -41,7 +41,7 @@ export namespace GetAppAssistant {
         public constructor(
             public override readonly params: {
                 appId: string
-            }
+            },
         ) {
             super(METHOD, params);
         }
@@ -51,7 +51,7 @@ export namespace GetAppAssistant {
 
         public constructor(
             public override readonly id: string,
-            public override readonly result: AppAssistant
+            public override readonly result: AppAssistant,
         ) {
             super(id, result);
         }

--- a/ui/src/app/edge/settings/app/jsonrpc/getAppDescriptor.ts
+++ b/ui/src/app/edge/settings/app/jsonrpc/getAppDescriptor.ts
@@ -38,7 +38,7 @@ export namespace GetAppDescriptor {
         public constructor(
             public override readonly params: {
                 appId: string
-            }
+            },
         ) {
             super(METHOD, params);
         }
@@ -48,7 +48,7 @@ export namespace GetAppDescriptor {
 
         public constructor(
             public override readonly id: string,
-            public override readonly result: AppDescriptor
+            public override readonly result: AppDescriptor,
         ) {
             super(id, result);
         }

--- a/ui/src/app/edge/settings/app/jsonrpc/getAppInstances.ts
+++ b/ui/src/app/edge/settings/app/jsonrpc/getAppInstances.ts
@@ -40,7 +40,7 @@ export namespace GetAppInstances {
         public constructor(
             public override readonly params: {
                 appId: string
-            }
+            },
         ) {
             super(METHOD, params);
         }
@@ -52,7 +52,7 @@ export namespace GetAppInstances {
             public override readonly id: string,
             public override readonly result: {
                 instances: AppInstance[]
-            }
+            },
         ) {
             super(id, result);
         }

--- a/ui/src/app/edge/settings/app/jsonrpc/getApps.ts
+++ b/ui/src/app/edge/settings/app/jsonrpc/getApps.ts
@@ -58,7 +58,7 @@ export namespace GetApps {
             public override readonly id: string,
             public override readonly result: {
                 apps: App[]
-            }
+            },
         ) {
             super(id, result);
         }

--- a/ui/src/app/edge/settings/app/jsonrpc/updateAppInstance.ts
+++ b/ui/src/app/edge/settings/app/jsonrpc/updateAppInstance.ts
@@ -42,7 +42,7 @@ export namespace UpdateAppInstance {
                 instanceId: string,
                 alias: string,
                 properties: {}
-            }
+            },
         ) {
             super(METHOD, params);
         }
@@ -56,7 +56,7 @@ export namespace UpdateAppInstance {
             public override readonly result: {
                 instance: GetAppInstances.AppInstance,
                 warnings: String[]
-            }
+            },
         ) {
             super(id, result);
         }

--- a/ui/src/app/edge/settings/app/keypopup/appCenter.ts
+++ b/ui/src/app/edge/settings/app/keypopup/appCenter.ts
@@ -33,7 +33,7 @@ export namespace AppCenter {
         public constructor(
             public override readonly params: {
                 payload: JsonrpcRequest
-            }
+            },
         ) {
             super(AppCenter.METHOD, params);
         }

--- a/ui/src/app/edge/settings/app/keypopup/appCenterAddRegisterKeyHistory.ts
+++ b/ui/src/app/edge/settings/app/keypopup/appCenterAddRegisterKeyHistory.ts
@@ -42,7 +42,7 @@ export namespace AppCenterAddRegisterKeyHistory {
             public override readonly params: {
                 key: string,
                 appId: string,
-            }
+            },
         ) {
             super(METHOD, params);
         }

--- a/ui/src/app/edge/settings/app/keypopup/appCenterGetPossibleApps.ts
+++ b/ui/src/app/edge/settings/app/keypopup/appCenterGetPossibleApps.ts
@@ -44,7 +44,7 @@ export namespace AppCenterGetPossibleApps {
         public constructor(
             public override readonly params: {
                 key: string
-            }
+            },
         ) {
             super(METHOD, params);
         }
@@ -56,7 +56,7 @@ export namespace AppCenterGetPossibleApps {
             public override readonly id: string,
             public override readonly result: {
                 bundles: (App[])[]
-            }
+            },
         ) {
             super(id, result);
         }

--- a/ui/src/app/edge/settings/app/keypopup/appCenterGetRegisteredKeys.ts
+++ b/ui/src/app/edge/settings/app/keypopup/appCenterGetRegisteredKeys.ts
@@ -44,7 +44,7 @@ export namespace AppCenterGetRegisteredKeys {
         public constructor(
             public override readonly params: {
                 appId?: string,
-            }
+            },
         ) {
             super(METHOD, params);
         }
@@ -56,7 +56,7 @@ export namespace AppCenterGetRegisteredKeys {
             public override readonly id: string,
             public override readonly result: {
                 keys: Key[]
-            }
+            },
         ) {
             super(id, result);
         }

--- a/ui/src/app/edge/settings/app/keypopup/appCenterInstallAppWithSuppliedKey.ts
+++ b/ui/src/app/edge/settings/app/keypopup/appCenterInstallAppWithSuppliedKey.ts
@@ -33,7 +33,7 @@ export namespace AppCenterInstallAppWithSuppliedKeyRequest {
         public constructor(
             public override readonly params: {
                 installRequest: JsonrpcRequest
-            }
+            },
         ) {
             super(METHOD, params);
         }

--- a/ui/src/app/edge/settings/app/keypopup/appCenterIsAppFree.ts
+++ b/ui/src/app/edge/settings/app/keypopup/appCenterIsAppFree.ts
@@ -42,7 +42,7 @@ export namespace AppCenterIsAppFree {
         public constructor(
             public override readonly params: {
                 appId: string,
-            }
+            },
         ) {
             super(METHOD, params);
         }
@@ -54,7 +54,7 @@ export namespace AppCenterIsAppFree {
             public override readonly id: string,
             public override readonly result: {
                 isAppFree: boolean
-            }
+            },
         ) {
             super(id, result);
         }

--- a/ui/src/app/edge/settings/app/keypopup/appCenterIsKeyApplicable.ts
+++ b/ui/src/app/edge/settings/app/keypopup/appCenterIsKeyApplicable.ts
@@ -58,7 +58,7 @@ export namespace AppCenterIsKeyApplicable {
             public override readonly params: {
                 key: string,
                 appId: string,
-            }
+            },
         ) {
             super(METHOD, params);
         }
@@ -82,7 +82,7 @@ export namespace AppCenterIsKeyApplicable {
                         installedInstances: number
                     }[]
                 }
-            }
+            },
         ) {
             super(id, result);
         }

--- a/ui/src/app/edge/settings/app/keypopup/modal.component.ts
+++ b/ui/src/app/edge/settings/app/keypopup/modal.component.ts
@@ -17,7 +17,7 @@ import { hasPredefinedKey } from '../permissions';
 
 @Component({
     selector: KeyModalComponent.SELECTOR,
-    templateUrl: './modal.component.html'
+    templateUrl: './modal.component.html',
 })
 export class KeyModalComponent implements OnInit {
 
@@ -49,7 +49,7 @@ export class KeyModalComponent implements OnInit {
         protected modalCtrl: ModalController,
         private router: Router,
         private websocket: Websocket,
-        private translate: TranslateService
+        private translate: TranslateService,
     ) { }
 
 
@@ -57,13 +57,13 @@ export class KeyModalComponent implements OnInit {
         this.form = new FormGroup({});
         this.options = {
             formState: {
-                gotInvalidKeyResponse: false
-            }
+                gotInvalidKeyResponse: false,
+            },
         };
         this.model = {
             useRegisteredKeys: false,
             registeredKey: '',
-            key: ''
+            key: '',
         };
 
         if (this.behaviour === KeyValidationBehaviour.REGISTER) {
@@ -73,8 +73,8 @@ export class KeyModalComponent implements OnInit {
         this.service.startSpinner(this.spinnerId);
         this.edge.sendRequest(this.websocket, new AppCenter.Request({
             payload: new AppCenterGetRegisteredKeys.Request({
-                ...(this.appId && { appId: this.appId })
-            })
+                ...(this.appId && { appId: this.appId }),
+            }),
         })).then(response => {
             const result = (response as AppCenterGetRegisteredKeys.Response).result;
             this.registeredKeys = result.keys;
@@ -89,7 +89,7 @@ export class KeyModalComponent implements OnInit {
                 (selectRegisteredKey.props.options as any[]).push({
                     value: key.keyId,
                     label: key.keyId,
-                    description: desc
+                    description: desc,
                 });
             });
         }).catch(reason => {
@@ -176,12 +176,12 @@ export class KeyModalComponent implements OnInit {
             key: 'useRegisteredKeys',
             type: 'checkbox',
             props: {
-                label: this.translate.instant('Edge.Config.App.Key.useRegisteredKey')
+                label: this.translate.instant('Edge.Config.App.Key.useRegisteredKey'),
             },
             hide: this.registeredKeys.length === 0,
             expressions: {
-                'props.disabled': field => field.model.useMasterKey
-            }
+                'props.disabled': field => field.model.useMasterKey,
+            },
         });
 
         fields.push({
@@ -190,13 +190,13 @@ export class KeyModalComponent implements OnInit {
             props: {
                 label: this.translate.instant('Edge.Config.App.Key.registeredKey'),
                 required: true,
-                options: []
+                options: [],
             },
             expressions: {
                 'hide': () => this.registeredKeys.length === 0,
-                'props.disabled': field => !field.model.useRegisteredKeys || field.model.useMasterKey
+                'props.disabled': field => !field.model.useRegisteredKeys || field.model.useMasterKey,
             },
-            wrappers: ['formly-select-extended-wrapper']
+            wrappers: ['formly-select-extended-wrapper'],
         });
 
         fields.push({
@@ -205,13 +205,13 @@ export class KeyModalComponent implements OnInit {
             props: {
                 label: this.translate.instant('Edge.Config.App.Key.key'),
                 required: true,
-                placeholder: 'XXXX-XXXX-XXXX-XXXX'
+                placeholder: 'XXXX-XXXX-XXXX-XXXX',
             },
             expressions: {
-                'props.disabled': field => field.model.useRegisteredKeys || field.model.useMasterKey
+                'props.disabled': field => field.model.useRegisteredKeys || field.model.useMasterKey,
             },
             validators: {
-                validation: ['key']
+                validation: ['key'],
             },
             hooks: {
                 onInit: (field) => {
@@ -222,8 +222,8 @@ export class KeyModalComponent implements OnInit {
                         }
                         field.formControl.setValue(nextInput);
                     });
-                }
-            }
+                },
+            },
         });
 
         if (this.behaviour !== KeyValidationBehaviour.REGISTER
@@ -234,27 +234,27 @@ export class KeyModalComponent implements OnInit {
                     key: 'useMasterKey',
                     type: 'checkbox',
                     props: {
-                        label: this.translate.instant('Edge.Config.App.Key.useMasterKey')
-                    }
+                        label: this.translate.instant('Edge.Config.App.Key.useMasterKey'),
+                    },
                 },
                 {
                     type: 'text',
                     props: {
-                        description: this.translate.instant('Edge.Config.App.Key.MASTER_KEY_HINT')
+                        description: this.translate.instant('Edge.Config.App.Key.MASTER_KEY_HINT'),
                     },
                     expressions: {
-                        hide: '!model.useMasterKey'
-                    }
-                }
+                        hide: '!model.useMasterKey',
+                    },
+                },
             );
         }
 
         fields.push({
             type: 'text',
             props: {
-                description: this.translate.instant('Edge.Config.App.Key.KEY_TYPO_MESSAGE_HINT')
+                description: this.translate.instant('Edge.Config.App.Key.KEY_TYPO_MESSAGE_HINT'),
             },
-            hideExpression: '!formState.gotInvalidKeyResponse'
+            hideExpression: '!formState.gotInvalidKeyResponse',
         });
 
         return fields;
@@ -370,8 +370,8 @@ export class KeyModalComponent implements OnInit {
             this.edge.sendRequest(this.websocket, new AppCenter.Request({
                 payload: new AppCenterAddRegisterKeyHistory.Request({
                     key: this.getRawAppKey(),
-                    ...(this.appId && { appId: this.appId })
-                })
+                    ...(this.appId && { appId: this.appId }),
+                }),
             })).then(() => {
                 resolve();
             }).catch(reason => {
@@ -401,7 +401,7 @@ export class KeyModalComponent implements OnInit {
         }
         const appKey = this.getRawAppKey();
         const request = new AppCenter.Request({
-            payload: new AppCenterIsKeyApplicable.Request({ key: appKey, appId: this.appId })
+            payload: new AppCenterIsKeyApplicable.Request({ key: appKey, appId: this.appId }),
         });
 
         this.service.startSpinner(this.spinnerId);

--- a/ui/src/app/edge/settings/app/single.component.ts
+++ b/ui/src/app/edge/settings/app/single.component.ts
@@ -19,7 +19,7 @@ import { InstallAppComponent } from './install.component';
 
 @Component({
   selector: SingleAppComponent.SELECTOR,
-  templateUrl: './single.component.html'
+  templateUrl: './single.component.html',
 })
 export class SingleAppComponent implements OnInit, OnDestroy {
 
@@ -59,7 +59,7 @@ export class SingleAppComponent implements OnInit, OnDestroy {
     private websocket: Websocket,
     private service: Service,
     private sanitizer: DomSanitizer,
-    protected modalController: ModalController
+    protected modalController: ModalController,
   ) {
   }
 
@@ -76,9 +76,9 @@ export class SingleAppComponent implements OnInit, OnDestroy {
       this.edge.sendRequest(this.websocket,
         new AppCenter.Request({
           payload: new AppCenterIsAppFree.Request({
-            appId: this.appId
-          })
-        })
+            appId: this.appId,
+          }),
+        }),
       ).then(response => {
         const result = (response as AppCenterIsAppFree.Response).result;
         this.isFreeApp = result.isAppFree;
@@ -90,7 +90,7 @@ export class SingleAppComponent implements OnInit, OnDestroy {
       if (hasKeyModel(this.edge)) {
         this.edge.getConfig(this.websocket).pipe(
           filter(config => config !== null),
-          takeUntil(this.stopOnDestroy)
+          takeUntil(this.stopOnDestroy),
         ).subscribe(next => {
           let appManager = next.getComponent("_appManager");
           let newKeyForFreeApps = appManager.properties["keyForFreeApps"];
@@ -105,8 +105,8 @@ export class SingleAppComponent implements OnInit, OnDestroy {
           // update free apps
           this.edge.sendRequest(this.websocket, new AppCenter.Request({
             payload: new AppCenterGetPossibleApps.Request({
-              key: this.keyForFreeApps
-            })
+              key: this.keyForFreeApps,
+            }),
           })).then(response => {
             const result = (response as AppCenterGetPossibleApps.Response).result;
             this.isPreInstalledApp = result.bundles.some(bundle => {
@@ -146,7 +146,7 @@ export class SingleAppComponent implements OnInit, OnDestroy {
         edge.sendRequest(this.websocket,
           new ComponentJsonApiRequest({
             componentId: '_appManager',
-            payload: new GetApp.Request({ appId: appId })
+            payload: new GetApp.Request({ appId: appId }),
           })).then(response => {
             let app = (response as GetApp.Response).result.app;
             this.setApp(app);
@@ -159,7 +159,7 @@ export class SingleAppComponent implements OnInit, OnDestroy {
       edge.sendRequest(this.websocket,
         new ComponentJsonApiRequest({
           componentId: '_appManager',
-          payload: new GetAppDescriptor.Request({ appId: appId })
+          payload: new GetAppDescriptor.Request({ appId: appId }),
         })).then(response => {
           let descriptor = (response as GetAppDescriptor.Response).result;
           this.descriptor = GetAppDescriptor.postprocess(descriptor, this.sanitizer);
@@ -187,7 +187,7 @@ export class SingleAppComponent implements OnInit, OnDestroy {
 
   protected iFrameStyle() {
     let styles = {
-      'height': (this.isXL) ? '100%' : window.innerHeight + 'px'
+      'height': (this.isXL) ? '100%' : window.innerHeight + 'px',
     };
     return styles;
   }
@@ -214,9 +214,9 @@ export class SingleAppComponent implements OnInit, OnDestroy {
         edge: this.edge,
         appId: appId,
         behaviour: behaviour,
-        appName: this.appName
+        appName: this.appName,
       },
-      cssClass: 'auto-height'
+      cssClass: 'auto-height',
     });
     return await modal.present();
   }

--- a/ui/src/app/edge/settings/app/update.component.ts
+++ b/ui/src/app/edge/settings/app/update.component.ts
@@ -22,7 +22,7 @@ interface MyInstance {
 
 @Component({
   selector: UpdateAppComponent.SELECTOR,
-  templateUrl: './update.component.html'
+  templateUrl: './update.component.html',
 })
 export class UpdateAppComponent implements OnInit {
 
@@ -41,7 +41,7 @@ export class UpdateAppComponent implements OnInit {
     private websocket: Websocket,
     private service: Service,
     private router: Router,
-    private translate: TranslateService
+    private translate: TranslateService,
   ) {
   }
 
@@ -54,14 +54,14 @@ export class UpdateAppComponent implements OnInit {
       edge.sendRequest(this.websocket,
         new ComponentJsonApiRequest({
           componentId: '_appManager',
-          payload: new GetAppInstances.Request({ appId: appId })
+          payload: new GetAppInstances.Request({ appId: appId }),
         })).then(getInstancesResponse => {
           let recInstances = (getInstancesResponse as GetAppInstances.Response).result.instances;
 
           edge.sendRequest(this.websocket,
             new ComponentJsonApiRequest({
               componentId: '_appManager',
-              payload: new GetAppAssistant.Request({ appId: appId })
+              payload: new GetAppAssistant.Request({ appId: appId }),
             })).then(getAppAssistantResponse => {
               let appAssistant = (getAppAssistantResponse as GetAppAssistant.Response).result;
               this.appName = appAssistant.name;
@@ -70,7 +70,7 @@ export class UpdateAppComponent implements OnInit {
                 const form = new FormGroup({});
                 const model = {
                   'ALIAS': instance.alias,
-                  ...instance.properties
+                  ...instance.properties,
                 };
                 this.instances.push({
                   instanceId: instance.instanceId,
@@ -78,7 +78,7 @@ export class UpdateAppComponent implements OnInit {
                   isDeleting: false,
                   isUpdating: false,
                   fields: GetAppAssistant.setInitialModel(GetAppAssistant.postprocess(structuredClone(appAssistant)).fields, structuredClone(model)),
-                  properties: model
+                  properties: model,
                 });
               }
 
@@ -106,8 +106,8 @@ export class UpdateAppComponent implements OnInit {
         payload: new UpdateAppInstance.Request({
           instanceId: instance.instanceId,
           alias: alias,
-          properties: clonedFields
-        })
+          properties: clonedFields,
+        }),
       })).then(response => {
         const result = (response as UpdateAppInstance.Response).result;
 
@@ -133,8 +133,8 @@ export class UpdateAppComponent implements OnInit {
       new ComponentJsonApiRequest({
         componentId: '_appManager',
         payload: new DeleteAppInstance.Request({
-          instanceId: instance.instanceId
-        })
+          instanceId: instance.instanceId,
+        }),
       })).then(response => {
         this.instances.splice(this.instances.indexOf(instance), 1);
         this.service.toast(this.translate.instant('Edge.Config.App.successDelete'), 'success');

--- a/ui/src/app/edge/settings/channels/channels.component.ts
+++ b/ui/src/app/edge/settings/channels/channels.component.ts
@@ -12,7 +12,7 @@ export type ComponentChannels = {
 
 @Component({
   selector: ChannelsComponent.SELECTOR,
-  templateUrl: './channels.component.html'
+  templateUrl: './channels.component.html',
 })
 export class ChannelsComponent {
 
@@ -31,11 +31,11 @@ export class ChannelsComponent {
     private websocket: Websocket,
     private route: ActivatedRoute,
     private router: Router,
-    protected translate: TranslateService
+    protected translate: TranslateService,
   ) { }
 
   public customAlertOptions: any = {
-    cssClass: 'wide-alert'
+    cssClass: 'wide-alert',
   };
 
   ionViewWillEnter() {
@@ -107,8 +107,8 @@ export class ChannelsComponent {
         new SetChannelValueRequest({
           componentId: address.componentId,
           channelId: address.channelId,
-          value: channelValue
-        })
+          value: channelValue,
+        }),
       ).then(() => {
         this.service.toast("Successfully set " + address.toString() + " to [" + channelValue + "]", "success");
       }).catch(() => {

--- a/ui/src/app/edge/settings/component/install/index.component.ts
+++ b/ui/src/app/edge/settings/component/install/index.component.ts
@@ -11,7 +11,7 @@ interface MyCategorizedFactories extends CategorizedFactories {
 
 @Component({
   selector: IndexComponent.SELECTOR,
-  templateUrl: './index.component.html'
+  templateUrl: './index.component.html',
 })
 export class IndexComponent implements OnInit {
 
@@ -24,7 +24,7 @@ export class IndexComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private service: Service,
-    private translate: TranslateService
+    private translate: TranslateService,
   ) {
   }
 
@@ -50,8 +50,8 @@ export class IndexComponent implements OnInit {
         Utils.matchAll(filters, [
           entry.id.toLowerCase(),
           entry.name.toLowerCase(),
-          entry.description.toLowerCase()
-        ])
+          entry.description.toLowerCase(),
+        ]),
       );
       countFilteredEntries += entry.filteredFactories.length;
     }

--- a/ui/src/app/edge/settings/component/install/install.component.ts
+++ b/ui/src/app/edge/settings/component/install/install.component.ts
@@ -7,7 +7,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: ComponentInstallComponent.SELECTOR,
-  templateUrl: './install.component.html'
+  templateUrl: './install.component.html',
 })
 export class ComponentInstallComponent implements OnInit {
 
@@ -26,7 +26,7 @@ export class ComponentInstallComponent implements OnInit {
     protected utils: Utils,
     private websocket: Websocket,
     private service: Service,
-    private translate: TranslateService
+    private translate: TranslateService,
   ) {
   }
 
@@ -53,8 +53,8 @@ export class ComponentInstallComponent implements OnInit {
           templateOptions: {
             label: property.name,
             required: defaultValue === null,
-            description: property.description
-          }
+            description: property.description,
+          },
         };
         // add Property Schema 
         Utils.deepCopy(property.schema, field);

--- a/ui/src/app/edge/settings/component/shared.ts
+++ b/ui/src/app/edge/settings/component/shared.ts
@@ -4,5 +4,5 @@ export const IGNORE_NATURES = [
   "io.openems.edge.bridge.modbus.api.BridgeModbusSerial",
   "io.openems.edge.bridge.modbus.api.BridgeModbusTcp",
   "io.openems.edge.common.jsonapi.JsonApi",
-  "org.osgi.service.cm.ConfigurationListener"
+  "org.osgi.service.cm.ConfigurationListener",
 ];

--- a/ui/src/app/edge/settings/component/update/index.component.ts
+++ b/ui/src/app/edge/settings/component/update/index.component.ts
@@ -10,7 +10,7 @@ interface MyCategorizedComponents extends CategorizedComponents {
 
 @Component({
   selector: IndexComponent.SELECTOR,
-  templateUrl: './index.component.html'
+  templateUrl: './index.component.html',
 })
 export class IndexComponent implements OnInit {
 
@@ -23,7 +23,7 @@ export class IndexComponent implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
-    private service: Service
+    private service: Service,
   ) {
   }
 
@@ -51,8 +51,8 @@ export class IndexComponent implements OnInit {
         Utils.matchAll(filters, [
           entry.id.toLowerCase(),
           entry.alias.toLowerCase(),
-          entry.factoryId
-        ])
+          entry.factoryId,
+        ]),
       );
       countFilteredEntries += entry.filteredComponents.length;
     }

--- a/ui/src/app/edge/settings/component/update/update.component.ts
+++ b/ui/src/app/edge/settings/component/update/update.component.ts
@@ -7,7 +7,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: ComponentUpdateComponent.SELECTOR,
-  templateUrl: './update.component.html'
+  templateUrl: './update.component.html',
 })
 export class ComponentUpdateComponent implements OnInit {
 
@@ -27,7 +27,7 @@ export class ComponentUpdateComponent implements OnInit {
     protected utils: Utils,
     private websocket: Websocket,
     private service: Service,
-    private translate: TranslateService
+    private translate: TranslateService,
   ) {
   }
 
@@ -54,8 +54,8 @@ export class ComponentUpdateComponent implements OnInit {
           templateOptions: {
             label: property.name,
             description: property.description,
-            required: property.isRequired
-          }
+            required: property.isRequired,
+          },
         };
         // add Property Schema 
         Utils.deepCopy(property.schema, field);

--- a/ui/src/app/edge/settings/network/getNetworkConfigResponse.ts
+++ b/ui/src/app/edge/settings/network/getNetworkConfigResponse.ts
@@ -32,7 +32,7 @@ export class GetNetworkConfigResponse extends JsonrpcResponseSuccess {
             interfaces: {
                 [name: string]: NetworkInterface
             }
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/edge/settings/network/network.component.ts
+++ b/ui/src/app/edge/settings/network/network.component.ts
@@ -20,7 +20,7 @@ export type InterfaceForm = {
 
 @Component({
   selector: NetworkComponent.SELECTOR,
-  templateUrl: './network.component.html'
+  templateUrl: './network.component.html',
 })
 export class NetworkComponent implements OnInit {
 
@@ -34,7 +34,7 @@ export class NetworkComponent implements OnInit {
     private translate: TranslateService,
     private service: Service,
     private websocket: Websocket,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) { }
 
   public ngOnInit() {
@@ -88,7 +88,7 @@ export class NetworkComponent implements OnInit {
       addressJson.push({
         label: '', //TODO with specific labels with specific systems.
         address: ip[0],
-        subnetmask: subnetmask
+        subnetmask: subnetmask,
       });
     }
 
@@ -103,7 +103,7 @@ export class NetworkComponent implements OnInit {
       addressJson.push({
         label: 'static',
         address: iface.model.ip,
-        subnetmask: iface.model.subnetmask
+        subnetmask: iface.model.subnetmask,
       });
     }
 
@@ -111,7 +111,7 @@ export class NetworkComponent implements OnInit {
     iface.model.addresses = addressJson;
 
     let request = {
-      interfaces: {}
+      interfaces: {},
     };
     request.interfaces[iface.name] = iface.model;
     const interfaceName = iface.name === 'eth0' ? 'eth0' : iface.name;
@@ -119,7 +119,7 @@ export class NetworkComponent implements OnInit {
     // Sends the request to edge with the configuration.
     this.edge.sendRequest(this.websocket,
       new ComponentJsonApiRequest({
-        componentId: '_host', payload: new SetNetworkConfigRequest(request)
+        componentId: '_host', payload: new SetNetworkConfigRequest(request),
       })).then(response => {
         this.service.toast(this.translate.instant('Edge.Network.successUpdate') + '[' + interfaceName + '].', 'success');
       }).catch(reason => {
@@ -191,7 +191,7 @@ export class NetworkComponent implements OnInit {
       name: name,
       fields: this.fillFields(addressArray),
       formGroup: new FormGroup({}),
-      model: source
+      model: source,
     });
   }
 
@@ -207,8 +207,8 @@ export class NetworkComponent implements OnInit {
         type: 'checkbox',
         defaultValue: true,
         templateOptions: {
-          label: 'DHCP'
-        }
+          label: 'DHCP',
+        },
       },
       {
         hideExpression: 'model.dhcp',
@@ -218,11 +218,11 @@ export class NetworkComponent implements OnInit {
         templateOptions: {
           label: this.translate.instant('Edge.Network.ipAddress'),
           placeholder: 'z.B. 192.168.0.50',
-          required: true
+          required: true,
         },
         validators: {
-          validation: ['ip']
-        }
+          validation: ['ip'],
+        },
       },
       {
         hideExpression: 'model.dhcp',
@@ -232,11 +232,11 @@ export class NetworkComponent implements OnInit {
         templateOptions: {
           label: this.translate.instant('Edge.Network.subnetmask'),
           placeholder: 'z.B. 255.255.255.0',
-          required: true
+          required: true,
         },
         validators: {
-          validation: ['subnetmask']
-        }
+          validation: ['subnetmask'],
+        },
       },
       {
         hideExpression: 'model.dhcp',
@@ -246,11 +246,11 @@ export class NetworkComponent implements OnInit {
         templateOptions: {
           label: 'Gateway',
           placeholder: 'z.B. 192.168.0.1',
-          required: true
+          required: true,
         },
         validators: {
-          validation: ['ip']
-        }
+          validation: ['ip'],
+        },
       },
       {
         hideExpression: 'model.dhcp',
@@ -260,20 +260,20 @@ export class NetworkComponent implements OnInit {
         templateOptions: {
           label: 'DNS-Server',
           placeholder: 'z.B. 192.168.0.1',
-          required: true
+          required: true,
         },
         validators: {
-          validation: ['ip']
-        }
+          validation: ['ip'],
+        },
       },
       {
         key: 'linkLocalAddressing',
         type: 'checkbox',
         resetOnHide: false,
         templateOptions: {
-          label: 'Link-Local Address (z. B. 169.254.XXX.XXX)'
+          label: 'Link-Local Address (z. B. 169.254.XXX.XXX)',
         },
-        hide: true
+        hide: true,
       },
       {
         hide: true,
@@ -282,13 +282,13 @@ export class NetworkComponent implements OnInit {
         resetOnHide: false,
         defaultValue: addressArray,
         templateOptions: {
-          label: this.translate.instant('Edge.Network.addIP')
+          label: this.translate.instant('Edge.Network.addIP'),
         },
         fieldArray: {
           type: 'input',
-          resetOnHide: false
-        }
-      }
+          resetOnHide: false,
+        },
+      },
     ];
 
     return fields;

--- a/ui/src/app/edge/settings/network/setNetworkConfigRequest.ts
+++ b/ui/src/app/edge/settings/network/setNetworkConfigRequest.ts
@@ -31,7 +31,7 @@ export class SetNetworkConfigRequest extends JsonrpcRequest {
             interfaces: {
                 [name: string]: NetworkInterface
             }
-        }
+        },
     ) {
         super(SetNetworkConfigRequest.METHOD, params);
     }

--- a/ui/src/app/edge/settings/profile/aliasupdate.component.ts
+++ b/ui/src/app/edge/settings/profile/aliasupdate.component.ts
@@ -6,7 +6,7 @@ import { Edge, EdgeConfig, Service, Websocket } from 'src/app/shared/shared';
 
 @Component({
     selector: 'aliasupdate',
-    templateUrl: './aliasupdate.component.html'
+    templateUrl: './aliasupdate.component.html',
 })
 export class AliasUpdateComponent implements OnInit {
 
@@ -22,7 +22,7 @@ export class AliasUpdateComponent implements OnInit {
         private route: ActivatedRoute,
         private websocket: Websocket,
         private translate: TranslateService,
-        private formBuilder: FormBuilder
+        private formBuilder: FormBuilder,
     ) { }
 
     ngOnInit() {
@@ -35,7 +35,7 @@ export class AliasUpdateComponent implements OnInit {
             this.factory = config.factories[this.component.factoryId];
             this.componentIcon = config.getFactoryIcon(this.factory);
             this.formGroup = this.formBuilder.group({
-                alias: new FormControl(this.component.alias)
+                alias: new FormControl(this.component.alias),
             });
         });
     }
@@ -47,7 +47,7 @@ export class AliasUpdateComponent implements OnInit {
                 this.service.toast(this.translate.instant('General.inputNotValid'), 'danger');
             } else {
                 this.edge.updateComponentConfig(this.websocket, this.component.id, [
-                    { name: 'alias', value: newAlias }
+                    { name: 'alias', value: newAlias },
                 ]).then(() => {
                     this.formGroup.markAsPristine();
                     this.service.toast(this.translate.instant('General.changeAccepted'), 'success');

--- a/ui/src/app/edge/settings/profile/channelexport/channelExportXlsxRequest.ts
+++ b/ui/src/app/edge/settings/profile/channelexport/channelExportXlsxRequest.ts
@@ -21,7 +21,7 @@ export class ChannelExportXlsxRequest extends JsonrpcRequest {
     public constructor(
         public override readonly params: {
             componentId: string
-        }
+        },
     ) {
         super(ChannelExportXlsxRequest.METHOD, params);
     }

--- a/ui/src/app/edge/settings/profile/modbusapi/getModbusProtocolResponse.ts
+++ b/ui/src/app/edge/settings/profile/modbusapi/getModbusProtocolResponse.ts
@@ -31,7 +31,7 @@ export class GetModbusProtocolResponse extends JsonrpcResponseSuccess {
                 unit: string,
                 type: string
             }]
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/edge/settings/profile/profile.component.ts
+++ b/ui/src/app/edge/settings/profile/profile.component.ts
@@ -13,7 +13,7 @@ import { GetModbusProtocolExportXlsxRequest } from './modbusapi/getModbusProtoco
 
 @Component({
   selector: ProfileComponent.SELECTOR,
-  templateUrl: './profile.component.html'
+  templateUrl: './profile.component.html',
 })
 export class ProfileComponent implements OnInit {
 
@@ -31,7 +31,7 @@ export class ProfileComponent implements OnInit {
     private service: Service,
     private route: ActivatedRoute,
     public popoverController: PopoverController,
-    private translate: TranslateService
+    private translate: TranslateService,
   ) { }
 
   public ngOnInit() {

--- a/ui/src/app/edge/settings/settings.component.ts
+++ b/ui/src/app/edge/settings/settings.component.ts
@@ -6,7 +6,7 @@ import { canSeeAppCenter } from './app/permissions';
 
 @Component({
   selector: 'settings',
-  templateUrl: './settings.component.html'
+  templateUrl: './settings.component.html',
 })
 export class SettingsComponent implements OnInit {
 
@@ -19,7 +19,7 @@ export class SettingsComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     protected utils: Utils,
-    private service: Service
+    private service: Service,
   ) {
   }
 

--- a/ui/src/app/edge/settings/settings.module.ts
+++ b/ui/src/app/edge/settings/settings.module.ts
@@ -20,7 +20,7 @@ import { SystemUpdateComponent } from './systemupdate/systemupdate.component';
   imports: [
     AppModule,
     SharedModule,
-    ChangelogModule
+    ChangelogModule,
   ],
   declarations: [
     AliasUpdateComponent,
@@ -35,12 +35,12 @@ import { SystemUpdateComponent } from './systemupdate/systemupdate.component';
     SettingsComponent,
     SystemExecuteComponent,
     SystemUpdateComponent,
-    AlertingComponent
+    AlertingComponent,
   ],
   entryComponents: [
   ],
   exports: [
-    OeSystemUpdateComponent
-  ]
+    OeSystemUpdateComponent,
+  ],
 })
 export class SettingsModule { }

--- a/ui/src/app/edge/settings/systemexecute/systemexecute.component.ts
+++ b/ui/src/app/edge/settings/systemexecute/systemexecute.component.ts
@@ -8,7 +8,7 @@ import { Service, Utils, Websocket } from '../../../shared/shared';
 
 @Component({
   selector: SystemExecuteComponent.SELECTOR,
-  templateUrl: './systemexecute.component.html'
+  templateUrl: './systemexecute.component.html',
 })
 export class SystemExecuteComponent implements OnInit {
 
@@ -19,7 +19,7 @@ export class SystemExecuteComponent implements OnInit {
     protected utils: Utils,
     private websocket: Websocket,
     private service: Service,
-    private translate: TranslateService
+    private translate: TranslateService,
   ) {
   }
 
@@ -41,8 +41,8 @@ export class SystemExecuteComponent implements OnInit {
         new ComponentJsonApiRequest({
           componentId: "_host",
           payload: new ExecuteSystemCommandRequest(
-            { username: username, password: password, timeoutSeconds: timeout, runInBackground: background, command: command }
-          )
+            { username: username, password: password, timeoutSeconds: timeout, runInBackground: background, command: command },
+          ),
         })).then(response => {
           let result = (response as ExecuteSystemCommandResponse).result;
           this.loading = false;

--- a/ui/src/app/edge/settings/systemlog/systemlog.component.ts
+++ b/ui/src/app/edge/settings/systemlog/systemlog.component.ts
@@ -8,7 +8,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: SystemLogComponent.SELECTOR,
-  templateUrl: './systemlog.component.html'
+  templateUrl: './systemlog.component.html',
 })
 export class SystemLogComponent implements OnInit, OnDestroy {
 
@@ -30,7 +30,7 @@ export class SystemLogComponent implements OnInit, OnDestroy {
     protected utils: Utils,
     private websocket: Websocket,
     private service: Service,
-    private translate: TranslateService
+    private translate: TranslateService,
   ) {
   }
 
@@ -59,7 +59,7 @@ export class SystemLogComponent implements OnInit, OnDestroy {
         level: "----",
         color: "black",
         message: "",
-        source: ""
+        source: "",
       });
     }
 
@@ -74,7 +74,7 @@ export class SystemLogComponent implements OnInit, OnDestroy {
 
       // subscribe to notifications
       edge.systemLog.pipe(
-        takeUntil(this.ngUnsubscribe)
+        takeUntil(this.ngUnsubscribe),
       ).subscribe(line => {
         // add line
         this.lines.unshift({
@@ -82,7 +82,7 @@ export class SystemLogComponent implements OnInit, OnDestroy {
           color: this.getColor(line.level),
           level: line.level,
           source: line.source,
-          message: line.message
+          message: line.message,
         });
 
         // remove old lines

--- a/ui/src/app/edge/settings/systemupdate/executeSystemUpdate.ts
+++ b/ui/src/app/edge/settings/systemupdate/executeSystemUpdate.ts
@@ -22,7 +22,7 @@ export class ExecuteSystemUpdate {
 
     public constructor(
         private edge: Edge,
-        private websocket: Websocket
+        private websocket: Websocket,
     ) {
     }
 
@@ -61,7 +61,7 @@ export class ExecuteSystemUpdate {
                 this.edge.sendRequest(this.websocket,
                     new ComponentJsonApiRequest({
                         componentId: "_host",
-                        payload: new GetSystemUpdateStateRequest()
+                        payload: new GetSystemUpdateStateRequest(),
                     })).then(response => {
                         let result = (response as GetSystemUpdateStateResponse).result;
 
@@ -93,7 +93,7 @@ export class ExecuteSystemUpdate {
             this.edge.sendRequest(this.websocket,
                 new ComponentJsonApiRequest({
                     componentId: "_host",
-                    payload: new ExecuteSystemUpdateRequest({ isDebug: environment.debugMode })
+                    payload: new ExecuteSystemUpdateRequest({ isDebug: environment.debugMode }),
                 })).then(response => {
                     // Finished System Update (without restart of OpenEMS Edge)
                     let systemUpdateState = (response as GetSystemUpdateStateResponse).result;
@@ -123,7 +123,7 @@ export class ExecuteSystemUpdate {
         return new Promise<SystemUpdateState>((resolve, reject) => {
             const source = timer(0, 15000);
             source.pipe(
-                takeUntil(this.ngUnsubscribe)
+                takeUntil(this.ngUnsubscribe),
             ).subscribe(ignore => {
                 if (!this.edge.isOnline) {
                     return;

--- a/ui/src/app/edge/settings/systemupdate/executeSystemUpdateRequest.ts
+++ b/ui/src/app/edge/settings/systemupdate/executeSystemUpdateRequest.ts
@@ -21,7 +21,7 @@ export class ExecuteSystemUpdateRequest extends JsonrpcRequest {
     public constructor(
         public override readonly params: {
             isDebug: boolean
-        }
+        },
     ) {
         super(ExecuteSystemUpdateRequest.METHOD, params);
     }

--- a/ui/src/app/edge/settings/systemupdate/executesystemupdate.component.ts
+++ b/ui/src/app/edge/settings/systemupdate/executesystemupdate.component.ts
@@ -6,7 +6,7 @@ import { SystemUpdateState } from './getSystemUpdateStateResponse';
 
 @Component({
   selector: ExecuteSystemUpdateComponent.SELECTOR,
-  templateUrl: './executesystemupdate.component.html'
+  templateUrl: './executesystemupdate.component.html',
 })
 export class ExecuteSystemUpdateComponent implements OnInit, OnDestroy {
 

--- a/ui/src/app/edge/settings/systemupdate/getSystemUpdateStateResponse.ts
+++ b/ui/src/app/edge/settings/systemupdate/getSystemUpdateStateResponse.ts
@@ -49,7 +49,7 @@ export class GetSystemUpdateStateResponse extends JsonrpcResponseSuccess {
 
     public constructor(
         public override readonly id: string,
-        public override readonly result: SystemUpdateState
+        public override readonly result: SystemUpdateState,
     ) {
         super(id, result);
     }

--- a/ui/src/app/edge/settings/systemupdate/oe-system-update.component.ts
+++ b/ui/src/app/edge/settings/systemupdate/oe-system-update.component.ts
@@ -6,7 +6,7 @@ import { SystemUpdateState } from './getSystemUpdateStateResponse';
 
 @Component({
   selector: OeSystemUpdateComponent.SELECTOR,
-  templateUrl: './oe-system-update.component.html'
+  templateUrl: './oe-system-update.component.html',
 })
 export class OeSystemUpdateComponent implements OnInit, OnDestroy {
 

--- a/ui/src/app/edge/settings/systemupdate/systemupdate.component.ts
+++ b/ui/src/app/edge/settings/systemupdate/systemupdate.component.ts
@@ -5,7 +5,7 @@ import { Edge, Service, Utils } from '../../../shared/shared';
 
 @Component({
   selector: SystemUpdateComponent.SELECTOR,
-  templateUrl: './systemupdate.component.html'
+  templateUrl: './systemupdate.component.html',
 })
 export class SystemUpdateComponent implements OnInit {
 
@@ -22,7 +22,7 @@ export class SystemUpdateComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     protected utils: Utils,
-    private service: Service
+    private service: Service,
   ) { }
 
   ngOnInit() {

--- a/ui/src/app/index/filter/filter.component.ts
+++ b/ui/src/app/index/filter/filter.component.ts
@@ -7,7 +7,7 @@ import { Utils } from "src/app/shared/shared";
 
 @Component({
   selector: 'oe-filter',
-  templateUrl: './filter.component.html'
+  templateUrl: './filter.component.html',
 })
 export class FilterComponent {
 

--- a/ui/src/app/index/index.module.ts
+++ b/ui/src/app/index/index.module.ts
@@ -10,13 +10,13 @@ import { LoginComponent } from './login.component';
 @NgModule({
   imports: [
     SharedModule,
-    RegistrationModule
+    RegistrationModule,
   ],
   declarations: [
     FilterComponent,
     SumStateComponent,
     LoginComponent,
-    OverViewComponent
-  ]
+    OverViewComponent,
+  ],
 })
 export class IndexModule { }

--- a/ui/src/app/index/login.component.ts
+++ b/ui/src/app/index/login.component.ts
@@ -9,7 +9,7 @@ import { Edge, Service, Utils, Websocket } from '../shared/shared';
 
 @Component({
   selector: 'login',
-  templateUrl: './login.component.html'
+  templateUrl: './login.component.html',
 })
 export class LoginComponent implements OnInit, AfterContentChecked, OnDestroy {
   public environment = environment;
@@ -24,7 +24,7 @@ export class LoginComponent implements OnInit, AfterContentChecked, OnDestroy {
     public utils: Utils,
     private router: Router,
     private route: ActivatedRoute,
-    private cdref: ChangeDetectorRef
+    private cdref: ChangeDetectorRef,
   ) { }
 
   ngAfterContentChecked() {
@@ -77,7 +77,7 @@ export class LoginComponent implements OnInit, AfterContentChecked, OnDestroy {
   public static trimCredentials(password: string, username?: string): { password: string, username?: string } {
     return {
       password: password?.trim(),
-      ...(username && { username: username?.trim() })
+      ...(username && { username: username?.trim() }),
     };
   }
 
@@ -129,7 +129,7 @@ export class LoginComponent implements OnInit, AfterContentChecked, OnDestroy {
         });
     }).finally(() => {
       this.service.stopSpinner('loginspinner');
-    }
+    },
     );
   }
 

--- a/ui/src/app/index/overview/overview.component.ts
+++ b/ui/src/app/index/overview/overview.component.ts
@@ -14,7 +14,7 @@ import { ChosenFilter } from "../filter/filter.component";
 
 @Component({
     selector: 'overview',
-    templateUrl: './overview.component.html'
+    templateUrl: './overview.component.html',
 })
 export class OverViewComponent implements OnInit, OnDestroy {
     public environment = environment;
@@ -45,7 +45,7 @@ export class OverViewComponent implements OnInit, OnDestroy {
         private router: Router,
         private route: ActivatedRoute,
         public translate: TranslateService,
-        public pagination: Pagination
+        public pagination: Pagination,
     ) { }
 
     ngOnInit() {
@@ -91,7 +91,7 @@ export class OverViewComponent implements OnInit, OnDestroy {
             this.service.metadata
                 .pipe(
                     filter(metadata => !!metadata),
-                    take(1)
+                    take(1),
                 )
                 .subscribe(metadata => {
 

--- a/ui/src/app/index/shared/sumState.ts
+++ b/ui/src/app/index/shared/sumState.ts
@@ -40,7 +40,7 @@ export enum SumState {
   .sum-state-icon > ion-icon{
     font-size: 20pt !important;
 }
-  `]
+  `],
 })
 export class SumStateComponent implements OnInit {
 
@@ -66,23 +66,23 @@ export const SUM_STATES = (translate: TranslateService): Filter => ({
   options: [
     {
       name: 'Ok',
-      value: "ok"
+      value: "ok",
     },
     {
       name: translate.instant('General.info'),
-      value: "Info"
+      value: "Info",
     },
     {
       name: translate.instant('General.warning'),
-      value: "Warning"
+      value: "Warning",
     },
     {
       name: translate.instant("General.fault"),
-      value: "Fault"
-    }
+      value: "Fault",
+    },
   ],
   setAdditionalFilter: () => ({
     key: 'isOnline',
-    value: true
-  })
+    value: true,
+  }),
 });

--- a/ui/src/app/registration/modal/modal.component.ts
+++ b/ui/src/app/registration/modal/modal.component.ts
@@ -9,7 +9,7 @@ import { environment } from 'src/environments';
 
 @Component({
   selector: 'registration-modal',
-  templateUrl: './modal.component.html'
+  templateUrl: './modal.component.html',
 })
 export class RegistrationModalComponent implements OnInit {
 
@@ -22,7 +22,7 @@ export class RegistrationModalComponent implements OnInit {
     public modalCtrl: ModalController,
     private translate: TranslateService,
     private service: Service,
-    private websocket: Websocket
+    private websocket: Websocket,
   ) { }
 
   ngOnInit() {
@@ -75,17 +75,17 @@ export class RegistrationModalComponent implements OnInit {
           street: this.formGroup.value.street,
           zip: this.formGroup.value.zip,
           city: this.formGroup.value.city,
-          country: this.formGroup.value.country
+          country: this.formGroup.value.country,
         },
-        role: this.activeSegment
+        role: this.activeSegment,
       },
-      oem: environment.theme
+      oem: environment.theme,
     });
 
     let companyName = this.formGroup.value.companyName;
     if (companyName) {
       request.params.user.company = {
-        name: companyName
+        name: companyName,
       };
     }
 
@@ -117,7 +117,7 @@ export class RegistrationModalComponent implements OnInit {
         email: new FormControl("", [Validators.required, Validators.email]),
         confirmEmail: new FormControl("", [Validators.required, Validators.email]),
         password: new FormControl("", Validators.required),
-        confirmPassword: new FormControl("", Validators.required)
+        confirmPassword: new FormControl("", Validators.required),
       });
     } else {
       return this.formBuilder.group({
@@ -131,7 +131,7 @@ export class RegistrationModalComponent implements OnInit {
         email: new FormControl("", [Validators.required, Validators.email]),
         confirmEmail: new FormControl("", [Validators.required, Validators.email]),
         password: new FormControl("", Validators.required),
-        confirmPassword: new FormControl("", Validators.required)
+        confirmPassword: new FormControl("", Validators.required),
       });
     }
   }

--- a/ui/src/app/registration/registration.component.ts
+++ b/ui/src/app/registration/registration.component.ts
@@ -4,7 +4,7 @@ import { RegistrationModalComponent } from './modal/modal.component';
 
 @Component({
   selector: 'registration',
-  templateUrl: './registration.component.html'
+  templateUrl: './registration.component.html',
 })
 export class RegistrationComponent {
 
@@ -12,7 +12,7 @@ export class RegistrationComponent {
 
   async presentModal() {
     const modal = await this.modalController.create({
-      component: RegistrationModalComponent
+      component: RegistrationModalComponent,
     });
     return await modal.present();
   }

--- a/ui/src/app/registration/registration.module.ts
+++ b/ui/src/app/registration/registration.module.ts
@@ -7,14 +7,14 @@ import { RegistrationComponent } from './registration.component';
 @NgModule({
   declarations: [
     RegistrationComponent,
-    RegistrationModalComponent
+    RegistrationModalComponent,
   ],
   imports: [
     CommonModule,
-    SharedModule
+    SharedModule,
   ],
   exports: [
-    RegistrationComponent
-  ]
+    RegistrationComponent,
+  ],
 })
 export class RegistrationModule { }

--- a/ui/src/app/shared/chartoptions/chartoptions.component.ts
+++ b/ui/src/app/shared/chartoptions/chartoptions.component.ts
@@ -6,7 +6,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 @Component({
     selector: 'chartOptions',
-    templateUrl: './chartoptions.component.html'
+    templateUrl: './chartoptions.component.html',
 })
 export class ChartOptionsComponent {
 
@@ -18,7 +18,7 @@ export class ChartOptionsComponent {
     constructor(
         public service: Service,
         public translate: TranslateService,
-        public popoverCtrl: PopoverController
+        public popoverCtrl: PopoverController,
     ) { }
 
     async presentPopover(ev: any) {
@@ -33,7 +33,7 @@ export class ChartOptionsComponent {
             component: ChartOptionsPopoverComponent,
             event: ev,
             translucent: false,
-            componentProps: componentProps
+            componentProps: componentProps,
         });
         await popover.present();
         popover.onDidDismiss().then((data) => {

--- a/ui/src/app/shared/chartoptions/popover/popover.component.ts
+++ b/ui/src/app/shared/chartoptions/popover/popover.component.ts
@@ -5,7 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 @Component({
     selector: 'chartoptionspopover',
-    templateUrl: './popover.component.html'
+    templateUrl: './popover.component.html',
 })
 export class ChartOptionsPopoverComponent {
 
@@ -15,7 +15,7 @@ export class ChartOptionsPopoverComponent {
     constructor(
         public service: Service,
         public popoverCtrl: PopoverController,
-        public translate: TranslateService
+        public translate: TranslateService,
     ) { }
 
     public setPhases() {

--- a/ui/src/app/shared/directive/directive.ts
+++ b/ui/src/app/shared/directive/directive.ts
@@ -4,19 +4,19 @@ import { VarDirective } from './ngvar';
 
 @NgModule({
     imports: [
-        BrowserModule
+        BrowserModule,
     ],
     entryComponents: [
-        VarDirective
+        VarDirective,
     ],
     declarations: [
-        VarDirective
+        VarDirective,
     ],
     exports: [
-        VarDirective
+        VarDirective,
     ],
     providers: [
-        VarDirective
-    ]
+        VarDirective,
+    ],
 })
 export class DirectiveModule { }

--- a/ui/src/app/shared/directive/ngvar.ts
+++ b/ui/src/app/shared/directive/ngvar.ts
@@ -1,7 +1,7 @@
 import { Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
 
 @Directive({
-    selector: '[ngVar]'
+    selector: '[ngVar]',
 })
 export class VarDirective {
     @Input()
@@ -19,13 +19,13 @@ export class VarDirective {
         ngVar: unknown;
     } = {
             $implicit: null,
-            ngVar: null
+            ngVar: null,
         };
 
     private hasView: boolean = false;
 
     constructor(
         private templateRef: TemplateRef<any>,
-        private vcRef: ViewContainerRef
+        private vcRef: ViewContainerRef,
     ) { }
 }

--- a/ui/src/app/shared/edge/currentdata.ts
+++ b/ui/src/app/shared/edge/currentdata.ts
@@ -9,7 +9,7 @@ export class CurrentData {
   public readonly summary: DefaultTypes.Summary;
 
   constructor(
-    public readonly channel: { [channelAddress: string]: any } = {}
+    public readonly channel: { [channelAddress: string]: any } = {},
   ) {
     this.summary = this.getSummary(channel);
   }
@@ -20,7 +20,7 @@ export class CurrentData {
         totalPower: null,
         autarchy: null,
         selfConsumption: null,
-        state: null
+        state: null,
       }, storage: {
         soc: null,
         activePowerL1: null,
@@ -42,7 +42,7 @@ export class CurrentData {
         effectivePower: null,
         effectiveChargePower: null,
         effectiveDischargePower: null,
-        capacity: null
+        capacity: null,
       }, production: {
         hasDC: false,
         powerRatio: null,
@@ -52,7 +52,7 @@ export class CurrentData {
         activePowerAcL2: null,
         activePowerAcL3: null,
         activePowerDc: null,
-        maxActivePower: null
+        maxActivePower: null,
       }, grid: {
         gridMode: null,
         powerRatio: null,
@@ -65,14 +65,14 @@ export class CurrentData {
         sellActivePowerL1: null,
         sellActivePowerL2: null,
         sellActivePowerL3: null,
-        maxSellActivePower: null
+        maxSellActivePower: null,
       }, consumption: {
         powerRatio: null,
         activePower: null,
         activePowerL1: null,
         activePowerL2: null,
-        activePowerL3: null
-      }
+        activePowerL3: null,
+      },
     };
 
     {
@@ -180,7 +180,7 @@ export class CurrentData {
 
         effectivePower = Utils.subtractSafely(
           Utils.subtractSafely(
-            Utils.orElse(result.storage.dischargeActivePowerAc, 0), result.storage.chargeActivePowerAc
+            Utils.orElse(result.storage.dischargeActivePowerAc, 0), result.storage.chargeActivePowerAc,
           ), result.production.activePowerDc);
         result.storage.effectivePower = effectivePower;
       }
@@ -227,7 +227,7 @@ export class CurrentData {
         result.grid.sellActivePower
         + (result.production.activePower < 0 ? result.production.activePower * -1 : 0)
         + result.storage.chargeActivePowerAc,
-        + (result.consumption.activePower > 0 ? result.consumption.activePower : 0)
+        + (result.consumption.activePower > 0 ? result.consumption.activePower : 0),
       );
       result.system.autarchy = CurrentData.calculateAutarchy(result.grid.buyActivePower, result.consumption.activePower);
       result.system.selfConsumption = Utils.calculateSelfConsumption(result.grid.sellActivePower, result.production.activePower);
@@ -244,10 +244,10 @@ export class CurrentData {
             1 - (
               Utils.divideSafely(
                 Utils.orElse(buyFromGrid, 0),
-                Math.max(Utils.orElse(consumptionActivePower, 0), 0)
+                Math.max(Utils.orElse(consumptionActivePower, 0), 0),
               )
             )
-          ) * 100, 0
+          ) * 100, 0,
         ), 0);
     } else {
       return null;

--- a/ui/src/app/shared/edge/edge.ts
+++ b/ui/src/app/shared/edge/edge.ts
@@ -33,7 +33,7 @@ export class Edge {
     public isOnline: boolean,
     public readonly lastmessage: Date,
     public readonly sumState: SumState,
-    public readonly firstSetupProtocol: Date
+    public readonly firstSetupProtocol: Date,
   ) { }
 
   // holds currently subscribed channels, identified by source id

--- a/ui/src/app/shared/edge/edgeconfig.spec.ts
+++ b/ui/src/app/shared/edge/edgeconfig.spec.ts
@@ -12,7 +12,7 @@ export namespace DummyConfig {
 
         return new EdgeConfig(DUMMY_EDGE, <EdgeConfig><unknown>{
             components: <unknown>components?.reduce((acc, c) => ({ ...acc, [c.id]: c }), {}),
-            factories: <unknown>components?.map(c => c.factory)
+            factories: <unknown>components?.map(c => c.factory),
         });
     };
 
@@ -31,14 +31,14 @@ export namespace DummyConfig {
                     id: component['factoryId'],
                     name: component['factoryId'],
                     natureIds: component['factory'].natureIds,
-                    properties: []
+                    properties: [],
                 };
             }
         });
 
         return new EdgeConfig(DUMMY_EDGE, <EdgeConfig>{
             components: edgeConfig.components,
-            factories: factories
+            factories: factories,
         });
     }
 }
@@ -60,8 +60,8 @@ namespace Factory {
             "io.openems.edge.common.modbusslave.ModbusSlave",
             "io.openems.edge.meter.api.ElectricityMeter",
             "io.openems.edge.meter.socomec.SocomecMeter",
-            "io.openems.edge.meter.socomec.threephase.SocomecMeterThreephase"
-        ]
+            "io.openems.edge.meter.socomec.threephase.SocomecMeterThreephase",
+        ],
     };
 
     export const METER_GOODWE_GRID = {
@@ -72,8 +72,8 @@ namespace Factory {
             "io.openems.edge.bridge.modbus.api.ModbusComponent",
             "io.openems.edge.common.modbusslave.ModbusSlave",
             "io.openems.edge.common.component.OpenemsComponent",
-            "io.openems.edge.timedata.api.TimedataProvider"
-        ]
+            "io.openems.edge.timedata.api.TimedataProvider",
+        ],
     };
 
     export const EVCS_KEBA_KECONTACT = {
@@ -83,8 +83,8 @@ namespace Factory {
             "io.openems.edge.common.modbusslave.ModbusSlave",
             "io.openems.edge.common.component.OpenemsComponent",
             "io.openems.edge.evcs.api.ManagedEvcs",
-            "io.openems.edge.evcs.api.Evcs"
-        ]
+            "io.openems.edge.evcs.api.Evcs",
+        ],
     };
 
     export const ESS_GENERIC_MANAGEDSYMMETRIC = {
@@ -98,15 +98,15 @@ namespace Factory {
             "io.openems.edge.ess.api.HybridEss",
             "io.openems.edge.goodwe.ess.GoodWeEss",
             "io.openems.edge.ess.api.ManagedSymmetricEss",
-            "io.openems.edge.timedata.api.TimedataProvider"
-        ]
+            "io.openems.edge.timedata.api.TimedataProvider",
+        ],
     };
 
     export const SOLAR_EDGE_PV_INVERTER = {
         id: "SolarEdge.PV-Inverter",
         natureIds: [
-            "io.openems.edge.pvinverter.sunspec.SunSpecPvInverter", "io.openems.edge.meter.api.AsymmetricMeter", "io.openems.edge.meter.api.SymmetricMeter", "io.openems.edge.bridge.modbus.api.ModbusComponent", "io.openems.edge.common.modbusslave.ModbusSlave", "io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter", "io.openems.edge.common.component.OpenemsComponent"
-        ]
+            "io.openems.edge.pvinverter.sunspec.SunSpecPvInverter", "io.openems.edge.meter.api.AsymmetricMeter", "io.openems.edge.meter.api.SymmetricMeter", "io.openems.edge.bridge.modbus.api.ModbusComponent", "io.openems.edge.common.modbusslave.ModbusSlave", "io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter", "io.openems.edge.common.component.OpenemsComponent",
+        ],
     };
 }
 
@@ -130,9 +130,9 @@ export const SOCOMEC_GRID_METER = (id: string, alias?: string): Component => ({
     properties: {
         invert: false,
         modbusUnitId: 5,
-        type: "GRID"
+        type: "GRID",
     },
-    channels: {}
+    channels: {},
 });
 
 export const SOCOMEC_CONSUMPTION_METER = (id: string, alias?: string): Component => ({
@@ -143,9 +143,9 @@ export const SOCOMEC_CONSUMPTION_METER = (id: string, alias?: string): Component
     properties: {
         invert: false,
         modbusUnitId: 5,
-        type: "CONSUMPTION_METERED"
+        type: "CONSUMPTION_METERED",
     },
-    channels: {}
+    channels: {},
 });
 export const GOODWE_GRID_METER = (id: string, alias?: string): Component => ({
     id: id,
@@ -154,9 +154,9 @@ export const GOODWE_GRID_METER = (id: string, alias?: string): Component => ({
     properties: {
         invert: false,
         modbusUnitId: 5,
-        type: "PRODUCTION"
+        type: "PRODUCTION",
     },
-    channels: {}
+    channels: {},
 });
 
 export const SOLAR_EDGE_PV_INVERTER = (id: string, alias?: string): Component => ({
@@ -167,9 +167,9 @@ export const SOLAR_EDGE_PV_INVERTER = (id: string, alias?: string): Component =>
     properties: {
         invert: false,
         modbusUnitId: 5,
-        type: "PRODUCTION"
+        type: "PRODUCTION",
     },
-    channels: {}
+    channels: {},
 });
 
 export const ESS_GENERIC_MANAGEDSYMMETRIC = (id: string, alias?: string): Component => ({
@@ -179,9 +179,9 @@ export const ESS_GENERIC_MANAGEDSYMMETRIC = (id: string, alias?: string): Compon
     factory: Factory.ESS_GENERIC_MANAGEDSYMMETRIC,
     properties: {
         invert: false,
-        modbusUnitId: 5
+        modbusUnitId: 5,
     },
-    channels: {}
+    channels: {},
 });
 
 export const EVCS_KEBA_KECONTACT = (id: string, alias?: string): Component => ({
@@ -192,9 +192,9 @@ export const EVCS_KEBA_KECONTACT = (id: string, alias?: string): Component => ({
         invert: false,
         modbusUnitId: 5,
         // TODO
-        type: "CONSUMPTION_METERED"
+        type: "CONSUMPTION_METERED",
     },
-    channels: {}
+    channels: {},
 });
 
 
@@ -202,14 +202,14 @@ export const CHANNEL_LINE = (name: string, value: string, indentation?: TextInde
     type: "channel-line",
     name: name,
     ...(indentation && { indentation: indentation }),
-    value: value
+    value: value,
 });
 
 export const VALUE_FROM_CHANNELS_LINE = (name: string, value: string, indentation?: TextIndentation): OeFormlyViewTester.Field => ({
     type: "value-from-channels-line",
     name: name,
     ...(indentation && { indentation: indentation }),
-    value: value
+    value: value,
 });
 
 export const PHASE_ADMIN = (name: string, voltage: string, current: string, power: string): OeFormlyViewTester.Field => ({
@@ -219,17 +219,17 @@ export const PHASE_ADMIN = (name: string, voltage: string, current: string, powe
     children: [
         {
             type: "item",
-            value: voltage
+            value: voltage,
         },
         {
             type: "item",
-            value: current
+            value: current,
         },
         {
             type: "item",
-            value: power
-        }
-    ]
+            value: power,
+        },
+    ],
 });
 
 export const PHASE_GUEST = (name: string, power: string): OeFormlyViewTester.Field => ({
@@ -239,21 +239,21 @@ export const PHASE_GUEST = (name: string, power: string): OeFormlyViewTester.Fie
     children: [
         {
             type: "item",
-            value: power
-        }
-    ]
+            value: power,
+        },
+    ],
 });
 
 export const LINE_HORIZONTAL: OeFormlyViewTester.Field = {
-    type: "horizontal-line"
+    type: "horizontal-line",
 };
 
 export const LINE_INFO_PHASES_DE: OeFormlyViewTester.Field = {
     type: "info-line",
-    name: "Die Summe der einzelnen Phasen kann aus technischen Gründen geringfügig von der Gesamtsumme abweichen."
+    name: "Die Summe der einzelnen Phasen kann aus technischen Gründen geringfügig von der Gesamtsumme abweichen.",
 };
 
 export const LINE_INFO = (text: string): OeFormlyViewTester.Field => ({
     type: "info-line",
-    name: text
+    name: text,
 });

--- a/ui/src/app/shared/edge/edgeconfig.ts
+++ b/ui/src/app/shared/edge/edgeconfig.ts
@@ -51,7 +51,7 @@ export class EdgeConfig {
                     this.natures[natureId] = {
                         id: natureId,
                         name: name,
-                        factoryIds: []
+                        factoryIds: [],
                     };
                 }
                 this.natures[natureId].factoryIds.push(factoryId);
@@ -368,23 +368,23 @@ export class EdgeConfig {
         let allFactories = [
             {
                 category: { title: 'Simulatoren', icon: 'flask-outline' },
-                factories: Object.values(this.factories).filter(factory => factory.id.startsWith('Simulator.'))
+                factories: Object.values(this.factories).filter(factory => factory.id.startsWith('Simulator.')),
             },
             {
                 category: { title: 'Zähler', icon: 'speedometer-outline' },
                 factories: [
                     this.getFactoriesByNature("io.openems.edge.meter.api.SymmetricMeter"), // TODO replaced by ElectricityMeter
                     this.getFactoriesByNature("io.openems.edge.meter.api.ElectricityMeter"),
-                    this.getFactoriesByNature("io.openems.edge.ess.dccharger.api.EssDcCharger")
-                ]
+                    this.getFactoriesByNature("io.openems.edge.ess.dccharger.api.EssDcCharger"),
+                ],
             },
             {
                 category: { title: 'Speichersysteme', icon: 'battery-charging-outline' },
                 factories: [
                     this.getFactoriesByNature("io.openems.edge.ess.api.SymmetricEss"),
                     this.getFactoriesByNature("io.openems.edge.battery.api.Battery"),
-                    this.getFactoriesByNature("io.openems.edge.batteryinverter.api.ManagedSymmetricBatteryInverter")
-                ]
+                    this.getFactoriesByNature("io.openems.edge.batteryinverter.api.ManagedSymmetricBatteryInverter"),
+                ],
             },
             {
                 category: { title: 'Speichersystem-Steuerung', icon: 'options-outline' },
@@ -392,30 +392,30 @@ export class EdgeConfig {
                     this.getFactoriesByIdsPattern([
                         /Controller\.Asymmetric.*/,
                         /Controller\.Ess.*/,
-                        /Controller\.Symmetric.*/
-                    ])
-                ]
+                        /Controller\.Symmetric.*/,
+                    ]),
+                ],
             },
             {
                 category: { title: 'E-Auto-Ladestation', icon: 'car-outline' },
                 factories: [
-                    this.getFactoriesByNature("io.openems.edge.evcs.api.Evcs")
-                ]
+                    this.getFactoriesByNature("io.openems.edge.evcs.api.Evcs"),
+                ],
             },
             {
                 category: { title: 'E-Auto-Ladestation-Steuerung', icon: 'options-outline' },
                 factories: [
                     this.getFactoriesByIds([
-                        'Controller.Evcs'
-                    ])
-                ]
+                        'Controller.Evcs',
+                    ]),
+                ],
             },
             {
                 category: { title: 'I/Os', icon: 'log-in-outline' },
                 factories: [
                     this.getFactoriesByNature("io.openems.edge.io.api.DigitalOutput"),
-                    this.getFactoriesByNature("io.openems.edge.io.api.DigitalInput")
-                ]
+                    this.getFactoriesByNature("io.openems.edge.io.api.DigitalInput"),
+                ],
             },
             {
                 category: { title: 'I/O-Steuerung', icon: 'options-outline' },
@@ -424,15 +424,15 @@ export class EdgeConfig {
                         'Controller.IO.ChannelSingleThreshold',
                         'Controller.Io.FixDigitalOutput',
                         'Controller.IO.HeatingElement',
-                        'Controller.Io.HeatPump.SgReady'
-                    ])
-                ]
+                        'Controller.Io.HeatPump.SgReady',
+                    ]),
+                ],
             },
             {
                 category: { title: 'Temperatursensoren', icon: 'thermometer-outline' },
                 factories: [
-                    this.getFactoriesByNature("io.openems.edge.thermometer.api.Thermometer")
-                ]
+                    this.getFactoriesByNature("io.openems.edge.thermometer.api.Thermometer"),
+                ],
             },
             {
                 category: { title: 'Externe Schnittstellen', icon: 'megaphone-outline' },
@@ -444,9 +444,9 @@ export class EdgeConfig {
                         'Controller.Api.ModbusTcp.ReadWrite',
                         'Controller.Api.MQTT',
                         'Controller.Api.Rest.ReadOnly',
-                        'Controller.Api.Rest.ReadWrite'
-                    ])
-                ]
+                        'Controller.Api.Rest.ReadWrite',
+                    ]),
+                ],
             },
             {
                 category: { title: 'Geräte-Schnittstellen', icon: 'swap-horizontal-outline' },
@@ -455,9 +455,9 @@ export class EdgeConfig {
                         'Bridge.Mbus',
                         'Bridge.Onewire',
                         'Bridge.Modbus.Serial',
-                        'Bridge.Modbus.Tcp'
-                    ])
-                ]
+                        'Bridge.Modbus.Tcp',
+                    ]),
+                ],
             },
             {
                 category: { title: 'Standard-Komponenten', icon: 'resize-outline' },
@@ -465,23 +465,23 @@ export class EdgeConfig {
                     this.getFactoriesByIds([
                         'Controller.Api.Backend',
                         'Controller.Debug.Log',
-                        'Controller.Debug.DetailedLog'
+                        'Controller.Debug.DetailedLog',
                     ]),
                     this.getFactoriesByNature("io.openems.edge.timedata.api.Timedata"),
                     this.getFactoriesByNature("io.openems.edge.predictor.api.oneday.Predictor24Hours"),
-                    this.getFactoriesByNature("io.openems.edge.scheduler.api.Scheduler")
-                ]
+                    this.getFactoriesByNature("io.openems.edge.scheduler.api.Scheduler"),
+                ],
             },
             {
                 category: { title: 'Spezial-Controller', icon: 'repeat-outline' },
                 factories: [
-                    this.getFactoriesByNature("io.openems.edge.controller.api.Controller")
-                ]
+                    this.getFactoriesByNature("io.openems.edge.controller.api.Controller"),
+                ],
             },
             {
                 category: { title: 'Weitere', icon: 'radio-button-off-outline' },
-                factories: Object.values(this.factories)
-            }
+                factories: Object.values(this.factories),
+            },
         ];
 
         let ignoreFactoryIds: string[] = [];
@@ -534,7 +534,7 @@ export class EdgeConfig {
             }
             allComponents.push({
                 category: entry.category,
-                components: components
+                components: components,
             });
         }
         let result: CategorizedComponents[] = [];
@@ -628,7 +628,7 @@ export module EdgeConfig {
         constructor(
             public readonly factoryId: string = "",
             public readonly properties: { [key: string]: any } = {},
-            public readonly channels: { [channelId: string]: ComponentChannel } = {}
+            public readonly channels: { [channelId: string]: ComponentChannel } = {},
         ) { }
     }
 
@@ -649,7 +649,7 @@ export module EdgeConfig {
             public readonly name: string,
             public readonly description: string,
             public readonly natureIds: string[] = [],
-            public readonly properties: FactoryProperty[] = []
+            public readonly properties: FactoryProperty[] = [],
         ) { }
 
         /**

--- a/ui/src/app/shared/edge/meter/electricity/modal.component.ts
+++ b/ui/src/app/shared/edge/meter/electricity/modal.component.ts
@@ -6,7 +6,7 @@ import { Role } from 'src/app/shared/type/role';
 
 @Component({
     selector: 'oe-electricity-meter',
-    templateUrl: './modal.component.html'
+    templateUrl: './modal.component.html',
 })
 export class ElectricityMeterComponent extends AbstractModalLine implements OnInit {
 
@@ -17,7 +17,7 @@ export class ElectricityMeterComponent extends AbstractModalLine implements OnIn
     protected readonly phases: { key: string, name: string, power: number | null, current: number | null, voltage: number | null }[] = [
         { key: "L1", name: "", power: null, current: null, voltage: null },
         { key: "L2", name: "", power: null, current: null, voltage: null },
-        { key: "L3", name: "", power: null, current: null, voltage: null }
+        { key: "L3", name: "", power: null, current: null, voltage: null },
     ];
 
     protected override getChannelAddresses(): ChannelAddress[] {
@@ -26,7 +26,7 @@ export class ElectricityMeterComponent extends AbstractModalLine implements OnIn
             channelAddresses.push(
                 new ChannelAddress(this.component.id, 'CurrentL' + phase),
                 new ChannelAddress(this.component.id, 'VoltageL' + phase),
-                new ChannelAddress(this.component.id, 'ActivePowerL' + phase)
+                new ChannelAddress(this.component.id, 'ActivePowerL' + phase),
             );
         }
         return channelAddresses;

--- a/ui/src/app/shared/edge/meter/esscharger/modal.component.ts
+++ b/ui/src/app/shared/edge/meter/esscharger/modal.component.ts
@@ -6,7 +6,7 @@ import { EdgeConfig } from '../../edgeconfig';
 
 @Component({
     selector: 'oe-ess-charger',
-    templateUrl: './modal.component.html'
+    templateUrl: './modal.component.html',
 })
 export class EssChargerComponent {
     @Input() public component: EdgeConfig.Component;

--- a/ui/src/app/shared/edge/meter/meter.module.ts
+++ b/ui/src/app/shared/edge/meter/meter.module.ts
@@ -12,17 +12,17 @@ import { EssChargerComponent } from "./esscharger/modal.component";
         BrowserModule,
         IonicModule,
         PipeModule,
-        Generic_ComponentsModule
+        Generic_ComponentsModule,
     ],
     entryComponents: [
     ],
     declarations: [
         ElectricityMeterComponent,
-        EssChargerComponent
+        EssChargerComponent,
     ],
     exports: [
         ElectricityMeterComponent,
-        EssChargerComponent
-    ]
+        EssChargerComponent,
+    ],
 })
 export class MeterModule { }

--- a/ui/src/app/shared/formly/form-field-checkbox-hyperlink/form-field-checkbox-hyperlink.wrapper.ts
+++ b/ui/src/app/shared/formly/form-field-checkbox-hyperlink/form-field-checkbox-hyperlink.wrapper.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '@ngx-formly/core';
 @Component({
     selector: 'form-field-checkbox-hyperlink',
     templateUrl: './form-field-checkbox-hyperlink.wrapper.html',
-    changeDetection: ChangeDetectionStrategy.OnPush
+    changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FormlyCheckBoxHyperlinkWrapperComponent extends FieldWrapper implements OnInit {
 

--- a/ui/src/app/shared/formly/form-field-default-cases.wrapper.ts
+++ b/ui/src/app/shared/formly/form-field-default-cases.wrapper.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '@ngx-formly/core';
 
 @Component({
     selector: 'formly-wrapper-default-of-cases',
-    template: `<ng-container #fieldComponent ></ng-container>`
+    template: `<ng-container #fieldComponent ></ng-container>`,
 })
 export class FormlyWrapperDefaultValueWithCasesComponent extends FieldWrapper implements OnInit {
 

--- a/ui/src/app/shared/formly/form-field.wrapper.ts
+++ b/ui/src/app/shared/formly/form-field.wrapper.ts
@@ -4,6 +4,6 @@ import { FieldWrapper } from '@ngx-formly/core';
 @Component({
     selector: 'formly-wrapper-ion-form-field',
     templateUrl: './form-field.wrapper.html',
-    changeDetection: ChangeDetectionStrategy.OnPush
+    changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FormlyWrapperFormFieldComponent extends FieldWrapper { }

--- a/ui/src/app/shared/formly/formly-field-checkbox-image/formly-field-checkbox-with-image.ts
+++ b/ui/src/app/shared/formly/formly-field-checkbox-image/formly-field-checkbox-with-image.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '@ngx-formly/core';
 @Component({
     selector: 'formly-field-checkbox-with-image',
     templateUrl: './formly-field-checkbox-with-image.html',
-    changeDetection: ChangeDetectionStrategy.OnPush
+    changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FormlyFieldCheckboxWithImageComponent extends FieldWrapper implements OnInit {
 

--- a/ui/src/app/shared/formly/formly-field-modal/formlyfieldmodal.ts
+++ b/ui/src/app/shared/formly/formly-field-modal/formlyfieldmodal.ts
@@ -3,6 +3,6 @@ import { FieldWrapper } from "@ngx-formly/core";
 
 @Component({
     selector: 'formly-field-modal',
-    templateUrl: './formlyfieldmodal.html'
+    templateUrl: './formlyfieldmodal.html',
 })
 export class FormlyFieldModalComponent extends FieldWrapper { }

--- a/ui/src/app/shared/formly/formly-field-radio-with-image/formly-field-radio-with-image.ts
+++ b/ui/src/app/shared/formly/formly-field-radio-with-image/formly-field-radio-with-image.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '@ngx-formly/core';
 @Component({
     selector: 'formly-field-radio-with-image',
     templateUrl: './formly-field-radio-with-image.html',
-    changeDetection: ChangeDetectionStrategy.OnPush
+    changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FormlyFieldRadioWithImageComponent extends FieldWrapper implements OnInit {
 

--- a/ui/src/app/shared/formly/formly-select-field-modal.component.ts
+++ b/ui/src/app/shared/formly/formly-select-field-modal.component.ts
@@ -3,7 +3,7 @@ import { ModalController } from "@ionic/angular";
 
 @Component({
     selector: 'formly-select-modal',
-    templateUrl: './formly-select-field-modal.component.html'
+    templateUrl: './formly-select-field-modal.component.html',
 })
 export class FormlySelectFieldModalComponent implements OnInit {
 
@@ -15,7 +15,7 @@ export class FormlySelectFieldModalComponent implements OnInit {
     protected selectedValue: string | null = null;
 
     constructor(
-        protected modalCtrl: ModalController
+        protected modalCtrl: ModalController,
     ) { }
 
     public ngOnInit(): void {

--- a/ui/src/app/shared/formly/formly-select-field.extended.ts
+++ b/ui/src/app/shared/formly/formly-select-field.extended.ts
@@ -5,14 +5,14 @@ import { FormlySelectFieldModalComponent } from "./formly-select-field-modal.com
 
 @Component({
     selector: 'formly-select-extended-wrapper',
-    templateUrl: './formly-select-field.extended.html'
+    templateUrl: './formly-select-field.extended.html',
 })
 export class FormlySelectFieldExtendedWrapperComponent extends FieldWrapper {
 
     // this wrapper is used to display a select which has more 
     // detailed information about an item when selecting them
     constructor(
-        private modalController: ModalController
+        private modalController: ModalController,
     ) {
         super();
 
@@ -31,9 +31,9 @@ export class FormlySelectFieldExtendedWrapperComponent extends FieldWrapper {
             componentProps: {
                 title: this.props.label,
                 options: this.props.options,
-                initialSelectedValue: this.formControl.value
+                initialSelectedValue: this.formControl.value,
             },
-            cssClass: ['auto-height', 'full-width']
+            cssClass: ['auto-height', 'full-width'],
         });
         modal.onDidDismiss().then(event => {
             if (!event.data) {

--- a/ui/src/app/shared/formly/formly-skeleton-wrapper.ts
+++ b/ui/src/app/shared/formly/formly-skeleton-wrapper.ts
@@ -20,7 +20,7 @@ import { FormlyFieldConfig } from '@ngx-formly/core';
   </ion-list>
   <formly-form *ngIf="show" [form]="form" [fields]="fields" [model]="model"></formly-form>
 </div>
-  `
+  `,
 })
 export class FormlyFieldWithLoadingAnimationComponent {
   @Input() public show: boolean = false;

--- a/ui/src/app/shared/formly/input-serial-number-wrapper.ts
+++ b/ui/src/app/shared/formly/input-serial-number-wrapper.ts
@@ -3,6 +3,6 @@ import { FieldWrapper } from '@ngx-formly/core';
 
 @Component({
     selector: 'formly-input-serial-number',
-    templateUrl: './input-serial-number-wrapper.html'
+    templateUrl: './input-serial-number-wrapper.html',
 })
 export class FormlyInputSerialNumberWrapperComponent extends FieldWrapper { }

--- a/ui/src/app/shared/formly/input.ts
+++ b/ui/src/app/shared/formly/input.ts
@@ -3,6 +3,6 @@ import { FieldType } from '@ngx-formly/core';
 
 @Component({
     selector: 'formly-input-section',
-    templateUrl: './input.html'
+    templateUrl: './input.html',
 })
 export class InputTypeComponent extends FieldType { }

--- a/ui/src/app/shared/formly/panel-wrapper.component.ts
+++ b/ui/src/app/shared/formly/panel-wrapper.component.ts
@@ -14,7 +14,7 @@ import { FieldWrapper } from "@ngx-formly/core";
             </ion-row>
         </ion-grid>
     </ion-item>
-    `
+    `,
 })
 export class PanelWrapperComponent extends FieldWrapper {
 }

--- a/ui/src/app/shared/formly/repeat.ts
+++ b/ui/src/app/shared/formly/repeat.ts
@@ -3,7 +3,7 @@ import { FieldArrayType } from '@ngx-formly/core';
 
 @Component({
     selector: 'formly-repeat-section',
-    templateUrl: './repeat.html'
+    templateUrl: './repeat.html',
 })
 export class RepeatTypeComponent extends FieldArrayType {
     // TODO: add explicit constructor

--- a/ui/src/app/shared/genericComponents/abstracthistorywidget.ts
+++ b/ui/src/app/shared/genericComponents/abstracthistorywidget.ts
@@ -33,7 +33,7 @@ export abstract class AbstractHistoryWidget implements OnInit, OnChanges, OnDest
     @Inject(ActivatedRoute) protected route: ActivatedRoute,
     @Inject(Service) public service: Service,
     @Inject(ModalController) protected modalController: ModalController,
-    @Inject(TranslateService) protected translate: TranslateService
+    @Inject(TranslateService) protected translate: TranslateService,
   ) { }
 
   public ngOnInit() {

--- a/ui/src/app/shared/genericComponents/chart/abstractHistoryChartOverview.ts
+++ b/ui/src/app/shared/genericComponents/chart/abstractHistoryChartOverview.ts
@@ -26,7 +26,7 @@ export abstract class AbstractHistoryChartOverview implements OnInit, OnChanges,
   constructor(
     public service: Service,
     protected route: ActivatedRoute,
-    public modalCtrl: ModalController
+    public modalCtrl: ModalController,
   ) { }
 
   public ngOnInit() {

--- a/ui/src/app/shared/genericComponents/chart/abstracthistorychart.ts
+++ b/ui/src/app/shared/genericComponents/chart/abstracthistorychart.ts
@@ -55,7 +55,7 @@ export abstract class AbstractHistoryChart implements OnInit {
     public service: Service,
     public cdRef: ChangeDetectorRef,
     protected translate: TranslateService,
-    protected route: ActivatedRoute
+    protected route: ActivatedRoute,
   ) {
     this.service.historyPeriod.subscribe(() => {
       this.updateChart();
@@ -171,7 +171,7 @@ export abstract class AbstractHistoryChart implements OnInit {
       datasets: datasets,
       colors: colors,
       labels: labels,
-      legendOptions: legendOptions
+      legendOptions: legendOptions,
     };
   }
 
@@ -197,7 +197,7 @@ export abstract class AbstractHistoryChart implements OnInit {
     return {
       datasets: datasets,
       colors: colors,
-      legendOptions: legendOptions
+      legendOptions: legendOptions,
     };
   }
 
@@ -213,7 +213,7 @@ export abstract class AbstractHistoryChart implements OnInit {
     return {
       label: label,
       strokeThroughHidingStyle: element.noStrokeThroughLegendIfHidden,
-      hideLabelInLegend: element.hideLabelInLegend ?? false
+      hideLabelInLegend: element.hideLabelInLegend ?? false,
     };
   }
 
@@ -226,7 +226,7 @@ export abstract class AbstractHistoryChart implements OnInit {
   public static getColors(color: string, chartType: 'line' | 'bar'): { backgroundColor: string, borderColor: string } {
     return {
       backgroundColor: 'rgba(' + (chartType == 'bar' ? color.split('(').pop().split(')')[0] + ',0.4)' : color.split('(').pop().split(')')[0] + ',0.05)'),
-      borderColor: 'rgba(' + color.split('(').pop().split(')')[0] + ',1)'
+      borderColor: 'rgba(' + color.split('(').pop().split(')')[0] + ',1)',
     };
   }
 
@@ -251,7 +251,7 @@ export abstract class AbstractHistoryChart implements OnInit {
       ...(element.borderDash != null && { borderDash: element.borderDash }),
       yAxisID: element.yAxisId != null ? element.yAxisId : chartObject.yAxes.find(element => element.yAxisId == ChartAxis.LEFT)?.yAxisId,
       order: element.order ?? Number.MAX_VALUE,
-      ...(element.hideShadow && { fill: !element.hideShadow })
+      ...(element.hideShadow && { fill: !element.hideShadow }),
     };
     return dataset;
   }
@@ -270,7 +270,7 @@ export abstract class AbstractHistoryChart implements OnInit {
       this.chartObject = this.getChartData();
       Promise.all([
         this.queryHistoricTimeseriesEnergyPerPeriod(this.service.historyPeriod.value.from, this.service.historyPeriod.value.to),
-        this.queryHistoricTimeseriesEnergy(this.service.historyPeriod.value.from, this.service.historyPeriod.value.to)
+        this.queryHistoricTimeseriesEnergy(this.service.historyPeriod.value.from, this.service.historyPeriod.value.to),
       ]).then(([energyPeriodResponse, energyResponse]) => {
 
 
@@ -323,7 +323,7 @@ export abstract class AbstractHistoryChart implements OnInit {
       // Shows Line-Chart
       Promise.all([
         this.queryHistoricTimeseriesData(this.service.historyPeriod.value.from, this.service.historyPeriod.value.to),
-        this.queryHistoricTimeseriesEnergy(this.service.historyPeriod.value.from, this.service.historyPeriod.value.to)
+        this.queryHistoricTimeseriesEnergy(this.service.historyPeriod.value.from, this.service.historyPeriod.value.to),
       ])
         .then(([dataResponse, energyResponse]) => {
           this.chartType = 'line';
@@ -363,7 +363,7 @@ export abstract class AbstractHistoryChart implements OnInit {
             } else {
               this.errorResponse = new JsonrpcResponseError(request.id, { code: 1, message: "Empty Result" });
               resolve(new QueryHistoricTimeseriesDataResponse(response.id, {
-                timestamps: [null], data: { null: null }
+                timestamps: [null], data: { null: null },
               }));
             }
           }).catch((response) => {
@@ -413,7 +413,7 @@ export abstract class AbstractHistoryChart implements OnInit {
               } else {
                 this.errorResponse = new JsonrpcResponseError(request.id, { code: 1, message: "Empty Result" });
                 resolve(new QueryHistoricTimeseriesEnergyPerPeriodResponse(response.id, {
-                  timestamps: [null], data: { null: null }
+                  timestamps: [null], data: { null: null },
                 }));
               }
             }).catch((response) => {
@@ -464,7 +464,7 @@ export abstract class AbstractHistoryChart implements OnInit {
               } else {
                 this.errorResponse = new JsonrpcResponseError(request.id, { code: 1, message: "Empty Result" });
                 resolve(new QueryHistoricTimeseriesEnergyResponse(response.id, {
-                  data: { null: null }
+                  data: { null: null },
                 }));
               }
             }).catch((response) => {
@@ -521,17 +521,17 @@ export abstract class AbstractHistoryChart implements OnInit {
             scaleLabel: {
               display: true,
               labelString: element.customTitle ?? AbstractHistoryChart.getYAxisTitle(element.unit, translate, chartType),
-              padding: 10
+              padding: 10,
             },
             gridLines: {
-              display: element.displayGrid ?? true
+              display: element.displayGrid ?? true,
             },
             ticks: {
               beginAtZero: true,
               max: 100,
               padding: 5,
-              stepSize: 20
-            }
+              stepSize: 20,
+            },
           });
           break;
 
@@ -544,14 +544,14 @@ export abstract class AbstractHistoryChart implements OnInit {
               display: true,
               labelString: element.customTitle ?? AbstractHistoryChart.getYAxisTitle(element.unit, translate, chartType),
               padding: 5,
-              fontSize: 11
+              fontSize: 11,
             },
             gridLines: {
-              display: element.displayGrid ?? true
+              display: element.displayGrid ?? true,
             },
             ticks: {
-              beginAtZero: false
-            }
+              beginAtZero: false,
+            },
           });
           break;
       }
@@ -587,7 +587,7 @@ export abstract class AbstractHistoryChart implements OnInit {
         }
 
         let afterTitle = typeof chartObject.tooltip?.afterTitle == 'function' ? chartObject.tooltip?.afterTitle(stack) : null;
-        let totalValue = items.filter(element => !element.label.includes(afterTitle
+        let totalValue = items.filter(element => !element.label.includes(afterTitle,
         )).reduce((a, e) => a + parseFloat(<string>e.yLabel), 0);
 
         if (afterTitle) {
@@ -651,7 +651,7 @@ export abstract class AbstractHistoryChart implements OnInit {
             hidden: isHidden != null ? isHidden : !chart.isDatasetVisible(index),
             lineWidth: 2,
             strokeStyle: dataset.borderColor.toString(),
-            lineDash: dataset.borderDash
+            lineDash: dataset.borderDash,
           });
         });
       });
@@ -712,7 +712,7 @@ export abstract class AbstractHistoryChart implements OnInit {
       if (this.chartObject?.input) {
         resolve({
           powerChannels: this.chartObject.input.map(element => element.powerChannel),
-          energyChannels: this.chartObject.input.map(element => element.energyChannel)
+          energyChannels: this.chartObject.input.map(element => element.energyChannel),
         });
       }
     });
@@ -806,7 +806,7 @@ export abstract class AbstractHistoryChart implements OnInit {
           }
         }
       }
-    }
+    },
   };
 
   /**

--- a/ui/src/app/shared/genericComponents/chart/chart.ts
+++ b/ui/src/app/shared/genericComponents/chart/chart.ts
@@ -9,7 +9,7 @@ import { Edge, Service } from "../../shared";
 
 @Component({
   selector: 'oe-chart',
-  templateUrl: './chart.html'
+  templateUrl: './chart.html',
 })
 export class ChartComponent implements OnInit, OnChanges {
 
@@ -31,7 +31,7 @@ export class ChartComponent implements OnInit, OnChanges {
     public popoverCtrl: PopoverController,
     protected translate: TranslateService,
     protected modalCtr: ModalController,
-    private ref: ChangeDetectorRef
+    private ref: ChangeDetectorRef,
   ) { }
 
   ngOnInit() {
@@ -65,8 +65,8 @@ export class ChartComponent implements OnInit, OnChanges {
       event: ev,
       componentProps: {
         showPhases: this.showPhases,
-        showTotal: this.showTotal
-      }
+        showTotal: this.showTotal,
+      },
     });
 
     await popover.present();

--- a/ui/src/app/shared/genericComponents/flat/abstract-flat-widget-line.ts
+++ b/ui/src/app/shared/genericComponents/flat/abstract-flat-widget-line.ts
@@ -50,7 +50,7 @@ export abstract class AbstractFlatWidgetLine implements OnChanges, OnDestroy {
     @Inject(ActivatedRoute) protected route: ActivatedRoute,
     @Inject(Service) protected service: Service,
     @Inject(ModalController) protected modalCtrl: ModalController,
-    @Inject(DataService) private dataService: DataService
+    @Inject(DataService) private dataService: DataService,
   ) { }
 
   public ngOnChanges() {

--- a/ui/src/app/shared/genericComponents/flat/abstract-flat-widget.ts
+++ b/ui/src/app/shared/genericComponents/flat/abstract-flat-widget.ts
@@ -36,7 +36,7 @@ export abstract class AbstractFlatWidget implements OnInit, OnDestroy {
         @Inject(Service) protected service: Service,
         @Inject(ModalController) protected modalController: ModalController,
         @Inject(TranslateService) protected translate: TranslateService,
-        private dataService: DataService
+        private dataService: DataService,
     ) {
     }
 

--- a/ui/src/app/shared/genericComponents/flat/flat-widget-horizontal-line/flat-widget-horizontal-line.ts
+++ b/ui/src/app/shared/genericComponents/flat/flat-widget-horizontal-line/flat-widget-horizontal-line.ts
@@ -5,7 +5,7 @@ import { Component, Input } from "@angular/core";
  */
 @Component({
     selector: 'oe-flat-widget-horizontal-line',
-    templateUrl: './flat-widget-horizontal-line.html'
+    templateUrl: './flat-widget-horizontal-line.html',
 })
 export class FlatWidgetHorizontalLineComponent {
     /** Components-Array to iterate over */

--- a/ui/src/app/shared/genericComponents/flat/flat-widget-line/flat-widget-line-item/flat-widget-line-item.ts
+++ b/ui/src/app/shared/genericComponents/flat/flat-widget-line/flat-widget-line-item/flat-widget-line-item.ts
@@ -4,6 +4,6 @@ import { AbstractFlatWidgetLine } from "../../abstract-flat-widget-line";
 @Component({
   /** If multiple items in line use this */
   selector: "oe-flat-widget-line-item",
-  templateUrl: "./flat-widget-line-item.html"
+  templateUrl: "./flat-widget-line-item.html",
 })
 export class FlatWidgetLineItemComponent extends AbstractFlatWidgetLine { }

--- a/ui/src/app/shared/genericComponents/flat/flat-widget-line/flat-widget-line.ts
+++ b/ui/src/app/shared/genericComponents/flat/flat-widget-line/flat-widget-line.ts
@@ -4,7 +4,7 @@ import { AbstractFlatWidgetLine } from "../abstract-flat-widget-line";
 
 @Component({
     selector: 'oe-flat-widget-line',
-    templateUrl: './flat-widget-line.html'
+    templateUrl: './flat-widget-line.html',
 })
 export class FlatWidgetLineComponent extends AbstractFlatWidgetLine {
     /** Name for parameter, displayed on the left side */

--- a/ui/src/app/shared/genericComponents/flat/flat-widget-percentagebar/flat-widget-percentagebar.ts
+++ b/ui/src/app/shared/genericComponents/flat/flat-widget-percentagebar/flat-widget-percentagebar.ts
@@ -3,6 +3,6 @@ import { AbstractFlatWidgetLine } from "../abstract-flat-widget-line";
 
 @Component({
     selector: 'oe-flat-widget-percentagebar',
-    templateUrl: './flat-widget-percentagebar.html'
+    templateUrl: './flat-widget-percentagebar.html',
 })
 export class FlatWidgetPercentagebarComponent extends AbstractFlatWidgetLine { }

--- a/ui/src/app/shared/genericComponents/flat/flat.ts
+++ b/ui/src/app/shared/genericComponents/flat/flat.ts
@@ -3,7 +3,7 @@ import { Icon } from 'src/app/shared/type/widget';
 
 @Component({
   selector: 'oe-flat-widget',
-  templateUrl: './flat.html'
+  templateUrl: './flat.html',
 })
 export class FlatWidgetComponent {
 

--- a/ui/src/app/shared/genericComponents/genericComponents.ts
+++ b/ui/src/app/shared/genericComponents/genericComponents.ts
@@ -30,7 +30,7 @@ import { FlatWidgetLineItemComponent } from './flat/flat-widget-line/flat-widget
         PipeModule,
         ReactiveFormsModule,
         RouterModule,
-        TranslateModule
+        TranslateModule,
     ],
     entryComponents: [
         PickDateComponent,
@@ -46,7 +46,7 @@ import { FlatWidgetLineItemComponent } from './flat/flat-widget-line/flat-widget
         ModalComponent,
         ModalLineItemComponent,
         ModalPhasesComponent,
-        ModalValueLineComponent
+        ModalValueLineComponent,
     ],
     declarations: [
         PickDateComponent,
@@ -64,7 +64,7 @@ import { FlatWidgetLineItemComponent } from './flat/flat-widget-line/flat-widget
         ChartComponent,
         ModalLineItemComponent,
         ModalPhasesComponent,
-        ModalValueLineComponent
+        ModalValueLineComponent,
     ],
     exports: [
         FlatWidgetComponent,
@@ -82,9 +82,9 @@ import { FlatWidgetLineItemComponent } from './flat/flat-widget-line/flat-widget
         PickDateComponent,
         ModalLineItemComponent,
         ModalPhasesComponent,
-        ModalValueLineComponent
+        ModalValueLineComponent,
     ],
-    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    schemas: [CUSTOM_ELEMENTS_SCHEMA],
 
 })
 export class Generic_ComponentsModule { }

--- a/ui/src/app/shared/genericComponents/modal/abstract-modal-line.ts
+++ b/ui/src/app/shared/genericComponents/modal/abstract-modal-line.ts
@@ -93,7 +93,7 @@ export abstract class AbstractModalLine implements OnInit, OnDestroy, OnChanges 
         @Inject(ModalController) protected modalCtrl: ModalController,
         @Inject(TranslateService) protected translate: TranslateService,
         @Inject(FormBuilder) public formBuilder: FormBuilder,
-        private ref: ChangeDetectorRef
+        private ref: ChangeDetectorRef,
     ) {
         ref.detach();
         setInterval(() => {

--- a/ui/src/app/shared/genericComponents/modal/abstractModal.ts
+++ b/ui/src/app/shared/genericComponents/modal/abstractModal.ts
@@ -43,7 +43,7 @@ export abstract class AbstractModal implements OnInit, OnDestroy {
         @Inject(ModalController) public modalController: ModalController,
         @Inject(TranslateService) protected translate: TranslateService,
         @Inject(FormBuilder) public formBuilder: FormBuilder,
-        public ref: ChangeDetectorRef
+        public ref: ChangeDetectorRef,
     ) {
         ref.detach();
         setInterval(() => {

--- a/ui/src/app/shared/genericComponents/modal/help-button/help-button.ts
+++ b/ui/src/app/shared/genericComponents/modal/help-button/help-button.ts
@@ -4,7 +4,7 @@ import { environment } from 'src/environments';
 
 @Component({
     selector: 'oe-help-button',
-    templateUrl: './help-button.html'
+    templateUrl: './help-button.html',
 })
 export class HelpButtonComponent {
 

--- a/ui/src/app/shared/genericComponents/modal/modal-button/modal-button.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal-button/modal-button.ts
@@ -4,7 +4,7 @@ import { AbstractModalLine } from "../abstract-modal-line";
 
 @Component({
     selector: 'oe-modal-buttons',
-    templateUrl: './modal-button.html'
+    templateUrl: './modal-button.html',
 })
 export class ModalButtonsComponent extends AbstractModalLine {
 

--- a/ui/src/app/shared/genericComponents/modal/modal-info-line/modal-info-line.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal-info-line/modal-info-line.ts
@@ -3,7 +3,7 @@ import { Icon } from "src/app/shared/type/widget";
 
 @Component({
     selector: 'oe-modal-info-line',
-    templateUrl: './modal-info-line.html'
+    templateUrl: './modal-info-line.html',
 })
 export class ModalInfoLineComponent {
 

--- a/ui/src/app/shared/genericComponents/modal/modal-line/modal-line-item/modal-line-item.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal-line/modal-line-item/modal-line-item.ts
@@ -4,6 +4,6 @@ import { AbstractModalLine } from "../../abstract-modal-line";
 @Component({
   /** If multiple items in line use this */
   selector: "oe-modal-line-item",
-  templateUrl: "./modal-line-item.html"
+  templateUrl: "./modal-line-item.html",
 })
 export class ModalLineItemComponent extends AbstractModalLine { }

--- a/ui/src/app/shared/genericComponents/modal/modal-line/modal-line.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal-line/modal-line.ts
@@ -4,7 +4,7 @@ import { ButtonLabel } from "../modal-button/modal-button";
 
 @Component({
     selector: 'oe-modal-line',
-    templateUrl: './modal-line.html'
+    templateUrl: './modal-line.html',
 })
 export class ModalLineComponent extends AbstractModalLine {
 

--- a/ui/src/app/shared/genericComponents/modal/modal-phases/modal-phases.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal-phases/modal-phases.ts
@@ -8,14 +8,14 @@ import { TextIndentation } from "../modal-line/modal-line";
 @Component({
   /** If multiple items in line use this */
   selector: "oe-modal-meter-phases",
-  templateUrl: "./modal-phases.html"
+  templateUrl: "./modal-phases.html",
 })
 export class ModalPhasesComponent extends AbstractModalLine {
 
   protected readonly phases: { key: string, name: string }[] = [
     { key: "L1", name: "" },
     { key: "L2", name: "" },
-    { key: "L3", name: "" }
+    { key: "L3", name: "" },
   ];
   @Input() private setTranslatedName = (powerPerPhase: number) => { return ""; };
 
@@ -26,7 +26,7 @@ export class ModalPhasesComponent extends AbstractModalLine {
 
     for (let phase of this.phases) {
       channelAddresses.push(
-        ChannelAddress.fromString(this.component.id + '/ActivePower' + phase.key)
+        ChannelAddress.fromString(this.component.id + '/ActivePower' + phase.key),
       );
     }
     return channelAddresses;

--- a/ui/src/app/shared/genericComponents/modal/modal-value-line/modal-value-line.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal-value-line/modal-value-line.ts
@@ -5,7 +5,7 @@ import { AbstractModalLine } from "../abstract-modal-line";
 
 @Component({
   selector: 'oe-modal-value-line',
-  templateUrl: './modal-value-line.html'
+  templateUrl: './modal-value-line.html',
 })
 export class ModalValueLineComponent extends AbstractModalLine {
 

--- a/ui/src/app/shared/genericComponents/modal/modal.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal.ts
@@ -20,7 +20,7 @@ export enum Status {
             height: 100%;
             font-size: 0.9em;
         }
-    `]
+    `],
 })
 export class ModalComponent {
 
@@ -44,7 +44,7 @@ export class ModalComponent {
         public modalController: ModalController,
         private websocket: Websocket,
         private service: Service,
-        private translate: TranslateService
+        private translate: TranslateService,
     ) {
         this.service.getCurrentEdge().then(edge => this.edge = edge);
     }
@@ -64,7 +64,7 @@ export class ModalComponent {
 
             updateComponentArray.push({
                 name: key,
-                value: this.formGroup.value[key]
+                value: this.formGroup.value[key],
             });
         }
 

--- a/ui/src/app/shared/genericComponents/modal/model-horizontal-line/modal-horizontal-line.ts
+++ b/ui/src/app/shared/genericComponents/modal/model-horizontal-line/modal-horizontal-line.ts
@@ -5,7 +5,7 @@ import { Component, Input } from "@angular/core";
  */
 @Component({
     selector: 'oe-modal-horizontal-line',
-    templateUrl: './modal-horizontal-line.html'
+    templateUrl: './modal-horizontal-line.html',
 })
 export class ModalHorizontalLineComponent {
 

--- a/ui/src/app/shared/genericComponents/shared/oe-formly-component.ts
+++ b/ui/src/app/shared/genericComponents/shared/oe-formly-component.ts
@@ -32,12 +32,12 @@ export abstract class AbstractFormlyComponent {
 
             templateOptions: {
               attributes: {
-                title: view.title
+                title: view.title,
               },
               required: true,
-              options: [{ lines: view.lines }]
+              options: [{ lines: view.lines }],
             },
-            wrappers: ['formly-field-modal']
+            wrappers: ['formly-field-modal'],
           }];
         });
     });

--- a/ui/src/app/shared/genericComponents/shared/testing/common.ts
+++ b/ui/src/app/shared/genericComponents/shared/testing/common.ts
@@ -26,25 +26,25 @@ export namespace OeTester {
         "maintainAspectRatio": false,
         "legend": {
           "labels": {},
-          "position": "bottom"
+          "position": "bottom",
         },
         "elements": {
           "point": {
             "radius": 0,
             "hitRadius": 0,
-            "hoverRadius": 0
+            "hoverRadius": 0,
           },
           "line": {
             "borderWidth": 2,
-            "tension": 0.1
+            "tension": 0.1,
           },
           "rectangle": {
-            "borderWidth": 2
-          }
+            "borderWidth": 2,
+          },
         },
         "hover": {
           "mode": "point",
-          "intersect": true
+          "intersect": true,
         },
         "scales": {
           "yAxes": [
@@ -55,15 +55,15 @@ export namespace OeTester {
                 "display": true,
                 "labelString": title ?? "kW",
                 "padding": 5,
-                "fontSize": 11
+                "fontSize": 11,
               },
               "gridLines": {
-                "display": true
+                "display": true,
               },
               "ticks": {
-                "beginAtZero": false
-              }
-            }
+                "beginAtZero": false,
+              },
+            },
           ],
           "xAxes": [
             {
@@ -81,22 +81,22 @@ export namespace OeTester {
                   "week": "ll",
                   "month": "MM",
                   "quarter": "[Q]Q - YYYY",
-                  "year": "YYYY"
+                  "year": "YYYY",
                 },
-                "unit": period as TimeUnit
+                "unit": period as TimeUnit,
               },
-              "bounds": "ticks"
-            }
-          ]
+              "bounds": "ticks",
+            },
+          ],
         },
         "tooltips": {
           "mode": "index",
           "intersect": false,
           "axis": "x",
-          "callbacks": {}
+          "callbacks": {},
         },
-        "responsive": true
-      }
+        "responsive": true,
+      },
     });
     export const BAR_CHART_OPTIONS = (period: string, title?: string): OeChartTester.Dataset.Option => ({
       type: 'option',
@@ -104,25 +104,25 @@ export namespace OeTester {
         "maintainAspectRatio": false,
         "legend": {
           "labels": {},
-          "position": "bottom"
+          "position": "bottom",
         },
         "elements": {
           "point": {
             "radius": 0,
             "hitRadius": 0,
-            "hoverRadius": 0
+            "hoverRadius": 0,
           },
           "line": {
             "borderWidth": 2,
-            "tension": 0.1
+            "tension": 0.1,
           },
           "rectangle": {
-            "borderWidth": 2
-          }
+            "borderWidth": 2,
+          },
         },
         "hover": {
           "mode": "point",
-          "intersect": true
+          "intersect": true,
         },
         "scales": {
           "yAxes": [
@@ -133,22 +133,22 @@ export namespace OeTester {
                 "display": true,
                 "labelString": title ?? "kWh",
                 "padding": 5,
-                "fontSize": 11
+                "fontSize": 11,
               },
               "gridLines": {
-                "display": true
+                "display": true,
               },
               "ticks": {
-                "beginAtZero": false
+                "beginAtZero": false,
               },
-              "stacked": true
-            }
+              "stacked": true,
+            },
           ],
           "xAxes": [
             {
               "ticks": {
                 "maxTicksLimit": 12,
-                "source": "data"
+                "source": "data",
               },
               "stacked": true,
               "type": "time",
@@ -163,23 +163,23 @@ export namespace OeTester {
                   "week": "ll",
                   "month": "MM",
                   "quarter": "[Q]Q - YYYY",
-                  "year": "YYYY"
+                  "year": "YYYY",
                 },
-                "unit": period as TimeUnit
+                "unit": period as TimeUnit,
               },
               "offset": true,
-              "bounds": "ticks"
-            }
-          ]
+              "bounds": "ticks",
+            },
+          ],
         },
         "tooltips": {
           "mode": "x",
           "intersect": false,
           "axis": "x",
-          "callbacks": {}
+          "callbacks": {},
         },
-        "responsive": true
-      }
+        "responsive": true,
+      },
     });
   }
 

--- a/ui/src/app/shared/genericComponents/shared/testing/tester.ts
+++ b/ui/src/app/shared/genericComponents/shared/testing/tester.ts
@@ -19,7 +19,7 @@ export class OeFormlyViewTester {
       title: view.title,
       lines: view.lines
         .map(line => OeFormlyViewTester.applyField(line, context))
-        .filter(line => line)
+        .filter(line => line),
     };
   };
 
@@ -34,7 +34,7 @@ export class OeFormlyViewTester {
         // Prepare result
         let result: OeFormlyViewTester.Field.ChildrenLine = {
           type: field.type,
-          name: tmp.value
+          name: tmp.value,
         };
 
         // Apply properties if available
@@ -68,7 +68,7 @@ export class OeFormlyViewTester {
         // Prepare result
         let result: OeFormlyViewTester.Field.ChannelLine = {
           type: field.type,
-          name: name
+          name: name,
         };
 
         // Apply properties if available
@@ -100,7 +100,7 @@ export class OeFormlyViewTester {
         // Prepare result
         let result: OeFormlyViewTester.Field.ValueLine = {
           type: field.type,
-          name: name
+          name: name,
         };
 
         // Apply properties if available
@@ -125,7 +125,7 @@ export class OeFormlyViewTester {
 
         return {
           type: field.type,
-          value: tmp.value
+          value: tmp.value,
         };
       }
 
@@ -135,7 +135,7 @@ export class OeFormlyViewTester {
       case "info-line": {
         return {
           type: field.type,
-          name: field.name
+          name: field.name,
         };
       }
 
@@ -144,7 +144,7 @@ export class OeFormlyViewTester {
        */
       case "horizontal-line": {
         return {
-          type: field.type
+          type: field.type,
         };
       }
     }
@@ -176,7 +176,7 @@ export class OeFormlyViewTester {
 
     return {
       rawValue: rawValue,
-      value: value
+      value: value,
     };
   }
 }
@@ -230,7 +230,7 @@ export class OeChartTester {
     testContext.service.historyPeriod.next({
       from: new Date(channelData.result.timestamps[0] ?? 0),
       to: new Date(channelData.result.timestamps.reverse()[0] ?? 0),
-      getText: () => testContext.service.historyPeriod.value.getText(testContext.translate)
+      getText: () => testContext.service.historyPeriod.value.getText(testContext.translate),
     });
 
     // Fill Data
@@ -243,8 +243,8 @@ export class OeChartTester {
       datasets: {
         data: data,
         labels: labels,
-        options: options
-      }
+        options: options,
+      },
     };
   };
 
@@ -257,7 +257,7 @@ export class OeChartTester {
   public static convertChartLabelsToLegendLabels(labels: Date[]): OeChartTester.Dataset.LegendLabel {
     return {
       type: 'label',
-      timestamps: labels
+      timestamps: labels,
     };
   }
 
@@ -275,7 +275,7 @@ export class OeChartTester {
         {
           type: 'data',
           label: dataset.label,
-          value: dataset.data as number[]
+          value: dataset.data as number[],
         });
     }
 
@@ -305,7 +305,7 @@ export class OeChartTester {
 
     return {
       type: 'option',
-      options: AbstractHistoryChart.getOptions(chartData, chartType, testContext.service, testContext.translate, legendOptions, channelData.result)
+      options: AbstractHistoryChart.getOptions(chartData, chartType, testContext.service, testContext.translate, legendOptions, channelData.result),
     };
   }
 
@@ -391,7 +391,7 @@ export namespace OeFormlyViewTester {
 
     return {
       rawValue: rawValue,
-      value: value
+      value: value,
     };
   }
 
@@ -414,7 +414,7 @@ export namespace OeFormlyViewTester {
 
     return {
       rawValues: rawValues,
-      value: value
+      value: value,
     };
   }
 }

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -11,7 +11,7 @@ import { StatusSingleComponent } from '../status/single/status.component';
 
 @Component({
     selector: 'header',
-    templateUrl: './header.component.html'
+    templateUrl: './header.component.html',
 })
 export class HeaderComponent implements OnInit, OnDestroy, AfterViewChecked {
 
@@ -31,7 +31,7 @@ export class HeaderComponent implements OnInit, OnDestroy, AfterViewChecked {
         public router: Router,
         public service: Service,
         public websocket: Websocket,
-        private route: ActivatedRoute
+        private route: ActivatedRoute,
     ) { }
 
     ngOnInit() {
@@ -40,7 +40,7 @@ export class HeaderComponent implements OnInit, OnDestroy, AfterViewChecked {
         // update backUrl on navigation events
         this.router.events.pipe(
             takeUntil(this.ngUnsubscribe),
-            filter(event => event instanceof NavigationEnd)
+            filter(event => event instanceof NavigationEnd),
         ).subscribe(event => {
             window.scrollTo(0, 0);
             this.updateUrl((<NavigationEnd>event).urlAfterRedirects);
@@ -172,7 +172,7 @@ export class HeaderComponent implements OnInit, OnDestroy, AfterViewChecked {
 
     async presentSingleStatusModal() {
         const modal = await this.modalCtrl.create({
-            component: StatusSingleComponent
+            component: StatusSingleComponent,
         });
         return await modal.present();
     }

--- a/ui/src/app/shared/history-data-error.component.ts
+++ b/ui/src/app/shared/history-data-error.component.ts
@@ -12,7 +12,7 @@ import { JsonrpcResponseError } from "src/app/shared/jsonrpc/base";
             <span *ngSwitchCase="'TEMPORARY'" translate>Edge.Index.Energymonitor.ERROR_TEMPORARY</span>
         </ng-container>
     </ion-label>
-</ion-item>`
+</ion-item>`,
 })
 export class HistoryDataErrorComponent {
 

--- a/ui/src/app/shared/jsonrpc/base.ts
+++ b/ui/src/app/shared/jsonrpc/base.ts
@@ -27,7 +27,7 @@ export abstract class JsonrpcMessage {
 export abstract class AbstractJsonrpcRequest extends JsonrpcMessage {
     protected constructor(
         public readonly method: string,
-        public readonly params: {}
+        public readonly params: {},
     ) {
         super();
     }
@@ -37,7 +37,7 @@ export class JsonrpcRequest extends AbstractJsonrpcRequest {
     public constructor(
         public override readonly method: string,
         public override readonly params: {},
-        public readonly id: string = uuidv4()
+        public readonly id: string = uuidv4(),
     ) {
         super(method, params);
     }
@@ -46,7 +46,7 @@ export class JsonrpcRequest extends AbstractJsonrpcRequest {
 export class JsonrpcNotification extends AbstractJsonrpcRequest {
     public constructor(
         public override readonly method: string,
-        public override readonly params: {}
+        public override readonly params: {},
     ) {
         super(method, params);
     }
@@ -54,7 +54,7 @@ export class JsonrpcNotification extends AbstractJsonrpcRequest {
 
 export abstract class JsonrpcResponse extends JsonrpcMessage {
     public constructor(
-        public readonly id: string
+        public readonly id: string,
     ) {
         super();
     }
@@ -63,7 +63,7 @@ export abstract class JsonrpcResponse extends JsonrpcMessage {
 export class JsonrpcResponseSuccess extends JsonrpcResponse {
     public constructor(
         public override readonly id: string,
-        public readonly result: {}
+        public readonly result: {},
     ) {
         super(id);
     }
@@ -76,7 +76,7 @@ export class JsonrpcResponseError extends JsonrpcResponse {
             code: number,
             message: string,
             data?: {}
-        }
+        },
     ) {
         super(id);
     }

--- a/ui/src/app/shared/jsonrpc/notification/currentDataNotification.ts
+++ b/ui/src/app/shared/jsonrpc/notification/currentDataNotification.ts
@@ -19,7 +19,7 @@ export class CurrentDataNotification extends JsonrpcNotification {
     public static readonly METHOD: string = "currentData";
 
     public constructor(
-        public override readonly params: { [channelAddress: string]: string | number }
+        public override readonly params: { [channelAddress: string]: string | number },
     ) {
         super(CurrentDataNotification.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/notification/edgeConfigNotification.ts
+++ b/ui/src/app/shared/jsonrpc/notification/edgeConfigNotification.ts
@@ -17,7 +17,7 @@ export class EdgeConfigNotification extends JsonrpcNotification {
     public static readonly METHOD: string = "edgeConfig";
 
     public constructor(
-        public override readonly params: EdgeConfig
+        public override readonly params: EdgeConfig,
     ) {
         super(EdgeConfigNotification.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/notification/edgeRpcNotification.ts
+++ b/ui/src/app/shared/jsonrpc/notification/edgeRpcNotification.ts
@@ -22,7 +22,7 @@ export class EdgeRpcNotification extends JsonrpcNotification {
         public override readonly params: {
             edgeId: string,
             payload: JsonrpcNotification
-        }
+        },
     ) {
         super(EdgeRpcNotification.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/notification/logMessageNotification.ts
+++ b/ui/src/app/shared/jsonrpc/notification/logMessageNotification.ts
@@ -22,7 +22,7 @@ export class LogMessageNotification extends JsonrpcNotification {
         public override readonly params: {
             level: Level,
             msg: string
-        }
+        },
     ) {
         super(LogMessageNotification.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/notification/systemLogNotification.ts
+++ b/ui/src/app/shared/jsonrpc/notification/systemLogNotification.ts
@@ -26,7 +26,7 @@ export class SystemLogNotification extends JsonrpcNotification {
     public constructor(
         public override readonly params: {
             line: SystemLog
-        }
+        },
     ) {
         super(SystemLogNotification.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/addEdgeToUserRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/addEdgeToUserRequest.ts
@@ -19,7 +19,7 @@ export class AddEdgeToUserRequest extends JsonrpcRequest {
     public constructor(
         public override readonly params: {
             setupPassword: string
-        }
+        },
     ) {
         super(AddEdgeToUserRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/authenticateWithPasswordRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/authenticateWithPasswordRequest.ts
@@ -26,7 +26,7 @@ export class AuthenticateWithPasswordRequest extends JsonrpcRequest {
         public override readonly params: {
             username?: string,
             password: string
-        }
+        },
     ) {
         super(AuthenticateWithPasswordRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/authenticateWithTokenRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/authenticateWithTokenRequest.ts
@@ -24,7 +24,7 @@ export class AuthenticateWithTokenRequest extends JsonrpcRequest {
     public constructor(
         public override readonly params: {
             token: string
-        }
+        },
     ) {
         super(AuthenticateWithTokenRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/componentJsonApiRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/componentJsonApiRequest.ts
@@ -23,7 +23,7 @@ export class ComponentJsonApiRequest extends JsonrpcRequest {
         public override readonly params: {
             componentId: string,
             payload: JsonrpcRequest
-        }
+        },
     ) {
         super(ComponentJsonApiRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/createComponentConfigRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/createComponentConfigRequest.ts
@@ -29,7 +29,7 @@ export class CreateComponentConfigRequest extends JsonrpcRequest {
                 name: string,
                 value: any
             }[]
-        }
+        },
     ) {
         super(CreateComponentConfigRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/deleteComponentConfigRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/deleteComponentConfigRequest.ts
@@ -21,7 +21,7 @@ export class DeleteComponentConfigRequest extends JsonrpcRequest {
     public constructor(
         public override readonly params: {
             componentId: string
-        }
+        },
     ) {
         super(DeleteComponentConfigRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/edgeRpcRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/edgeRpcRequest.ts
@@ -23,7 +23,7 @@ export class EdgeRpcRequest extends JsonrpcRequest {
         public override readonly params: {
             edgeId: string,
             payload: JsonrpcRequest
-        }
+        },
     ) {
         super(EdgeRpcRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/executeCommandRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/executeCommandRequest.ts
@@ -29,7 +29,7 @@ export class ExecuteSystemCommandRequest extends JsonrpcRequest {
             timeoutSeconds: number,
             username?: string,
             password?: string
-        }
+        },
     ) {
         super(ExecuteSystemCommandRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/get24HoursPredictionRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/get24HoursPredictionRequest.ts
@@ -21,10 +21,10 @@ export class Get24HoursPredictionRequest extends JsonrpcRequest {
     private static METHOD: string = "get24HoursPrediction";
 
     public constructor(
-        private channels: ChannelAddress[]
+        private channels: ChannelAddress[],
     ) {
         super(Get24HoursPredictionRequest.METHOD, {
-            channels: JsonRpcUtils.channelsToStringArray(channels)
+            channels: JsonRpcUtils.channelsToStringArray(channels),
         });
         // delete local fields, otherwise they are sent with the JSON-RPC Request
         delete this.channels;

--- a/ui/src/app/shared/jsonrpc/request/getEdgeRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/getEdgeRequest.ts
@@ -24,7 +24,7 @@ export class GetEdgeRequest extends JsonrpcRequest {
     public constructor(
         public override readonly params: {
             edgeId: string
-        }
+        },
     ) {
         super(GetEdgeRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/getEdgesRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/getEdgesRequest.ts
@@ -31,7 +31,7 @@ export class GetEdgesRequest extends JsonrpcRequest {
             query?: string,
             limit?: number,
             searchParams?: {}
-        }
+        },
     ) {
         super(GetEdgesRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/getSetupProtocolRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/getSetupProtocolRequest.ts
@@ -18,7 +18,7 @@ export class GetSetupProtocolRequest extends JsonrpcRequest {
     public constructor(
         public override readonly params: {
             setupProtocolId: string
-        }
+        },
     ) {
         super(GetSetupProtocolRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/getUserAlertingConfigsRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/getUserAlertingConfigsRequest.ts
@@ -21,7 +21,7 @@ export class GetUserAlertingConfigsRequest extends JsonrpcRequest {
     public constructor(
         public override readonly params: {
             edgeId: string
-        }
+        },
     ) {
         super(GetUserAlertingConfigsRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesDataRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesDataRequest.ts
@@ -29,14 +29,14 @@ export class QueryHistoricTimeseriesDataRequest extends JsonrpcRequest {
         private fromDate: Date,
         private toDate: Date,
         private channels: ChannelAddress[],
-        private resolution: Resolution
+        private resolution: Resolution,
     ) {
         super(QueryHistoricTimeseriesDataRequest.METHOD, {
             timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
             fromDate: format(fromDate, 'yyyy-MM-dd'),
             toDate: format(toDate, 'yyyy-MM-dd'),
             channels: JsonRpcUtils.channelsToStringArray(channels),
-            resolution: resolution
+            resolution: resolution,
         });
         // delete local fields, otherwise they are sent with the JSON-RPC Request
         delete this.fromDate;

--- a/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesEnergyPerPeriodRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesEnergyPerPeriodRequest.ts
@@ -31,14 +31,14 @@ export class QueryHistoricTimeseriesEnergyPerPeriodRequest extends JsonrpcReques
         private fromDate: Date,
         private toDate: Date,
         private channels: ChannelAddress[],
-        private resolution: Resolution
+        private resolution: Resolution,
     ) {
         super(QueryHistoricTimeseriesEnergyPerPeriodRequest.METHOD, {
             timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
             fromDate: format(fromDate, 'yyyy-MM-dd'),
             toDate: format(toDate, 'yyyy-MM-dd'),
             channels: JsonRpcUtils.channelsToStringArray(channels),
-            resolution: resolution
+            resolution: resolution,
         });
         // delete local fields, otherwise they are sent with the JSON-RPC Request
         delete this.fromDate;

--- a/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesEnergyRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesEnergyRequest.ts
@@ -27,13 +27,13 @@ export class QueryHistoricTimeseriesEnergyRequest extends JsonrpcRequest {
     public constructor(
         private fromDate: Date,
         private toDate: Date,
-        private channels: ChannelAddress[]
+        private channels: ChannelAddress[],
     ) {
         super(QueryHistoricTimeseriesEnergyRequest.METHOD, {
             timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
             fromDate: format(fromDate, 'yyyy-MM-dd'),
             toDate: format(toDate, 'yyyy-MM-dd'),
-            channels: JsonRpcUtils.channelsToStringArray(channels)
+            channels: JsonRpcUtils.channelsToStringArray(channels),
         });
         // delete local fields, otherwise they are sent with the JSON-RPC Request
         delete this.fromDate;

--- a/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesExportXlxs.ts
+++ b/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesExportXlxs.ts
@@ -23,12 +23,12 @@ export class QueryHistoricTimeseriesExportXlxsRequest extends JsonrpcRequest {
 
     public constructor(
         private fromDate: Date,
-        private toDate: Date
+        private toDate: Date,
     ) {
         super(QueryHistoricTimeseriesExportXlxsRequest.METHOD, {
             timezone: new Date().getTimezoneOffset() * 60,
             fromDate: format(fromDate, 'yyyy-MM-dd'),
-            toDate: format(toDate, 'yyyy-MM-dd')
+            toDate: format(toDate, 'yyyy-MM-dd'),
         });
         // delete local fields, otherwise they are sent with the JSON-RPC Request
         delete this.fromDate;

--- a/ui/src/app/shared/jsonrpc/request/registerUserRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/registerUserRequest.ts
@@ -50,7 +50,7 @@ export class RegisterUserRequest extends JsonrpcRequest {
                 role: string
             },
             oem: string
-        }
+        },
     ) {
         super(RegisterUserRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/setChannelValueRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/setChannelValueRequest.ts
@@ -25,7 +25,7 @@ export class SetChannelValueRequest extends JsonrpcRequest {
             componentId: string,
             channelId: string,
             value: any
-        }
+        },
     ) {
         super(SetChannelValueRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/setEmergencyReserveRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/setEmergencyReserveRequest.ts
@@ -21,7 +21,7 @@ export class SetEmergencyReserveRequest extends JsonrpcRequest {
     public constructor(
         public readonly params: {
             value: number
-        }
+        },
     ) {
         super(SetEmergencyReserveRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/setUserAlertingConfigsRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/setUserAlertingConfigsRequest.ts
@@ -32,7 +32,7 @@ export class SetUserAlertingConfigsRequest extends JsonrpcRequest {
         public override readonly params: {
             edgeId: string,
             userSettings: UserSetting[],
-        }
+        },
     ) {
         super(SetUserAlertingConfigsRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/setUserInformationRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/setUserInformationRequest.ts
@@ -44,7 +44,7 @@ export class SetUserInformationRequest extends JsonrpcRequest {
                     country: string
                 }
             }
-        }
+        },
     ) {
         super(SetUserInformationRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/subscribeChannelsRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/subscribeChannelsRequest.ts
@@ -26,11 +26,11 @@ export class SubscribeChannelsRequest extends JsonrpcRequest {
     private static METHOD: string = "subscribeChannels";
 
     public constructor(
-        private channels: ChannelAddress[]
+        private channels: ChannelAddress[],
     ) {
         super(SubscribeChannelsRequest.METHOD, {
             count: SubscribeChannelsRequest.lastCount++,
-            channels: JsonRpcUtils.channelsToStringArray(channels)
+            channels: JsonRpcUtils.channelsToStringArray(channels),
         });
         // delete local fields, otherwise they are sent with the JSON-RPC Request
         delete this.channels;

--- a/ui/src/app/shared/jsonrpc/request/subscribeEdgesRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/subscribeEdgesRequest.ts
@@ -19,7 +19,7 @@ export class SubscribeEdgesRequest extends JsonrpcRequest {
     public constructor(
         public override readonly params: {
             edges: string[]
-        }
+        },
     ) {
         super(SubscribeEdgesRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/subscribeSystemLogRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/subscribeSystemLogRequest.ts
@@ -25,7 +25,7 @@ export class SubscribeSystemLogRequest extends JsonrpcRequest {
     public constructor(
         public override readonly params: {
             subscribe: boolean
-        }
+        },
     ) {
         super(SubscribeSystemLogRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/updateComponentConfigRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/updateComponentConfigRequest.ts
@@ -29,7 +29,7 @@ export class UpdateComponentConfigRequest extends JsonrpcRequest {
                 name: string,
                 value: any
             }[]
-        }
+        },
     ) {
         super(UpdateComponentConfigRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/request/updateUserLanguageRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/updateUserLanguageRequest.ts
@@ -20,7 +20,7 @@ export class UpdateUserLanguageRequest extends JsonrpcRequest {
     public constructor(
         public override readonly params: {
             language: string
-        }
+        },
     ) {
         super(UpdateUserLanguageRequest.METHOD, params);
     }

--- a/ui/src/app/shared/jsonrpc/response/addEdgeToUserResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/addEdgeToUserResponse.ts
@@ -33,7 +33,7 @@ export class AddEdgeToUserResponse extends JsonrpcResponseSuccess {
                 online: boolean
             },
             serialNumber: string
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/jsonrpc/response/authenticateResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/authenticateResponse.ts
@@ -24,7 +24,7 @@ export class AuthenticateResponse extends JsonrpcResponseSuccess {
             token: string,
             user: User,
             edges: Edges
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/jsonrpc/response/base64PayloadResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/base64PayloadResponse.ts
@@ -19,7 +19,7 @@ export class Base64PayloadResponse extends JsonrpcResponseSuccess {
         public override readonly id: string,
         public override readonly result: {
             payload: string
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/jsonrpc/response/edgeRpcResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/edgeRpcResponse.ts
@@ -19,7 +19,7 @@ export class EdgeRpcResponse extends JsonrpcResponseSuccess {
         public readonly id: string,
         public readonly params: {
             payload: JsonrpcRequest
-        }
+        },
     ) {
         super(id, params);
     }

--- a/ui/src/app/shared/jsonrpc/response/executeSystemCommandResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/executeSystemCommandResponse.ts
@@ -27,7 +27,7 @@ export class ExecuteSystemCommandResponse extends JsonrpcResponseSuccess {
         public override readonly result: {
             stdout: string[],
             stderr: string[]
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/jsonrpc/response/get24HoursPredictionResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/get24HoursPredictionResponse.ts
@@ -23,7 +23,7 @@ export class Get24HoursPredictionResponse extends JsonrpcResponseSuccess {
 
     public constructor(
         public readonly id: string,
-        public readonly result: Prediction
+        public readonly result: Prediction,
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/jsonrpc/response/getEdgeConfigResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/getEdgeConfigResponse.ts
@@ -16,7 +16,7 @@ export class GetEdgeConfigResponse extends JsonrpcResponseSuccess {
 
     public constructor(
         public override readonly id: string,
-        public override readonly result: EdgeConfig
+        public override readonly result: EdgeConfig,
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/jsonrpc/response/getEdgeResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/getEdgeResponse.ts
@@ -21,7 +21,7 @@ export class GetEdgeResponse extends JsonrpcResponseSuccess {
         public override readonly id: string,
         public override readonly result: {
             edge: Edge
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/jsonrpc/response/getEdgesResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/getEdgesResponse.ts
@@ -20,7 +20,7 @@ export class GetEdgesResponse extends JsonrpcResponseSuccess {
         public override readonly id: string,
         public override readonly result: {
             edges: Edge[]
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/jsonrpc/response/getUserAlertingConfigsResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/getUserAlertingConfigsResponse.ts
@@ -34,7 +34,7 @@ export class GetUserAlertingConfigsResponse extends JsonrpcResponseSuccess {
         public override readonly id: string,
         public override readonly result: {
             userSettings: UserSettingResponse[]
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/jsonrpc/response/getUserInformationResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/getUserInformationResponse.ts
@@ -47,7 +47,7 @@ export class GetUserInformationResponse extends JsonrpcResponseSuccess {
                     name: string
                 }
             }
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/jsonrpc/response/queryHistoricTimeseriesDataResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/queryHistoricTimeseriesDataResponse.ts
@@ -27,7 +27,7 @@ export class QueryHistoricTimeseriesDataResponse extends JsonrpcResponseSuccess 
         public override readonly result: {
             timestamps: string[],
             data: { [channelAddress: string]: any[] }
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/jsonrpc/response/queryHistoricTimeseriesEnergyPerPeriodResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/queryHistoricTimeseriesEnergyPerPeriodResponse.ts
@@ -20,7 +20,7 @@ export class QueryHistoricTimeseriesEnergyPerPeriodResponse extends JsonrpcRespo
         public override readonly result: {
             timestamps: string[],
             data: { [channelAddress: string]: any[] }
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/jsonrpc/response/queryHistoricTimeseriesEnergyResponse.ts
+++ b/ui/src/app/shared/jsonrpc/response/queryHistoricTimeseriesEnergyResponse.ts
@@ -23,7 +23,7 @@ export class QueryHistoricTimeseriesEnergyResponse extends JsonrpcResponseSucces
         public override readonly id: string,
         public override readonly result: {
             data: Cumulated;
-        }
+        },
     ) {
         super(id, result);
     }

--- a/ui/src/app/shared/percentagebar/percentagebar.component.ts
+++ b/ui/src/app/shared/percentagebar/percentagebar.component.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 
 @Component({
     selector: 'percentagebar',
-    templateUrl: './percentagebar.component.html'
+    templateUrl: './percentagebar.component.html',
 })
 export class PercentageBarComponent {
 

--- a/ui/src/app/shared/pickdate/pickdate.component.spec.ts
+++ b/ui/src/app/shared/pickdate/pickdate.component.spec.ts
@@ -15,7 +15,7 @@ describe('Pickdate', () => {
 
   let TEST_CONTEXT: TestContext;
   beforeEach(() =>
-    TEST_CONTEXT = sharedSetup()
+    TEST_CONTEXT = sharedSetup(),
   );
 
   it('#isPreviousPeriodAllowed && #isNextPeriodAllowed - Day-View: firstSetupProtocol = today', () => {

--- a/ui/src/app/shared/pickdate/pickdate.component.ts
+++ b/ui/src/app/shared/pickdate/pickdate.component.ts
@@ -9,7 +9,7 @@ import { PickDatePopoverComponent } from './popover/popover.component';
 
 @Component({
     selector: 'pickdate',
-    templateUrl: './pickdate.component.html'
+    templateUrl: './pickdate.component.html',
 })
 export class PickDateComponent implements OnInit, OnDestroy {
 
@@ -25,7 +25,7 @@ export class PickDateComponent implements OnInit, OnDestroy {
     constructor(
         public service: Service,
         public translate: TranslateService,
-        public popoverCtrl: PopoverController
+        public popoverCtrl: PopoverController,
     ) { }
 
     public ngOnInit() {
@@ -334,8 +334,8 @@ export class PickDateComponent implements OnInit, OnDestroy {
             cssClass: 'pickdate-popover',
             componentProps: {
                 setDateRange: this.setDateRange,
-                edge: this.edge
-            }
+                edge: this.edge,
+            },
         });
         await popover.present();
         popover.onDidDismiss().then(() => {

--- a/ui/src/app/shared/pickdate/popover/popover.component.ts
+++ b/ui/src/app/shared/pickdate/popover/popover.component.ts
@@ -11,7 +11,7 @@ import { Service, Utils } from '../../shared';
 
 @Component({
     selector: 'pickdatepopover',
-    templateUrl: './popover.component.html'
+    templateUrl: './popover.component.html',
 })
 export class PickDatePopoverComponent implements OnInit {
 
@@ -34,7 +34,7 @@ export class PickDatePopoverComponent implements OnInit {
                    border-bottom: 2px solid #2d8fab;
                    color: #2d8fab;
                 }
-             `
+             `,
         },
         calendarAnimation: { in: CalAnimation.FlipDiagonal, out: CalAnimation.ScaleCenter },
         dateFormat: 'dd.mm.yyyy',
@@ -44,13 +44,13 @@ export class PickDatePopoverComponent implements OnInit {
         inline: true,
         selectorHeight: '225px',
         selectorWidth: '251px',
-        showWeekNumbers: true
+        showWeekNumbers: true,
     };
 
     constructor(
         public service: Service,
         public popoverCtrl: PopoverController,
-        public translate: TranslateService
+        public translate: TranslateService,
     ) { }
 
     ngOnInit() {

--- a/ui/src/app/shared/pipe/classname/classname.pipe.ts
+++ b/ui/src/app/shared/pipe/classname/classname.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: 'classname'
+  name: 'classname',
 })
 export class ClassnamePipe implements PipeTransform {
   transform(value, args: string[]): any {

--- a/ui/src/app/shared/pipe/formatSecondsToDuration/formatSecondsToDuration.pipe.ts
+++ b/ui/src/app/shared/pipe/formatSecondsToDuration/formatSecondsToDuration.pipe.ts
@@ -2,7 +2,7 @@ import { DecimalPipe } from '@angular/common';
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-    name: 'formatSecondsToDuration'
+    name: 'formatSecondsToDuration',
 })
 export class FormatSecondsToDurationPipe implements PipeTransform {
 

--- a/ui/src/app/shared/pipe/isclass/isclass.pipe.ts
+++ b/ui/src/app/shared/pipe/isclass/isclass.pipe.ts
@@ -5,7 +5,7 @@ import { Pipe, PipeTransform } from '@angular/core';
  * Use like: *ngIf="bridge | isclass:'io.openems.impl.protocol.simulator.SimulatorBridge'"
  */
 @Pipe({
-  name: 'isclass'
+  name: 'isclass',
 })
 export class IsclassPipe implements PipeTransform {
   transform(object: any, classname: string): boolean {

--- a/ui/src/app/shared/pipe/keys/keys.pipe.ts
+++ b/ui/src/app/shared/pipe/keys/keys.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: 'keys'
+  name: 'keys',
 })
 export class KeysPipe implements PipeTransform {
   transform(value, args: string[]): any {

--- a/ui/src/app/shared/pipe/pipe.ts
+++ b/ui/src/app/shared/pipe/pipe.ts
@@ -12,7 +12,7 @@ import { VersionPipe } from './version/version.pipe';
 
 @NgModule({
     imports: [
-        BrowserModule
+        BrowserModule,
     ],
     entryComponents: [
         UnitvaluePipe,
@@ -22,7 +22,7 @@ import { VersionPipe } from './version/version.pipe';
         IsclassPipe,
         ClassnamePipe,
         VersionPipe,
-        TypeofPipe
+        TypeofPipe,
     ],
     declarations: [
         UnitvaluePipe,
@@ -32,7 +32,7 @@ import { VersionPipe } from './version/version.pipe';
         IsclassPipe,
         ClassnamePipe,
         VersionPipe,
-        TypeofPipe
+        TypeofPipe,
     ],
     exports: [
         UnitvaluePipe,
@@ -42,13 +42,13 @@ import { VersionPipe } from './version/version.pipe';
         IsclassPipe,
         ClassnamePipe,
         VersionPipe,
-        TypeofPipe
+        TypeofPipe,
     ],
     providers: [
         DecimalPipe,
         FormatSecondsToDurationPipe,
         UnitvaluePipe,
-        TypeofPipe
-    ]
+        TypeofPipe,
+    ],
 })
 export class PipeModule { }

--- a/ui/src/app/shared/pipe/sign/sign.pipe.ts
+++ b/ui/src/app/shared/pipe/sign/sign.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-    name: 'sign'
+    name: 'sign',
 })
 export class SignPipe implements PipeTransform {
     transform(value, args: string[]): any {

--- a/ui/src/app/shared/pipe/typeof/typeof.pipe.ts
+++ b/ui/src/app/shared/pipe/typeof/typeof.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: 'typeof'
+  name: 'typeof',
 })
 export class TypeofPipe implements PipeTransform {
 

--- a/ui/src/app/shared/pipe/unitvalue/unitvalue.pipe.ts
+++ b/ui/src/app/shared/pipe/unitvalue/unitvalue.pipe.ts
@@ -4,7 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { Language } from '../../type/language';
 
 @Pipe({
-    name: 'unitvalue'
+    name: 'unitvalue',
 })
 export class UnitvaluePipe implements PipeTransform {
 

--- a/ui/src/app/shared/pipe/version/version.pipe.ts
+++ b/ui/src/app/shared/pipe/version/version.pipe.ts
@@ -3,7 +3,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { Role } from '../../type/role';
 
 @Pipe({
-    name: 'version'
+    name: 'version',
 })
 export class VersionPipe implements PipeTransform {
 

--- a/ui/src/app/shared/service/defaulttypes.ts
+++ b/ui/src/app/shared/service/defaulttypes.ts
@@ -148,7 +148,7 @@ export module DefaultTypes {
 
     constructor(
       public from: Date = new Date(),
-      public to: Date = new Date()
+      public to: Date = new Date(),
     ) { }
 
     public getText(translate: TranslateService): string {
@@ -164,7 +164,7 @@ export module DefaultTypes {
         } else {
           // Selected one single day
           return HistoryPeriod.getTranslatedDayString(translate, this.from) + ", " + translate.instant('Edge.History.selectedDay', {
-            value: format(this.from, translate.instant('General.dateFormat'))
+            value: format(this.from, translate.instant('General.dateFormat')),
           });
         }
 
@@ -180,7 +180,7 @@ export module DefaultTypes {
         return translate.instant(
           'General.periodFromTo', {
           value1: format(this.from, translate.instant('General.dateFormatShort')),
-          value2: format(this.to, translate.instant('General.dateFormat'))
+          value2: format(this.to, translate.instant('General.dateFormat')),
         });
       }
     }

--- a/ui/src/app/shared/service/globalRouteChangeHandler.ts
+++ b/ui/src/app/shared/service/globalRouteChangeHandler.ts
@@ -6,14 +6,14 @@ import { filter, map } from 'rxjs/operators';
 import { Service } from "./service";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class GlobalRouteChangeHandler {
 
   constructor(
     public service: Service,
     private router: Router,
-    private translate: TranslateService
+    private translate: TranslateService,
   ) {
 
     this.router.events.pipe(
@@ -28,7 +28,7 @@ export class GlobalRouteChangeHandler {
         }
 
         return data;
-      })
+      }),
     ).subscribe(e => {
 
       if (e.navbarTitle != null && e.navbarTitleToBeTranslated != null) {

--- a/ui/src/app/shared/service/myerrorhandler.ts
+++ b/ui/src/app/shared/service/myerrorhandler.ts
@@ -5,7 +5,7 @@ import { Logger } from "./logger";
 @Injectable()
 export class MyErrorHandler implements ErrorHandler {
     constructor(
-        private injector: Injector
+        private injector: Injector,
     ) { }
 
     handleError(error: any) {
@@ -14,11 +14,11 @@ export class MyErrorHandler implements ErrorHandler {
         if (error.message) {
             let json = {
                 error: {
-                    message: error.message
+                    message: error.message,
                 },
                 metadata: {
-                    browser: navigator.userAgent
-                }
+                    browser: navigator.userAgent,
+                },
             };
 
             logger.error(JSON.stringify(json));

--- a/ui/src/app/shared/service/pagination.ts
+++ b/ui/src/app/shared/service/pagination.ts
@@ -11,7 +11,7 @@ export class Pagination {
 
   constructor(
     public service: Service,
-    private router: Router
+    private router: Router,
   ) { }
 
   getAndSubscribeEdge(edge: Edge): Promise<void> {
@@ -22,7 +22,7 @@ export class Pagination {
         this.service.websocket.sendRequest(new SubscribeEdgesRequest({ edges: [edge.id] }));
       }).then(() => {
         this.edge.subscribeChannels(this.service.websocket, '', [
-          new ChannelAddress('_sum', 'State')
+          new ChannelAddress('_sum', 'State'),
         ]);
       })
         .finally(resolve)

--- a/ui/src/app/shared/service/service.ts
+++ b/ui/src/app/shared/service/service.ts
@@ -74,7 +74,7 @@ export class Service extends AbstractService {
     private router: Router,
     private spinner: NgxSpinnerService,
     private toaster: ToastController,
-    public translate: TranslateService
+    public translate: TranslateService,
   ) {
     super();
     // add language
@@ -138,7 +138,7 @@ export class Service extends AbstractService {
         } else {
           // Translate from key
           this.translate.get(currentPageTitle.languageKey, currentPageTitle.interpolateParams).pipe(
-            take(1)
+            take(1),
           ).subscribe(title => this.currentPageTitle = title);
         }
       }
@@ -155,7 +155,7 @@ export class Service extends AbstractService {
     return new Promise<Edge>((resolve) => {
       this.currentEdge.pipe(
         filter(edge => edge != null),
-        first()
+        first(),
       ).toPromise().then(resolve);
       if (this.currentEdge.value) {
         resolve(this.currentEdge.value);
@@ -168,7 +168,7 @@ export class Service extends AbstractService {
       this.getCurrentEdge().then(edge => {
         edge.getConfig(this.websocket).pipe(
           filter(config => config != null && config.isValid()),
-          first()
+          first(),
         ).toPromise()
           .then(config => resolve(config))
           .catch(reason => reject(reason));
@@ -199,7 +199,7 @@ export class Service extends AbstractService {
       promise.reject = reject;
     });
     this.queryEnergyQueue.push(
-      { fromDate: fromDate, toDate: toDate, channels: channels, promises: [promise] }
+      { fromDate: fromDate, toDate: toDate, channels: channels, promises: [promise] },
     );
     // try to merge requests within 100 ms
     if (this.queryEnergyTimeout == null) {
@@ -291,7 +291,7 @@ export class Service extends AbstractService {
           page: page,
           ...(query && query != "" && { query: query }),
           ...(limit && { limit: limit }),
-          ...(searchParamsObj && { searchParams: searchParamsObj })
+          ...(searchParamsObj && { searchParams: searchParamsObj }),
         })).then((response) => {
 
           const result = (response as GetEdgesResponse).result;
@@ -309,7 +309,7 @@ export class Service extends AbstractService {
               edge.isOnline,
               edge.lastmessage,
               edge.sumState,
-              DateUtils.stringToDate(edge.firstSetupProtocol?.toString())
+              DateUtils.stringToDate(edge.firstSetupProtocol?.toString()),
             );
             value.edges[edge.id] = mappedEdge;
             mappedResult.push(mappedEdge);
@@ -369,7 +369,7 @@ export class Service extends AbstractService {
       fullScreen: false,
       bdColor: "rgba(0, 0, 0, 0.8)",
       size: "medium",
-      color: "#fff"
+      color: "#fff",
     });
   }
 
@@ -379,7 +379,7 @@ export class Service extends AbstractService {
       fullScreen: false,
       bdColor: "rgba(0, 0, 0, 0)",
       size: "medium",
-      color: "var(--ion-color-primary)"
+      color: "var(--ion-color-primary)",
     });
   }
 
@@ -392,7 +392,7 @@ export class Service extends AbstractService {
       message: message,
       color: level,
       duration: 2000,
-      cssClass: 'container'
+      cssClass: 'container',
     });
     toast.present();
   }

--- a/ui/src/app/shared/service/utils.ts
+++ b/ui/src/app/shared/service/utils.ts
@@ -446,7 +446,7 @@ export class Utils {
       view[i] = binary.charCodeAt(i);
     }
     const data: Blob = new Blob([view], {
-      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8'
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8',
     });
 
     saveAs(data, filename + '.xlsx');
@@ -496,7 +496,7 @@ export class Utils {
       } else {
         return /* min 0 */ Math.max(0,
         /* max 100 */ Math.min(100,
-          /* calculate autarchy */(1 - buyFromGrid / consumptionActivePower) * 100
+          /* calculate autarchy */(1 - buyFromGrid / consumptionActivePower) * 100,
         ));
       }
 
@@ -585,7 +585,7 @@ export namespace HistoryUtils {
     return [{
       label: translate.instant("Edge.History.noData"),
       data: [],
-      hidden: false
+      hidden: false,
     }];
   }
 

--- a/ui/src/app/shared/service/websocket.ts
+++ b/ui/src/app/shared/service/websocket.ts
@@ -44,7 +44,7 @@ export class Websocket implements WebsocketInterface {
     private translate: TranslateService,
     private cookieService: CookieService,
     private router: Router,
-    private pagination: Pagination
+    private pagination: Pagination,
   ) {
     service.websocket = this;
 
@@ -90,7 +90,7 @@ export class Websocket implements WebsocketInterface {
             this.status = 'waiting for credentials';
             this.router.navigate(['/login']);
           }
-        }
+        },
       },
       closeObserver: {
         next: (value) => {
@@ -100,8 +100,8 @@ export class Websocket implements WebsocketInterface {
           }
           // trying to connect
           this.status = 'connecting';
-        }
-      }
+        },
+      },
     });
 
     this.socket.pipe(
@@ -109,7 +109,7 @@ export class Websocket implements WebsocketInterface {
       retryWhen((errors) => {
         console.warn(errors);
         return errors.pipe(delay(1000));
-      })
+      }),
 
     ).subscribe(originalMessage => {
       // Receive message from server
@@ -172,7 +172,7 @@ export class Websocket implements WebsocketInterface {
         // Metadata
         this.service.metadata.next({
           user: authenticateResponse.user,
-          edges: {}
+          edges: {},
         });
 
         // Resubscribe Channels

--- a/ui/src/app/shared/service/wsdata.ts
+++ b/ui/src/app/shared/service/wsdata.ts
@@ -83,7 +83,7 @@ export class WsData {
         // TODO use OpenemsError code
         promise.reject(
           new JsonrpcResponseError(response.id, {
-            code: 0, message: "Response is neither JsonrpcResponseSuccess nor JsonrpcResponseError: " + response, data: {}
+            code: 0, message: "Response is neither JsonrpcResponseSuccess nor JsonrpcResponseError: " + response, data: {},
           }));
       }
     } else {

--- a/ui/src/app/shared/shared.module.ts
+++ b/ui/src/app/shared/shared.module.ts
@@ -63,7 +63,7 @@ export function SubnetmaskValidatorMessage(err, field: FormlyFieldConfig) {
     FormsModule,
     IonicModule,
     NgxSpinnerModule.forRoot({
-      type: 'ball-clip-rotate-multiple'
+      type: 'ball-clip-rotate-multiple',
     }),
     ReactiveFormsModule,
     RouterModule,
@@ -77,24 +77,24 @@ export function SubnetmaskValidatorMessage(err, field: FormlyFieldConfig) {
         { name: 'formly-wrapper-default-of-cases', component: FormlyWrapperDefaultValueWithCasesComponent },
         { name: 'panel', component: PanelWrapperComponent },
         { name: 'formly-field-modal', component: FormlyFieldModalComponent },
-        { name: 'formly-field-checkbox-with-image', component: FormlyFieldCheckboxWithImageComponent }
+        { name: 'formly-field-checkbox-with-image', component: FormlyFieldCheckboxWithImageComponent },
       ],
       types: [
         { name: 'input', component: InputTypeComponent },
-        { name: 'repeat', component: RepeatTypeComponent }
+        { name: 'repeat', component: RepeatTypeComponent },
       ],
       validators: [
         { name: 'ip', validation: IpValidator },
-        { name: 'subnetmask', validation: SubnetmaskValidator }
+        { name: 'subnetmask', validation: SubnetmaskValidator },
       ],
       validationMessages: [
         { name: 'ip', message: IpValidatorMessage },
-        { name: 'subnetmask', message: SubnetmaskValidatorMessage }
-      ]
+        { name: 'subnetmask', message: SubnetmaskValidatorMessage },
+      ],
     }),
     PipeModule,
     Generic_ComponentsModule,
-    TranslateModule
+    TranslateModule,
   ],
   declarations: [
     // components
@@ -115,7 +115,7 @@ export function SubnetmaskValidatorMessage(err, field: FormlyFieldConfig) {
     FormlyFieldModalComponent,
     PanelWrapperComponent,
     FormlyFieldWithLoadingAnimationComponent,
-    FormlyFieldCheckboxWithImageComponent
+    FormlyFieldCheckboxWithImageComponent,
   ],
   exports: [
     // modules
@@ -139,15 +139,15 @@ export function SubnetmaskValidatorMessage(err, field: FormlyFieldConfig) {
     HeaderComponent,
     HistoryDataErrorComponent,
     PercentageBarComponent,
-    FormlyFieldWithLoadingAnimationComponent
+    FormlyFieldWithLoadingAnimationComponent,
   ],
   providers: [
     appRoutingProviders,
     Service,
     Utils,
     Websocket,
-    Logger
-  ]
+    Logger,
+  ],
 })
 
 export class SharedModule {

--- a/ui/src/app/shared/shared.ts
+++ b/ui/src/app/shared/shared.ts
@@ -22,7 +22,7 @@ addIcons({
   'oe-grid-storage': 'assets/img/icon/gridStorage.svg',
   'oe-offgrid': 'assets/img/icon/offgrid.svg',
   'oe-production': 'assets/img/icon/production.svg',
-  'oe-storage': 'assets/img/icon/storage.svg'
+  'oe-storage': 'assets/img/icon/storage.svg',
 });
 
 export class UserPermission {

--- a/ui/src/app/shared/status/single/status.component.spec.ts
+++ b/ui/src/app/shared/status/single/status.component.spec.ts
@@ -14,8 +14,8 @@ describe('StatusComponent', () => {
             category: "ENUM",
             type: "BOOLEAN",
             unit: "W",
-            level: "OK"
-        }
+            level: "OK",
+        },
     });
     let statusComponent: StatusSingleComponent;
     // initialize variables only in beforeEach, beforeAll
@@ -26,8 +26,8 @@ describe('StatusComponent', () => {
                 StatusSingleComponent,
                 { provide: ModalController, useClass: DummyModalController },
                 { provide: Service, useClass: DummyService },
-                { provide: Websocket, useClass: DummyWebsocket }
-            ]
+                { provide: Websocket, useClass: DummyWebsocket },
+            ],
         });
         statusComponent = TestBed.inject(StatusSingleComponent);
     }));

--- a/ui/src/app/shared/status/single/status.component.ts
+++ b/ui/src/app/shared/status/single/status.component.ts
@@ -7,7 +7,7 @@ import { CategorizedComponents, EdgeConfig } from '../../edge/edgeconfig';
 
 @Component({
     selector: StatusSingleComponent.SELECTOR,
-    templateUrl: './status.component.html'
+    templateUrl: './status.component.html',
 })
 export class StatusSingleComponent implements OnInit, OnDestroy {
 
@@ -24,7 +24,7 @@ export class StatusSingleComponent implements OnInit, OnDestroy {
     constructor(
         public modalCtrl: ModalController,
         public service: Service,
-        private websocket: Websocket
+        private websocket: Websocket,
     ) { }
 
     ngOnInit() {
@@ -37,7 +37,7 @@ export class StatusSingleComponent implements OnInit, OnDestroy {
                     // sets all arrow buttons to standard position (folded)
                     component['showProperties'] = false;
                     this.subscribedInfoChannels.push(
-                        new ChannelAddress(component.id, 'State')
+                        new ChannelAddress(component.id, 'State'),
                     );
                 });
             });

--- a/ui/src/app/shared/test/utils.spec.ts
+++ b/ui/src/app/shared/test/utils.spec.ts
@@ -14,18 +14,18 @@ export type TestContext = { translate: TranslateService, service: Service };
 export function sharedSetup(): TestContext {
     TestBed.configureTestingModule({
         imports: [
-            TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: MyTranslateLoader }, defaultLanguage: Language.DEFAULT.key })
+            TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: MyTranslateLoader }, defaultLanguage: Language.DEFAULT.key }),
         ],
         providers: [
             TranslateService,
             { provide: FORMLY_CONFIG, multi: true, useFactory: registerTranslateExtension, deps: [TranslateService] },
-            Service
-        ]
+            Service,
+        ],
     }).compileComponents();
     registerLocaleData(localeDe, 'de', localeDeExtra);
     return {
         translate: TestBed.inject(TranslateService),
-        service: TestBed.inject(Service)
+        service: TestBed.inject(Service),
     };
 };
 

--- a/ui/src/app/shared/translate.extension.ts
+++ b/ui/src/app/shared/translate.extension.ts
@@ -12,7 +12,7 @@ export class TranslateExtension implements FormlyExtension {
         props._translated = true;
         field.expressions = {
             ...(field.expressions || {}),
-            'props.label': this.translate.stream(props.label)
+            'props.label': this.translate.stream(props.label),
         };
     }
 }
@@ -23,9 +23,9 @@ export function registerTranslateExtension(translate: TranslateService) {
         extensions: [
             {
                 name: 'translate',
-                extension: new TranslateExtension(translate)
-            }
-        ]
+                extension: new TranslateExtension(translate),
+            },
+        ],
     };
 }
 

--- a/ui/src/app/shared/type/channeladdress.ts
+++ b/ui/src/app/shared/type/channeladdress.ts
@@ -12,7 +12,7 @@ export class ChannelAddress {
 
     constructor(
         public readonly componentId: string,
-        public readonly channelId: string
+        public readonly channelId: string,
     ) { }
 
     public toString() {

--- a/ui/src/app/shared/type/country.ts
+++ b/ui/src/app/shared/type/country.ts
@@ -16,6 +16,6 @@ export const COUNTRY_OPTIONS = (translate: TranslateService) => {
         { value: Country.SWITZERLAND, label: translate.instant('General.Country.switzerland') },
         { value: Country.SWEDEN, label: translate.instant('General.Country.sweden') },
         { value: Country.NETHERLANDS, label: translate.instant('General.Country.netherlands') },
-        { value: Country.CZECH_REPUBLIK, label: translate.instant('General.Country.czech') }
+        { value: Country.CZECH_REPUBLIK, label: translate.instant('General.Country.czech') },
     ];
 };

--- a/ui/src/app/shared/type/language.ts
+++ b/ui/src/app/shared/type/language.ts
@@ -74,7 +74,7 @@ export class Language {
         public readonly key: string,
         public readonly i18nLocaleKey: string,
         public readonly json: any,
-        public readonly locale: any
+        public readonly locale: any,
     ) {
     }
 }

--- a/ui/src/app/shared/type/widget.ts
+++ b/ui/src/app/shared/type/widget.ts
@@ -134,7 +134,7 @@ export class Widgets {
         /**
          * List of Widget-Classes.
          */
-        public readonly classes: String[]
+        public readonly classes: String[],
     ) {
         // fill names
         for (let widget of list) {

--- a/ui/src/app/shared/utils/dateutils/dateutils.spec.ts
+++ b/ui/src/app/shared/utils/dateutils/dateutils.spec.ts
@@ -4,7 +4,7 @@ describe('DateUtils', () => {
 
   const dates: Date[] = [
     new Date(Date.parse("2023-01-01")),
-    new Date(Date.parse("2023-01-02"))
+    new Date(Date.parse("2023-01-02")),
   ];
 
   it('#minDate - smallest date', () => {

--- a/ui/src/app/shared/utils/dateutils/dateutils.ts
+++ b/ui/src/app/shared/utils/dateutils/dateutils.ts
@@ -14,7 +14,7 @@ export namespace DateUtils {
     }
 
     return new Date(
-      Math.max(...dates.filter(date => !!date).map(Number))
+      Math.max(...dates.filter(date => !!date).map(Number)),
     );
   }
 
@@ -31,7 +31,7 @@ export namespace DateUtils {
     }
 
     return new Date(
-      Math.min(...dates.filter(date => !!date).map(Number))
+      Math.min(...dates.filter(date => !!date).map(Number)),
     );
   }
 

--- a/ui/src/app/user/user.component.ts
+++ b/ui/src/app/user/user.component.ts
@@ -24,7 +24,7 @@ type UserInformation = {
   country: string
 }
 @Component({
-  templateUrl: './user.component.html'
+  templateUrl: './user.component.html',
 })
 export class UserComponent implements OnInit {
 
@@ -41,7 +41,7 @@ export class UserComponent implements OnInit {
     public translate: TranslateService,
     public service: Service,
     private route: ActivatedRoute,
-    private websocket: Websocket
+    private websocket: Websocket,
   ) { }
 
   ngOnInit() {
@@ -51,7 +51,7 @@ export class UserComponent implements OnInit {
     this.getUserInformation().then((userInformation) => {
       this.form = {
         formGroup: new FormGroup({}),
-        model: userInformation
+        model: userInformation,
       };
       this.showInformation = true;
     });
@@ -68,9 +68,9 @@ export class UserComponent implements OnInit {
           street: this.form.model.street,
           zip: this.form.model.zip,
           city: this.form.model.city,
-          country: this.form.model.country
-        }
-      }
+          country: this.form.model.country,
+        },
+      },
     };
     this.service.websocket.sendRequest(new SetUserInformationRequest(user)).then(() => {
       this.service.toast(this.translate.instant('General.changeAccepted'), 'success');
@@ -86,7 +86,7 @@ export class UserComponent implements OnInit {
       this.getUserInformation().then((userInformation) => {
         this.form = {
           formGroup: new FormGroup({}),
-          model: userInformation
+          model: userInformation,
         };
       });
     }
@@ -108,40 +108,40 @@ export class UserComponent implements OnInit {
     type: "input",
     templateOptions: {
       label: this.translate.instant("Register.Form.firstname"),
-      disabled: true
-    }
+      disabled: true,
+    },
   },
   {
     key: "lastname",
     type: "input",
     templateOptions: {
       label: this.translate.instant("Register.Form.lastname"),
-      disabled: true
-    }
+      disabled: true,
+    },
   },
   {
     key: "street",
     type: "input",
     templateOptions: {
       label: this.translate.instant("Register.Form.street"),
-      disabled: true
-    }
+      disabled: true,
+    },
   },
   {
     key: "zip",
     type: "input",
     templateOptions: {
       label: this.translate.instant("Register.Form.zip"),
-      disabled: true
-    }
+      disabled: true,
+    },
   },
   {
     key: "city",
     type: "input",
     templateOptions: {
       label: this.translate.instant("Register.Form.city"),
-      disabled: true
-    }
+      disabled: true,
+    },
   },
   {
     key: "country",
@@ -149,27 +149,27 @@ export class UserComponent implements OnInit {
     templateOptions: {
       label: this.translate.instant("Register.Form.country"),
       options: COUNTRY_OPTIONS(this.translate),
-      disabled: true
-    }
+      disabled: true,
+    },
   },
   {
     key: "email",
     type: "input",
     templateOptions: {
       label: this.translate.instant("Register.Form.email"),
-      disabled: true
+      disabled: true,
     },
     validators: {
-      validation: [Validators.email]
-    }
+      validation: [Validators.email],
+    },
   },
   {
     key: "phone",
     type: "input",
     templateOptions: {
       label: this.translate.instant("Register.Form.phone"),
-      disabled: true
-    }
+      disabled: true,
+    },
   }];
 
   public getUserInformation(): Promise<UserInformation> {
@@ -188,7 +188,7 @@ export class UserComponent implements OnInit {
               street: user.address.street,
               zip: user.address.zip,
               city: user.address.city,
-              country: user.address.country
+              country: user.address.country,
             });
           }).catch(() => {
             resolve({
@@ -199,7 +199,7 @@ export class UserComponent implements OnInit {
               street: "",
               zip: "",
               city: "",
-              country: ""
+              country: "",
             });
           });
           clearInterval(interval);

--- a/ui/src/app/user/user.module.ts
+++ b/ui/src/app/user/user.module.ts
@@ -4,10 +4,10 @@ import { UserComponent } from './user.component';
 
 @NgModule({
   imports: [
-    SharedModule
+    SharedModule,
   ],
   declarations: [
-    UserComponent
-  ]
+    UserComponent,
+  ],
 })
 export class UserModule { }

--- a/ui/src/test.ts
+++ b/ui/src/test.ts
@@ -11,11 +11,11 @@ import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
+  platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );

--- a/ui/src/themes/openems/environments/backend-dev.ts
+++ b/ui/src/themes/openems/environments/backend-dev.ts
@@ -8,6 +8,6 @@ export const environment: Environment = {
         url: "ws://" + location.hostname + ":8082",
 
         production: false,
-        debugMode: true
-    }
+        debugMode: true,
+    },
 };

--- a/ui/src/themes/openems/environments/backend-prod.ts
+++ b/ui/src/themes/openems/environments/backend-prod.ts
@@ -8,6 +8,6 @@ export const environment: Environment = {
         url: "ws://" + location.hostname + ":8082",
 
         production: true,
-        debugMode: false
-    }
+        debugMode: false,
+    },
 };

--- a/ui/src/themes/openems/environments/edge-dev.ts
+++ b/ui/src/themes/openems/environments/edge-dev.ts
@@ -8,6 +8,6 @@ export const environment: Environment = {
         url: "ws://" + location.hostname + ":8085",
 
         production: false,
-        debugMode: true
-    }
+        debugMode: true,
+    },
 };

--- a/ui/src/themes/openems/environments/edge-prod.ts
+++ b/ui/src/themes/openems/environments/edge-prod.ts
@@ -8,6 +8,6 @@ export const environment: Environment = {
         url: "ws://" + location.hostname + ":8075",
 
         production: true,
-        debugMode: false
-    }
+        debugMode: false,
+    },
 };

--- a/ui/src/themes/openems/environments/gitpod.ts
+++ b/ui/src/themes/openems/environments/gitpod.ts
@@ -9,6 +9,6 @@ export const environment: Environment = {
         url: "wss://8082-" + location.hostname.substring(location.hostname.indexOf("-") + 1),
 
         production: false,
-        debugMode: true
-    }
+        debugMode: true,
+    },
 };

--- a/ui/src/themes/openems/environments/theme.ts
+++ b/ui/src/themes/openems/environments/theme.ts
@@ -30,7 +30,7 @@ export const theme = {
 
         SETTINGS_ALERTING: null,
         SETTINGS_NETWORK_CONFIGURATION: null,
-        EVCS_CLUSTER: "io.openems.edge.evcs.cluster/readme.adoc"
+        EVCS_CLUSTER: "io.openems.edge.evcs.cluster/readme.adoc",
     },
-    PRODUCT_TYPES: () => null
+    PRODUCT_TYPES: () => null,
 };


### PR DESCRIPTION
eslint src/ --fix

1. Typically, using trailing comma minimize diff and easy to review, merging.
2. on the other hand, snipping trailing comma has compatibility old javascript implementation.

in this project, /ui codes are using typescript so its not need to care about 2.
so I changed tailing comma style.