### PR TITLE
BatteryInverterCluster - Adds support for clustering of DC-parallel battery inverters

### DIFF
--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -43,6 +43,7 @@
 	bnd.identity;id='io.openems.edge.battery.fenecon.commercial',\
 	bnd.identity;id='io.openems.edge.battery.fenecon.home',\
 	bnd.identity;id='io.openems.edge.battery.soltaro',\
+	bnd.identity;id='io.openems.edge.batteryinverter.cluster',\
 	bnd.identity;id='io.openems.edge.batteryinverter.kaco.blueplanetgridsave',\
 	bnd.identity;id='io.openems.edge.batteryinverter.refu88k',\
 	bnd.identity;id='io.openems.edge.batteryinverter.sinexcel',\
@@ -200,6 +201,7 @@
 	io.openems.edge.battery.fenecon.home;version=snapshot,\
 	io.openems.edge.battery.soltaro;version=snapshot,\
 	io.openems.edge.batteryinverter.api;version=snapshot,\
+	io.openems.edge.batteryinverter.cluster;version=snapshot,\
 	io.openems.edge.batteryinverter.kaco.blueplanetgridsave;version=snapshot,\
 	io.openems.edge.batteryinverter.refu88k;version=snapshot,\
 	io.openems.edge.batteryinverter.sinexcel;version=snapshot,\

--- a/io.openems.edge.batteryinverter.cluster/.classpath
+++ b/io.openems.edge.batteryinverter.cluster/.classpath
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="src" output="bin_test" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/io.openems.edge.batteryinverter.cluster/.gitignore
+++ b/io.openems.edge.batteryinverter.cluster/.gitignore
@@ -1,0 +1,2 @@
+/bin_test/
+/generated/

--- a/io.openems.edge.batteryinverter.cluster/.project
+++ b/io.openems.edge.batteryinverter.cluster/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openems.edge.batteryinverter.cluster</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/io.openems.edge.batteryinverter.cluster/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.batteryinverter.cluster/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+encoding//src/io/openems/edge/batteryinverter/cluster/BatteryInverterCluster.java=UTF-8
+encoding//src/io/openems/edge/batteryinverter/cluster/BatteryInverterClusterImpl.java=UTF-8
+encoding//src/io/openems/edge/batteryinverter/cluster/Config.java=UTF-8
+encoding//test/io/openems/edge/batteryinverter/cluster/BatteryInverterClusterTest.java=UTF-8
+encoding//test/io/openems/edge/batteryinverter/cluster/MyConfig.java=UTF-8
+encoding/<project>=UTF-8
+encoding/bnd.bnd=UTF-8
+encoding/readme.adoc=UTF-8

--- a/io.openems.edge.batteryinverter.cluster/bnd.bnd
+++ b/io.openems.edge.batteryinverter.cluster/bnd.bnd
@@ -1,0 +1,14 @@
+Bundle-Name: OpenEMS Edge io.openems.edge.batteryinverter.cluster
+Bundle-Vendor: RVR Energy Technology Ltd.
+Bundle-License: https://opensource.org/licenses/EPL-2.0
+Bundle-Version: 1.0.0.${tstamp}
+
+-buildpath: \
+	${buildpath},\
+	io.openems.common,\
+	io.openems.edge.common,\
+	io.openems.edge.batteryinverter.api,\
+	io.openems.edge.battery.api
+
+-testpath: \
+	${testpath}

--- a/io.openems.edge.batteryinverter.cluster/readme.adoc
+++ b/io.openems.edge.batteryinverter.cluster/readme.adoc
@@ -1,0 +1,3 @@
+= io.openems.edge.batteryinverter.cluster
+
+https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.batteryinverter.cluster[Source Code icon:github[]]

--- a/io.openems.edge.batteryinverter.cluster/src/io/openems/edge/batteryinverter/cluster/BatteryInverterCluster.java
+++ b/io.openems.edge.batteryinverter.cluster/src/io/openems/edge/batteryinverter/cluster/BatteryInverterCluster.java
@@ -1,0 +1,29 @@
+package io.openems.edge.batteryinverter.cluster;
+
+import org.osgi.service.event.EventHandler;
+
+import io.openems.edge.batteryinverter.api.ManagedSymmetricBatteryInverter;
+import io.openems.edge.batteryinverter.api.SymmetricBatteryInverter;
+import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.modbusslave.ModbusSlave;
+
+public interface BatteryInverterCluster extends SymmetricBatteryInverter, ManagedSymmetricBatteryInverter, 
+		OpenemsComponent, ModbusSlave { // TODO: BatteryInverterMeta
+
+	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+		;
+
+		private final Doc doc;
+
+		private ChannelId(Doc doc) {
+			this.doc = doc;
+		}
+
+		@Override
+		public Doc doc() {
+			return this.doc;
+		}
+	}
+
+}

--- a/io.openems.edge.batteryinverter.cluster/src/io/openems/edge/batteryinverter/cluster/BatteryInverterClusterImpl.java
+++ b/io.openems.edge.batteryinverter.cluster/src/io/openems/edge/batteryinverter/cluster/BatteryInverterClusterImpl.java
@@ -1,0 +1,254 @@
+papackage io.openems.edge.batteryinverter.cluster;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.event.propertytypes.EventTopics;
+import org.osgi.service.metatype.annotations.Designate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.openems.common.channel.AccessMode;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.edge.battery.api.Battery;
+import io.openems.edge.batteryinverter.api.ManagedSymmetricBatteryInverter;
+import io.openems.edge.batteryinverter.api.SymmetricBatteryInverter;
+import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.component.AbstractOpenemsComponent;
+import io.openems.edge.common.component.ComponentManager;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.event.EdgeEventConstants;
+import io.openems.edge.common.modbusslave.ModbusSlaveNatureTable;
+import io.openems.edge.common.modbusslave.ModbusSlaveTable;
+import io.openems.edge.common.startstop.StartStop;
+import io.openems.edge.common.startstop.StartStoppable;
+import io.openems.edge.common.type.TypeUtils;
+
+@Designate(ocd = Config.class, factory = true)
+@Component(//
+		name = "BatteryInverter.cluster", //
+		immediate = true, //
+		configurationPolicy = ConfigurationPolicy.REQUIRE //
+)
+@EventTopics({ //
+	EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE //
+})
+public class BatteryInverterClusterImpl extends AbstractOpenemsComponent implements BatteryInverterCluster, SymmetricBatteryInverter, ManagedSymmetricBatteryInverter, 
+											OpenemsComponent, StartStoppable, EventHandler {
+
+	private final Logger log = LoggerFactory.getLogger(BatteryInverterCluster.class);
+	private final AtomicReference<StartStop> startStopTarget = new AtomicReference<>(StartStop.UNDEFINED);
+	private final ChannelManager channelManager = new ChannelManager(this);
+	private final List<SymmetricBatteryInverter> inverters = new CopyOnWriteArrayList<>();
+
+	@Reference
+	private ConfigurationAdmin cm;
+
+	@Reference 
+	protected ComponentManager componentManager;
+
+	private Config config;
+
+
+	@Reference(//
+			policy = ReferencePolicy.DYNAMIC,//
+			policyOption = ReferencePolicyOption.GREEDY,//
+			cardinality = ReferenceCardinality.MULTIPLE, //
+			target = "(&(enabled=true)(!(service.factoryPid=BatteryInverter.Cluster)))")
+
+	protected synchronized void addBatteryInverter(SymmetricBatteryInverter inverter) {
+		this.inverters.add(inverter);
+		this.channelManager.deactivate();
+		this.channelManager.activate(this.inverters);
+	}
+
+	protected synchronized void removeBatteryInverter(SymmetricBatteryInverter inverter) {
+		this.inverters.remove(inverter);
+		this.channelManager.deactivate();
+		this.channelManager.activate(this.inverters);
+	}
+
+	public BatteryInverterClusterImpl() {
+		super(//
+				OpenemsComponent.ChannelId.values(), //
+				SymmetricBatteryInverter.ChannelId.values(), //
+				ManagedSymmetricBatteryInverter.ChannelId.values(), //
+				StartStoppable.ChannelId.values(), //
+				BatteryInverterCluster.ChannelId.values() //
+		);
+	}
+
+	@Activate
+	private void activate(ComponentContext context, Config config) throws OpenemsException {
+		this.config = config;
+		super.activate(context, config.id(), config.alias(), config.enabled());
+
+		// TODO: Update filter references for inverters
+		if (OpenemsComponent.updateReferenceFilter(this.cm, this.servicePid(), "BatteryInverter", config.batteryInverterIds())) {
+			return;
+		}
+
+		this.channelManager.activate(this.inverters);
+	}
+
+	@Override
+	@Deactivate
+	protected void deactivate() {
+		this.channelManager.deactivate();
+		super.deactivate();
+	}
+
+	@Override
+	public String debugLog() {
+		StringBuilder sb = new StringBuilder();
+
+		for (int i = 0; i < this.inverters.size(); i++) {
+			sb.append(inverters.get(i).debugLog());
+
+			if (i < inverters.size() - 1) {
+                sb.append("|");
+            }
+		}
+
+		return sb.toString();
+	}
+
+	@Override
+	public ModbusSlaveTable getModbusSlaveTable(AccessMode accessMode) {
+		return new ModbusSlaveTable(
+				OpenemsComponent.getModbusSlaveNatureTable(accessMode), //
+				SymmetricBatteryInverter.getModbusSlaveNatureTable(accessMode), //
+				ManagedSymmetricBatteryInverter.getModbusSlaveNatureTable(accessMode), //
+				ModbusSlaveNatureTable.of(BatteryInverterClusterImpl.class, accessMode, 300).build());
+	}
+
+	@Override
+	public void run(Battery battery, int setActivePower, int setReactivePower) throws OpenemsNamedException {
+		// Basic strategy is to divide the active and reactive power amongst the inverter in proportion to the maxApparentPower available for each one
+
+		// Filter and cast to make a list of inverters which are instances of ManagedSymmetricBatteryInverter and isManaged==true
+		List<ManagedSymmetricBatteryInverter> managedInverters = this.inverters.stream()
+				.filter(ManagedSymmetricBatteryInverter.class::isInstance)
+				.map(ManagedSymmetricBatteryInverter.class::cast)
+				.filter(ManagedSymmetricBatteryInverter::isManaged)
+				.collect(Collectors.toList());
+
+		Integer totalMaxApparentPower = inverters.stream()
+				.mapToInt(inverter -> inverter.getMaxApparentPower().get())
+				.sum();
+
+
+		Integer totalActivePowerSoFar = 0;
+		Integer totalReactivePowerSoFar = 0;
+
+		for (int i = 0; i < managedInverters.size(); i++) {
+
+			ManagedSymmetricBatteryInverter inverter = managedInverters.get(i);
+			Boolean isLast = (i == (managedInverters.size() -1 )); // Is this the last inverter in the list
+			if (!isLast) {
+
+				Double weight = (double) inverter.getMaxApparentPower().get() / totalMaxApparentPower;
+
+				Integer activePower = (int) (setActivePower * weight); // This truncates the decimal power (rounds down)
+				Integer reactivePower = (int) (setReactivePower * weight); // This truncates the decimal power (rounds down)
+
+				inverter.run(battery, activePower, reactivePower);
+
+				totalActivePowerSoFar += activePower;
+				totalReactivePowerSoFar += reactivePower;
+			} else { // If this is the last inverter, assign all remaining power to it.
+
+				Integer activePower = setActivePower - totalActivePowerSoFar;
+				Integer reactivePower = setReactivePower - totalReactivePowerSoFar;
+
+				inverter.run(battery, activePower, reactivePower);
+
+			}
+		}	
+	}
+
+	@Override
+	public int getPowerPrecision() {
+		Integer result = null;
+		for (SymmetricBatteryInverter inverter : this.inverters) {
+			if (inverter instanceof ManagedSymmetricBatteryInverter) {
+				result = TypeUtils.min(result, ((ManagedSymmetricBatteryInverter) inverter).getPowerPrecision());
+			}
+		}
+		return TypeUtils.orElse(result, 1);
+	}
+
+	@Override
+	public void handleEvent(Event event) {
+		if (!this.isEnabled()) {
+			return;
+		}
+		switch (event.getTopic()) {
+		case EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE:
+			this.handleStartStop();
+			break;
+		}
+	}
+
+	/**
+	 * Handles the Start/Stop target from {@link Config} or set via
+	 * {@link #setStartStop(StartStop)}.
+	 */
+	private void handleStartStop() {
+		StartStop target = StartStop.UNDEFINED;
+
+		switch (this.config.startStop()) {
+		case AUTO: {
+			target = this.startStopTarget.get();
+			break;
+		}
+		case START: {
+			target = StartStop.START;
+			break;
+		}
+		case STOP: {
+			target = StartStop.STOP;
+			break;
+		}
+		}
+
+		if (target == StartStop.UNDEFINED) {
+			this.logInfo(this.log, "Start-Stop-Target is Undefined");
+			return;
+		}
+
+		for (SymmetricBatteryInverter inverter : this.inverters) {
+			if (inverter instanceof StartStoppable) {
+				try {
+					((StartStoppable) inverter).setStartStop(target);
+				} catch (OpenemsNamedException e) {
+					this.logError(this.log, e.getMessage());
+					e.printStackTrace();
+				}
+			}
+		}
+	}
+
+	@Override
+	public void setStartStop(StartStop value) throws OpenemsNamedException {
+		this.startStopTarget.set(value);
+	}
+
+
+}

--- a/io.openems.edge.batteryinverter.cluster/src/io/openems/edge/batteryinverter/cluster/ChannelManager.java
+++ b/io.openems.edge.batteryinverter.cluster/src/io/openems/edge/batteryinverter/cluster/ChannelManager.java
@@ -1,0 +1,97 @@
+package io.openems.edge.batteryinverter.cluster;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import io.openems.edge.batteryinverter.api.SymmetricBatteryInverter;
+import io.openems.edge.common.channel.AbstractChannelListenerManager;
+import io.openems.edge.common.channel.Channel;
+import io.openems.edge.common.channel.value.Value;
+import io.openems.edge.common.sum.GridMode;
+import io.openems.edge.common.type.TypeUtils;
+
+public class ChannelManager extends AbstractChannelListenerManager {
+
+	private final BatteryInverterCluster parent;
+
+	public ChannelManager(BatteryInverterCluster parent) {
+		this.parent = parent;
+	}
+
+	protected void activate(List<SymmetricBatteryInverter> inverters) {
+		this.calculateGridMode(inverters);
+		this.calculate(INTEGER_SUM, inverters, SymmetricBatteryInverter.ChannelId.ACTIVE_POWER);
+		this.calculate(INTEGER_SUM, inverters, SymmetricBatteryInverter.ChannelId.REACTIVE_POWER);
+		this.calculate(INTEGER_SUM, inverters, SymmetricBatteryInverter.ChannelId.MAX_APPARENT_POWER);
+		this.calculate(LONG_SUM, inverters, SymmetricBatteryInverter.ChannelId.ACTIVE_CHARGE_ENERGY);
+		this.calculate(LONG_SUM, inverters, SymmetricBatteryInverter.ChannelId.ACTIVE_DISCHARGE_ENERGY);
+	}
+
+	private static final Function<Integer, Integer> DIVIDE_BY_THREE = value -> TypeUtils.divide(value, 3);
+	private static final BiFunction<Integer, Integer, Integer> INTEGER_MIN = TypeUtils::min;
+	private static final BiFunction<Integer, Integer, Integer> INTEGER_MAX = TypeUtils::max;
+	private static final BiFunction<Integer, Integer, Integer> INTEGER_SUM = TypeUtils::sum;
+	private static final BiFunction<Long, Long, Long> LONG_SUM = TypeUtils::sum;
+
+	/**
+	 * Calculate effective Grid-Mode of {@link SymmetricEss}.
+	 *
+	 * @param inverters the List of {@link SymmetricEss}
+	 */
+	private void calculateGridMode(List<SymmetricBatteryInverter> inverters) {
+		final BiConsumer<Value<Integer>, Value<Integer>> callback = (oldValue, newValue) -> {
+			var onGrids = 0;
+			var offGrids = 0;
+			for (SymmetricBatteryInverter inverter : inverters) {
+				switch (inverter.getGridMode()) {
+				case OFF_GRID:
+					offGrids++;
+					break;
+				case ON_GRID:
+					onGrids++;
+					break;
+				case UNDEFINED:
+					break;
+				}
+			}
+			final GridMode result;
+			if (inverters.size() == onGrids) {
+				result = GridMode.ON_GRID;
+			} else if (inverters.size() == offGrids) {
+				result = GridMode.OFF_GRID;
+			} else {
+				result = GridMode.UNDEFINED;
+			}
+			this.parent._setGridMode(result);
+		};
+		for (SymmetricBatteryInverter inverter : inverters) {
+			this.addOnChangeListener(inverter, SymmetricBatteryInverter.ChannelId.GRID_MODE, callback);
+		}
+	}
+
+	/**
+	 * Aggregate Channels of {@link SymmetricBatteryInverter}s.
+	 *
+	 * @param <T>        the Channel Type
+	 * @param aggregator the aggregator function
+	 * @param inverters       the List of {@link SymmetricBatteryInverter}
+	 * @param channelId  the SymmetricBatteryInverter.ChannelId
+	 */
+	private <T> void calculate(BiFunction<T, T, T> aggregator, List<SymmetricBatteryInverter> inverters,
+			SymmetricBatteryInverter.ChannelId channelId) {
+		final BiConsumer<Value<T>, Value<T>> callback = (oldValue, newValue) -> {
+			T result = null;
+			for (SymmetricBatteryInverter inverter : inverters) {
+				Channel<T> channel = inverter.channel(channelId);
+				result = aggregator.apply(result, channel.getNextValue().get());
+			}
+			Channel<T> channel = this.parent.channel(channelId);
+			channel.setNextValue(result);
+		};
+		for (SymmetricBatteryInverter inverter : inverters) {
+			this.addOnChangeListener(inverter, channelId, callback);
+		}
+	}
+}

--- a/io.openems.edge.batteryinverter.cluster/src/io/openems/edge/batteryinverter/cluster/Config.java
+++ b/io.openems.edge.batteryinverter.cluster/src/io/openems/edge/batteryinverter/cluster/Config.java
@@ -1,0 +1,30 @@
+package io.openems.edge.batteryinverter.cluster;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+import io.openems.edge.common.startstop.StartStopConfig;
+
+@ObjectClassDefinition(//
+		name = "Battery Inverter Cluster", //
+		description = "Combines several battery inverters into one. Should be used only for parallel inverters connected to a single battery")
+@interface Config {
+
+	@AttributeDefinition(name = "Component-ID", description = "Unique ID of this Component")
+	String id() default "batteryInverter0";
+
+	@AttributeDefinition(name = "Alias", description = "Human-readable name of this Component; defaults to Component-ID")
+	String alias() default "";
+
+	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
+	boolean enabled() default true;
+
+	@AttributeDefinition(name = "Start/stop behaviour?", description = "Should this Component be forced to start or stop?")
+	StartStopConfig startStop() default StartStopConfig.START;
+
+	@AttributeDefinition(name = "BatteryInverter-IDs", description = "The IDs of the battery inverter")
+	String[] batteryInverterIds();
+
+	String webconsole_configurationFactory_nameHint() default "Battery Inverter Cluster [{id}]";
+
+}

--- a/io.openems.edge.batteryinverter.cluster/test/io/openems/edge/batteryinverter/cluster/BatteryInverterClusterTest.java
+++ b/io.openems.edge.batteryinverter.cluster/test/io/openems/edge/batteryinverter/cluster/BatteryInverterClusterTest.java
@@ -1,0 +1,118 @@
+package io.openems.edge.batteryinverter.cluster;
+
+import org.junit.Test;
+
+import io.openems.edge.common.test.AbstractComponentTest.TestCase;
+import io.openems.common.types.ChannelAddress;
+import io.openems.edge.batteryinverter.api.SymmetricBatteryInverter;
+import io.openems.edge.batteryinverter.test.DummyManagedSymmetricBatteryInverter;
+import io.openems.edge.common.startstop.StartStopConfig;
+import io.openems.edge.common.sum.GridMode;
+import io.openems.edge.common.test.ComponentTest;
+import io.openems.edge.common.test.DummyConfigurationAdmin;
+
+public class BatteryInverterClusterTest {
+
+	private static final String CLUSTER_ID = "ess0";
+	private static final String BATTERY_INVERTER1_ID = "batteryInverter0";
+	private static final String BATTERY_INVERTER2_ID = "batteryInverter1";
+
+	private static final ChannelAddress CLUSTER_GRID_MODE = new ChannelAddress(CLUSTER_ID, SymmetricBatteryInverter.ChannelId.GRID_MODE.id());
+	private static final ChannelAddress INVERTER1_GRID_MODE = new ChannelAddress(BATTERY_INVERTER1_ID, SymmetricBatteryInverter.ChannelId.GRID_MODE.id());
+	private static final ChannelAddress INVERTER2_GRID_MODE = new ChannelAddress(BATTERY_INVERTER2_ID, SymmetricBatteryInverter.ChannelId.GRID_MODE.id());
+
+	private static final ChannelAddress CLUSTER_ACTIVE_POWER = new ChannelAddress(CLUSTER_ID, SymmetricBatteryInverter.ChannelId.ACTIVE_POWER.id());
+	private static final ChannelAddress INVERTER1_ACTIVE_POWER = new ChannelAddress(BATTERY_INVERTER1_ID, SymmetricBatteryInverter.ChannelId.ACTIVE_POWER.id());
+	private static final ChannelAddress INVERTER2_ACTIVE_POWER = new ChannelAddress(BATTERY_INVERTER2_ID, SymmetricBatteryInverter.ChannelId.ACTIVE_POWER.id());
+
+	private static final ChannelAddress CLUSTER_REACTIVE_POWER = new ChannelAddress(CLUSTER_ID, SymmetricBatteryInverter.ChannelId.REACTIVE_POWER.id());
+	private static final ChannelAddress INVERTER1_REACTIVE_POWER = new ChannelAddress(BATTERY_INVERTER1_ID, SymmetricBatteryInverter.ChannelId.REACTIVE_POWER.id());
+	private static final ChannelAddress INVERTER2_REACTIVE_POWER = new ChannelAddress(BATTERY_INVERTER2_ID, SymmetricBatteryInverter.ChannelId.REACTIVE_POWER.id());
+
+	private static final ChannelAddress CLUSTER_MAX_APPARENT_POWER = new ChannelAddress(CLUSTER_ID, SymmetricBatteryInverter.ChannelId.MAX_APPARENT_POWER.id());
+	private static final ChannelAddress INVERTER1_MAX_APPARENT_POWER = new ChannelAddress(BATTERY_INVERTER1_ID, SymmetricBatteryInverter.ChannelId.MAX_APPARENT_POWER.id());
+	private static final ChannelAddress INVERTER2_MAX_APPARENT_POWER = new ChannelAddress(BATTERY_INVERTER2_ID, SymmetricBatteryInverter.ChannelId.MAX_APPARENT_POWER.id());
+
+	private static final ChannelAddress CLUSTER_ACTIVE_CHARGE_ENERGY = new ChannelAddress(CLUSTER_ID, SymmetricBatteryInverter.ChannelId.ACTIVE_CHARGE_ENERGY.id());
+	private static final ChannelAddress INVERTER1_ACTIVE_CHARGE_ENERGY = new ChannelAddress(BATTERY_INVERTER1_ID, SymmetricBatteryInverter.ChannelId.ACTIVE_CHARGE_ENERGY.id());
+	private static final ChannelAddress INVERTER2_ACTIVE_CHARGE_ENERGY = new ChannelAddress(BATTERY_INVERTER2_ID, SymmetricBatteryInverter.ChannelId.ACTIVE_CHARGE_ENERGY.id());
+
+	private static final ChannelAddress CLUSTER_ACTIVE_DISCHARGE_ENERGY = new ChannelAddress(CLUSTER_ID, SymmetricBatteryInverter.ChannelId.ACTIVE_DISCHARGE_ENERGY.id());
+	private static final ChannelAddress INVERTER1_ACTIVE_DISCHARGE_ENERGY = new ChannelAddress(BATTERY_INVERTER1_ID, SymmetricBatteryInverter.ChannelId.ACTIVE_DISCHARGE_ENERGY.id());
+	private static final ChannelAddress INVERTER2_ACTIVE_DISCHARGE_ENERGY = new ChannelAddress(BATTERY_INVERTER2_ID, SymmetricBatteryInverter.ChannelId.ACTIVE_DISCHARGE_ENERGY.id());
+
+	@Test
+	public void testCluster() throws Exception {
+		new ComponentTest(new BatteryInverterClusterImpl()) //
+				.addReference("cm", new DummyConfigurationAdmin()) //
+				.addReference("addBatteryInverter", new DummyManagedSymmetricBatteryInverter(BATTERY_INVERTER1_ID)) //
+				.addReference("addBatteryInverter", new DummyManagedSymmetricBatteryInverter(BATTERY_INVERTER2_ID)) //
+				.activate(MyConfig.create() //
+						.setId(CLUSTER_ID) //
+						.setBatteryInverterIds(BATTERY_INVERTER1_ID, BATTERY_INVERTER2_ID) //
+						.setStartStop(StartStopConfig.START) //
+						.build())
+				.next(new TestCase() //
+						.input(INVERTER1_GRID_MODE, GridMode.ON_GRID)
+						.input(INVERTER2_GRID_MODE, GridMode.ON_GRID)
+						.output(CLUSTER_GRID_MODE, GridMode.ON_GRID)
+
+						.input(INVERTER1_ACTIVE_POWER, 1500) //
+						.input(INVERTER2_ACTIVE_POWER, 1500) //
+						.output(CLUSTER_ACTIVE_POWER, 3000) //
+
+						.input(INVERTER1_REACTIVE_POWER, 1111) //
+						.input(INVERTER2_REACTIVE_POWER, 450) //
+						.output(CLUSTER_REACTIVE_POWER, 1561) //
+
+						.input(INVERTER1_MAX_APPARENT_POWER, 92000) //
+						.input(INVERTER2_MAX_APPARENT_POWER, 92000) //
+						.output(CLUSTER_MAX_APPARENT_POWER, 184000) //
+
+						// This test was failing when I passed integer values. It works when casting to (long) 
+						.input(INVERTER1_ACTIVE_CHARGE_ENERGY, (long) 1450.0) // 
+						.input(INVERTER2_ACTIVE_CHARGE_ENERGY, (long) 1550.0) //
+						.output(CLUSTER_ACTIVE_CHARGE_ENERGY, (long) 3000.0) //
+
+						.input(INVERTER1_ACTIVE_DISCHARGE_ENERGY, (long) 46000.0) // 
+						.input(INVERTER2_ACTIVE_DISCHARGE_ENERGY, (long) 54000.0) //
+						.output(CLUSTER_ACTIVE_DISCHARGE_ENERGY, (long) 100000.0) //
+
+						);
+	}
+
+	@Test
+	public void testGridMode() throws Exception {
+		new ComponentTest(new BatteryInverterClusterImpl()) //
+				.addReference("cm", new DummyConfigurationAdmin()) //
+				.addReference("addBatteryInverter", new DummyManagedSymmetricBatteryInverter(BATTERY_INVERTER1_ID)) //
+				.addReference("addBatteryInverter", new DummyManagedSymmetricBatteryInverter(BATTERY_INVERTER2_ID)) //
+				.activate(MyConfig.create() //
+						.setId(CLUSTER_ID) //
+						.setBatteryInverterIds(BATTERY_INVERTER1_ID, BATTERY_INVERTER2_ID) //
+						.setStartStop(StartStopConfig.START) //
+						.build())
+				.next(new TestCase() //
+						.input(INVERTER1_GRID_MODE, GridMode.ON_GRID) //
+						.input(INVERTER2_GRID_MODE, GridMode.ON_GRID) //
+						.output(CLUSTER_GRID_MODE, GridMode.ON_GRID) //
+				) //
+				.next(new TestCase() //
+						.input(INVERTER1_GRID_MODE, GridMode.OFF_GRID) //
+						.input(INVERTER2_GRID_MODE, GridMode.OFF_GRID) //
+						.output(CLUSTER_GRID_MODE, GridMode.OFF_GRID) //
+				) //
+				.next(new TestCase() //
+						.input(INVERTER1_GRID_MODE, GridMode.OFF_GRID) //
+						.input(INVERTER2_GRID_MODE, GridMode.UNDEFINED) //
+						.output(CLUSTER_GRID_MODE, GridMode.UNDEFINED) //
+				) //
+				.next(new TestCase() //
+						.input(INVERTER1_GRID_MODE, GridMode.OFF_GRID) //
+						.input(INVERTER2_GRID_MODE, GridMode.ON_GRID) //
+						.output(CLUSTER_GRID_MODE, GridMode.UNDEFINED) //
+				) //
+		;
+	}
+
+}

--- a/io.openems.edge.batteryinverter.cluster/test/io/openems/edge/batteryinverter/cluster/MyConfig.java
+++ b/io.openems.edge.batteryinverter.cluster/test/io/openems/edge/batteryinverter/cluster/MyConfig.java
@@ -1,0 +1,66 @@
+package io.openems.edge.batteryinverter.cluster;
+
+import io.openems.common.utils.ConfigUtils;
+import io.openems.edge.common.startstop.StartStopConfig;
+import io.openems.common.test.AbstractComponentConfig;
+
+@SuppressWarnings("all")
+public class MyConfig extends AbstractComponentConfig implements Config {
+
+	protected static class Builder {
+		private String id;
+		private String[] batteryInverterIds;
+		private StartStopConfig startStop;
+
+		private Builder() {
+		}
+
+		public Builder setId(String id) {
+			this.id = id;
+			return this;
+		}
+
+		public Builder setBatteryInverterIds(String... batteryInverterIds) {
+			this.batteryInverterIds = batteryInverterIds;
+			return this;
+		}
+
+		public Builder setStartStop(StartStopConfig startStop) {
+			this.startStop = startStop;
+			return this;
+		}
+
+		public MyConfig build() {
+			return new MyConfig(this);
+		}
+	}
+
+	/**
+	 * Create a Config builder.
+	 * 
+	 * @return a {@link Builder}
+	 */
+	public static Builder create() {
+		return new Builder();
+	}
+
+	private final Builder builder;
+
+	private MyConfig(Builder builder) {
+		super(Config.class, builder.id);
+		this.builder = builder;
+	}
+
+	@Override
+	public String[] batteryInverterIds() {
+		return this.builder.batteryInverterIds;
+	}
+
+	@Override
+	public StartStopConfig startStop() {
+		return this.builder.startStop;
+	}
+
+
+
+}


### PR DESCRIPTION
Added bundle io.openems.edge.batteryinverter.cluster

This supports the parallel clustering of battery inverters attached to the same battery.

The bundle operates in a similar manner to the ESS Cluster device (io.openems.edge.ess.cluster) where you must instantiate the individual inverters first and then the cluster.