### PR TITLE
Handle en-US language for US browsers

### DIFF
--- a/ui/src/app/shared/type/language.ts
+++ b/ui/src/app/shared/type/language.ts
@@ -48,7 +48,9 @@ export class Language {
     public static getByBrowserLang(browserLang: string): Language | null {
         switch (browserLang) {
             case "de": return Language.DE;
-            case "en": return Language.EN;
+            case "en":
+            case "en-US":
+                return Language.EN;
             case "es": return Language.ES;
             case "nl": return Language.NL;
             case "cz": return Language.CZ;


### PR DESCRIPTION
US English browsers report language as `en-US`.  Because this wasn't handled in the switch statement, the application falls back to the default language.