### PR TITLE
Add the state of charge in kWh to storage system widgets

### DIFF
--- a/ui/src/app/edge/live/common/storage/modal/modal.component.html
+++ b/ui/src/app/edge/live/common/storage/modal/modal.component.html
@@ -24,8 +24,8 @@
                         <div style="padding-top: 5px;"></div>
                         <tr>
                             <td style="width:65%" translate>General.soc</td>
-                            <td style="width: 35%" class="align_right">
-                                {{ sum.soc | unitvalue:'%' }}
+                            <td style="width: 35%; white-space: nowrap;" class="align_right">
+                                {{ sum.soc | unitvalue:'%' }} ({{ totalCurrentSoc | unitvalue: 'kWh'}})
                             </td>
                         </tr>
                         <!-- Charge/Discharge -->
@@ -311,8 +311,8 @@
                         <div style="padding-top: 5px;"></div>
                         <tr>
                             <td style="width: 65%" translate>General.soc</td>
-                            <td style="width:35%" class="align_right">
-                                {{ sum.soc | unitvalue:'%' }}
+                            <td style="width:35%; white-space: nowrap;" class="align_right">
+                                {{ sum.soc | unitvalue:'%' }} ({{ totalCurrentSoc | unitvalue: 'kWh'}})
                             </td>
                         </tr>
                         <tr>
@@ -413,7 +413,7 @@
             </ion-card-content>
 
             <ng-container *ngIf="(edge.currentData | async)['channel'] as currentData">
-                <ng-container *ngFor="let component of essComponents">
+                <ng-container *ngFor="let component of essComponents, let i = index">
                     <ng-container *ngIf="config.factories[component.factoryId] as factory">
                         <ion-card-content
                             [class.underline]="chargerComponents?.length > 0 || !isLastElement(component, essComponents)">
@@ -426,8 +426,8 @@
                                 <div style="padding-top: 5px;"></div>
                                 <tr>
                                     <td style="width: 65%" translate>General.soc</td>
-                                    <td style="width: 35%" class="align_right">
-                                        {{ currentData[component.id + '/Soc'] | unitvalue:'%' }}
+                                    <td style="width: 35%; white-space: nowrap;" class="align_right">
+                                        {{ currentData[component.id + '/Soc'] | unitvalue:'%' }} ({{ currentSocs[i] | unitvalue: 'kWh' }})
                                     </td>
                                 </tr>
                             </table>

--- a/ui/src/app/edge/live/common/storage/modal/modal.component.ts
+++ b/ui/src/app/edge/live/common/storage/modal/modal.component.ts
@@ -28,6 +28,8 @@ export class StorageModalComponent implements OnInit, OnDestroy {
     protected isAtLeastInstaller: boolean;
     protected isTargetTimeInValid: Map<string, boolean> = new Map();
     protected controllerIsRequiredEdgeVersion: boolean = false;
+    private currentSocs: Array<number> = []
+    private totalCurrentSoc: number;
 
     constructor(
         public service: Service,
@@ -142,6 +144,18 @@ export class StorageModalComponent implements OnInit, OnDestroy {
 
                 if (!this.formGroup.dirty) {
                     this.formGroup = controls;
+                }
+
+                // Calculate state of charge in kWh for each storage component.
+                this.totalCurrentSoc = 0;
+                this.currentSocs = new Array<number>(Object.keys(components).length);
+                for (let i = 0; i < this.essComponents.length; i++) {
+                    const component = this.essComponents[i];
+                    const capacity = currentData.channel[component.alias + '/Capacity'];
+                    const socPercent = currentData.channel[component.alias + '/Soc'];
+                    const socWh = capacity * socPercent / 100;
+                    this.currentSocs[i] = socWh;
+                    this.totalCurrentSoc += socWh;
                 }
             });
     }

--- a/ui/src/app/edge/live/common/storage/storage.component.html
+++ b/ui/src/app/edge/live/common/storage/storage.component.html
@@ -25,7 +25,7 @@
         </ng-container>
 
         <ng-template #noReserve>
-            <oe-flat-widget-percentagebar [channelAddress]="component.id + '/Soc'">
+            <oe-flat-widget-percentagebar [channelAddress]="component.id + '/Soc'" [secondaryValue]="currentSocs[i]">
             </oe-flat-widget-percentagebar>
         </ng-template>
 

--- a/ui/src/app/shared/components/flat/flat-widget-percentagebar/flat-widget-percentagebar.html
+++ b/ui/src/app/shared/components/flat/flat-widget-percentagebar/flat-widget-percentagebar.html
@@ -5,6 +5,9 @@
     <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" style="font-weight: 500"
         ngClass="secondary-color">
         {{ displayValue | unitvalue: '%' }}
+        <ng-container *ngIf="secondaryValue">
+            ({{ secondaryValue }}) 
+        </ng-container>
     </text>
     <ng-content></ng-content>
 </svg>

--- a/ui/src/app/shared/components/flat/flat-widget-percentagebar/flat-widget-percentagebar.ts
+++ b/ui/src/app/shared/components/flat/flat-widget-percentagebar/flat-widget-percentagebar.ts
@@ -1,8 +1,14 @@
-import { Component } from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { AbstractFlatWidgetLine } from "../abstract-flat-widget-line";
 
 @Component({
     selector: "oe-flat-widget-percentagebar",
     templateUrl: "./flat-widget-percentagebar.html",
 })
-export class FlatWidgetPercentagebarComponent extends AbstractFlatWidgetLine { }
+export class FlatWidgetPercentagebarComponent extends AbstractFlatWidgetLine { 
+    /*
+    * Secondary information that gets displayed in parentheses behind the percentage value.
+    */
+    @Input()    
+    public secondaryValue:string | null = null;
+}


### PR DESCRIPTION
Currently the state of charge (SOC) of storage systems is only shown in %. This change adds the SOC in kWh to the
flat-widget displayed on the dashboard and the modal-widget that pops up when clicking on the storage system.

To do this, the percentagebar-widget needed to be extended to support a secondary parameter, which is displayed in parenthesis behind the percentage value.