### PR TITLE
adding stylistic eslint plugin to ui project

### DIFF
--- a/ui/.eslintrc.json
+++ b/ui/.eslintrc.json
@@ -20,7 +20,8 @@
         "createDefaultProgram": true
       },
       "plugins": [
-        "unused-imports"
+        "unused-imports",
+        "@stylistic"
       ],
       "extends": [
         "eslint:recommended",
@@ -30,11 +31,11 @@
       ],
       "rules": {
         "unused-imports/no-unused-imports": "error",
-        "semi": [
+        "@stylistic/semi": [
           "error",
           "always"
         ],
-        "quote-props": [
+        "@stylistic/quote-props": [
           "warn",
           "consistent"
         ],
@@ -67,15 +68,15 @@
           }
         ],
         "curly": "error",
-        "comma-dangle": [
+        "@stylistic/comma-dangle": [
           "error",
           "always-multiline"
         ],
-        "eol-last": [
+        "@stylistic/eol-last": [
           "error",
           "always"
         ],
-        "no-trailing-spaces": "error",
+        "@stylistic/no-trailing-spaces": "error",
         "@typescript-eslint/no-unused-vars": [
           "error",
           {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -52,6 +52,7 @@
         "@angular/compiler-cli": "^16.2.12",
         "@angular/language-service": "^16.2.12",
         "@ionic/angular-toolkit": "^11.0.1",
+        "@stylistic/eslint-plugin": "^2.1.0",
         "@types/jasmine": "~4.3.6",
         "@types/jasminewd2": "~2.0.13",
         "@types/node": "^20.12.6",
@@ -3955,6 +3956,441 @@
         "npm": ">=6.0.0"
       }
     },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.1.0.tgz",
+      "integrity": "sha512-cBBowKP2u/+uE5CzgH5w8pE9VKqcM7BXdIDPIbGt2rmLJGnA6MJPr9vYGaqgMoJFs7R/FzsMQerMvvEP40g2uw==",
+      "dev": true,
+      "dependencies": {
+        "@stylistic/eslint-plugin-js": "2.1.0",
+        "@stylistic/eslint-plugin-jsx": "2.1.0",
+        "@stylistic/eslint-plugin-plus": "2.1.0",
+        "@stylistic/eslint-plugin-ts": "2.1.0",
+        "@types/eslint": "^8.56.10"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.1.0.tgz",
+      "integrity": "sha512-gdXUjGNSsnY6nPyqxu6lmDTtVrwCOjun4x8PUn0x04d5ucLI74N3MT1Q0UhdcOR9No3bo5PGDyBgXK+KmD787A==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "^8.56.10",
+        "acorn": "^8.11.3",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/eslint-visitor-keys": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/espree": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
+      "integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.3",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-jsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.1.0.tgz",
+      "integrity": "sha512-mMD7S+IndZo2vxmwpHVTCwx2O1VdtE5tmpeNwgaEcXODzWV1WTWpnsc/PECQKIr/mkLPFWiSIqcuYNhQ/3l6AQ==",
+      "dev": true,
+      "dependencies": {
+        "@stylistic/eslint-plugin-js": "^2.1.0",
+        "@types/eslint": "^8.56.10",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-jsx/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-jsx/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.1.0.tgz",
+      "integrity": "sha512-S5QAlgYXESJaSBFhBSBLZy9o36gXrXQwWSt6QkO+F0SrT9vpV5JF/VKoh+ojO7tHzd8Ckmyouq02TT9Sv2B0zQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "^8.56.10",
+        "@typescript-eslint/utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.0.tgz",
+      "integrity": "sha512-ZrMCe1R6a01T94ilV13egvcnvVJ1pxShkE0+NDjDzH4nvG1wXpwsVI5bZCvE7AEDH1mXEx5tJSVR68bLgG7Dng==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.0.tgz",
+      "integrity": "sha512-QWuwm9wcGMAuTsxP+qz6LBBd3Uq8I5Nv8xb0mk54jmNoCyDspnMvVsOxI6IsMmway5d1S9Su2+sCKv1st2l6eA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.0.tgz",
+      "integrity": "sha512-cAvBvUoobaoIcoqox1YatXOnSl3gx92rCZoMRPzMNisDiM12siGilSM4+dJAekuuHTibI2hVC2fYK79iSFvWjw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/utils": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.0.tgz",
+      "integrity": "sha512-jceD8RgdKORVnB4Y6BqasfIkFhl4pajB1wVxrF4akxD2QPM8GNYjgGwEzYS+437ewlqqrg7Dw+6dhdpjMpeBFQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.13.0",
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/typescript-estree": "7.13.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.0.tgz",
+      "integrity": "sha512-nxn+dozQx+MK61nn/JP+M4eCkHDSxSLDpgE3WcQo0+fkjEolnaB5jswvIKC4K56By8MMgIho7f1PVxERHEo8rw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.1.0.tgz",
+      "integrity": "sha512-2ioFibufHYBALx2TBrU4KXovCkN8qCqcb9yIHc0fyOfTaO5jw4d56WW7YRcF3Zgde6qFyXwAN6z/+w4pnmos1g==",
+      "dev": true,
+      "dependencies": {
+        "@stylistic/eslint-plugin-js": "2.1.0",
+        "@types/eslint": "^8.56.10",
+        "@typescript-eslint/utils": "^7.8.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.0.tgz",
+      "integrity": "sha512-ZrMCe1R6a01T94ilV13egvcnvVJ1pxShkE0+NDjDzH4nvG1wXpwsVI5bZCvE7AEDH1mXEx5tJSVR68bLgG7Dng==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.0.tgz",
+      "integrity": "sha512-QWuwm9wcGMAuTsxP+qz6LBBd3Uq8I5Nv8xb0mk54jmNoCyDspnMvVsOxI6IsMmway5d1S9Su2+sCKv1st2l6eA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.0.tgz",
+      "integrity": "sha512-cAvBvUoobaoIcoqox1YatXOnSl3gx92rCZoMRPzMNisDiM12siGilSM4+dJAekuuHTibI2hVC2fYK79iSFvWjw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/utils": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.0.tgz",
+      "integrity": "sha512-jceD8RgdKORVnB4Y6BqasfIkFhl4pajB1wVxrF4akxD2QPM8GNYjgGwEzYS+437ewlqqrg7Dw+6dhdpjMpeBFQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.13.0",
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/typescript-estree": "7.13.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.0.tgz",
+      "integrity": "sha512-nxn+dozQx+MK61nn/JP+M4eCkHDSxSLDpgE3WcQo0+fkjEolnaB5jswvIKC4K56By8MMgIho7f1PVxERHEo8rw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "dev": true,
@@ -4077,9 +4513,10 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.56.2",
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -16037,11 +16474,12 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.0.3",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=16.13.0"
+        "node": ">=16"
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -47,6 +47,7 @@
     "@angular/compiler-cli": "^16.2.12",
     "@angular/language-service": "^16.2.12",
     "@ionic/angular-toolkit": "^11.0.1",
+    "@stylistic/eslint-plugin": "^2.1.0",
     "@types/jasmine": "~4.3.6",
     "@types/jasminewd2": "~2.0.13",
     "@types/node": "^20.12.6",

--- a/ui/src/app/edge/history/abstracthistorychart.ts
+++ b/ui/src/app/edge/history/abstracthistorychart.ts
@@ -242,12 +242,12 @@ export abstract class AbstractHistoryChart {
     /**
      * Sets the Label of Chart
      */
-    protected abstract setLabel(config: EdgeConfig)
+    protected abstract setLabel(config: EdgeConfig);
 
     /**
      * Updates and Fills the Chart
      */
-    protected abstract updateChart()
+    protected abstract updateChart();
 
     /**
      * Initializes empty chart on error

--- a/ui/src/app/edge/history/abstracthistorywidget.ts
+++ b/ui/src/app/edge/history/abstracthistorywidget.ts
@@ -96,5 +96,5 @@ export abstract class AbstractHistoryWidget {
     /**
      * Updates and Fills the Chart
      */
-    protected abstract updateValues()
+    protected abstract updateValues();
 }

--- a/ui/src/app/edge/history/shared.ts
+++ b/ui/src/app/edge/history/shared.ts
@@ -27,7 +27,7 @@ export type Data = {
         label: string,
         _meta: {}
     }[]
-}
+};
 
 export type TooltipItem = {
     datasetIndex: number,
@@ -37,7 +37,7 @@ export type TooltipItem = {
     value: number,
     y: number,
     yLabel: number
-}
+};
 
 export type YAxis = {
 
@@ -61,7 +61,7 @@ export type YAxis = {
         stepSize?: number,
         callback?(value: number | string, index: number, values: number[] | string[]): string | number | null | undefined;
     }
-}
+};
 
 export type ChartOptions = {
     plugins: {},
@@ -144,7 +144,7 @@ export type ChartOptions = {
         }
     },
     legendCallback?(chart: Chart.Chart): string
-}
+};
 
 export const DEFAULT_TIME_CHART_OPTIONS: Chart.ChartOptions = {
     responsive: true,
@@ -409,7 +409,7 @@ export function setLabelVisible(label: string, visible: boolean | null): void {
 export type Resolution = {
     value: number,
     unit: ChronoUnit.Type
-}
+};
 
 export namespace ChronoUnit {
 
@@ -419,7 +419,7 @@ export namespace ChronoUnit {
         HOURS = "Hours",
         DAYS = "Days",
         MONTHS = "Months",
-        YEARS = "Years"
+        YEARS = "Years",
     }
 
     /**
@@ -460,5 +460,5 @@ export type ChartData = {
     },
     /** Name to be displayed on the left y-axis */
     yAxisTitle: string,
-}
+};
 

--- a/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/modal/predictionChart.ts
+++ b/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/modal/predictionChart.ts
@@ -244,4 +244,4 @@ export type ChannelChartDescription = {
     channelName: string,
     datasets: number[],
     colorRgb: string,
-}
+};

--- a/ui/src/app/edge/live/Controller/Ess/TimeOfUseTariff/Ess_TimeOfUseTariff.ts
+++ b/ui/src/app/edge/live/Controller/Ess/TimeOfUseTariff/Ess_TimeOfUseTariff.ts
@@ -162,6 +162,6 @@ export namespace Controller_Ess_TimeOfUseTariff {
 
     export enum ControlMode {
         CHARGE_CONSUMPTION = 'CHARGE_CONSUMPTION',
-        DELAY_DISCHARGE = 'DELAY_DISCHARGE'
+        DELAY_DISCHARGE = 'DELAY_DISCHARGE',
     }
 }

--- a/ui/src/app/edge/live/Controller/Evcs/flat/flat.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/flat/flat.ts
@@ -190,7 +190,7 @@ enum ChargeState {
   ERROR,                    //Error
   AUTHORIZATION_REJECTED,   //Authorization rejected
   ENERGY_LIMIT_REACHED,     //Energy limit reached
-  CHARGING_FINISHED         //Charging has finished
+  CHARGING_FINISHED,         //Charging has finished
 }
 
 
@@ -200,9 +200,9 @@ enum ChargePlug {
   PLUGGED_ON_EVCS,                          //Plugged on EVCS
   PLUGGED_ON_EVCS_AND_LOCKED = 3,           //Plugged on EVCS and locked
   PLUGGED_ON_EVCS_AND_ON_EV = 5,            //Plugged on EVCS and on EV
-  PLUGGED_ON_EVCS_AND_ON_EV_AND_LOCKED = 7  //Plugged on EVCS and on EV and locked
+  PLUGGED_ON_EVCS_AND_ON_EV_AND_LOCKED = 7,  //Plugged on EVCS and on EV and locked
 }
 enum Prioritization {
   CAR,
-  STORAGE
+  STORAGE,
 }

--- a/ui/src/app/edge/live/Controller/Evcs/modal/modal.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/modal/modal.ts
@@ -286,7 +286,7 @@ enum ChargeState {
   ERROR,                    //Error
   AUTHORIZATION_REJECTED,   //Authorization rejected
   ENERGY_LIMIT_REACHED,     //Energy limit reached
-  CHARGING_FINISHED         //Charging has finished
+  CHARGING_FINISHED,         //Charging has finished
 }
 
 enum ChargePlug {
@@ -295,5 +295,5 @@ enum ChargePlug {
   PLUGGED_ON_EVCS,                          //Plugged on EVCS
   PLUGGED_ON_EVCS_AND_LOCKED = 3,           //Plugged on EVCS and locked
   PLUGGED_ON_EVCS_AND_ON_EV = 5,            //Plugged on EVCS and on EV
-  PLUGGED_ON_EVCS_AND_ON_EV_AND_LOCKED = 7  //Plugged on EVCS and on EV and locked
+  PLUGGED_ON_EVCS_AND_ON_EV_AND_LOCKED = 7,  //Plugged on EVCS and on EV and locked
 }

--- a/ui/src/app/edge/live/Controller/Io/ChannelSingleThreshold/modal/modal.component.ts
+++ b/ui/src/app/edge/live/Controller/Io/ChannelSingleThreshold/modal/modal.component.ts
@@ -6,7 +6,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { ChannelAddress, Edge, EdgeConfig, Service, Websocket } from 'src/app/shared/shared';
 
 type mode = 'ON' | 'AUTOMATIC' | 'OFF';
-type inputMode = 'SOC' | 'GRIDSELL' | 'GRIDBUY' | 'PRODUCTION' | 'OTHER'
+type inputMode = 'SOC' | 'GRIDSELL' | 'GRIDBUY' | 'PRODUCTION' | 'OTHER';
 
 @Component({
   selector: 'Io_ChannelSingleThresholdModalComponent',

--- a/ui/src/app/edge/live/Controller/Io/HeatingElement/flat/flat.ts
+++ b/ui/src/app/edge/live/Controller/Io/HeatingElement/flat/flat.ts
@@ -105,5 +105,5 @@ export enum Status {
     "Undefined" = -1,
     "Inactive" = 0,
     "Active" = 1,
-    "ActiveForced" = 2
+    "ActiveForced" = 2,
 }

--- a/ui/src/app/edge/live/Controller/Io/Heatpump/modal/modal.component.ts
+++ b/ui/src/app/edge/live/Controller/Io/Heatpump/modal/modal.component.ts
@@ -6,7 +6,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Edge, EdgeConfig, Service, Websocket } from 'src/app/shared/shared';
 
 type ManualMode = 'FORCE_ON' | 'RECOMMENDATION' | 'REGULAR' | 'LOCK';
-type AutomaticEnableMode = 'automaticRecommendationCtrlEnabled' | 'automaticForceOnCtrlEnabled' | 'automaticLockCtrlEnabled'
+type AutomaticEnableMode = 'automaticRecommendationCtrlEnabled' | 'automaticForceOnCtrlEnabled' | 'automaticLockCtrlEnabled';
 
 @Component({
   selector: 'heatpump-modal',

--- a/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/modal/evcs-chart/evcs.chart.ts
+++ b/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/modal/evcs-chart/evcs.chart.ts
@@ -212,11 +212,11 @@ export type BarChartOptions = {
       }
     }]
   }
-}
+};
 
 export type BarChartTooltipItem = {
   datasetIndex: number,
   index: number,
   y: number,
   yLabel: number
-}
+};

--- a/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/modal/evcsCluster-modal.page.ts
+++ b/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/modal/evcsCluster-modal.page.ts
@@ -348,7 +348,7 @@ enum ChargeState {
     ERROR,                    //Error
     AUTHORIZATION_REJECTED,   //Authorization rejected
     ENERGY_LIMIT_REACHED,     //Charge limit reached
-    CHARGING_FINISHED         //Charging has finished
+    CHARGING_FINISHED,         //Charging has finished
 }
 
 enum ChargePlug {
@@ -357,5 +357,5 @@ enum ChargePlug {
     PLUGGED_ON_EVCS,                          //Plugged on EVCS
     PLUGGED_ON_EVCS_AND_LOCKED = 3,           //Plugged on EVCS and locked
     PLUGGED_ON_EVCS_AND_ON_EV = 5,            //Plugged on EVCS and on EV
-    PLUGGED_ON_EVCS_AND_ON_EV_AND_LOCKED = 7  //Plugged on EVCS and on EV and locked
+    PLUGGED_ON_EVCS_AND_ON_EV_AND_LOCKED = 7,  //Plugged on EVCS and on EV and locked
 }

--- a/ui/src/app/edge/live/energymonitor/chart/section/abstractsection.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/abstractsection.component.ts
@@ -119,7 +119,7 @@ export class EnergyFlow {
 export enum GridMode {
     "undefined",
     "ongrid",
-    "offgrid"
+    "offgrid",
 }
 
 export abstract class AbstractSection {

--- a/ui/src/app/edge/settings/alerting/alerting.component.ts
+++ b/ui/src/app/edge/settings/alerting/alerting.component.ts
@@ -11,7 +11,7 @@ import { Edge, Service, Utils, Websocket } from 'src/app/shared/shared';
 export enum AlertingType {
   offline = 0,
   fault = 1,
-  warning = 2
+  warning = 2,
 }
 
 type DefaultValues = { [K in AlertingType]: Delay[]; };

--- a/ui/src/app/edge/settings/app/formly/option-group-picker/optionGroupPickerConfiguration.ts
+++ b/ui/src/app/edge/settings/app/formly/option-group-picker/optionGroupPickerConfiguration.ts
@@ -10,25 +10,25 @@ export type OptionConfig = {
         title?: (field: FormlyFieldConfig) => string,
         disabled?: (field: FormlyFieldConfig) => boolean,
     }
-}
+};
 
 export type OptionGroupConfig = {
     group: string,
     title: string,
     options: OptionConfig[]
-}
+};
 
 export type OptionGroup = {
     group: string,
     title: string,
     options: Option[]
-}
+};
 export type Option = {
     value: string,
     title: string,
     disabled: boolean,
     selected: boolean,
-}
+};
 
 /**
  * Gets the title of an OptionConfig that should be display.

--- a/ui/src/app/edge/settings/app/formly/reorder-select/formly-reorder-array.component.ts
+++ b/ui/src/app/edge/settings/app/formly/reorder-select/formly-reorder-array.component.ts
@@ -116,7 +116,7 @@ export type SelectOptionConfig = {
     expressions?: {
         locked?: (field: FormlyFieldConfig) => boolean,
     }
-}
+};
 
 type SelectOption = {
     label: string,
@@ -124,4 +124,4 @@ type SelectOption = {
     expressions: {
         locked: boolean,
     }
-}
+};

--- a/ui/src/app/edge/settings/app/jsonrpc/getAppAssistant.ts
+++ b/ui/src/app/edge/settings/app/jsonrpc/getAppAssistant.ts
@@ -343,4 +343,4 @@ function convertFormlyReorderArray(rootFields: FormlyFieldConfig[], field: Forml
 }
 
 
-type FormlyFieldConfigWithInitialModel = FormlyFieldConfig & { initialModel: {} }
+type FormlyFieldConfigWithInitialModel = FormlyFieldConfig & { initialModel: {} };

--- a/ui/src/app/edge/settings/app/keypopup/app.ts
+++ b/ui/src/app/edge/settings/app/keypopup/app.ts
@@ -4,4 +4,4 @@
 export type App = {
     id: number,
     appId: string
-}
+};

--- a/ui/src/app/edge/settings/app/keypopup/key.ts
+++ b/ui/src/app/edge/settings/app/keypopup/key.ts
@@ -3,4 +3,4 @@ import { App } from "./app";
 export type Key = {
     keyId: string
     bundles?: (App[])[]
-}
+};

--- a/ui/src/app/edge/settings/jsonrpctest/jsonrpctest.ts
+++ b/ui/src/app/edge/settings/jsonrpctest/jsonrpctest.ts
@@ -135,21 +135,21 @@ type EndpointResponse = {
     examples: RequestExample[]
   },
   parent: { method: string, request: { base: any, pathToSubrequest: string[] } }[],
-}
+};
 
 type Tag = {
   name: string
-}
+};
 
 type Guard = {
   name: string,
   description: string
-}
+};
 
 type RequestExample = {
   key: string,
   value: {}
-}
+};
 
 type EndpointType =
   {
@@ -159,7 +159,7 @@ type EndpointType =
   | {
     type: 'string',
     constraints: string[]
-  }
+  };
 
 type Endpoint = {
   method: string,
@@ -185,4 +185,4 @@ type Endpoint = {
     loading?: boolean,
     response?: string;
   }
-}
+};

--- a/ui/src/app/edge/settings/network/shared.ts
+++ b/ui/src/app/edge/settings/network/shared.ts
@@ -8,13 +8,13 @@ export type NetworkInterface = {
   linkLocalAddressing?: boolean,
   metric?: number,
   addresses?: IpAddress[]
-}
+};
 
 export type IpAddress = {
   label: string,
   address: string,
   subnetmask: string
-}
+};
 
 export type InterfaceForm = {
   name: string,
@@ -27,13 +27,13 @@ export type InterfaceModel = NetworkInterface & {
   addressesList?: string[],
   ip?: string | null,
   subnetmask?: string | null,
-}
+};
 
 export type NetworkConfig = {
   interfaces: {
     [name: string]: NetworkInterface;
   }
-}
+};
 
 export namespace NetworkUtils {
 

--- a/ui/src/app/index/filter/filter.component.ts
+++ b/ui/src/app/index/filter/filter.component.ts
@@ -69,7 +69,7 @@ export class FilterComponent {
   }
 }
 
-export type ChosenFilter = TKeyValue<string | string[] | boolean | null>
+export type ChosenFilter = TKeyValue<string | string[] | boolean | null>;
 
 export type Filter = {
   placeholder: string,
@@ -78,9 +78,9 @@ export type Filter = {
 
   // sets additional filter
   setAdditionalFilter?: () => ChosenFilter
-}
+};
 
 export type FilterOption = {
   name: string,
   value: string | null
-}
+};

--- a/ui/src/app/index/shared/sumState.ts
+++ b/ui/src/app/index/shared/sumState.ts
@@ -8,7 +8,7 @@ export enum SumState {
   OK = 'OK',
   INFO = 'INFO',
   WARNING = 'WARNING',
-  FAULT = 'FAULT'
+  FAULT = 'FAULT',
 }
 
 @Component({

--- a/ui/src/app/shared/formly/form-field-default-cases.wrapper.ts
+++ b/ui/src/app/shared/formly/form-field-default-cases.wrapper.ts
@@ -94,4 +94,4 @@ export class FormlyWrapperDefaultValueWithCasesComponent extends FieldWrapper im
 
 }
 
-type FieldDefaultCases = { field: string, cases: [{ case: any, defaultValue: any }] }
+type FieldDefaultCases = { field: string, cases: [{ case: any, defaultValue: any }] };

--- a/ui/src/app/shared/genericComponents/modal/modal-button/modal-button.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal-button/modal-button.ts
@@ -19,4 +19,4 @@ export type ButtonLabel = {
     /** Icons for Button, displayed above the corresponding name */
     icons?: Icon;
     callback?: Function;
-}
+};

--- a/ui/src/app/shared/genericComponents/modal/modal-line/modal-line.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal-line/modal-line.ts
@@ -32,5 +32,5 @@ export class ModalLineComponent extends AbstractModalLine {
 export enum TextIndentation {
     NONE = '0%',
     SINGLE = '5%',
-    DOUBLE = '10%'
+    DOUBLE = '10%',
 }

--- a/ui/src/app/shared/genericComponents/modal/modal-value-line/modal-value-line.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal-value-line/modal-value-line.ts
@@ -37,5 +37,5 @@ export class ModalValueLineComponent extends AbstractModalLine {
 export enum TextIndentation {
   NONE = '0%',
   SINGLE = '5%',
-  DOUBLE = '10%'
+  DOUBLE = '10%',
 }

--- a/ui/src/app/shared/genericComponents/modal/modal.ts
+++ b/ui/src/app/shared/genericComponents/modal/modal.ts
@@ -10,7 +10,7 @@ import { Icon } from "../../type/widget";
 export enum Status {
     SUCCESS,
     ERROR,
-    PENDING
+    PENDING,
 }
 
 @Component({

--- a/ui/src/app/shared/genericComponents/shared/oe-formly-component.ts
+++ b/ui/src/app/shared/genericComponents/shared/oe-formly-component.ts
@@ -50,13 +50,13 @@ export abstract class AbstractFormlyComponent {
     * @param role  the Role of the User for this Edge
     * @param translate the Translate-Service
     */
-  protected abstract generateView(config: EdgeConfig, role: Role, translate: TranslateService): OeFormlyView
+  protected abstract generateView(config: EdgeConfig, role: Role, translate: TranslateService): OeFormlyView;
 }
 
 export type OeFormlyView = {
   title: string,
   lines: OeFormlyField[]
-}
+};
 
 export type OeFormlyField =
   | OeFormlyField.InfoLine
@@ -71,21 +71,21 @@ export namespace OeFormlyField {
   export type InfoLine = {
     type: 'info-line',
     name: string
-  }
+  };
 
   export type Item = {
     type: 'item',
     channel: string,
     filter?: (value: number | null) => boolean,
     converter?: (value: number | null) => string
-  }
+  };
 
   export type ChildrenLine = {
     type: 'children-line',
     name: /* actual name string */ string | /* name string derived from channel value */ { channel: ChannelAddress, converter: Converter },
     indentation?: TextIndentation,
     children: Item[],
-  }
+  };
 
   export type ChannelLine = {
     type: 'channel-line',
@@ -94,7 +94,7 @@ export namespace OeFormlyField {
     filter?: (value: number | null) => boolean,
     converter?: (value: number | null) => string
     indentation?: TextIndentation,
-  }
+  };
 
   export type ValueFromChannelsLine = {
     type: 'value-from-channels-line',
@@ -103,9 +103,9 @@ export namespace OeFormlyField {
     channelsToSubscribe: ChannelAddress[],
     indentation?: TextIndentation,
     filter?: (value: number[] | null) => boolean,
-  }
+  };
 
   export type HorizontalLine = {
     type: 'horizontal-line',
-  }
+  };
 }

--- a/ui/src/app/shared/genericComponents/shared/testing/common.ts
+++ b/ui/src/app/shared/genericComponents/shared/testing/common.ts
@@ -18,7 +18,7 @@ export namespace OeTester {
       energyPerPeriodChannelWithValues?: QueryHistoricTimeseriesEnergyPerPeriodResponse,
       /** data from a {@link QueryHistoricTimeseriesDataResponse} */
       dataChannelWithValues?: QueryHistoricTimeseriesDataResponse
-    }
+    };
   }
 
   export namespace ChartOptions {

--- a/ui/src/app/shared/genericComponents/shared/testing/tester.ts
+++ b/ui/src/app/shared/genericComponents/shared/testing/tester.ts
@@ -187,7 +187,7 @@ export namespace OeChartTester {
   export type Context = {
     energyChannel: { [id: string]: number[] }[]
     powerChannel: { [id: string]: number[] }[]
-  }[]
+  }[];
 
   export type View = {
     datasets: {
@@ -195,12 +195,12 @@ export namespace OeChartTester {
       labels: OeChartTester.Dataset.LegendLabel,
       options: OeChartTester.Dataset.Option
     }
-  }
+  };
 
   export type Dataset =
     | Dataset.Data
     | Dataset.LegendLabel
-    | Dataset.Option
+    | Dataset.Option;
 
   export namespace Dataset {
 
@@ -208,16 +208,16 @@ export namespace OeChartTester {
       type: 'data',
       label: string | Converter,
       value: number[] | null
-    }
+    };
 
     export type LegendLabel = {
       type: 'label',
       timestamps: Date[]
-    }
+    };
     export type Option = {
       type: 'option',
       options: Chart.ChartOptions
-    }
+    };
   }
 }
 
@@ -327,7 +327,7 @@ export namespace OeFormlyViewTester {
   export type View = {
     title: string,
     lines: Field[]
-  }
+  };
 
   export type Field =
     | Field.InfoLine
@@ -342,37 +342,37 @@ export namespace OeFormlyViewTester {
     export type InfoLine = {
       type: 'info-line',
       name: string
-    }
+    };
 
     export type Item = {
       type: 'item',
       value: string
-    }
+    };
 
     export type ChannelLine = {
       type: 'channel-line',
       name: string,
       value?: string,
       indentation?: TextIndentation,
-    }
+    };
 
     export type ValueLine = {
       type: 'value-from-channels-line',
       name: string,
       value?: string,
       indentation?: TextIndentation,
-    }
+    };
 
     export type ChildrenLine = {
       type: 'children-line',
       name: string,
       indentation?: TextIndentation,
       children?: Field[]
-    }
+    };
 
     export type HorizontalLine = {
       type: 'horizontal-line',
-    }
+    };
   }
 
   export function applyLineWithChildren(field: OeFormlyField.ChildrenLine, context: Context): { rawValue: number | null, value: string }

--- a/ui/src/app/shared/service/defaulttypes.ts
+++ b/ui/src/app/shared/service/defaulttypes.ts
@@ -102,7 +102,7 @@ export module DefaultTypes {
 
     export enum YAxisTitle {
       PERCENTAGE,
-      ENERGY
+      ENERGY,
     }
     export type InputChannel = {
 
@@ -113,7 +113,7 @@ export module DefaultTypes {
 
       /** Choose between predefined converters */
       converter?: (value: number) => number | null,
-    }
+    };
     export type DisplayValues = {
       name: string,
       /** suffix to the name */
@@ -128,11 +128,11 @@ export module DefaultTypes {
       color: string,
       /** the stack for barChart */
       stack?: number,
-    }
+    };
 
     export type ChannelData = {
       [name: string]: number[]
-    }
+    };
 
     export type ChartData = {
       /** Input Channels that need to be queried from the database */
@@ -146,7 +146,7 @@ export module DefaultTypes {
       },
       /** Name to be displayed on the left y-axis, also the unit to be displayed in tooltips and legend */
       unit: YAxisTitle,
-    }
+    };
   }
 
   export class HistoryPeriod {
@@ -241,4 +241,4 @@ export module DefaultTypes {
 export type TKeyValue<T> = {
   key: string,
   value: T
-}
+};

--- a/ui/src/app/shared/service/logger.ts
+++ b/ui/src/app/shared/service/logger.ts
@@ -10,7 +10,7 @@ export enum Level {
     DEBUG = "debug",
     INFO = "info",
     WARNING = "warning",
-    ERROR = "error"
+    ERROR = "error",
 }
 
 @Injectable()

--- a/ui/src/app/shared/service/utils.ts
+++ b/ui/src/app/shared/service/utils.ts
@@ -618,7 +618,7 @@ export enum YAxisTitle {
   ENERGY,
   VOLTAGE,
   TIME,
-  CURRENCY
+  CURRENCY,
 }
 
 export enum ChartAxis {
@@ -655,7 +655,7 @@ export namespace HistoryUtils {
 
     /** Choose between predefined converters */
     converter?: (value: number) => number | null,
-  }
+  };
   export type DisplayValues = {
     name: string,
     /** suffix to the name */
@@ -696,7 +696,7 @@ export namespace HistoryUtils {
      * @default Number.MAX_VALUE
      */
     order?: number,
-  }
+  };
 
   /**
  * Data from a subscription to Channel or from a historic data query.
@@ -705,7 +705,7 @@ export namespace HistoryUtils {
  */
   export type ChannelData = {
     [name: string]: number[]
-  }
+  };
 
   export type ChartData = {
     /** Input Channels that need to be queried from the database */
@@ -718,7 +718,7 @@ export namespace HistoryUtils {
       afterTitle?: (stack: string) => string,
     },
     yAxes: yAxes[],
-  }
+  };
 
   export type yAxes = {
     /** Name to be displayed on the left y-axis, also the unit to be displayed in tooltips and legend */
@@ -728,7 +728,7 @@ export namespace HistoryUtils {
     yAxisId: ChartAxis,
     /** Default: true */
     displayGrid?: boolean
-  }
+  };
 
   export namespace ValueConverter {
 

--- a/ui/src/app/shared/shared.ts
+++ b/ui/src/app/shared/shared.ts
@@ -137,7 +137,7 @@ export namespace Currency {
 
   export enum Label {
     OERE_PER_KWH = "Öre/kWh",
-    CENT_PER_KWH = "Cent/kWh"
+    CENT_PER_KWH = "Cent/kWh",
   }
 }
 

--- a/ui/src/app/shared/type/general.ts
+++ b/ui/src/app/shared/type/general.ts
@@ -6,9 +6,9 @@ export enum GridMode {
 export enum Mode {
     MANUAL_ON = 'MANUAL_ON',
     MANUAL_OFF = 'MANUAL_OFF',
-    AUTOMATIC = 'AUTOMATIC'
+    AUTOMATIC = 'AUTOMATIC',
 }
 export enum WorkMode {
     TIME = 'TIME',
-    NONE = 'NONE'
+    NONE = 'NONE',
 }

--- a/ui/src/app/shared/type/widget.ts
+++ b/ui/src/app/shared/type/widget.ts
@@ -10,7 +10,7 @@ export enum WidgetClass {
     'Grid',
     'Common_Production',
     'Consumption',
-    'Controller_ChannelThreshold'
+    'Controller_ChannelThreshold',
 }
 
 export enum WidgetNature {
@@ -42,7 +42,7 @@ export type Icon = {
     color: string;
     size: string;
     name: string;
-}
+};
 
 export class Widget {
     public name: WidgetNature | WidgetFactory | string;
@@ -151,5 +151,5 @@ export class Widgets {
 }
 
 export enum ProductType {
-    HOME = "home"
+    HOME = "home",
 }

--- a/ui/src/app/user/user.component.ts
+++ b/ui/src/app/user/user.component.ts
@@ -26,7 +26,7 @@ type UserInformation = {
   zip: string,
   city: string,
   country: string
-}
+};
 
 @Component({
   templateUrl: './user.component.html',


### PR DESCRIPTION
This PR migrate eslint formatting rules to stylistic plugin rules.

// current eslint version of this project is `"eslint": "^8.57.0",`. this means currently eslnt formatting check is not working, I think. // ^8.41 → ^8.57 bump is happen on #2623 

The below text is the background to this problem.

last year, eslint deprecated formatting rules in v8.53.0 release.

https://eslint.org/blog/2023/11/eslint-v8.53.0-released/
> Core formatting rules have been deprecated.

https://eslint.org/blog/2023/10/deprecating-formatting-rules/
> The next minor release of ESLint will deprecate core formatting rules. We recommend you use a source code formatter instead.

And also they mentioned stylistic eslint plugin for migration.

> If the idea of using a dedicated source code formatter doesn’t appeal to you, you can also use [@stylistic/eslint-plugin-js](https://eslint.style/packages/js) for JavaScript or [@stylistic/eslint-plugin-ts](https://eslint.style/packages/ts) for TypeScript. These packages contain the deprecated formatting rules from the ESLint core and [typescript-eslint](https://typescript-eslint.io/), respectively. The packages are maintained by [Anthony Fu](https://github.com/antfu), who has decided to continue maintaining these rules going forward. If you’d like to continue using the rules mentioned in this post, then we recommend switching to these packages.

