### PR TITLE
Optimize Footer Visibility in `/history` Routes

### DIFF
--- a/ui/src/app/shared/footer/footer.html
+++ b/ui/src/app/shared/footer/footer.html
@@ -1,4 +1,4 @@
-<ion-footer *ngIf="!service.isSmartphoneResolution">
+<ion-footer *ngIf="!service.isSmartphoneResolution && showFooter">
   <ion-item color="primary" *ngIf="user && edge && displayValues" lines="none">
     <ion-grid>
       <ion-row>

--- a/ui/src/app/shared/footer/footer.ts
+++ b/ui/src/app/shared/footer/footer.ts
@@ -1,6 +1,7 @@
 import { Component, HostBinding, OnInit } from "@angular/core";
 import { Title } from "@angular/platform-browser";
 import { filter } from "rxjs/operators";
+import { Router, NavigationEnd } from '@angular/router';
 
 import { environment } from '../../../environments';
 import { User } from "../jsonrpc/shared";
@@ -39,6 +40,7 @@ export class FooterComponent implements OnInit {
   protected edge: Edge | null = null;
   protected displayValues: { version: string, id: string, comment: string } | null = null;
   protected isAtLeastOwner: boolean | null = null;
+  protected showFooter: boolean = true;
 
   @HostBinding('attr.data-isSmartPhone')
   public isSmartPhone: boolean = this.service.isSmartphoneResolution;
@@ -46,6 +48,7 @@ export class FooterComponent implements OnInit {
   constructor(
     protected service: Service,
     private title: Title,
+    private router: Router,
   ) { }
 
   ngOnInit() {
@@ -64,6 +67,9 @@ export class FooterComponent implements OnInit {
           }
         }
 
+        this.router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(() => {
+          this.showFooter = !this.router.url.includes('/history');
+        });
         this.title.setTitle(title);
         this.isAtLeastOwner = Role.isAtLeast(this.user.globalRole, Role.OWNER);
       });


### PR DESCRIPTION
### Summary

This PR addresses an issue with the footer overlaying content in the `/history/***` tab, which detracts from the user experience by obscuring important information. To enhance usability and content visibility, we've implemented conditional logic to hide the footer on specific `/history/***` routes that present detailed content.

### Changes Made

The main change involves modifying the `FooterComponent` to dynamically adjust its visibility based on the current route. Here's an overview of the code adjustments:

```typescript
import { Router, NavigationEnd } from '@angular/router';
// Additional imports remain unchanged

@Component({
  selector: 'oe-footer',
  // Styles and template remain unchanged
})
export class FooterComponent implements OnInit {
  showFooter: boolean = true; // Flag to control footer visibility

  constructor(
    // Constructor dependencies remain unchanged
    private router: Router, // Injected Router for route tracking
  ) {}

  ngOnInit() 
this.router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(() => {
          this.showFooter = !this.router.url.includes('/history');
        });

    // The rest of the ngOnInit logic remains unchanged
  }
}
```

## Justification:
Given the /history tab's purpose to display detailed historical data and analyses, ensuring that this content is fully visible and unobstructed is crucial for user engagement and effectiveness of data presentation. This change directly contributes to improving the overall user experience by making adjustments based on the application's context and user needs.