### PR TITLE
fix: specify eslint as vscode workspace default formatter

### DIFF
--- a/ui/.vscode/extensions.json
+++ b/ui/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/ui/.vscode/settings.json
+++ b/ui/.vscode/settings.json
@@ -20,5 +20,7 @@
         "**/node_modules/**": true
     },
     "files.eol": "\n",
-    "files.insertFinalNewline": true
+    "files.insertFinalNewline": true,
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "eslint.format.enable": true
 }


### PR DESCRIPTION
close #2447 