### PR TITLE
Fix documentation for allowed charge power of managed symmetric ess

### DIFF
--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/api/ManagedSymmetricEss.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/api/ManagedSymmetricEss.java
@@ -291,7 +291,7 @@ public interface ManagedSymmetricEss extends SymmetricEss {
 	}
 
 	/**
-	 * Gets the Allowed Charge Power in [W], range "&lt;= 0". See
+	 * Gets the Allowed Charge Power in [W], range "<= 0". See
 	 * {@link ChannelId#ALLOWED_CHARGE_POWER}.
 	 *
 	 * @return the Channel {@link Value}
@@ -330,7 +330,7 @@ public interface ManagedSymmetricEss extends SymmetricEss {
 	}
 
 	/**
-	 * Gets the Allowed Discharge Power in [W], range "&lt;= 0". See
+	 * Gets the Allowed Discharge Power in [W], range ">= 0". See
 	 * {@link ChannelId#ALLOWED_DISCHARGE_POWER}.
 	 *
 	 * @return the Channel {@link Value}


### PR DESCRIPTION
Documentation stated that both allowed charge and discharge power are `<= 0`.