### PR TITLE
Minor corrections to the edge component implementation guide

### DIFF
--- a/doc/modules/ROOT/pages/edge/implement.adoc
+++ b/doc/modules/ROOT/pages/edge/implement.adoc
@@ -405,9 +405,9 @@ NOTE: Most Modbus function codes are available by their respective _FC*_ impleme
 - For more advanced channel-to-element mapping functionalities the internal *cm()* method can be used - e.g. to map one Modbus element to multiple Channels.
 +
 Using this principle a complete Modbus table consisting of multiple register blocks that need to be read or written with different Modbus function codes can be defined. For details have a look at the existing implementation classes inside the Modbus Bridge source code.
+====
 <17> The ElectricityMeter Nature requires us to provide a *MeterType* via a `MeterType getMeterType()` method. The MeterType is provided by the Config.
 <18> Finally it is always a good idea to define a *debugLog()* method. This method is called in each cycle by the *Controller.Debug.Log* and very helpful for continuous debugging.
-====
 
 === JUnit tests
 
@@ -508,7 +508,7 @@ Select the `io.openems.edge.meter.simulated` bundle in the left *Repositories* l
 
 Press btn:[Ctrl] + btn:[s] to save the `EdgeApp.bndrun` file.
 
-Click on btn:[Resolve] to update the list of bundles that are required to run OpenEMS Edge. After a few seconds the *Resolution Results* window should appear; acknowledge by pressing btn:[Finish].
+Click on btn:[Resolve] to update the list of bundles that are required to run OpenEMS Edge. After a few seconds the *Resolution Results* window should appear; acknowledge by pressing btn:[Update].
 
 .Eclipse IDE Resolve EdgeApp.bndrun
 image::eclipse-edgeapp-resolve.png[Eclipse IDE Resolve EdgeApp.bndrun]


### PR DESCRIPTION
There was a small formatting error in section the 1.4. Implement the OpenEMS Component and the wrong button name in section 1.7. Enable the Component. 