### PR TITLE
Fix for Configuration & Status not populated Fully

### DIFF
--- a/ui/src/app/shared/components/edge/edgeconfig.ts
+++ b/ui/src/app/shared/components/edge/edgeconfig.ts
@@ -586,9 +586,9 @@ export class EdgeConfig {
         const allComponents = [];
         const factories = this.listAvailableFactories();
         for (const entry of factories) {
-            const components: EdgeConfig.Component[] = [];
+            const components: EdgeConfig.Component[] = []; // Option 2: let components: EdgeConfig.Component[] = [];
             for (const factory of entry.factories) {
-                components.push(...this.getComponentsByFactory(factory.id));
+                components.push(...this.getComponentsByFactory(factory.id)); // Option 2: components = components.concat(...this.getComponentsByFactory(factory.id));
             }
             allComponents.push({
                 category: entry.category,

--- a/ui/src/app/shared/components/edge/edgeconfig.ts
+++ b/ui/src/app/shared/components/edge/edgeconfig.ts
@@ -588,7 +588,7 @@ export class EdgeConfig {
         for (const entry of factories) {
             const components: EdgeConfig.Component[] = [];
             for (const factory of entry.factories) {
-                components.concat(...this.getComponentsByFactory(factory.id));
+                components.push(...this.getComponentsByFactory(factory.id));
             }
             allComponents.push({
                 category: entry.category,

--- a/ui/src/app/shared/components/edge/edgeconfig.ts
+++ b/ui/src/app/shared/components/edge/edgeconfig.ts
@@ -586,9 +586,9 @@ export class EdgeConfig {
         const allComponents = [];
         const factories = this.listAvailableFactories();
         for (const entry of factories) {
-            const components: EdgeConfig.Component[] = []; // Option 2: let components: EdgeConfig.Component[] = [];
+            const components: EdgeConfig.Component[] = [];
             for (const factory of entry.factories) {
-                components.push(...this.getComponentsByFactory(factory.id)); // Option 2: components = components.concat(...this.getComponentsByFactory(factory.id));
+                components.push(...this.getComponentsByFactory(factory.id));
             }
             allComponents.push({
                 category: entry.category,


### PR DESCRIPTION
This pull request offers two alternative solutions to fix the issue in the `listActiveComponents` method. 

## Option 1: Use `push` Instead of `concat`

### Changes
```typescript
components.push(...this.getComponentsByFactory(factory.id));
```

### Explanation
In this approach, we use the `push` method to add elements to the `components` array directly. 

### Advantages
- **Simplicity**: The code is straightforward and easy to understand.
- **Performance**: `push` modifies the array in place, which is generally faster than creating a new array with `concat`.

### Disadvantages
- **In-Place Modification**: `push` modifies the original array, which might not be desirable if you need to maintain immutability.

## Option 2: Assign the Result of `concat`

### Changes
```typescript
public listActiveComponents(ignoreComponentIds: string[] = []): CategorizedComponents[] {
    const allComponents = [];
    const factories = this.listAvailableFactories();
    for (const entry of factories) {
        let components: EdgeConfig.Component[] = [];
        for (const factory of entry.factories) {
            components = components.concat(...this.getComponentsByFactory(factory.id));
        }
        allComponents.push({
            category: entry.category,
            components: components,
        });
    }
    // (rest of the code remains the same)
}
```

### Explanation
In this approach, we use `concat` to combine the current `components` array with new elements and assign the result back to `components`.

### Advantages
- **Immutability**: `concat` does not modify the original array; instead, it returns a new array. This can be useful if you want to keep the original array unchanged.

### Disadvantages
- **Performance**: `concat` creates a new array each time, which may be less efficient than `push` for large arrays.
- **Complexity**: This approach adds a bit more complexity by reassigning the array.
