### PR TITLE
Fix: Cycle time change from wait for trigger to actual time

### DIFF
--- a/io.openems.edge.common/src/io/openems/edge/common/test/AbstractComponentTest.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/test/AbstractComponentTest.java
@@ -725,6 +725,28 @@ public abstract class AbstractComponentTest<SELF extends AbstractComponentTest<S
 	}
 
 	/**
+	 * Calls the 'modify()' method of the 'system-under-test'.
+	 *
+	 * @param config the configuration
+	 * @return itself, to use as a builder
+	 * @throws Exception on error
+	 */
+	public SELF modify(AbstractComponentConfig config) throws Exception {
+
+		// Add the configuration to ConfigurationAdmin
+		for (Object object : this.references) {
+			if (object instanceof DummyConfigurationAdmin) {
+				var cm = (DummyConfigurationAdmin) object;
+				cm.addConfig(config);
+			}
+		}
+
+		this.callModified(config);
+
+		return this.self();
+	}
+
+	/**
 	 * Calls the 'deactivate()' method of the 'system-under-test'.
 	 *
 	 * @return itself, to use as a builder

--- a/io.openems.edge.core/src/io/openems/edge/core/cycle/CycleImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/cycle/CycleImpl.java
@@ -131,4 +131,11 @@ public class CycleImpl extends AbstractOpenemsComponent implements OpenemsCompon
 		return Cycle.DEFAULT_CYCLE_TIME;
 	}
 
+	/**
+	 * Triggers the execution of the next cycle.
+	 */
+	public void triggerNextCycle() {
+		this.worker.triggerNextRun();
+	}
+
 }

--- a/io.openems.edge.core/test/io/openems/edge/core/cycle/CycleImplTest.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/cycle/CycleImplTest.java
@@ -1,0 +1,116 @@
+package io.openems.edge.core.cycle;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import io.openems.common.worker.AbstractWorker;
+import io.openems.edge.common.component.AbstractOpenemsComponent;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.sum.DummySum;
+import io.openems.edge.common.test.AbstractComponentTest.TestCase;
+import io.openems.edge.common.test.ComponentTest;
+import io.openems.edge.common.test.DummyComponentManager;
+import io.openems.edge.common.test.DummyConfigurationAdmin;
+import io.openems.edge.common.test.DummyEventAdmin;
+import io.openems.edge.controller.test.DummyController;
+import io.openems.edge.scheduler.api.Scheduler;
+
+public class CycleImplTest {
+
+	private final class SchedulerImplementation extends AbstractOpenemsComponent implements Scheduler {
+
+		private LinkedHashSet<String> controllers;
+
+		protected SchedulerImplementation(LinkedHashSet<String> controllers) {
+			super(OpenemsComponent.ChannelId.values(), Scheduler.ChannelId.values());
+			this.controllers = controllers;
+		}
+
+		@Override
+		public LinkedHashSet<String> getControllers() {
+			return this.controllers;
+		}
+
+		@Override
+		public String id() {
+			return "Bla";
+		}
+	}
+
+	@Test
+	public void testChangeCycleTime() throws Exception {
+
+		var dummyController = new DummyController("BlaDummyController");
+		var eventAdmin = new DummyEventAdmin();
+		var controllerExecutionCount = new AtomicInteger();
+		var newValueForCycle = new AtomicInteger();
+		dummyController.setRunCallback(() -> {
+			controllerExecutionCount.set(newValueForCycle.get());
+		});
+
+		var scheduler = new SchedulerImplementation(
+				new LinkedHashSet<String>(Collections.singleton(dummyController.id())));
+
+		var sut = new CycleImpl();
+		new ComponentTest(sut) //
+				.addReference("cm", new DummyConfigurationAdmin()) //
+				.addReference("componentManager", new DummyComponentManager()) //
+				.addReference("sumComponent", new DummySum()) //
+				.addReference("addScheduler", scheduler) //
+				.addReference("eventAdmin", eventAdmin) //
+				.addComponent(dummyController) //
+				.activate(MyConfig.create().cycleTime(AbstractWorker.DO_NOT_WAIT).build()) //
+				.next(new TestCase("Run cycle with 0 cycle time") //
+						.onAfterControllersCallbacks(() -> {
+							newValueForCycle.getAndIncrement();
+							Thread.sleep(20); // required, because cycle does not have an external clock stopwatch
+							assertEquals(newValueForCycle.get(), controllerExecutionCount.get()); //
+						})) //
+				.modify(MyConfig.create().cycleTime(AbstractWorker.ALWAYS_WAIT_FOR_TRIGGER_NEXT_RUN).build()) //
+				.next(new TestCase("No new cycle executes, as next run must be triggered manually") //
+						.onAfterControllersCallbacks(() -> {
+							newValueForCycle.getAndIncrement();
+							Thread.sleep(20); // required, because cycle does not have an external clock stopwatch
+							assertEquals(newValueForCycle.get() - 1, controllerExecutionCount.get()); //
+						})) //
+				.next(new TestCase("New cycle execution manually triggered") //
+						.onAfterControllersCallbacks(() -> {
+							sut.triggerNextCycle();
+							Thread.sleep(20); // required, because cycle does not have an external clock stopwatch
+							assertEquals(newValueForCycle.get(), controllerExecutionCount.get());
+							System.out.println("Done");
+						}))
+				.modify(MyConfig.create().cycleTime(20).build()) //
+				.next(new TestCase("Set wait time again, but do not wait") //
+						.onAfterControllersCallbacks(() -> {
+							newValueForCycle.getAndIncrement();
+							assertEquals(newValueForCycle.get() - 1, controllerExecutionCount.get());
+						}))
+				.next(new TestCase("Wait until cycle time passed") //
+						.onAfterControllersCallbacks(() -> {
+							Thread.sleep(50); // required, because cycle does not have an external clock stopwatch
+							assertEquals(newValueForCycle.get(), controllerExecutionCount.get());
+						}))
+				.modify(MyConfig.create().cycleTime(5000).build()) //
+				.next(new TestCase("Set wait time again, but do not wait") //
+						.onAfterControllersCallbacks(() -> {
+							newValueForCycle.getAndIncrement();
+							// cycle is not passed yet
+							assertEquals(newValueForCycle.get() - 1, controllerExecutionCount.get());
+						}))
+				.modify(MyConfig.create().cycleTime(20).build()) //
+				.next(new TestCase("Set wait time again before previous cycle completed") //
+						.onAfterControllersCallbacks(() -> {
+							newValueForCycle.getAndIncrement();
+							Thread.sleep(100); // required, because cycle does not have an external clock stopwatch
+							assertEquals(newValueForCycle.get(), controllerExecutionCount.get());
+						}));
+
+	}
+
+}

--- a/io.openems.edge.core/test/io/openems/edge/core/cycle/MyConfig.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/cycle/MyConfig.java
@@ -1,0 +1,45 @@
+package io.openems.edge.core.cycle;
+
+import io.openems.common.test.AbstractComponentConfig;
+
+@SuppressWarnings("all")
+public class MyConfig extends AbstractComponentConfig implements Config {
+
+	protected static class Builder {
+
+		private int cycleTime;
+
+		private Builder() {
+		}
+
+		public MyConfig build() {
+			return new MyConfig(this);
+		}
+
+		public Builder cycleTime(int cycleTime) {
+			this.cycleTime = cycleTime;
+			return this;
+		}
+	}
+
+	/**
+	 * Create a Config builder.
+	 *
+	 * @return a {@link Builder}
+	 */
+	public static Builder create() {
+		return new Builder();
+	}
+
+	private final Builder builder;
+
+	private MyConfig(Builder builder) {
+		super(Config.class, CycleImpl.SINGLETON_COMPONENT_ID);
+		this.builder = builder;
+	}
+
+	@Override
+	public int cycleTime() {
+		return this.builder.cycleTime;
+	}
+}


### PR DESCRIPTION
If the config was changed from `AbstractWorker.ALWAYS_WAIT_FOR_TRIGGER_NEXT_RUN` to a value >= 0 again the cycle thread remaind in a waiting state. The reason for that is that the thread was put in an await state as soon as `AbstractWorker.ALWAYS_WAIT_FOR_TRIGGER_NEXT_RUN` was configured.
This change allows a change at releases the thread again.

Testing: Unit tests, and the simulator app starts up and starts executing cycles

Note: The cycle worker implementation is using a stopwatch that does not allow to inject a custom clock. To improve unit tests, I can provide a pull request that refactors the stopwatch implementation first, if this change is wanted.

This change fixes an error that surfaces when using the SimulatorApp. The cycle never actually starts to execute.
