### PR TITLE
Metadata Dummy: fix filter for product types

### DIFF
--- a/io.openems.backend.metadata.dummy/src/io/openems/backend/metadata/dummy/MetadataDummy.java
+++ b/io.openems.backend.metadata.dummy/src/io/openems/backend/metadata/dummy/MetadataDummy.java
@@ -307,7 +307,7 @@ public class MetadataDummy extends AbstractMetadata implements Metadata, EventHa
 			if (searchParams.searchIsOnline()) {
 				pagesStream = pagesStream.filter(edge -> edge.isOnline() == searchParams.isOnline());
 			}
-			if (searchParams.productTypes() != null) {
+			if (searchParams.productTypes() != null && !searchParams.productTypes().isEmpty()) {
 				pagesStream = pagesStream.filter(edge -> searchParams.productTypes().contains(edge.getProducttype()));
 			}
 			// TODO sum state filter


### PR DESCRIPTION
By default the filter is an empty list, which caused zero results. See Community posts:
- https://community.openems.io/t/openems-backend-not-showing-anything-in-ui/1979/4
- https://community.openems.io/t/getting-started-problem-when-adding-the-backend-metadata-related/2116/4