### PR TITLE
Generate jacoco xml report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
 		
 		jacocoTestReport {
 			reports {
-				xml.required = false
+				xml.required = true
 				csv.required = true
 				html.required = false
 			}


### PR DESCRIPTION
For some build processes the xml file is better integrated (e.g. if you need to transform the jacoco report to a cobertura report). So far only the csv report was generated.