### PR TITLE
UI: modal-line element INPUT with optional unit

### DIFF
--- a/ui/src/app/shared/genericComponents/modal/modal-line/modal-line.html
+++ b/ui/src/app/shared/genericComponents/modal/modal-line/modal-line.html
@@ -29,7 +29,17 @@
                     <ion-label class="regularFont">&nbsp;W&nbsp;</ion-label>
                 </ion-item>
             </td>
-
+          
+            <!-- 'Input' Line, name and changeable value with unit -->
+            <td style="width: 30%" class="align_right" *ngIf="control.type === 'INPUT_UNIT'" [formGroup]="formGroup">
+                <ion-item>
+                    <ion-input class="regularFont" type="number" style="text-align: right;"
+                        [formControlName]="controlName">
+                    </ion-input>
+                    <ion-label class="regularFont">&nbsp;{{control.properties.unit}}&nbsp;</ion-label>
+                </ion-item>
+            </td>
+          
             <!-- 'TOGGLE' Line, provides toggle option -->
             <td *ngIf="control.type === 'TOGGLE'" [formGroup]="formGroup"
                 [style]="this.service.isSmartphoneResolution ? 'transform: scale(0.7)': ''" class="align_right">

--- a/ui/src/app/shared/genericComponents/modal/modal-line/modal-line.html
+++ b/ui/src/app/shared/genericComponents/modal/modal-line/modal-line.html
@@ -26,17 +26,8 @@
                     <ion-input class="regularFont" type="number" style="text-align: right;"
                         [formControlName]="controlName">
                     </ion-input>
-                    <ion-label class="regularFont">&nbsp;W&nbsp;</ion-label>
-                </ion-item>
-            </td>
-          
-            <!-- 'Input' Line, name and changeable value with unit -->
-            <td style="width: 30%" class="align_right" *ngIf="control.type === 'INPUT_UNIT'" [formGroup]="formGroup">
-                <ion-item>
-                    <ion-input class="regularFont" type="number" style="text-align: right;"
-                        [formControlName]="controlName">
-                    </ion-input>
-                    <ion-label class="regularFont">&nbsp;{{control.properties.unit}}&nbsp;</ion-label>
+                    <ion-label class="regularFont">&nbsp;{{control?.properties?.unit ?? 'W' }}&nbsp;
+                    </ion-label>
                 </ion-item>
             </td>
           

--- a/ui/src/app/shared/genericComponents/modal/modal-line/modal-line.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal-line/modal-line.ts
@@ -19,6 +19,7 @@ export class ModalLineComponent extends AbstractModalLine {
     @Input() protected control:
         { type: 'TOGGLE' } |
         { type: 'INPUT' } |
+        { type: 'INPUT_UNIT', properties: {unit: 'H'} } |
         /* the available select options*/
         { type: 'SELECT', options: { value: string, name: string }[] } |
         /* the properties for range slider*/

--- a/ui/src/app/shared/genericComponents/modal/modal-line/modal-line.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal-line/modal-line.ts
@@ -18,8 +18,7 @@ export class ModalLineComponent extends AbstractModalLine {
     /** ControlName for Toggle Button */
     @Input() protected control:
         { type: 'TOGGLE' } |
-        { type: 'INPUT' } |
-        { type: 'INPUT_UNIT', properties: {unit: 'H'} } |
+        { type: 'INPUT', properties?: {unit:'W'} } |
         /* the available select options*/
         { type: 'SELECT', options: { value: string, name: string }[] } |
         /* the properties for range slider*/


### PR DESCRIPTION
Implements a new modal-line element INPUT_UNIT. It's the similar to INPUT with the option to change the unit with the following code line. 
eg: [control]="{type: 'INPUT_UNIT', properties: {unit: 'mA'}}">