### PR TITLE
UI: Install/Update Component filter to lower case

### DIFF
--- a/ui/src/app/edge/settings/component/install/index.component.ts
+++ b/ui/src/app/edge/settings/component/install/index.component.ts
@@ -42,7 +42,7 @@ export class IndexComponent implements OnInit {
 
   updateFilter(completeFilter: string) {
     // take each space-separated string as an individual and-combined filter
-    let filters = completeFilter.split(' ');
+    let filters = completeFilter.toLowerCase().split(' ');
     let countFilteredEntries = 0;
     for (let entry of this.list) {
       entry.filteredFactories = entry.factories.filter(entry =>

--- a/ui/src/app/edge/settings/component/update/index.component.ts
+++ b/ui/src/app/edge/settings/component/update/index.component.ts
@@ -43,7 +43,7 @@ export class IndexComponent implements OnInit {
 
   updateFilter(completeFilter: string) {
     // take each space-separated string as an individual and-combined filter
-    let filters = completeFilter.split(' ');
+    let filters = completeFilter.toLowerCase().split(' ');
     let countFilteredEntries = 0;
     for (let entry of this.list) {
       entry.filteredComponents = entry.components.filter(entry =>


### PR DESCRIPTION
## Issue

When entering CamelCased / Uppercase entries in the search bar of component install/update -> the components won't show/cannot be found since the filter is CaseSensitive, while the filteredComponents are not.

see :
https://github.com/OpenEMS/openems/blob/2c938aab7a19407e6ab5dcac7b33c5e15da971df/ui/src/app/edge/settings/component/update/index.component.ts#L49-L55

## Fix

set filter to lowerCase

Co-authored-by:  Ulrich Laupp  <38915524+laupp@users.noreply.github.com>


## Comparison


### Before

![Before](https://github.com/OpenEMS/openems/assets/39899210/4f984582-bc9c-44a0-a04c-2138a8c5b22a)


### After

![After](https://github.com/OpenEMS/openems/assets/39899210/bf28f90f-4495-4313-99d8-e8b31228bafb)
