### PR TITLE
Fix Error in currentVoltage Chart

### DIFF
--- a/ui/src/app/shared/components/chart/abstracthistorychart.ts
+++ b/ui/src/app/shared/components/chart/abstracthistorychart.ts
@@ -241,6 +241,15 @@ export abstract class AbstractHistoryChart implements OnInit {
    * @returns chart options
    */
   public static applyChartTypeSpecificOptionsChanges(chartType: 'bar' | 'line', options: Chart.ChartOptions, service: Service, chartObject: HistoryUtils.ChartData | null): Chart.ChartOptions {
+    options.scales = options.scales || {};
+    options.scales.x = options.scales.x || {};
+
+    if (chartObject && chartObject.yAxes) {
+      chartObject.yAxes.forEach(yAxis => {
+        options.scales[yAxis.yAxisId] = options.scales[yAxis.yAxisId] || {};
+      });
+    }
+
     switch (chartType) {
       case 'bar': {
         options.plugins.tooltip.mode = 'x';
@@ -248,26 +257,15 @@ export abstract class AbstractHistoryChart implements OnInit {
         options.scales.x.ticks['source'] = 'data';
         let barPercentage = 1;
         switch (service.periodString) {
-          case DefaultTypes.PeriodString.CUSTOM: {
+          case DefaultTypes.PeriodString.CUSTOM:
             barPercentage = 0.7;
             break;
-          }
-          case DefaultTypes.PeriodString.MONTH: {
-            if (service.isSmartphoneResolution == true) {
-              barPercentage = 1;
-            } else {
-              barPercentage = 0.9;
-            }
+          case DefaultTypes.PeriodString.MONTH:
+            barPercentage = service.isSmartphoneResolution ? 1 : 0.9;
             break;
-          }
-          case DefaultTypes.PeriodString.YEAR: {
-            if (service.isSmartphoneResolution == true) {
-              barPercentage = 1;
-            } else {
-              barPercentage = 0.8;
-            }
+          case DefaultTypes.PeriodString.YEAR:
+            barPercentage = service.isSmartphoneResolution ? 1 : 0.8;
             break;
-          }
         }
 
         options.datasets.bar = {
@@ -283,7 +281,9 @@ export abstract class AbstractHistoryChart implements OnInit {
 
         if (chartObject) {
           for (const yAxis of chartObject.yAxes) {
-            options.scales[yAxis.yAxisId]['stacked'] = false;
+            if (options.scales[yAxis.yAxisId]) {
+              options.scales[yAxis.yAxisId]['stacked'] = false;
+            }
           }
         }
         break;

--- a/ui/src/app/shared/components/edge/meter/currentVoltage/chart/chart.ts
+++ b/ui/src/app/shared/components/edge/meter/currentVoltage/chart/chart.ts
@@ -53,7 +53,7 @@ export class CurrentVoltageChartComponent extends AbstractHistoryChart {
       yAxes: [{
         unit: YAxisTitle.VOLTAGE,
         position: 'left',
-        yAxisId: ChartAxis.LEFT,
+        yAxisId: ChartAxis.RIGHT,
       },
       {
         unit: YAxisTitle.CURRENT,


### PR DESCRIPTION
main.7d9b4e486fa59deb.js:1 Error: Uncaught (in promise): TypeError: Cannot set properties of undefined (setting 'stacked') TypeError: Cannot set properties of undefined (setting 'stacked')
    at t.applyChartTypeSpecificOptionsChanges (main.7d9b4e486fa59deb.js:1:1531526)
    at t.getOptions (main.7d9b4e486fa59deb.js:1:1531920)
    at t.setChartLabel (main.7d9b4e486fa59deb.js:1:1540779)
    at main.7d9b4e486fa59deb.js:1:1540730
    at h.invoke (polyfills.8e26eddce4e355a6.js:1:10141)
    at Object.onInvoke (main.7d9b4e486fa59deb.js:1:143692)
    at h.invoke (polyfills.8e26eddce4e355a6.js:1:10081)
    at h.run (polyfills.8e26eddce4e355a6.js:1:5176)
    at polyfills.8e26eddce4e355a6.js:1:21059
    at h.invokeTask (polyfills.8e26eddce4e355a6.js:1:10825)
    at q (polyfills.8e26eddce4e355a6.js:1:20264)
    at polyfills.8e26eddce4e355a6.js:1:21116
    at h.invokeTask (polyfills.8e26eddce4e355a6.js:1:10825)
    at Object.onInvokeTask (main.7d9b4e486fa59deb.js:1:143508)
    at h.invokeTask (polyfills.8e26eddce4e355a6.js:1:10746)
    at h.runTask (polyfills.8e26eddce4e355a6.js:1:5850)
    at T (polyfills.8e26eddce4e355a6.js:1:13216)
    at h.invokeTask [as invoke] (polyfills.8e26eddce4e355a6.js:1:11988)
    at C (polyfills.8e26eddce4e355a6.js:1:25554)
    at I (polyfills.8e26eddce4e355a6.js:1:25829)