### PR TITLE
Modbus bridge skip cycle function

### DIFF
--- a/io.openems.edge.bridge.modbus/readme.adoc
+++ b/io.openems.edge.bridge.modbus/readme.adoc
@@ -28,6 +28,32 @@ Read-Tasks can have two different priorities, that are defined in the ModbusProt
 - `LOW`: only one task of all defined LOW priority tasks of all components registered on the same bridge is executed per Cycle
 Write-Tasks always have `HIGH` priority, i.e. a set-point is always executed as-soon-as-possible - as long as the Component is not marked as defective
 
+=== Skip cycles
+
+OpenEMS's core cycle time is usually 1 second, but some modbus devices can be very slow. It's possible to lower the core cycle time but the whole system is slowed down.
+
+The function `setSkipCycles` can be applied to each modbus tasks, for example:
+```
+...
+new FC16WriteRegistersTask(40149, //
+    m(EssSmaSunnyIsland.ChannelId.SET_ACTIVE_POWER, new SignedDoublewordElement(40149)), //
+    m(EssSmaSunnyIsland.ChannelId.SET_CONTROL_MODE, new UnsignedDoublewordElement(40151)), //
+    m(EssSmaSunnyIsland.ChannelId.SET_REACTIVE_POWER, new SignedDoublewordElement(40153))).setSkipCycles(1),
+new FC16WriteRegistersTask(43090, //
+    m(EssSmaSunnyIsland.ChannelId.GRID_GUARD_CODE, new UnsignedDoublewordElement(43090))).setSkipCycles(2), //
+...
+```
+The `FC16WriteRegistersTask` task at register address 40149 is set to skip 1 cycle, which means every 2 cycles the register writing task is performed, while the `FC16WriteRegistersTask` task at register address 43090 is performed every 3 cycles.
+
+`setSkipCycles` can also be applied to protocol level, for example:
+```
+@Override
+protected ModbusProtocol defineModbusProtocol() throws OpenemsException {
+    return new ModbusProtocol(...).setSkipCycles(2);
+}
+```
+protocol level skip cycle setting will override the settings in each task.
+
 === Channels
 
 Each Modbus Bridge provides Channels for more detailed information:

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/ModbusProtocol.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/ModbusProtocol.java
@@ -78,4 +78,10 @@ public class ModbusProtocol {
 		this.taskManager.getTasks() //
 				.forEach(Task::deactivate);
 	}
+
+	public ModbusProtocol setSkipCycles(int cycles) {
+		this.taskManager.getTasks() //
+				.forEach(t -> t.setSkipCycles(cycles));
+		return this;
+	}
 }

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/task/AbstractTask.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/task/AbstractTask.java
@@ -34,6 +34,7 @@ public abstract non-sealed class AbstractTask<//
 	protected final int startAddress;
 	protected final int length;
 	protected final ModbusElement[] elements;
+	private int skipCycles = 0;
 
 	private final Logger log = LoggerFactory.getLogger(AbstractTask.class);
 
@@ -76,6 +77,14 @@ public abstract non-sealed class AbstractTask<//
 
 	public void setParent(AbstractOpenemsModbusComponent parent) {
 		this.parent = parent;
+	}
+
+	public void setSkipCycles(int cycles) {
+		this.skipCycles = cycles;
+	}
+
+	public int getSkipCycles() {
+		return this.skipCycles;
 	}
 
 	public AbstractOpenemsModbusComponent getParent() {

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/task/AbstractTask.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/task/AbstractTask.java
@@ -79,8 +79,9 @@ public abstract non-sealed class AbstractTask<//
 		this.parent = parent;
 	}
 
-	public void setSkipCycles(int cycles) {
+	public AbstractTask setSkipCycles(int cycles) {
 		this.skipCycles = cycles;
+		return this;
 	}
 
 	public int getSkipCycles() {

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/task/Task.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/task/Task.java
@@ -43,6 +43,10 @@ public sealed interface Task extends ManagedTask permits AbstractTask, ReadTask,
 	 */
 	public ModbusComponent getParent();
 
+	public void setSkipCycles(int cycles);
+
+	public int getSkipCycles();
+
 	/**
 	 * This is called on deactivate of the Modbus-Bridge. It can be used to clear
 	 * any references like listeners.

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/task/Task.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/task/Task.java
@@ -43,8 +43,19 @@ public sealed interface Task extends ManagedTask permits AbstractTask, ReadTask,
 	 */
 	public ModbusComponent getParent();
 
-	public void setSkipCycles(int cycles);
+	/**
+	 * Set skip cycles.
+	 *
+	 * @param cycles the task should be delayed cycles
+	 * @return Task itself
+	 */
+	public Task setSkipCycles(int cycles);
 
+	/**
+	 * Get skip cycles.
+	 *
+	 * @return cycles the task should be delayed cycles
+	 */
 	public int getSkipCycles();
 
 	/**

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/task/WaitTask.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/task/WaitTask.java
@@ -17,6 +17,8 @@ public abstract non-sealed class WaitTask implements Task {
 	private final Logger log = LoggerFactory.getLogger(WaitTask.class);
 	private AbstractOpenemsModbusComponent parent = null;
 
+	private int skipCycles = 0;
+
 	@Override
 	public final void setParent(AbstractOpenemsModbusComponent parent) {
 		this.parent = parent;
@@ -45,6 +47,15 @@ public abstract non-sealed class WaitTask implements Task {
 	@Override
 	public final int getLength() {
 		return 0;
+	}
+
+	@Override
+	public void setSkipCycles(int cycles) {
+		this.skipCycles = cycles;
+	}
+	@Override
+	public int getSkipCycles() {
+		return this.skipCycles;
 	}
 
 	@Override

--- a/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/task/WaitTask.java
+++ b/io.openems.edge.bridge.modbus/src/io/openems/edge/bridge/modbus/api/task/WaitTask.java
@@ -50,9 +50,11 @@ public abstract non-sealed class WaitTask implements Task {
 	}
 
 	@Override
-	public void setSkipCycles(int cycles) {
+	public WaitTask setSkipCycles(int cycles) {
 		this.skipCycles = cycles;
+		return this;
 	}
+
 	@Override
 	public int getSkipCycles() {
 		return this.skipCycles;

--- a/io.openems.edge.common/src/io/openems/edge/common/taskmanager/ManagedTask.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/taskmanager/ManagedTask.java
@@ -9,5 +9,10 @@ public interface ManagedTask {
 	 */
 	public Priority getPriority();
 
+	/**
+	 * Get skip cycles.
+	 *
+	 * @return cycles the task should be delayed cycles
+	 */
 	public int getSkipCycles();
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/taskmanager/ManagedTask.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/taskmanager/ManagedTask.java
@@ -9,4 +9,5 @@ public interface ManagedTask {
 	 */
 	public Priority getPriority();
 
+	public int getSkipCycles();
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/taskmanager/TasksManager.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/taskmanager/TasksManager.java
@@ -82,6 +82,12 @@ public class TasksManager<T extends ManagedTask> {
 		return this.tasks.size();
 	}
 
+	public synchronized int countTasks(long cycleIdx) {
+		return (int)this.tasks.stream()
+				.filter(t -> cycleIdx % (1 + t.getSkipCycles()) == 0)
+				.count();
+	}
+
 	/**
 	 * Gets all Tasks.
 	 *

--- a/io.openems.edge.common/src/io/openems/edge/common/taskmanager/TasksManager.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/taskmanager/TasksManager.java
@@ -82,6 +82,13 @@ public class TasksManager<T extends ManagedTask> {
 		return this.tasks.size();
 	}
 
+	/**
+	 * Gets the number of Tasks.
+	 * Use this function when setSkipCycles is applied
+	 *
+	 * @param cycleIdx current cycle
+	 * @return number of Tasks
+	 */
 	public synchronized int countTasks(long cycleIdx) {
 		return (int)this.tasks.stream()
 				.filter(t -> cycleIdx % (1 + t.getSkipCycles()) == 0)

--- a/io.openems.edge.common/test/io/openems/edge/common/taskmanager/TasksManagerTest.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/taskmanager/TasksManagerTest.java
@@ -10,6 +10,8 @@ public class TasksManagerTest {
 
 		private final Priority priority;
 
+		private final int skipCycles = 0;
+
 		public Task(Priority priority) {
 			this.priority = priority;
 		}
@@ -17,6 +19,11 @@ public class TasksManagerTest {
 		@Override
 		public Priority getPriority() {
 			return this.priority;
+		}
+
+		@Override
+		public int getSkipCycles() {
+			return this.skipCycles;
 		}
 
 	}

--- a/io.openems.edge.kostal.piko/src/io/openems/edge/kostal/piko/core/impl/ReadTask.java
+++ b/io.openems.edge.kostal.piko/src/io/openems/edge/kostal/piko/core/impl/ReadTask.java
@@ -12,6 +12,7 @@ public class ReadTask implements ManagedTask {
 	private final Priority priority;
 	private final FieldType fieldType;
 	private final int address;
+	private final int skipCycles = 0;
 
 	public ReadTask(OpenemsComponent component, ChannelId channelId, Priority priority, FieldType fieldType,
 			int address) {
@@ -41,6 +42,10 @@ public class ReadTask implements ManagedTask {
 	@Override
 	public Priority getPriority() {
 		return this.priority;
+	}
+
+	public int getSkipCycles() {
+		return this.skipCycles;
 	}
 
 	@Override


### PR DESCRIPTION
OpenEMS's core cycle time is usually 1 second, but some modbus devices can be very slow. It's possible to lower the core cycle time but the whole system is slowed down.

The function `setSkipCycles` can be applied to each modbus tasks, for example:
```
...
new FC16WriteRegistersTask(40149, //
    m(EssSmaSunnyIsland.ChannelId.SET_ACTIVE_POWER, new SignedDoublewordElement(40149)), //
    m(EssSmaSunnyIsland.ChannelId.SET_CONTROL_MODE, new UnsignedDoublewordElement(40151)), //
    m(EssSmaSunnyIsland.ChannelId.SET_REACTIVE_POWER, new SignedDoublewordElement(40153))).setSkipCycles(1),
new FC16WriteRegistersTask(43090, //
    m(EssSmaSunnyIsland.ChannelId.GRID_GUARD_CODE, new UnsignedDoublewordElement(43090))).setSkipCycles(2), //
...
```
The `FC16WriteRegistersTask` task at register address 40149 is set to skip 1 cycle, which means every 2 cycles the register writing task is performed, while the `FC16WriteRegistersTask` task at register address 43090 is performed every 3 cycles.

`setSkipCycles` can also be applied to protocol level, for example:
```
@Override
protected ModbusProtocol defineModbusProtocol() throws OpenemsException {
    return new ModbusProtocol(...).setSkipCycles(2);
}
```
protocol level skip cycle setting will override the settings in each task.
