### PR TITLE
Update Config.java for the Reconnection Interval

### DIFF
--- a/io.openems.edge.controller.api.mqtt/src/io/openems/edge/controller/api/mqtt/Config.java
+++ b/io.openems.edge.controller.api.mqtt/src/io/openems/edge/controller/api/mqtt/Config.java
@@ -44,6 +44,9 @@ import io.openems.common.channel.PersistencePriority;
 	@AttributeDefinition(name = "Persistence Priority", description = "Send only Channels with a Persistence Priority greater-or-equals this.")
 	PersistencePriority persistencePriority() default PersistencePriority.VERY_LOW;
 
+	@AttributeDefinition(name = "Reconnection Attempt Interval", description = "Interval in seconds between reconnection attempts to the MQTT broker")
+	long reconnectionAttemptInterval() default 60;
+
 	@AttributeDefinition(name = "Debug Mode", description = "Activates the debug mode")
 	boolean debugMode() default false;
 


### PR DESCRIPTION
Dynamic Reconnection Interval: Added a new configuration parameter (reconnectionAttemptInterval) to the Config interface. This parameter allows users to specify the interval between reconnection attempts to the MQTT broker, enhancing the component's adaptability to network conditions or broker availability.