### PR TITLE
feat: dynamic numberformat conversion by using current locale

### DIFF
--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -57,7 +57,7 @@ import { UserModule } from "./user/user.module";
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     CookieService,
     { provide: ErrorHandler, useClass: MyErrorHandler },
-    { provide: LOCALE_ID, useValue: Language.DEFAULT.key },
+    { provide: LOCALE_ID, useFactory: () => (Language.getByKey(localStorage.LANGUAGE) ?? Language.getByBrowserLang(navigator.language)).key },
     // Use factory for formly. This allows us to use translations in validationMessages.
     { provide: FORMLY_CONFIG, multi: true, useFactory: registerTranslateExtension, deps: [TranslateService] },
     DeviceDetectorService,

--- a/ui/src/app/edge/history/abstracthistorychart.ts
+++ b/ui/src/app/edge/history/abstracthistorychart.ts
@@ -153,7 +153,7 @@ export abstract class AbstractHistoryChart {
                     const value = tooltipItem.dataset.data[tooltipItem.dataIndex];
 
                     const customUnit = tooltipItem.dataset.unit ?? null;
-                    return label.split(":")[0] + ": " + NewAbstractHistoryChart.getToolTipsSuffix("", value, formatNumber, customUnit ?? unit, "line", locale, translate, conf);
+                    return label.split(":")[0] + ": " + NewAbstractHistoryChart.getToolTipsSuffix("", value, formatNumber, customUnit ?? unit, "line", translate, conf);
                 };
 
                 options.plugins.tooltip.callbacks.labelColor = (item: Chart.TooltipItem<any>) => {
@@ -247,7 +247,7 @@ export abstract class AbstractHistoryChart {
                     });
 
                 // Only one yAxis defined
-                options = NewAbstractHistoryChart.getYAxisOptions(options, yAxis, this.translate, "line", locale, this.datasets, true);
+                options = NewAbstractHistoryChart.getYAxisOptions(options, yAxis, this.translate, "line", this.datasets, true);
                 options = NewAbstractHistoryChart.applyChartTypeSpecificOptionsChanges("line", options, this.service, chartObject);
                 options.scales[ChartAxis.LEFT]["stacked"] = false;
                 options.scales.x["stacked"] = true;

--- a/ui/src/app/edge/history/abstracthistorychart.ts
+++ b/ui/src/app/edge/history/abstracthistorychart.ts
@@ -116,7 +116,6 @@ export abstract class AbstractHistoryChart {
     public setOptions(options: Chart.ChartOptions): Promise<void> {
 
         return new Promise<void>((resolve) => {
-            const locale = this.service.translate.currentLang;
             const yAxis: HistoryUtils.yAxes = { position: "left", unit: this.unit, yAxisId: ChartAxis.LEFT };
             const chartObject: HistoryUtils.ChartData = {
                 input: [],

--- a/ui/src/app/edge/history/storage/singlechart.component.ts
+++ b/ui/src/app/edge/history/storage/singlechart.component.ts
@@ -6,6 +6,7 @@ import { TranslateService } from "@ngx-translate/core";
 import * as Chart from "chart.js";
 import { DefaultTypes } from "src/app/shared/service/defaulttypes";
 import { ChartAxis, YAxisType } from "src/app/shared/service/utils";
+import { Language } from "src/app/shared/type/language"
 
 import { ObjectUtils } from "src/app/shared/utils/object/object.utils";
 import { ChannelAddress, Edge, EdgeConfig, Service, Utils } from "../../../shared/shared";
@@ -210,6 +211,7 @@ export class StorageSingleChartComponent extends AbstractHistoryChart implements
 
     private applyControllerSpecificChartOptions(options: Chart.ChartOptions) {
         const translate = this.translate;
+        const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
 
         options.scales[ChartAxis.LEFT].min = null;
         options.plugins.tooltip.callbacks.label = function (tooltipItem: Chart.TooltipItem<any>) {
@@ -229,7 +231,7 @@ export class StorageSingleChartComponent extends AbstractHistoryChart implements
                     label = translate.instant("General.DISCHARGE");
                 }
             }
-            return label + ": " + formatNumber(value, "de", "1.0-2") + " kW";
+            return label + ": " + formatNumber(value, locale, "1.0-2") + " kW";
         };
 
         // Data doesnt have all datapoints for period

--- a/ui/src/app/edge/history/storage/singlechart.component.ts
+++ b/ui/src/app/edge/history/storage/singlechart.component.ts
@@ -6,7 +6,7 @@ import { TranslateService } from "@ngx-translate/core";
 import * as Chart from "chart.js";
 import { DefaultTypes } from "src/app/shared/service/defaulttypes";
 import { ChartAxis, YAxisType } from "src/app/shared/service/utils";
-import { Language } from "src/app/shared/type/language"
+import { Language } from "src/app/shared/type/language";
 
 import { ObjectUtils } from "src/app/shared/utils/object/object.utils";
 import { ChannelAddress, Edge, EdgeConfig, Service, Utils } from "../../../shared/shared";

--- a/ui/src/app/edge/history/storage/totalchart.component.ts
+++ b/ui/src/app/edge/history/storage/totalchart.component.ts
@@ -7,7 +7,7 @@ import * as Chart from "chart.js";
 import { DefaultTypes } from "src/app/shared/service/defaulttypes";
 import { ChartAxis, Utils, YAxisType } from "src/app/shared/service/utils";
 import { ChannelAddress, Edge, EdgeConfig, Service } from "src/app/shared/shared";
-import { Language } from "src/app/shared/type/language"
+import { Language } from "src/app/shared/type/language";
 
 import { ObjectUtils } from "src/app/shared/utils/object/object.utils";
 import { AbstractHistoryChart } from "../abstracthistorychart";

--- a/ui/src/app/edge/history/storage/totalchart.component.ts
+++ b/ui/src/app/edge/history/storage/totalchart.component.ts
@@ -7,6 +7,7 @@ import * as Chart from "chart.js";
 import { DefaultTypes } from "src/app/shared/service/defaulttypes";
 import { ChartAxis, Utils, YAxisType } from "src/app/shared/service/utils";
 import { ChannelAddress, Edge, EdgeConfig, Service } from "src/app/shared/shared";
+import { Language } from "src/app/shared/type/language"
 
 import { ObjectUtils } from "src/app/shared/utils/object/object.utils";
 import { AbstractHistoryChart } from "../abstracthistorychart";
@@ -248,6 +249,7 @@ export class StorageTotalChartComponent extends AbstractHistoryChart implements 
 
     private applyControllerSpecificChartOptions(options: Chart.ChartOptions) {
         const translate = this.translate;
+        const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
 
         options.scales[ChartAxis.LEFT].min = null;
         options.plugins.tooltip.callbacks.label = function (tooltipItem: Chart.TooltipItem<any>) {
@@ -259,7 +261,7 @@ export class StorageTotalChartComponent extends AbstractHistoryChart implements 
             } else if (value > 0.005) {
                 label += " " + translate.instant("General.DISCHARGE");
             }
-            return label + ": " + formatNumber(value, "de", "1.0-2") + " kW";
+            return label + ": " + formatNumber(value, locale, "1.0-2") + " kW";
         };
     }
 }

--- a/ui/src/app/edge/live/Controller/Ess/TimeOfUseTariff/modal/powerSocChart.ts
+++ b/ui/src/app/edge/live/Controller/Ess/TimeOfUseTariff/modal/powerSocChart.ts
@@ -206,10 +206,9 @@ export class SchedulePowerAndSocChartComponent extends AbstractHistoryChart impl
     private applyControllerSpecificOptions() {
         const rightYAxis: HistoryUtils.yAxes = { position: "right", unit: YAxisType.PERCENTAGE, yAxisId: ChartAxis.RIGHT };
         const leftYAxis: HistoryUtils.yAxes = { position: "left", unit: YAxisType.POWER, yAxisId: ChartAxis.LEFT };
-        const locale = this.service.translate.currentLang;
 
-        this.options = NewAbstractHistoryChart.getYAxisOptions(this.options, rightYAxis, this.translate, "line", locale, ChartConstants.EMPTY_DATASETS, true);
-        this.options = NewAbstractHistoryChart.getYAxisOptions(this.options, leftYAxis, this.translate, "line", locale, ChartConstants.EMPTY_DATASETS, true);
+        this.options = NewAbstractHistoryChart.getYAxisOptions(this.options, rightYAxis, this.translate, "line", ChartConstants.EMPTY_DATASETS, true);
+        this.options = NewAbstractHistoryChart.getYAxisOptions(this.options, leftYAxis, this.translate, "line", ChartConstants.EMPTY_DATASETS, true);
 
         this.datasets = this.datasets.map((el: Chart.ChartDataset) => {
 

--- a/ui/src/app/edge/live/Controller/Ess/TimeOfUseTariff/modal/statePriceChart.ts
+++ b/ui/src/app/edge/live/Controller/Ess/TimeOfUseTariff/modal/statePriceChart.ts
@@ -114,12 +114,11 @@ export class ScheduleStateAndPriceChartComponent extends AbstractHistoryChart im
     }
 
     private applyControllerSpecificOptions() {
-        const locale = this.service.translate.currentLang;
         const rightYaxisSoc: HistoryUtils.yAxes = { position: "right", unit: YAxisType.PERCENTAGE, yAxisId: ChartAxis.RIGHT, displayGrid: true };
-        this.options = NewAbstractHistoryChart.getYAxisOptions(this.options, rightYaxisSoc, this.translate, "line", locale, this.datasets, true);
+        this.options = NewAbstractHistoryChart.getYAxisOptions(this.options, rightYaxisSoc, this.translate, "line", this.datasets, true);
 
         const rightYAxisPower: HistoryUtils.yAxes = { position: "right", unit: YAxisType.POWER, yAxisId: ChartAxis.RIGHT_2 };
-        this.options = NewAbstractHistoryChart.getYAxisOptions(this.options, rightYAxisPower, this.translate, "line", locale, this.datasets, true);
+        this.options = NewAbstractHistoryChart.getYAxisOptions(this.options, rightYAxisPower, this.translate, "line", this.datasets, true);
 
         this.options.scales.x["time"].unit = calculateResolution(this.service, this.service.historyPeriod.value.from, this.service.historyPeriod.value.to).timeFormat;
         this.options.scales.x["ticks"] = { source: "auto", autoSkip: false };
@@ -176,7 +175,7 @@ export class ScheduleStateAndPriceChartComponent extends AbstractHistoryChart im
         });
         const leftYAxis: HistoryUtils.yAxes = { position: "left", unit: this.unit, yAxisId: ChartAxis.LEFT, customTitle: this.currencyUnit, scale: { dynamicScale: true } };
         [rightYaxisSoc, rightYAxisPower].forEach((element) => {
-            this.options = NewAbstractHistoryChart.getYAxisOptions(this.options, element, this.translate, "line", locale, this.datasets, true);
+            this.options = NewAbstractHistoryChart.getYAxisOptions(this.options, element, this.translate, "line", this.datasets, true);
         });
 
         this.options.scales[ChartAxis.LEFT] = {

--- a/ui/src/app/edge/live/common/storage/storage.component.ts
+++ b/ui/src/app/edge/live/common/storage/storage.component.ts
@@ -4,6 +4,7 @@ import { Component } from "@angular/core";
 import { AbstractFlatWidget } from "src/app/shared/components/flat/abstract-flat-widget";
 import { ChannelAddress, CurrentData, EdgeConfig, Utils } from "src/app/shared/shared";
 import { DateUtils } from "src/app/shared/utils/date/dateutils";
+import { Language, MyTranslateLoader } from "src/app/shared/type/language";
 
 import { StorageModalComponent } from "./modal/modal.component";
 
@@ -51,6 +52,7 @@ export class StorageComponent extends AbstractFlatWidget {
      * @returns only positive and 0
      */
     public convertPower(value: number, isCharge?: boolean) {
+        const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
         if (value == null) {
             return "-";
         }
@@ -59,7 +61,7 @@ export class StorageComponent extends AbstractFlatWidget {
 
         // Round thisValue to Integer when decimal place equals 0
         if (thisValue > 0) {
-            return formatNumber(thisValue, "de", "1.0-1") + " kW"; // TODO get locale dynamically
+            return formatNumber(thisValue, locale, "1.0-1") + " kW";
 
         } else if (thisValue == 0 && isCharge) {
             // if thisValue is 0, then show only when charge and not discharge

--- a/ui/src/app/edge/live/common/storage/storage.component.ts
+++ b/ui/src/app/edge/live/common/storage/storage.component.ts
@@ -3,8 +3,8 @@ import { formatNumber } from "@angular/common";
 import { Component } from "@angular/core";
 import { AbstractFlatWidget } from "src/app/shared/components/flat/abstract-flat-widget";
 import { ChannelAddress, CurrentData, EdgeConfig, Utils } from "src/app/shared/shared";
+import { Language } from "src/app/shared/type/language";
 import { DateUtils } from "src/app/shared/utils/date/dateutils";
-import { Language, MyTranslateLoader } from "src/app/shared/type/language";
 
 import { StorageModalComponent } from "./modal/modal.component";
 

--- a/ui/src/app/edge/settings/powerassistant/powerassistant.ts
+++ b/ui/src/app/edge/settings/powerassistant/powerassistant.ts
@@ -3,6 +3,7 @@ import { formatNumber } from "@angular/common";
 import { Component } from "@angular/core";
 import { AbstractFlatWidget } from "src/app/shared/components/flat/abstract-flat-widget";
 import { DataService } from "src/app/shared/components/shared/dataservice";
+import { Language } from "src/app/shared/type/language"
 import { ChannelAddress, CurrentData, EdgeConfig, Utils } from "../../../shared/shared";
 import { LiveDataService } from "../../live/livedataservice";
 
@@ -222,10 +223,11 @@ export class PowerAssistantComponent extends AbstractFlatWidget {
 export namespace Converter {
   export function unit(unit: string): (value: any) => string {
     return function (value: any): string {
+      const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
       if (value == null) {
         return "-";
       } else if (value >= 0) {
-        return formatNumber(value, "de", "1.0-0") + " " + unit;
+        return formatNumber(value, locale, "1.0-0") + " " + unit;
       }
     };
   }

--- a/ui/src/app/edge/settings/powerassistant/powerassistant.ts
+++ b/ui/src/app/edge/settings/powerassistant/powerassistant.ts
@@ -3,7 +3,7 @@ import { formatNumber } from "@angular/common";
 import { Component } from "@angular/core";
 import { AbstractFlatWidget } from "src/app/shared/components/flat/abstract-flat-widget";
 import { DataService } from "src/app/shared/components/shared/dataservice";
-import { Language } from "src/app/shared/type/language"
+import { Language } from "src/app/shared/type/language";
 import { ChannelAddress, CurrentData, EdgeConfig, Utils } from "../../../shared/shared";
 import { LiveDataService } from "../../live/livedataservice";
 

--- a/ui/src/app/shared/components/chart/abstracthistorychart.ts
+++ b/ui/src/app/shared/components/chart/abstracthistorychart.ts
@@ -130,6 +130,7 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy {
     const datasets: Chart.ChartDataset[] = [];
     const displayValues: HistoryUtils.DisplayValue<HistoryUtils.CustomOptions>[] = chartObject.output(channelData.data, labels);
     const legendOptions: { label: string, strokeThroughHidingStyle: boolean, hideLabelInLegend: boolean; }[] = [];
+    const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
     displayValues.forEach((displayValue, index) => {
       let nameSuffix = null;
 
@@ -352,19 +353,17 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy {
     translate: TranslateService,
     legendOptions: { label: string, strokeThroughHidingStyle: boolean; }[],
     channelData: { data: { [name: string]: number[]; }; },
-    locale: string,
     config: EdgeConfig,
     datasets: Chart.ChartDataset[],
     chartOptionsType: XAxisType,
     labels: (Date | string)[],
   ): Chart.ChartOptions {
-
     let tooltipsLabel: string | null = null;
     let options: Chart.ChartOptions = Utils.deepCopy(<Chart.ChartOptions>Utils.deepCopy(AbstractHistoryChart.getDefaultOptions(chartOptionsType, service, labels)));
     const displayValues: HistoryUtils.DisplayValue<HistoryUtils.CustomOptions>[] = chartObject.output(channelData.data, labels);
 
     chartObject.yAxes.forEach((element) => {
-      options = AbstractHistoryChart.getYAxisOptions(options, element, translate, chartType, locale, datasets, true);
+      options = AbstractHistoryChart.getYAxisOptions(options, element, translate, chartType, datasets, true);
     });
 
     options.plugins.tooltip.callbacks.title = (tooltipItems: Chart.TooltipItem<any>[]): string => {
@@ -395,7 +394,7 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy {
         tooltipsLabel = AbstractHistoryChart.getToolTipsAfterTitleLabel(unit, chartType, value, translate);
       }
 
-      return label.split(":")[0] + ": " + AbstractHistoryChart.getToolTipsSuffix(tooltipsLabel, value, displayValue.custom?.formatNumber ?? chartObject.tooltip.formatNumber, unit, chartType, locale, translate, config);
+      return label.split(":")[0] + ": " + AbstractHistoryChart.getToolTipsSuffix(tooltipsLabel, value, displayValue.custom?.formatNumber ?? chartObject.tooltip.formatNumber, unit, chartType, translate, config);
     };
 
     options.plugins.tooltip.callbacks.labelColor = (item: Chart.TooltipItem<any>) => {
@@ -445,6 +444,7 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy {
     };
 
     options.plugins.tooltip.callbacks.afterTitle = function (items: Chart.TooltipItem<any>[]) {
+      const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
 
       if (items?.length === 0) {
         return null;
@@ -468,7 +468,7 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy {
 
       const totalValue = datasets.filter(el => el.stack == stack).reduce((_total, dataset) => Utils.addSafely(_total, Math.abs(dataset.data[datasetIndex])), 0);
       if (afterTitle) {
-        return afterTitle + ": " + formatNumber(totalValue, "de", chartObject.tooltip.formatNumber) + " " + tooltipsLabel;
+        return afterTitle + ": " + formatNumber(totalValue, locale, chartObject.tooltip.formatNumber) + " " + tooltipsLabel;
       }
 
       return null;
@@ -483,7 +483,7 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy {
       function rebuildScales(chart: Chart.Chart) {
         let options = chart.options;
         chartObject.yAxes.forEach((element) => {
-          options = AbstractHistoryChart.getYAxisOptions(options, element, translate, chartType, locale, _dataSets, true);
+          options = AbstractHistoryChart.getYAxisOptions(options, element, translate, chartType, _dataSets, true);
         });
       }
 
@@ -534,8 +534,8 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy {
    * @param locale the current locale
    * @returns the chart options {@link Chart.ChartOptions}
    */
-  public static getYAxisOptions(options: Chart.ChartOptions, element: HistoryUtils.yAxes, translate: TranslateService, chartType: "line" | "bar", locale: string, datasets: Chart.ChartDataset[], showYAxisType?: boolean): Chart.ChartOptions {
-
+  public static getYAxisOptions(options: Chart.ChartOptions, element: HistoryUtils.yAxes, translate: TranslateService, chartType: "line" | "bar", datasets: Chart.ChartDataset[], showYAxisType?: boolean): Chart.ChartOptions {
+    const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
     const baseConfig = ChartConstants.DEFAULT_Y_SCALE_OPTIONS(element, translate, chartType, datasets, showYAxisType);
     switch (element.unit) {
       case YAxisType.RELAY:
@@ -633,15 +633,16 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy {
    * @returns a string, that is either the baseName, if no suffix is provided, or a baseName with a formatted number
    */
   public static getTooltipsLabelName(baseName: string, unit: YAxisType, suffix?: number | string): string {
+    const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
     if (suffix != null) {
       if (typeof suffix === "string") {
         return baseName + " " + suffix;
       } else {
         switch (unit) {
           case YAxisType.ENERGY:
-            return baseName + ": " + formatNumber(suffix / 1000, "de", "1.0-1") + " kWh";
+            return baseName + ": " + formatNumber(suffix / 1000, locale, "1.0-1") + " kWh";
           case YAxisType.PERCENTAGE:
-            return baseName + ": " + formatNumber(suffix, "de", "1.0-1") + " %";
+            return baseName + ": " + formatNumber(suffix, locale, "1.0-1") + " %";
           case YAxisType.RELAY:
           case YAxisType.TIME: {
             const pipe = new FormatSecondsToDurationPipe(new DecimalPipe(Language.DE.key));
@@ -661,7 +662,9 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy {
    * @param title the YAxisType
    * @returns the tooltips suffix
    */
-  public static getToolTipsSuffix(label: any, value: number, format: string, title: YAxisType, chartType: "bar" | "line", language: string, translate: TranslateService, config: EdgeConfig): string {
+  public static getToolTipsSuffix(label: any, value: number, format: string, title: YAxisType, chartType: "bar" | "line", translate: TranslateService, config: EdgeConfig): string {
+    const language: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).key;
+    const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
     let tooltipsLabel: string | null = null;
     switch (title) {
       case YAxisType.RELAY: {
@@ -704,7 +707,7 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy {
         break;
     }
 
-    return formatNumber(value, "de", format) + " " + tooltipsLabel;
+    return formatNumber(value, locale, format) + " " + tooltipsLabel;
   }
 
   public static getDefaultOptions(xAxisType: XAxisType, service: Service, labels: (Date | string)[]): Chart.ChartOptions {
@@ -1084,8 +1087,7 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy {
    * Sets the Labels of the Chart
    */
   protected setChartLabel() {
-    const locale = this.service.translate.currentLang;
-    this.options = AbstractHistoryChart.getOptions(this.chartObject, this.chartType, this.service, this.translate, this.legendOptions, this.channelData, locale, this.config, this.datasets, this.xAxisScalingType, this.labels);
+    this.options = AbstractHistoryChart.getOptions(this.chartObject, this.chartType, this.service, this.translate, this.legendOptions, this.channelData, this.config, this.datasets, this.xAxisScalingType, this.labels);
     this.loading = false;
     this.stopSpinner();
   }

--- a/ui/src/app/shared/components/chart/abstracthistorychart.ts
+++ b/ui/src/app/shared/components/chart/abstracthistorychart.ts
@@ -130,7 +130,6 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy {
     const datasets: Chart.ChartDataset[] = [];
     const displayValues: HistoryUtils.DisplayValue<HistoryUtils.CustomOptions>[] = chartObject.output(channelData.data, labels);
     const legendOptions: { label: string, strokeThroughHidingStyle: boolean, hideLabelInLegend: boolean; }[] = [];
-    const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
     displayValues.forEach((displayValue, index) => {
       let nameSuffix = null;
 

--- a/ui/src/app/shared/components/flat/abstract-flat-widget.ts
+++ b/ui/src/app/shared/components/flat/abstract-flat-widget.ts
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
-import { FormBuilder, FormGroup } from "@angular/forms";
 import { Directive, Input, OnDestroy, OnInit, Inject } from "@angular/core";
+import { FormBuilder, FormGroup } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ModalController } from "@ionic/angular";
 import { TranslateService } from "@ngx-translate/core";

--- a/ui/src/app/shared/components/flat/abstract-flat-widget.ts
+++ b/ui/src/app/shared/components/flat/abstract-flat-widget.ts
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
-import { Directive, Inject, Input, OnDestroy, OnInit } from "@angular/core";
 import { FormBuilder, FormGroup } from "@angular/forms";
+import { Directive, Input, OnDestroy, OnInit, Inject } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ModalController } from "@ionic/angular";
 import { TranslateService } from "@ngx-translate/core";

--- a/ui/src/app/shared/components/modal/modal-phases/modal-phases.ts
+++ b/ui/src/app/shared/components/modal/modal-phases/modal-phases.ts
@@ -1,7 +1,7 @@
 import { formatNumber } from "@angular/common";
 import { Component, Input } from "@angular/core";
 import { ChannelAddress, CurrentData, Utils } from "src/app/shared/shared";
-import { Language } from "src/app/shared/type/language"
+import { Language } from "src/app/shared/type/language";
 
 import { AbstractModalLine } from "../abstract-modal-line";
 import { TextIndentation } from "../modal-line/modal-line";

--- a/ui/src/app/shared/components/modal/modal-phases/modal-phases.ts
+++ b/ui/src/app/shared/components/modal/modal-phases/modal-phases.ts
@@ -1,6 +1,7 @@
 import { formatNumber } from "@angular/common";
 import { Component, Input } from "@angular/core";
 import { ChannelAddress, CurrentData, Utils } from "src/app/shared/shared";
+import { Language } from "src/app/shared/type/language"
 
 import { AbstractModalLine } from "../abstract-modal-line";
 import { TextIndentation } from "../modal-line/modal-line";
@@ -47,8 +48,8 @@ export class ModalPhasesComponent extends AbstractModalLine {
    * @returns converted value
    */
   protected CONVERT_TO_POSITIVE_WATT = (value: number | null): string => {
-
+    const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
     value = Utils.absSafely(value) ?? 0;
-    return formatNumber(value, "de", "1.0-0") + " W";
+    return formatNumber(value, locale, "1.0-0") + " W";
   };
 }

--- a/ui/src/app/shared/components/shared/testing/tester.ts
+++ b/ui/src/app/shared/components/shared/testing/tester.ts
@@ -308,7 +308,7 @@ export class OeChartTester {
       legendOptions.push(AbstractHistoryChart.getLegendOptions(label, displayValue));
     });
 
-    let options: Chart.ChartOptions = AbstractHistoryChart.getOptions(chartData, chartType, testContext.service, testContext.translate, legendOptions, channelData.result, locale, config, datasets, xAxisType, labels);
+    let options: Chart.ChartOptions = AbstractHistoryChart.getOptions(chartData, chartType, testContext.service, testContext.translate, legendOptions, channelData.result, config, datasets, xAxisType, labels);
     options = prepareOptionsForTesting(options, chartData);
 
     return {

--- a/ui/src/app/shared/service/utils.ts
+++ b/ui/src/app/shared/service/utils.ts
@@ -8,6 +8,7 @@ import { JsonrpcResponseSuccess } from "../jsonrpc/base";
 import { Base64PayloadResponse } from "../jsonrpc/response/base64PayloadResponse";
 import { QueryHistoricTimeseriesEnergyResponse } from "../jsonrpc/response/queryHistoricTimeseriesEnergyResponse";
 import { ChannelAddress, Currency, EdgeConfig } from "../shared";
+import { Language } from "src/app/shared/type/language"
 
 export class Utils {
 
@@ -251,10 +252,11 @@ export class Utils {
    * @returns converted value
    */
   public static CONVERT_TO_WATT = (value: number | null): string => {
+    const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
     if (value == null) {
       return "-";
     } else if (value >= 0) {
-      return formatNumber(value, "de", "1.0-0") + " W";
+      return formatNumber(value, locale, "1.0-0") + " W";
     } else {
       return "0 W";
     }
@@ -267,13 +269,14 @@ export class Utils {
    * @returns converted value
    */
   public static CONVERT_WATT_TO_KILOWATT = (value: number | null): string => {
+    const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
     if (value == null) {
       return "-";
     }
     const thisValue: number = (value / 1000);
 
     if (thisValue >= 0) {
-      return formatNumber(thisValue, "de", "1.0-1") + " kW";
+      return formatNumber(thisValue, locale, "1.0-1") + " kW";
     } else {
       return "0 kW";
     }
@@ -306,7 +309,8 @@ export class Utils {
    * @returns converted value
    */
   public static CONVERT_TO_WATTHOURS = (value: number): string => {
-    return formatNumber(value, "de", "1.0-1") + " Wh";
+    const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
+    return formatNumber(value, locale, "1.0-1") + " Wh";
   };
 
   /**
@@ -316,7 +320,8 @@ export class Utils {
    * @returns converted value
    */
   public static CONVERT_TO_KILO_WATTHOURS = (value: number): string => {
-    return formatNumber(Utils.divideSafely(value, 1000), "de", "1.0-1") + " kWh";
+    const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
+    return formatNumber(Utils.divideSafely(value, 1000), locale, "1.0-1") + " kWh";
   };
 
   /**
@@ -395,6 +400,7 @@ export class Utils {
    * @returns converted value
    */
   public static CONVERT_PRICE_TO_CENT_PER_KWH = (decimal: number, label: string) => {
+    const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
     return (value: number | null | undefined): string =>
       (value == null ? "-" : formatNumber(value / 10, "de", "1.0-" + decimal)) + " " + label;
   };
@@ -863,7 +869,7 @@ export namespace TimeOfUseTariffUtils {
    * @returns The formatted label, or exits if the value is not valid.
    */
   export function getLabel(value: number, label: string, translate: TranslateService, currencyLabel?: Currency.Label): string {
-
+    const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
     // Error handling: Return undefined if value is not valid
     if (value === undefined || value === null || Number.isNaN(Number.parseInt(value.toString()))) {
       return;
@@ -878,18 +884,18 @@ export namespace TimeOfUseTariffUtils {
     // Switch case to handle different labels
     switch (label) {
       case socLabel:
-        return label + ": " + formatNumber(value, "de", "1.0-0") + " %";
+        return label + ": " + formatNumber(value, locale, "1.0-0") + " %";
 
       case dischargeLabel:
       case chargeConsumptionLabel:
       case balancingLabel:
         // Show floating point number for values between 0 and 1
-        return label + ": " + formatNumber(value, "de", "1.0-4") + " " + currencyLabel;
+        return label + ": " + formatNumber(value, locale, "1.0-4") + " " + currencyLabel;
 
       default:
       case gridBuyLabel:
         // Power values
-        return label + ": " + formatNumber(value, "de", "1.0-2") + " kW";
+        return label + ": " + formatNumber(value, locale, "1.0-2") + " kW";
     }
   }
 

--- a/ui/src/app/shared/service/utils.ts
+++ b/ui/src/app/shared/service/utils.ts
@@ -4,11 +4,11 @@ import { TranslateService } from "@ngx-translate/core";
 import { ChartDataset } from "chart.js";
 import { saveAs } from "file-saver-es";
 import { DefaultTypes } from "src/app/shared/service/defaulttypes";
+import { Language } from "src/app/shared/type/language";
 import { JsonrpcResponseSuccess } from "../jsonrpc/base";
 import { Base64PayloadResponse } from "../jsonrpc/response/base64PayloadResponse";
 import { QueryHistoricTimeseriesEnergyResponse } from "../jsonrpc/response/queryHistoricTimeseriesEnergyResponse";
 import { ChannelAddress, Currency, EdgeConfig } from "../shared";
-import { Language } from "src/app/shared/type/language"
 
 export class Utils {
 
@@ -402,7 +402,7 @@ export class Utils {
   public static CONVERT_PRICE_TO_CENT_PER_KWH = (decimal: number, label: string) => {
     const locale: string = (Language.getByKey(localStorage.LANGUAGE) ?? Language.DEFAULT).i18nLocaleKey;
     return (value: number | null | undefined): string =>
-      (value == null ? "-" : formatNumber(value / 10, "de", "1.0-" + decimal)) + " " + label;
+      (value == null ? "-" : formatNumber(value / 10, locale, "1.0-" + decimal)) + " " + label;
   };
 
   /**


### PR DESCRIPTION
Locale is depends on locale(tautology). but current openems-ui code is using `de` as hardcoding. This PR add mecanizm for locale determining by user environment.

 - formatNumber is pure function, no state. so locale need to be specified by argument. In this change I added `locale` argument to utility functions and set LOCALE_ID as `utility` argument in caller.
 - In angular global locale context is in root module provider so it is difficult to change from function calling from outside.  In this change I changed LOCAL_ID provider initialization from `useValue` to `useFactory`. Factory function use localstorage language setting currently because language and locale is not clearly separated.
 - I don't understand testing code well, so for now, I just added `de` to testing function calling directly.