### PR TITLE
UI: Methods in shared/EdgeConfig.ts returning EdgeConfig.Component[]  -> sort via component alias

### DIFF
--- a/ui/src/app/shared/edge/edgeconfig.ts
+++ b/ui/src/app/shared/edge/edgeconfig.ts
@@ -180,7 +180,7 @@ export class EdgeConfig {
         for (let componentId of componentIds) {
             result.push(this.components[componentId]);
         }
-        return result;
+        return result.sort((c1, c2) => c1.alias.localeCompare(c2.alias));
     }
 
     /**
@@ -230,7 +230,7 @@ export class EdgeConfig {
                 result.push(...this.getComponentsImplementingNature("io.openems.edge.meter.api.SymmetricMeter"));
         }
 
-        return result;
+        return result.sort((c1, c2) => c1.alias.localeCompare(c2.alias));
     }
 
     /**


### PR DESCRIPTION
## Description

src/app/shared/edge/edgeconfig.ts -> methods returning an EdgeConfig.Component[] sort their content via component.alias.

## Methods 

- getComponentsByFactory
- getComponentsImplementingNature

## Reason

This is mainly a beautification within the Flat/Modal Widgets of Live and History.

We got feedback of users, and they find it more visually appealing, when the widget contents are sorted by their "name" (alias)
This simple sorting would solve this request.

This may be in your interest too.

Co-authored-by: Ulrich Laupp <38915524+laupp@users.noreply.github.com>