### PR TITLE
WebSocket: enable permessage-deflate to communication

### DIFF
--- a/io.openems.common/src/io/openems/common/websocket/AbstractWebsocketClient.java
+++ b/io.openems.common/src/io/openems/common/websocket/AbstractWebsocketClient.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.drafts.Draft;
 import org.java_websocket.drafts.Draft_6455;
+import org.java_websocket.extensions.permessage_deflate.PerMessageDeflateExtension;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
 import org.java_websocket.framing.CloseFrame;
 import org.java_websocket.handshake.ServerHandshake;
@@ -34,7 +35,7 @@ public abstract class AbstractWebsocketClient<T extends WsData> extends Abstract
 
 	public static final Map<String, String> NO_HTTP_HEADERS = new HashMap<>();
 	public static final Proxy NO_PROXY = null;
-	public static final Draft DEFAULT_DRAFT = new Draft_6455();
+	public static final Draft DEFAULT_DRAFT = new Draft_6455(new PerMessageDeflateExtension());
 
 	protected final WebSocketClient ws;
 

--- a/io.openems.common/src/io/openems/common/websocket/AbstractWebsocketServer.java
+++ b/io.openems.common/src/io/openems/common/websocket/AbstractWebsocketServer.java
@@ -14,6 +14,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import org.java_websocket.WebSocket;
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.drafts.Draft_6455;
+import org.java_websocket.extensions.permessage_deflate.PerMessageDeflateExtension;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
 import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.server.WebSocketServer;
@@ -63,6 +66,7 @@ public abstract class AbstractWebsocketServer<T extends WsData> extends Abstract
 	private final WebSocketServer ws;
 	private final DebugMode debugMode;
 	private final Collection<WebSocket> connections = ConcurrentHashMap.newKeySet();
+	private final Draft perMessageDeflateDraft = new Draft_6455(new PerMessageDeflateExtension());
 
 	/**
 	 * Construct an {@link AbstractWebsocketServer}.
@@ -80,7 +84,7 @@ public abstract class AbstractWebsocketServer<T extends WsData> extends Abstract
 		this.port = port;
 		this.ws = new WebSocketServer(new InetSocketAddress(port),
 				/* AVAILABLE_PROCESSORS */ Runtime.getRuntime().availableProcessors(), //
-				/* drafts, no filter */ Collections.emptyList(), //
+				/* enable perMessageDeflate */ Collections.singletonList(this.perMessageDeflateDraft), //
 				this.connections) {
 
 			@Override


### PR DESCRIPTION
This PR changes websocket communication use compression.

cf.

 - https://datatracker.ietf.org/doc/html/rfc7692
 - https://github.com/TooTallNate/Java-WebSocket/blob/master/src/main/example/PerMessageDeflateExample.java