### PR TITLE
fix: add null type to null initialization variables

### DIFF
--- a/ui/src/app/edge/history/chpsoc/chpsocchartoverview/chpsocchartoverview.component.ts
+++ b/ui/src/app/edge/history/chpsoc/chpsocchartoverview/chpsocchartoverview.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
@@ -10,9 +9,9 @@ import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
 export class ChpSocChartOverviewComponent implements OnInit {
 
     private static readonly SELECTOR = "chpsoc-chart-overview";
-    public edge: Edge = null;
-    public config: EdgeConfig = null;
-    public component: EdgeConfig.Component = null;
+    public edge: Edge | null = null;
+    public config: EdgeConfig | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public service: Service,

--- a/ui/src/app/edge/history/chpsoc/widget.component.ts
+++ b/ui/src/app/edge/history/chpsoc/widget.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { QueryHistoricTimeseriesDataResponse } from 'src/app/shared/jsonrpc/response/queryHistoricTimeseriesDataResponse';
@@ -18,9 +17,9 @@ export class ChpSocWidgetComponent extends AbstractHistoryWidget implements OnIn
     @Input({ required: true }) public period!: DefaultTypes.HistoryPeriod;
     @Input({ required: true }) public componentId!: string;
 
-    public activeSecondsOverPeriod: number = null;
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public activeSecondsOverPeriod: number | null = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public override service: Service,

--- a/ui/src/app/edge/history/delayedselltogrid/symmetricpeakshavingchartoverview/delayedselltogridchartoverview.component.ts
+++ b/ui/src/app/edge/history/delayedselltogrid/symmetricpeakshavingchartoverview/delayedselltogridchartoverview.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
@@ -10,8 +9,8 @@ import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
 export class DelayedSellToGridChartOverviewComponent implements OnInit {
 
     private static readonly SELECTOR = "symmetricpeakshaving-chart-overview";
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public service: Service,

--- a/ui/src/app/edge/history/delayedselltogrid/widget.component.ts
+++ b/ui/src/app/edge/history/delayedselltogrid/widget.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ActivatedRoute } from '@angular/router';
 import { Component, Input, OnInit } from '@angular/core';
 import { DefaultTypes } from 'src/app/shared/service/defaulttypes';
@@ -14,8 +13,8 @@ export class DelayedSellToGridWidgetComponent implements OnInit {
     @Input({ required: true }) public period!: DefaultTypes.HistoryPeriod;
     @Input({ required: true }) public componentId!: string;
 
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public service: Service,

--- a/ui/src/app/edge/history/fixdigitaloutput/fixdigitaloutputchartoverview/fixdigitaloutputchartoverview.component.ts
+++ b/ui/src/app/edge/history/fixdigitaloutput/fixdigitaloutputchartoverview/fixdigitaloutputchartoverview.component.ts
@@ -11,8 +11,8 @@ export class FixDigitalOutputChartOverviewComponent implements OnInit {
 
     private static readonly SELECTOR = "fixdigitaloutput-chart-overview";
 
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     public showTotal: boolean = false;
     public fixDigitalOutputComponents: string[] = [];

--- a/ui/src/app/edge/history/fixdigitaloutput/widget.component.ts
+++ b/ui/src/app/edge/history/fixdigitaloutput/widget.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { QueryHistoricTimeseriesDataResponse } from 'src/app/shared/jsonrpc/response/queryHistoricTimeseriesDataResponse';
@@ -17,12 +16,11 @@ export class FixDigitalOutputWidgetComponent extends AbstractHistoryWidget imple
     private static readonly SELECTOR = "fixDigitalOutputWidget";
     @Input({ required: true }) public period!: DefaultTypes.HistoryPeriod;
     @Input({ required: true }) public componentId!: string;
-    public component: EdgeConfig.Component = null;
-    public activeSecondsOverPeriod: number = null;
-    public edge: Edge = null;
-    private config: EdgeConfig = null;
 
-
+    public component: EdgeConfig.Component | null = null;
+    public activeSecondsOverPeriod: number | null = null;
+    public edge: Edge | null = null;
+    private config: EdgeConfig | null = null;
 
     constructor(
         public override service: Service,

--- a/ui/src/app/edge/history/heatingelement/heatingelementchartoverview/heatingelementchartoverview.component.ts
+++ b/ui/src/app/edge/history/heatingelement/heatingelementchartoverview/heatingelementchartoverview.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
@@ -10,8 +9,8 @@ import { Edge, EdgeConfig, Service } from '../../../../shared/shared';
 export class HeatingelementChartOverviewComponent implements OnInit {
 
     private static readonly SELECTOR = "heatingelement-chart-overview";
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public service: Service,

--- a/ui/src/app/edge/history/heatingelement/widget.component.ts
+++ b/ui/src/app/edge/history/heatingelement/widget.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { QueryHistoricTimeseriesDataResponse } from 'src/app/shared/jsonrpc/response/queryHistoricTimeseriesDataResponse';
@@ -18,13 +17,13 @@ export class HeatingelementWidgetComponent extends AbstractHistoryWidget impleme
     @Input({ required: true }) public componentId!: string;
 
 
-    public component: EdgeConfig.Component = null;
+    public component: EdgeConfig.Component | null = null;
 
     public activeTimeOverPeriodLevel1: number | null = null;
     public activeTimeOverPeriodLevel2: number | null = null;
     public activeTimeOverPeriodLevel3: number | null = null;
 
-    public edge: Edge = null;
+    public edge: Edge | null = null;
 
     constructor(
         public override service: Service,

--- a/ui/src/app/edge/history/heatpump/heatpumpchartoverview/heatpumpchartoverview.component.ts
+++ b/ui/src/app/edge/history/heatpump/heatpumpchartoverview/heatpumpchartoverview.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ModalController } from '@ionic/angular';
@@ -12,8 +11,8 @@ export class HeatPumpChartOverviewComponent implements OnInit {
 
     private static readonly SELECTOR = "heatpump-chart-overview";
 
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public service: Service,

--- a/ui/src/app/edge/history/heatpump/widget.component.ts
+++ b/ui/src/app/edge/history/heatpump/widget.component.ts
@@ -24,7 +24,7 @@ export class HeatpumpWidgetComponent extends AbstractHistoryWidget implements On
     public activeTimeOverPeriodRecommendation: number | null = null;
     public activeTimeOverPeriodLock: number | null = null;
 
-    public edge: Edge = null;
+    public edge: Edge | null = null;
 
     constructor(
         public override service: Service,

--- a/ui/src/app/edge/history/history.component.ts
+++ b/ui/src/app/edge/history/history.component.ts
@@ -24,15 +24,15 @@ export class HistoryComponent implements OnInit {
   public energyChartHeight: string = "250px";
 
   // holds the Widgets
-  public widgets: Widgets = null;
+  public widgets: Widgets | null = null;
 
   // holds the current Edge
-  public edge: Edge = null;
+  public edge: Edge | null = null;
 
   // holds Channelthreshold Components to display effective active time in %
   // public channelthresholdComponents: string[] = [];
 
-  public config: EdgeConfig = null;
+  public config: EdgeConfig | null = null;
   protected errorResponse: JsonrpcResponseError | null = null;
 
   constructor(

--- a/ui/src/app/edge/history/peakshaving/asymmetric/asymmetricpeakshavingchartoverview/asymmetricpeakshavingchartoverview.component.ts
+++ b/ui/src/app/edge/history/peakshaving/asymmetric/asymmetricpeakshavingchartoverview/asymmetricpeakshavingchartoverview.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Edge, EdgeConfig, Service } from '../../../../../shared/shared';
@@ -10,8 +9,8 @@ import { Edge, EdgeConfig, Service } from '../../../../../shared/shared';
 export class AsymmetricPeakshavingChartOverviewComponent implements OnInit {
 
     private static readonly SELECTOR = "asymmetricpeakshaving-chart-overview";
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public service: Service,

--- a/ui/src/app/edge/history/peakshaving/asymmetric/widget.component.ts
+++ b/ui/src/app/edge/history/peakshaving/asymmetric/widget.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ActivatedRoute } from '@angular/router';
 import { Component, Input, OnInit } from '@angular/core';
 import { DefaultTypes } from 'src/app/shared/service/defaulttypes';
@@ -15,8 +14,8 @@ export class AsymmetricPeakshavingWidgetComponent implements OnInit {
     @Input({ required: true }) public componentId!: string;
 
 
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public service: Service,

--- a/ui/src/app/edge/history/peakshaving/symmetric/symmetricpeakshavingchartoverview/symmetricpeakshavingchartoverview.component.ts
+++ b/ui/src/app/edge/history/peakshaving/symmetric/symmetricpeakshavingchartoverview/symmetricpeakshavingchartoverview.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Edge, EdgeConfig, Service } from '../../../../../shared/shared';
@@ -11,8 +10,8 @@ export class SymmetricPeakshavingChartOverviewComponent implements OnInit {
 
     private static readonly SELECTOR = "symmetricpeakshaving-chart-overview";
 
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public service: Service,

--- a/ui/src/app/edge/history/peakshaving/symmetric/widget.component.ts
+++ b/ui/src/app/edge/history/peakshaving/symmetric/widget.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { DefaultTypes } from 'src/app/shared/service/defaulttypes';
@@ -15,8 +14,8 @@ export class SymmetricPeakshavingWidgetComponent implements OnInit {
     @Input({ required: true }) public componentId!: string;
 
 
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public service: Service,

--- a/ui/src/app/edge/history/peakshaving/timeslot/timeslotpeakshavingchartoverview/timeslotpeakshavingchartoverview.component.ts
+++ b/ui/src/app/edge/history/peakshaving/timeslot/timeslotpeakshavingchartoverview/timeslotpeakshavingchartoverview.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Edge, EdgeConfig, Service } from '../../../../../shared/shared';
@@ -11,8 +10,8 @@ export class TimeslotPeakshavingChartOverviewComponent implements OnInit {
 
     private static readonly SELECTOR = "timeslotpeakshaving-chart-overview";
 
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public service: Service,

--- a/ui/src/app/edge/history/peakshaving/timeslot/widget.component.ts
+++ b/ui/src/app/edge/history/peakshaving/timeslot/widget.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { DefaultTypes } from 'src/app/shared/service/defaulttypes';
@@ -15,8 +14,8 @@ export class TimeslotPeakshavingWidgetComponent implements OnInit {
     @Input({ required: true }) public componentId!: string;
 
 
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public service: Service,

--- a/ui/src/app/edge/history/singlethreshold/chart.component.ts
+++ b/ui/src/app/edge/history/singlethreshold/chart.component.ts
@@ -99,7 +99,7 @@ export class SinglethresholdChartComponent extends AbstractHistoryChart implemen
             });
           }
           if (channel == inputChannel) {
-            let inputLabel: string = null;
+            let inputLabel: string | null = null;
             const address = ChannelAddress.fromString(channel);
             switch (address.channelId) {
               case 'GridActivePower':

--- a/ui/src/app/edge/history/singlethreshold/singlethresholdchartoverview/singlethresholdchartoverview.component.ts
+++ b/ui/src/app/edge/history/singlethreshold/singlethresholdchartoverview/singlethresholdchartoverview.component.ts
@@ -11,9 +11,9 @@ export class SinglethresholdChartOverviewComponent implements OnInit {
 
     private static readonly SELECTOR = "channelthreshold-chart-overview";
 
-    public edge: Edge = null;
+    public edge: Edge | null = null;
 
-    public component: EdgeConfig.Component = null;
+    public component: EdgeConfig.Component | null = null;
     public inputChannel: string;
 
     // reference to the Utils method to access via html

--- a/ui/src/app/edge/history/singlethreshold/widget.component.ts
+++ b/ui/src/app/edge/history/singlethreshold/widget.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { QueryHistoricTimeseriesDataResponse } from 'src/app/shared/jsonrpc/response/queryHistoricTimeseriesDataResponse';
@@ -19,9 +18,9 @@ export class SinglethresholdWidgetComponent extends AbstractHistoryWidget implem
     @Input({ required: true }) public period!: DefaultTypes.HistoryPeriod;
     @Input({ required: true }) public componentId!: string;
 
-    public activeSecondsOverPeriod: number = null;
-    public edge: Edge = null;
-    public component: EdgeConfig.Component = null;
+    public activeSecondsOverPeriod: number | null = null;
+    public edge: Edge | null = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         public override service: Service,

--- a/ui/src/app/edge/history/storage/chargerchart.component.ts
+++ b/ui/src/app/edge/history/storage/chargerchart.component.ts
@@ -16,7 +16,7 @@ export class StorageChargerChartComponent extends AbstractHistoryChart implement
     @Input({ required: true }) public period!: DefaultTypes.HistoryPeriod;
     @Input({ required: true }) public componentId!: string;
 
-    private moreThanOneProducer: boolean = null;
+    private moreThanOneProducer: boolean | null = null;
 
     constructor(
         protected override service: Service,

--- a/ui/src/app/edge/history/storage/esschart.component.ts
+++ b/ui/src/app/edge/history/storage/esschart.component.ts
@@ -18,7 +18,7 @@ export class StorageESSChartComponent extends AbstractHistoryChart implements On
     @Input({ required: true }) public componentId!: string;
     @Input({ required: true }) public showPhases!: boolean;
 
-    private moreThanOneProducer: boolean = null;
+    private moreThanOneProducer: boolean | null = null;
 
     constructor(
         protected override service: Service,

--- a/ui/src/app/edge/history/storage/storagechartoverview/storagechartoverview.component.ts
+++ b/ui/src/app/edge/history/storage/storagechartoverview/storagechartoverview.component.ts
@@ -11,10 +11,10 @@ export class StorageChartOverviewComponent implements OnInit {
 
     private static readonly SELECTOR = "storage-chart-overview";
 
-    public edge: Edge = null;
+    public edge: Edge | null = null;
 
-    public essComponents: EdgeConfig.Component[] = null;
-    public chargerComponents: EdgeConfig.Component[] = null;
+    public essComponents: EdgeConfig.Component[] | null = null;
+    public chargerComponents: EdgeConfig.Component[] | null = null;
 
     public showPhases: boolean = false;
     public showTotal: boolean = false;

--- a/ui/src/app/edge/history/storage/widget.component.ts
+++ b/ui/src/app/edge/history/storage/widget.component.ts
@@ -18,8 +18,8 @@ export class StorageComponent extends AbstractHistoryWidget implements OnInit, O
     // reference to the Utils method to access via html
     public isLastElement = Utils.isLastElement;
 
-    public data: Cumulated = null;
-    public edge: Edge = null;
+    public data: Cumulated | null = null;
+    public edge: Edge | null = null;
     public essComponents: EdgeConfig.Component[] = [];
 
     constructor(

--- a/ui/src/app/edge/live/Controller/ChpSoc/ChpSoc.ts
+++ b/ui/src/app/edge/live/Controller/ChpSoc/ChpSoc.ts
@@ -13,10 +13,9 @@ import { Controller_ChpSocModalComponent } from './modal/modal.component';
 export class Controller_ChpSocComponent extends AbstractFlatWidget {
 
     private static PROPERTY_MODE: string = '_PropertyMode';
-
-    public inputChannel: ChannelAddress = null;
-    public outputChannel: ChannelAddress = null;
-    public propertyModeChannel: ChannelAddress = null;
+    public inputChannel: ChannelAddress | null = null;
+    public outputChannel: ChannelAddress | null = null;
+    public propertyModeChannel: ChannelAddress | null = null;
     public highThresholdValue: number;
     public lowThresholdValue: number;
     public state: string;

--- a/ui/src/app/edge/live/Controller/Ess/FixActivePower/flat/flat.ts
+++ b/ui/src/app/edge/live/Controller/Ess/FixActivePower/flat/flat.ts
@@ -16,7 +16,7 @@ export class FlatComponent extends AbstractFlatWidget {
   public readonly CONVERT_MANUAL_ON_OFF = Utils.CONVERT_MANUAL_ON_OFF(this.translate);
 
   public chargeDischargePower: { name: string, value: number };
-  public propertyMode: DefaultTypes.ManualOnOff = null;
+  public propertyMode: DefaultTypes.ManualOnOff | null = null;
 
   async presentModal() {
     if (!this.isInitialized) {

--- a/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/flat/flat.ts
+++ b/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/flat/flat.ts
@@ -11,7 +11,7 @@ import { ModalComponent } from '../modal/modal';
 })
 export class FlatComponent extends AbstractFlatWidget {
 
-    public override component: EdgeConfig.Component = null;
+    public override component: EdgeConfig.Component | null = null;
     public mode: string = '-';
     public state: string = '-';
     public isSellToGridLimitAvoided: boolean = false;

--- a/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/modal/modal.ts
+++ b/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/modal/modal.ts
@@ -22,11 +22,11 @@ export class ModalComponent extends AbstractModal {
     public state: string = '';
     public chargeLimit: { name: string, value: number };
     public delayChargeState: number | null = null;
-    public maximumSellToGridPower: number = null;
+    public maximumSellToGridPower: number | null = null;
     public targetMinute: number | null = null;
     public delayChargeMaximumChargeLimit: number | null = null;
     public targetEpochSeconds: number | null = null;
-    public chargeStartEpochSeconds: number = null;
+    public chargeStartEpochSeconds: number | null = null;
 
     protected override getChannelAddresses(): ChannelAddress[] {
         this.refreshChart = false;

--- a/ui/src/app/edge/live/Controller/Evcs/administration/administration.component.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/administration/administration.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ModalController } from '@ionic/angular';
@@ -17,7 +16,7 @@ export class AdministrationComponent implements OnInit {
   @Input({ required: true }) public edge!: Edge;
 
   // used for ion-toggle in html
-  public isCheckedZoe: boolean = null;
+  public isCheckedZoe: boolean | null = null;
 
   constructor(
     private route: ActivatedRoute,

--- a/ui/src/app/edge/live/Controller/Evcs/flat/flat.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/flat/flat.ts
@@ -19,7 +19,7 @@ export class FlatComponent extends AbstractFlatWidget {
   public readonly CONVERT_MANUAL_ON_OFF = Utils.CONVERT_MANUAL_ON_OFF(this.translate);
 
   protected controller: EdgeConfig.Component;
-  protected evcsComponent: EdgeConfig.Component = null;
+  protected evcsComponent: EdgeConfig.Component | null = null;
   protected isConnectionSuccessful: boolean = false;
   protected isEnergySinceBeginningAllowed: boolean = false;
   protected mode: string;
@@ -33,14 +33,14 @@ export class FlatComponent extends AbstractFlatWidget {
   protected minChargePower: number;
   protected maxChargePower: number;
   protected forceChargeMinPower: string;
-  protected chargeMode: ChargeMode = null;
+  protected chargeMode: ChargeMode | null = null;
   protected readonly CONVERT_TO_WATT = Utils.CONVERT_TO_WATT;
   protected readonly CONVERT_TO_KILO_WATTHOURS = Utils.CONVERT_TO_KILO_WATTHOURS;
   protected readonly CONVERT_MANUAL_ON_OFF_AUTOMATIC = Utils.CONVERT_MODE_TO_MANUAL_OFF_AUTOMATIC(this.translate);
   protected chargeTarget: string;
   protected energySession: string;
   protected chargeDischargePower: { name: string, value: number };
-  protected propertyMode: DefaultTypes.ManualOnOff = null;
+  protected propertyMode: DefaultTypes.ManualOnOff | null = null;
   protected status: string;
 
   formatNumber(i: number) {

--- a/ui/src/app/edge/live/Controller/Evcs/modal/modal.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/modal/modal.ts
@@ -32,7 +32,7 @@ export class ModalComponent extends AbstractModal {
   protected numberOfPhases: number = 3; // Defaults to three phases
   protected defaultChargeMinPower: number;
   protected energyLimit: boolean;
-  protected chargeMode: ChargeMode = null;
+  protected chargeMode: ChargeMode | null = null;
   protected isEnergySinceBeginningAllowed: boolean = false;
   protected isChargingEnabled: boolean = false;
   protected sessionLimit: number;

--- a/ui/src/app/edge/live/Controller/Io/Heatpump/Io_Heatpump.ts
+++ b/ui/src/app/edge/live/Controller/Io/Heatpump/Io_Heatpump.ts
@@ -14,7 +14,7 @@ export class Controller_Io_HeatpumpComponent extends AbstractFlatWidget {
 
   private static PROPERTY_MODE: string = '_PropertyMode';
 
-  public override component: EdgeConfig.Component = null;
+  public override component: EdgeConfig.Component | null = null;
   public status: BehaviorSubject<{ name: string }> = new BehaviorSubject(null);
   public isConnectionSuccessful: boolean;
   public mode: string;

--- a/ui/src/app/edge/live/Io/Api_DigitalInput/Io_Api_DigitalInput.ts
+++ b/ui/src/app/edge/live/Io/Api_DigitalInput/Io_Api_DigitalInput.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component } from '@angular/core';
 import { AbstractFlatWidget } from 'src/app/shared/components/flat/abstract-flat-widget';
 import { EdgeConfig } from 'src/app/shared/shared';
@@ -12,7 +11,7 @@ import { Io_Api_DigitalInput_ModalComponent } from './modal/modal.component';
 
 export class Io_Api_DigitalInputComponent extends AbstractFlatWidget {
 
-    public ioComponents: EdgeConfig.Component[] = null;
+    public ioComponents: EdgeConfig.Component[] | null = null;
     public ioComponentCount = 0;
 
     async presentModal() {

--- a/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/Evcs_Api_Cluster.ts
+++ b/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/Evcs_Api_Cluster.ts
@@ -14,7 +14,7 @@ export class Evcs_Api_ClusterComponent extends AbstractFlatWidget {
   public channelAddresses: ChannelAddress[] = [];
   public evcsIdsInCluster: string[] = [];
   public evcssInCluster: EdgeConfig.Component[] = [];
-  public evcsComponent: EdgeConfig.Component = null;
+  public evcsComponent: EdgeConfig.Component | null = null;
   public evcsMap: { [sourceId: string]: EdgeConfig.Component } = {};
   public isConnectionSuccessful: boolean;
   public alias: string;

--- a/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/modal/evcsCluster-modal.page.ts
+++ b/ui/src/app/edge/live/Multiple/Evcs_Api_Cluster/modal/evcsCluster-modal.page.ts
@@ -15,7 +15,7 @@ type Priority = 'CAR' | 'STORAGE';
 export class Evcs_Api_ClusterModalComponent implements OnInit {
 
     @Input({ required: true }) public edge!: Edge;
-    @Input() public config: EdgeConfig.Component = null;
+    @Input() public config: EdgeConfig.Component | null = null;
     @Input({ required: true }) public componentId!: string;
     @Input() public evcsMap: { [sourceId: string]: EdgeConfig.Component } = {};
 

--- a/ui/src/app/edge/live/common/consumption/flat/flat.ts
+++ b/ui/src/app/edge/live/common/consumption/flat/flat.ts
@@ -11,7 +11,7 @@ import { ModalComponent } from '../modal/modal';
 export class FlatComponent extends AbstractFlatWidget {
 
   public evcss: EdgeConfig.Component[] | null = null;
-  public consumptionMeters: EdgeConfig.Component[] = null;
+  public consumptionMeters: EdgeConfig.Component[] | null = null;
   public sumActivePower: number = 0;
   public evcsSumOfChargePower: number;
   public otherPower: number;

--- a/ui/src/app/edge/live/common/storage/modal/modal.component.ts
+++ b/ui/src/app/edge/live/common/storage/modal/modal.component.ts
@@ -19,7 +19,7 @@ export class StorageModalComponent implements OnInit, OnDestroy {
     @Input({ required: true }) protected config!: EdgeConfig;
     @Input() protected essComponents: EdgeConfig.Component[] | null = null;
     @Input({ required: true }) protected chargerComponents!: EdgeConfig.Component[];
-    @Input() protected singleComponent: EdgeConfig.Component = null;
+    @Input() protected singleComponent: EdgeConfig.Component | null = null;
 
     // reference to the Utils method to access via html
     public isLastElement = Utils.isLastElement;

--- a/ui/src/app/edge/live/common/storage/storage.component.ts
+++ b/ui/src/app/edge/live/common/storage/storage.component.ts
@@ -16,7 +16,7 @@ export class StorageComponent extends AbstractFlatWidget {
 
     public essComponents: EdgeConfig.Component[] = [];
     public chargerComponents: EdgeConfig.Component[] = [];
-    public storageIconStyle: string = null;
+    public storageIconStyle: string | null = null;
     public isHybridEss: boolean[] = [];
     public emergencyReserveComponents: { [essId: string]: EdgeConfig.Component } = {};
     public currentSoc: number[] = [];

--- a/ui/src/app/edge/live/delayedselltogrid/delayedselltogrid.component.ts
+++ b/ui/src/app/edge/live/delayedselltogrid/delayedselltogrid.component.ts
@@ -16,9 +16,9 @@ export class DelayedSellToGridComponent implements OnInit, OnDestroy {
 
     @Input({ required: true }) public componentId!: string;
 
-    public edge: Edge = null;
+    public edge: Edge | null = null;
 
-    public component: EdgeConfig.Component = null;
+    public component: EdgeConfig.Component | null = null;
 
     constructor(
         private route: ActivatedRoute,

--- a/ui/src/app/edge/live/energymonitor/chart/section/abstractsection.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/abstractsection.component.ts
@@ -120,7 +120,7 @@ export abstract class AbstractSection {
     public fillRef: string = "";
     public valuePath: string = "";
     public outlinePath: string = "";
-    public energyFlow: EnergyFlow = null;
+    public energyFlow: EnergyFlow | null = null;
     public square: SvgSquare;
     public squarePosition: SvgSquarePosition;
     public name: string = "";
@@ -136,7 +136,7 @@ export abstract class AbstractSection {
     protected gridMode: GridMode;
     protected restrictionMode: number;
 
-    private lastCurrentData: DefaultTypes.Summary = null;
+    private lastCurrentData: DefaultTypes.Summary | null = null;
 
     constructor(
         translateName: string,

--- a/ui/src/app/edge/live/energymonitor/energymonitor.component.ts
+++ b/ui/src/app/edge/live/energymonitor/energymonitor.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ChannelAddress, Edge, Service, Websocket } from '../../../shared/shared';

--- a/ui/src/app/edge/live/live.component.ts
+++ b/ui/src/app/edge/live/live.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { RefresherCustomEvent } from '@ionic/angular';
@@ -12,9 +11,9 @@ import { Edge, EdgeConfig, Service, Utils, Websocket, Widgets } from 'src/app/sh
 })
 export class LiveComponent implements OnInit, OnDestroy {
 
-  public edge: Edge = null;
-  public config: EdgeConfig = null;
-  public widgets: Widgets = null;
+  public edge: Edge | null = null;
+  public config: EdgeConfig | null = null;
+  public widgets: Widgets | null = null;
   private stopOnDestroy: Subject<void> = new Subject<void>();
 
   constructor(

--- a/ui/src/app/edge/settings/app/formly/safe-input/formly-safe-input-modal.component.ts
+++ b/ui/src/app/edge/settings/app/formly/safe-input/formly-safe-input-modal.component.ts
@@ -13,7 +13,7 @@ export class FormlySafeInputModalComponent implements OnInit {
     @Input({ required: true })
     protected title!: string;
     @Input()
-    protected fields: FormlyFieldConfig[] = null;
+    protected fields: FormlyFieldConfig[] | null = null;
     @Input({ required: true })
     protected model!: {};
 

--- a/ui/src/app/edge/settings/app/install.component.ts
+++ b/ui/src/app/edge/settings/app/install.component.ts
@@ -28,7 +28,7 @@ export class InstallAppComponent implements OnInit, OnDestroy {
   public readonly spinnerId: string = InstallAppComponent.SELECTOR;
 
   protected form: FormGroup | null = null;
-  protected fields: FormlyFieldConfig[] = null;
+  protected fields: FormlyFieldConfig[] | null = null;
   protected model: any | null = null;
   protected appName: string | null = null;
   protected isInstalling: boolean = false;

--- a/ui/src/app/edge/settings/channels/channels.component.ts
+++ b/ui/src/app/edge/settings/channels/channels.component.ts
@@ -24,8 +24,8 @@ export class ChannelsComponent {
   };
   protected readonly spinnerId = ChannelsComponent.SELECTOR;
   protected readonly environment = environment;
-  protected edge: Edge = null;
-  protected config: EdgeConfig = null;
+  protected edge: Edge | null = null;
+  protected config: EdgeConfig | null = null;
   protected channelsPerComponent = new Map<string, ComponentChannels>();
   protected selectedComponentChannels = new Map<string, Map<string, { showPersistencePriority: boolean }>>();
   // TODO should be a simple SET but equality checking in SETs is currently not changeable and therefore not very useful for objects

--- a/ui/src/app/edge/settings/component/install/install.component.ts
+++ b/ui/src/app/edge/settings/component/install/install.component.ts
@@ -13,13 +13,13 @@ export class ComponentInstallComponent implements OnInit {
 
   private static readonly SELECTOR = "componentInstall";
 
-  public edge: Edge = null;
-  public factory: EdgeConfig.Factory = null;
+  public edge: Edge | null = null;
+  public factory: EdgeConfig.Factory | null = null;
   public form = null;
   public model = null;
-  public fields: FormlyFieldConfig[] = null;
+  public fields: FormlyFieldConfig[] | null = null;
 
-  private factoryId: string = null;
+  private factoryId: string | null = null;
 
   constructor(
     private route: ActivatedRoute,

--- a/ui/src/app/edge/settings/component/update/index.component.ts
+++ b/ui/src/app/edge/settings/component/update/index.component.ts
@@ -16,7 +16,7 @@ export class IndexComponent implements OnInit {
 
   private static readonly SELECTOR = "indexComponentUpdate";
 
-  public config: EdgeConfig = null;
+  public config: EdgeConfig | null = null;
   public list: MyCategorizedComponents[];
 
   public showAllEntries = false;

--- a/ui/src/app/edge/settings/component/update/update.component.ts
+++ b/ui/src/app/edge/settings/component/update/update.component.ts
@@ -13,14 +13,14 @@ export class ComponentUpdateComponent implements OnInit {
 
   private static readonly SELECTOR = "componentUpdate";
 
-  public edge: Edge = null;
-  public factory: EdgeConfig.Factory = null;
-  public form: FormGroup = null;
+  public edge: Edge | null = null;
+  public factory: EdgeConfig.Factory | null = null;
+  public form: FormGroup | null = null;
   public model = null;
-  public fields: FormlyFieldConfig[] = null;
-  public componentIcon: string = null;
+  public fields: FormlyFieldConfig[] | null = null;
+  public componentIcon: string | null = null;
 
-  private componentId: string = null;
+  private componentId: string | null = null;
 
   constructor(
     private route: ActivatedRoute,

--- a/ui/src/app/edge/settings/profile/aliasupdate.component.ts
+++ b/ui/src/app/edge/settings/profile/aliasupdate.component.ts
@@ -11,10 +11,11 @@ import { Edge, EdgeConfig, Service, Websocket } from 'src/app/shared/shared';
 })
 export class AliasUpdateComponent implements OnInit {
 
-    public component: EdgeConfig.Component = null;
+    public component: EdgeConfig.Component | null = null;
+
     public formGroup: FormGroup | null = null;
-    public factory: EdgeConfig.Factory = null;
-    public componentIcon: string = null;
+    public factory: EdgeConfig.Factory | null = null;
+    public componentIcon: string | null = null;
 
     private edge: Edge;
 

--- a/ui/src/app/edge/settings/profile/profile.component.ts
+++ b/ui/src/app/edge/settings/profile/profile.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { PopoverController } from '@ionic/angular';
@@ -22,8 +21,8 @@ export class ProfileComponent implements OnInit {
 
   public environment = environment;
 
-  public edge: Edge = null;
-  public config: EdgeConfig = null;
+  public edge: Edge | null = null;
+  public config: EdgeConfig | null = null;
   public subscribedChannels: ChannelAddress[] = [];
 
   public components: CategorizedComponents[] | null = null;

--- a/ui/src/app/edge/settings/system/executesystemupdate.component.ts
+++ b/ui/src/app/edge/settings/system/executesystemupdate.component.ts
@@ -18,7 +18,7 @@ export class ExecuteSystemUpdateComponent implements OnInit, OnDestroy {
   public readonly spinnerId: string = ExecuteSystemUpdateComponent.SELECTOR;
 
   public readonly environment = environment;
-  protected executeUpdate: ExecuteSystemUpdate = null;
+  protected executeUpdate: ExecuteSystemUpdate | null = null;
 
   protected isWaiting: boolean;
 

--- a/ui/src/app/edge/settings/system/oe-system-update.component.ts
+++ b/ui/src/app/edge/settings/system/oe-system-update.component.ts
@@ -21,7 +21,7 @@ export class OeSystemUpdateComponent implements OnInit, OnDestroy {
   public readonly environment = environment;
   public readonly spinnerId: string = OeSystemUpdateComponent.SELECTOR;
 
-  protected executeUpdate: ExecuteSystemUpdate = null;
+  protected executeUpdate: ExecuteSystemUpdate | null = null;
   protected isWaiting: boolean;
 
   constructor(

--- a/ui/src/app/shared/components/abstracthistorywidget.ts
+++ b/ui/src/app/shared/components/abstracthistorywidget.ts
@@ -22,9 +22,9 @@ export abstract class AbstractHistoryWidget implements OnInit, OnChanges, OnDest
    * True after this.edge, this.config and this.component are set.
    */
   public isInitialized: boolean = false;
-  public edge: Edge = null;
-  public config: EdgeConfig = null;
-  public component: EdgeConfig.Component = null;
+  public edge: Edge | null = null;
+  public config: EdgeConfig | null = null;
+  public component: EdgeConfig.Component | null = null;
   public stopOnDestroy: Subject<void> = new Subject<void>();
 
   private selector: string = uuidv4();

--- a/ui/src/app/shared/components/chart/abstractHistoryChartOverview.ts
+++ b/ui/src/app/shared/components/chart/abstractHistoryChartOverview.ts
@@ -15,7 +15,7 @@ export abstract class AbstractHistoryChartOverview implements OnInit, OnChanges,
    */
   public isInitialized: boolean = false;
   public config: EdgeConfig = null;
-  public component: EdgeConfig.Component = null;
+  public component: EdgeConfig.Component | null = null;
   public stopOnDestroy: Subject<void> = new Subject<void>();
   public edge: Edge | null = null;
   public period: DefaultTypes.HistoryPeriod;

--- a/ui/src/app/shared/components/chart/abstracthistorychart.ts
+++ b/ui/src/app/shared/components/chart/abstracthistorychart.ts
@@ -97,7 +97,7 @@ export abstract class AbstractHistoryChart implements OnInit {
     }
 
     chartObject.input.forEach(element => {
-      let channelAddress: ChannelAddress = null;
+      let channelAddress: ChannelAddress | null = null;
       if (chartType == 'bar' && element.energyChannel) {
         channelAddress = element.energyChannel;
       } else {

--- a/ui/src/app/shared/components/flat/abstract-flat-widget-line.ts
+++ b/ui/src/app/shared/components/flat/abstract-flat-widget-line.ts
@@ -38,7 +38,7 @@ export abstract class AbstractFlatWidgetLine implements OnChanges, OnDestroy {
   */
   private selector: string = uuidv4();
   private stopOnDestroy: Subject<void> = new Subject<void>();
-  private edge: Edge = null;
+  private edge: Edge | null = null;
 
   constructor(
     @Inject(Websocket) protected websocket: Websocket,

--- a/ui/src/app/shared/components/modal/abstract-modal-line.ts
+++ b/ui/src/app/shared/components/modal/abstract-modal-line.ts
@@ -46,10 +46,10 @@ export abstract class AbstractModalLine implements OnInit, OnDestroy, OnChanges 
     /**
      * displayValue is the displayed @Input value in html
     */
-    public displayValue: string = null;
-    public displayName: string = null;
-    public edge: Edge = null;
-    public config: EdgeConfig = null;
+    public displayValue: string | null = null;
+    public displayName: string | null = null;
+    public edge: Edge | null = null;
+    public config: EdgeConfig | null = null;
     public stopOnDestroy: Subject<void> = new Subject<void>();
 
     /** Checks if any value of this line can be seen => hides line if false

--- a/ui/src/app/shared/components/modal/abstractModal.ts
+++ b/ui/src/app/shared/components/modal/abstractModal.ts
@@ -16,7 +16,7 @@ import { Converter } from "../shared/converter";
 @Directive()
 export abstract class AbstractModal implements OnInit, OnDestroy {
 
-    @Input() public component: EdgeConfig.Component = null;
+    @Input() public component: EdgeConfig.Component | null = null;
 
     /** Enum for User Role */
     public readonly Role = Role;
@@ -28,7 +28,7 @@ export abstract class AbstractModal implements OnInit, OnDestroy {
     public readonly Converter = Converter;
 
     public isInitialized: boolean = false;
-    public edge: Edge = null;
+    public edge: Edge | null = null;
     public config: EdgeConfig = null;
     public stopOnDestroy: Subject<void> = new Subject<void>();
     public formGroup: FormGroup | null = null;

--- a/ui/src/app/shared/components/modal/modal.ts
+++ b/ui/src/app/shared/components/modal/modal.ts
@@ -28,7 +28,7 @@ export class ModalComponent {
     /** Title in Header */
     @Input({ required: true }) public title!: string;
 
-    @Input() protected component: EdgeConfig.Component = null;
+    @Input() protected component: EdgeConfig.Component | null = null;
     @Input() protected formGroup: FormGroup = new FormGroup({});
 
     @Input() protected toolbarButtons: { url: string, icon: Icon }[] | { url: string, icon: Icon } | {
@@ -39,7 +39,7 @@ export class ModalComponent {
     @Input() protected helpKey: string | null = null;
     public readonly Role = Role;
 
-    private edge: Edge = null;
+    private edge: Edge | null = null;
 
     constructor(
         public modalController: ModalController,

--- a/ui/src/app/shared/service/service.ts
+++ b/ui/src/app/shared/service/service.ts
@@ -82,7 +82,7 @@ export class Service extends AbstractService {
   /**
    * Holds the current Activated Route
    */
-  private currentActivatedRoute: ActivatedRoute = null;
+  private currentActivatedRoute: ActivatedRoute | null = null;
 
   private queryEnergyQueue: {
     fromDate: Date, toDate: Date, channels: ChannelAddress[], promises: { resolve, reject }[]


### PR DESCRIPTION
```
$ npx tsc --strict
Found 3646 errors in 210 files.
↓
Found 3666 errors in 188 files.
```

This change adds null type to null initialization variables.
This change increases the number of typescript strict mode errors, but this typing is based on the fact of the code.