### PR TITLE
Add hint to README to fix an error with building a Docker image

### DIFF
--- a/tools/docker/backend/README.md
+++ b/tools/docker/backend/README.md
@@ -78,3 +78,9 @@
     ```
 
     *for UI Image see [ui/README.md](../ui/README.md)*
+
+# Common Problems and Solutions
+```
+ERROR: failed to solve: error from sender: context canceled
+```
+When building the Docker image this error may occur because another program is accessing the project files. Try closing these programs (e.g. Eclipse IDE) and run the build command again.

--- a/tools/docker/edge/README.md
+++ b/tools/docker/edge/README.md
@@ -37,7 +37,9 @@
 
     *for UI Image see [ui/README.md](../ui/README.md)*
 
-   Info: If you get the following error while building the Docker image try closing the Eclipse IDE and running the build again.
-    ```
-    ERROR: failed to solve: error from sender: context canceled
-    ```
+# Common Problems and Solutions
+```
+ERROR: failed to solve: error from sender: context canceled
+```
+When building the Docker image this error may occur because another program is accessing the project files. Try closing these programs (e.g. Eclipse IDE) and run the build command again.
+

--- a/tools/docker/edge/README.md
+++ b/tools/docker/edge/README.md
@@ -36,3 +36,8 @@
     ```
 
     *for UI Image see [ui/README.md](../ui/README.md)*
+
+   Info: If you get the following error while building the Docker image try closing the Eclipse IDE and running the build again.
+    ```
+    ERROR: failed to solve: error from sender: context canceled
+    ```


### PR DESCRIPTION
This is just a small commit that should help people trying to build their own Docker image. When running the build command from the readme file the error `failed to solve: error from sender: context canceled` can occur. This can easily be fixed by making sure the Eclipse IDE isn't open. To avoid others having to search for a solution I would like to add this info to the readme.