### PR TITLE
fix: reproduce single_document.adoc from nav.adoc and sed script

### DIFF
--- a/doc/tools/create_single_page_html.sh
+++ b/doc/tools/create_single_page_html.sh
@@ -7,4 +7,26 @@ cd ${DIR}/../modules/ROOT/pages
 
 echo "Creating ${DIR}/../modules/ROOT/pages/single_document.html"
 
-asciidoctor -b html5 -o single_document.html single_document.adoc
+SED_ARG="s/xref:/include::/"
+for NUM in $(seq 1 1 5); do
+  SED_ARG="${SED_ARG} -e s/^*\{$NUM\}.\(inc.*\)\[.*\]$/\1[leveloffset=+$NUM]/"
+done
+
+cat << SEC | asciidoctor -b html5 -o single_document.html - 
+= OpenEMS - Open Energy Management System
+ifndef::toc[]
+(c) 2023 OpenEMS Association e.V.
+:doctype: book
+:sectnums:
+:sectnumlevels: 4
+:toc:
+:toclevels: 2
+:toc-title: Inhalt
+:experimental:
+:keywords: AsciiDoc
+:source-highlighter: highlight.js
+:icons: font
+endif::toc[]
+
+$(cat ../nav.adoc | sed -e $(echo ${SED_ARG}) -e 's/^* \(.*\)$/== \1/g' | head -n-1)
+SEC

--- a/doc/tools/create_single_page_pdf.sh
+++ b/doc/tools/create_single_page_pdf.sh
@@ -10,4 +10,26 @@ cd ${DIR}/../modules/ROOT/${LANG}
 
 echo "Creating ${DIR}/../modules/ROOT/${LANG}/single_document.pdf"
 
-asciidoctor-pdf -o single_document.pdf single_document.adoc
+SED_ARG="s/xref:/include::/"
+for NUM in $(seq 1 1 5); do
+  SED_ARG="${SED_ARG} -e s/^*\{$NUM\}.\(inc.*\)\[.*\]$/\1[leveloffset=+$NUM]/"
+done
+
+cat << SEC | asciidoctor-pdf -o single_document.pdf -
+= OpenEMS - Open Energy Management System
+ifndef::toc[]
+(c) 2023 OpenEMS Association e.V.
+:doctype: book
+:sectnums:
+:sectnumlevels: 4
+:toc:
+:toclevels: 2
+:toc-title: Inhalt
+:experimental:
+:keywords: AsciiDoc
+:source-highlighter: highlight.js
+:icons: font
+endif::toc[]
+
+$(cat ../nav.adoc | sed -e $(echo ${SED_ARG}) -e 's/^* \(.*\)$/== \1/g' | head -n-1)
+SEC


### PR DESCRIPTION
This PR changes reparing single document generating shell script and supporting nav.adoc-based single document generation without management single_document.adoc

background:

Occording history of git-log, there was single_document.adoc to generate single page document output, but currently is not. so create_single_page_{pdf, html}.sh fails.

// I and ikegam guessed the reason is avoiding duplication of managing nav.adoc and single_document doc. because almost user mainly use multiple page document(based-on nav.adoc) on webui.

idea:

Therefore We forcus to difference nav.adoc and single_document.adoc and plant to re-use nav.adoc as single_documet.adoc by using sed because there are only little difference.

This commit is maded by multiple contributors