### PR TITLE
Fix Warnings in Wrapper

### DIFF
--- a/io.openems.wrapper/bnd.bnd
+++ b/io.openems.wrapper/bnd.bnd
@@ -28,3 +28,11 @@ Bundle-Description: This wraps external java libraries that do not have OSGi hea
 	org.dhatim:fastexcel-reader;version='0.18',\
 	org.eclipse.paho.mqttv5.client;version='1.2.5',\
 	org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm;version='1.7.3',\
+
+	
+Import-Package: \
+    de.bytefish.pgbulkinsert.pgsql.model.interval;resolution:=optional
+
+Export-Package: \
+    de.bytefish.pgbulkinsert.mapping, \
+    de.bytefish.pgbulkinsert.pgsql.model.interval


### PR DESCRIPTION
This fixes:

io.openems.wrapper.pgbulkinsert: Export de.bytefish.pgbulkinsert.mapping,  has 1,  private references [de.bytefish.pgbulkinsert.pgsql.model.interval]	bnd.bnd	/io.openems.wrapper	line 1	Bndtools Problem Marker