### PR TITLE
Janitza UMG 511: fix inverted active power

### DIFF
--- a/io.openems.edge.meter.janitza/src/io/openems/edge/meter/janitza/umg511/MeterJanitzaUmg511Impl.java
+++ b/io.openems.edge.meter.janitza/src/io/openems/edge/meter/janitza/umg511/MeterJanitzaUmg511Impl.java
@@ -120,7 +120,8 @@ public class MeterJanitzaUmg511Impl extends AbstractOpenemsModbusComponent
 						m(ElectricityMeter.ChannelId.REACTIVE_POWER_L3, new FloatDoublewordElement(3873), //
 								INVERT_IF_TRUE(this.invert))), //
 				new FC3ReadRegistersTask(3925, Priority.HIGH, //
-						m(ElectricityMeter.ChannelId.ACTIVE_POWER, new FloatDoublewordElement(3925)), //
+						m(ElectricityMeter.ChannelId.ACTIVE_POWER, new FloatDoublewordElement(3925), //
+								INVERT_IF_TRUE(this.invert)), //
 						m(ElectricityMeter.ChannelId.REACTIVE_POWER, new FloatDoublewordElement(3927), //
 								INVERT_IF_TRUE(this.invert))), //
 				new FC3ReadRegistersTask(3995, Priority.LOW, //


### PR DESCRIPTION
Previously, the overall active power was not inverted if configured, only the phase powers were. This is fixed here.