### PR TITLE
UI: AppCenter: RedeemKey -> Update of the SelectField

### DIFF
--- a/ui/src/app/shared/formly/formly-select-field.extended.ts
+++ b/ui/src/app/shared/formly/formly-select-field.extended.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { ChangeDetectorRef, Component } from "@angular/core";
 import { ModalController } from "@ionic/angular";
 import { FieldWrapper } from "@ngx-formly/core";
 import { FormlySelectFieldModalComponent } from "./formly-select-field-modal.component";
@@ -13,6 +13,7 @@ export class FormlySelectFieldExtendedWrapperComponent extends FieldWrapper {
     // detailed information about an item when selecting them
     constructor(
         private modalController: ModalController,
+        private cdr: ChangeDetectorRef,
     ) {
         super();
 
@@ -45,6 +46,7 @@ export class FormlySelectFieldExtendedWrapperComponent extends FieldWrapper {
                 return;
             }
             this.formControl.setValue(selectedValue);
+            this.cdr.detectChanges();
         });
         return await modal.present();
     }


### PR DESCRIPTION
### Issue

In the AppCenter -> redeemKey option
On selecting a different key -> the key doesn't get visually updated. This is a bit irritating for the user.

![RedeemKey](https://github.com/OpenEMS/openems/assets/39899210/22d0a4e5-b0ae-456e-8a8b-1efc9bc810d7)




### Fix

formly-select-field.extended -> Apply ChangeDetectorRef -> detectChanges() after setValue()


Note:

I am not sure if ChangeDetectorRef in this context is the best solution. But it worked.
