### PR TITLE
Fix % Sign on Chart for SoC

### DIFF
--- a/ui/src/app/edge/history/common/energy/chart/chart.ts
+++ b/ui/src/app/edge/history/common/energy/chart/chart.ts
@@ -165,6 +165,9 @@ export class ChartComponent extends AbstractHistoryChart {
             borderDash: [10, 10],
             yAxisId: ChartAxis.RIGHT,
             stack: 1,
+            custom: {
+              unit: YAxisTitle.PERCENTAGE,
+            },
           }],
         ];
       },


### PR DESCRIPTION
Reintroduce '%' sign to the SoC Line Tooltip