### PR TITLE
docker edge-ui: fix root path not handled correctly

### DIFF
--- a/tools/docker/ui/root/defaults/nginx/site-confs/openems.conf
+++ b/tools/docker/ui/root/defaults/nginx/site-confs/openems.conf
@@ -1,16 +1,13 @@
 server {
 	listen 80 default_server;
-    listen [::]:80 default_server;
+	listen [::]:80 default_server;
 
 	server_name openems openems.local localhost;
 
-	root /var/www/html/openems;
-
-    index	index.html;
-
 	# OpenEMS Web-Interface
 	location / {
-		try_files $uri $uri/ /index.html;
-		error_page	404 300 /index.html;
+		root /var/www/html/openems;
+		index index.html index.htm;
+		error_page 404 300 /index.html;
 	}
 }


### PR DESCRIPTION
currently root path (`http://<ip>/`) is not redirected correctly to login/main page. You have to call the subpage manually `/login` or `/index`. fixes also formatting (mixed tabs/spaces)