### PR TITLE
Docs: Contribution Guidelines: add section about Eclipse Version

### DIFF
--- a/doc/modules/ROOT/pages/contribute/coding-guidelines.adoc
+++ b/doc/modules/ROOT/pages/contribute/coding-guidelines.adoc
@@ -40,9 +40,14 @@
 
 While IntelliJ also works, Eclipse IDE is the officially supported development environment. It also provides tool support for guided assistance via bndtools.
 
+.Eclipse Version
+
+Some Eclipse default code formatting rules and warning settings change over time. Therefore, 
+always use the latest Version of the Eclipse IDE for Java Developers (4.30.0 +).
+  
 .Eclipse Code formatter
 
-Use `Eclipse [built-in]` Code Formatting Rules
+Use `Eclipse [built-in]` code formatting rules
 
  * Eclipse -> Window -> Preferences -> Java -> Code Style -> Formatter -> ActiveProfile -> select -> `Eclipse [built-in]`
      


### PR DESCRIPTION
Different Eclipse IDE versions produces different source files, when using autoformat, cleanup,.... Also they produce different warnings. Therefore it would be important, that all developers always use the same eclipse version before opening new PRs. 

This PR adds a documentation section to the contribution guidelines to always use the latest Eclipse version. By the time of now this is version 2023-12 (4.30.0)