### PR TITLE
Allow unauthenticated access to /live on Backend2Backend REST API

### DIFF
--- a/cnf/pom.xml
+++ b/cnf/pom.xml
@@ -414,5 +414,17 @@
 			<artifactId>rrd4j</artifactId>
 			<version>3.9</version>
 		</dependency>
+		<dependency>
+			<!-- Testing e.g. b2brest.RestHandlerTest-->
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.24.2</version>
+		</dependency>
+		<dependency>
+			<!-- Testing e.g. b2brest.RestHandlerTest-->
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.7.0</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/io.openems.backend.b2brest/bnd.bnd
+++ b/io.openems.backend.b2brest/bnd.bnd
@@ -12,4 +12,9 @@ Bundle-Version: 1.0.0.${tstamp}
 	org.apache.felix.http.servlet-api,\
 
 -testpath: \
-	${testpath}
+	${testpath}, \
+	assertj-core;version=3.24.2, \
+    org.mockito.mockito-core;version=5.7.0, \
+    net.bytebuddy.byte-buddy;version=1.12.21, \
+    net.bytebuddy.byte-buddy-agent;version=1.10.15, \
+    org.objenesis;version=3.1.0, \

--- a/io.openems.backend.b2brest/test/io/openems/backend/b2brest/RestHandlerTest.java
+++ b/io.openems.backend.b2brest/test/io/openems/backend/b2brest/RestHandlerTest.java
@@ -1,0 +1,121 @@
+package io.openems.backend.b2brest;
+
+import io.openems.backend.common.metadata.User;
+import io.openems.common.exceptions.OpenemsError;
+import io.openems.common.exceptions.OpenemsException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.Request;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(Enclosed.class)
+public class RestHandlerTest {
+
+  public static class HandleTests {
+
+    private Backend2BackendRest mockedB2bRest;
+    private Request mockedBaseRequest;
+    private HttpServletRequest mockedHttpServletRequest;
+    private HttpServletResponse mockedHttpServletResponse;
+
+    private User mockedUser;
+
+    @Before
+    public void setUp() {
+      this.mockedB2bRest = mock(Backend2BackendRest.class);
+      this.mockedBaseRequest = mock(Request.class);
+      this.mockedHttpServletRequest = mock(HttpServletRequest.class);
+      this.mockedHttpServletResponse = mock(HttpServletResponse.class);
+      this.mockedUser = mock(User.class);
+    }
+
+    @Test
+    public void shouldThrowOnEmptyEndpointPath() {
+      var sut = new RestHandler(this.mockedB2bRest);
+
+      assertThatExceptionOfType(IOException.class).isThrownBy(
+          () -> sut.handle("", this.mockedBaseRequest, this.mockedHttpServletRequest, this.mockedHttpServletResponse)
+      );
+    }
+
+    @Test
+    public void shouldThrowOnRootEndpoint() throws OpenemsError.OpenemsNamedException {
+      var sut = spy(new RestHandler(this.mockedB2bRest));
+      doReturn(this.mockedUser).when(sut).authenticate(any());
+
+      assertThatExceptionOfType(IOException.class).isThrownBy(
+          () -> sut.handle("/", this.mockedBaseRequest, this.mockedHttpServletRequest, this.mockedHttpServletResponse)
+      );
+    }
+
+    @Test
+    public void shouldThrowOtherRootEndpoint() throws OpenemsError.OpenemsNamedException {
+      var sut = spy(new RestHandler(this.mockedB2bRest));
+      doReturn(this.mockedUser).when(sut).authenticate(any());
+
+      assertThatExceptionOfType(IOException.class).isThrownBy(
+          () -> sut.handle("?query=something", this.mockedBaseRequest, this.mockedHttpServletRequest, this.mockedHttpServletResponse)
+      );
+    }
+
+    @Test
+    public void shouldThrowOnUnknownEndpoint() throws OpenemsError.OpenemsNamedException {
+      var sut = spy(new RestHandler(this.mockedB2bRest));
+      doReturn(this.mockedUser).when(sut).authenticate(any());
+
+      assertThatExceptionOfType(IOException.class).isThrownBy(
+          () -> sut.handle("/rubbish", this.mockedBaseRequest, this.mockedHttpServletRequest, this.mockedHttpServletResponse)
+      );
+    }
+
+    @Test
+    public void shouldReturnOkOnUnauthenticatedLiveEndpoint() throws IOException, OpenemsException {
+      var sut = spy(new RestHandler(this.mockedB2bRest));
+      doNothing().when(sut).sendOkResponse(any(), any(), any());
+
+      sut.handle("/live", this.mockedBaseRequest, this.mockedHttpServletRequest, this.mockedHttpServletResponse);
+
+      verify(sut).sendOkResponse(any(), any(), any());
+    }
+
+    @Test
+    public void shouldThrowOnUnauthenticatedJsonRpcRequest() throws OpenemsError.OpenemsNamedException {
+      var sut = spy(new RestHandler(this.mockedB2bRest));
+      var mockedUser = mock(User.class);
+      doThrow(OpenemsError.COMMON_AUTHENTICATION_FAILED.exception()).when(sut).authenticate(this.mockedHttpServletRequest);
+
+      assertThatExceptionOfType(IOException.class).isThrownBy(
+          () -> sut.handle("/jsonrpc", this.mockedBaseRequest, this.mockedHttpServletRequest, this.mockedHttpServletResponse)
+      );
+
+      verify(sut, times(0)).handleJsonRpc(mockedUser, this.mockedBaseRequest, this.mockedHttpServletRequest, this.mockedHttpServletResponse);
+    }
+
+    @Test
+    public void shouldHandleAuthenticatedJsonRpc() throws IOException, OpenemsError.OpenemsNamedException {
+      var sut = spy(new RestHandler(this.mockedB2bRest));
+      var mockedUser = mock(User.class);
+      doReturn(mockedUser).when(sut).authenticate(any());
+      doNothing().when(sut).handleJsonRpc(mockedUser, this.mockedBaseRequest, this.mockedHttpServletRequest, this.mockedHttpServletResponse);
+
+      sut.handle("/jsonrpc", this.mockedBaseRequest, this.mockedHttpServletRequest, this.mockedHttpServletResponse);
+
+      verify(sut).handleJsonRpc(mockedUser, this.mockedBaseRequest, this.mockedHttpServletRequest, this.mockedHttpServletResponse);
+    }
+  }
+}


### PR DESCRIPTION
**Motivation**
When running the OpenEMS backend in (docker) containers and/or connect them via (cloud) load balancers, it is handy to have an easy to call liveness probe which does not need any authentication.

_Side note_: As the `Backend2BackendRest` service is also reliant on an up-and-running `Metadata`service, I guess this check could even serve as a readiness probe, even though the `Metadata` isn't used actually. 