### PR TITLE
Add "Offline Icon" to Offline Page instead of showing nothing

### DIFF
--- a/ui/src/app/shared/header/header.component.html
+++ b/ui/src/app/shared/header/header.component.html
@@ -43,6 +43,7 @@
               *ngIf="currentPage === 'IndexLive' || currentPage === 'IndexHistory' || currentPage === 'EdgeSettings'"
               color="light" fill="solid" shape="round">
               <ng-container [ngSwitch]="sum.state">
+                <ion-icon *ngIf="!isOnline" color="danger" name="cloud-offline-outline"></ion-icon>
                 <ion-icon *ngSwitchCase="0" color="success" name="checkmark-circle-outline"></ion-icon>
                 <ion-icon *ngSwitchCase="1" color="success"
                   [name]="edge.roleIsAtLeast('admin') ? 'information-outline' : 'checkmark-circle-outline'"></ion-icon>
@@ -68,4 +69,4 @@
       </ion-buttons>
     </ion-toolbar>
   </ng-container>
-</ion-header>
+</ion-header>git commit -am

--- a/ui/src/app/shared/header/header.component.ts
+++ b/ui/src/app/shared/header/header.component.ts
@@ -22,6 +22,7 @@ export class HeaderComponent implements OnInit, OnDestroy, AfterViewChecked {
     public enableSideMenu: boolean;
     public currentPage: 'EdgeSettings' | 'Other' | 'IndexLive' | 'IndexHistory' = 'Other';
     public isSystemLogEnabled: boolean = false;
+    public isOnline: boolean = false;
     private ngUnsubscribe: Subject<void> = new Subject<void>();
 
     constructor(
@@ -44,6 +45,9 @@ export class HeaderComponent implements OnInit, OnDestroy, AfterViewChecked {
         ).subscribe(event => {
             window.scrollTo(0, 0);
             this.updateUrl((<NavigationEnd>event).urlAfterRedirects);
+        });
+        this.service.currentEdge.pipe(takeUntil(this.ngUnsubscribe)).subscribe(edge => {
+            this.isOnline = edge ? edge.isOnline : false;
         });
     }
 


### PR DESCRIPTION
This pull request introduces a small yet significant update to the user interface by adding an "Offline Icon" to the status page. Previously, when an Edge device was offline, the status page would not display any specific indicator, potentially causing confusion for users. With this update, an explicit "Offline Icon" is displayed whenever an Edge device is offline. This visual cue immediately informs users of the offline status, improving the overall user experience by making it clear when the device is not actively connected or operational.

Key Changes:

- A visually distinct "Offline Icon" is added to the status page.
- The icon appears only when an Edge device is detected as offline.
- This change enhances clarity and user understanding, particularly in scenarios where the device's connection status is not obvious.
- By implementing this feature, we aim to enhance user interface intuitiveness and ensure that users are well-informed about the device's connectivity status at a glance.