### PR TITLE
fix: Delete the duplicate button

### DIFF
--- a/ui/src/app/shared/components/header/header.component.html
+++ b/ui/src/app/shared/components/header/header.component.html
@@ -19,7 +19,6 @@
     </ion-title>
     <ng-container *ngIf="service.currentEdge | async as edge">
       <ng-container *ngIf="currentPage === 'IndexLive' || currentPage === 'IndexHistory'">
-        <ion-buttons>
           <ion-segment mode="md" (ionChange)="segmentChanged($event)" [(ngModel)]="currentPage"
             class="ion-justify-content-center">
             <ion-segment-button value="IndexLive">
@@ -29,7 +28,6 @@
               <ion-label translate>General.HISTORY</ion-label>
             </ion-segment-button>
           </ion-segment>
-        </ion-buttons>
       </ng-container>
     </ng-container>
     <!-- this title tag is for spacing purpose only -->

--- a/ui/src/app/shared/components/header/header.component.html
+++ b/ui/src/app/shared/components/header/header.component.html
@@ -19,15 +19,15 @@
     </ion-title>
     <ng-container *ngIf="service.currentEdge | async as edge">
       <ng-container *ngIf="currentPage === 'IndexLive' || currentPage === 'IndexHistory'">
-          <ion-segment mode="md" (ionChange)="segmentChanged($event)" [(ngModel)]="currentPage"
-            class="ion-justify-content-center">
-            <ion-segment-button value="IndexLive">
-              <ion-label translate>General.LIVE</ion-label>
-            </ion-segment-button>
-            <ion-segment-button value="IndexHistory">
-              <ion-label translate>General.HISTORY</ion-label>
-            </ion-segment-button>
-          </ion-segment>
+        <ion-segment mode="md" (ionChange)="segmentChanged($event)" [(ngModel)]="currentPage"
+          class="ion-justify-content-center">
+          <ion-segment-button value="IndexLive">
+            <ion-label translate>General.LIVE</ion-label>
+          </ion-segment-button>
+          <ion-segment-button value="IndexHistory">
+            <ion-label translate>General.HISTORY</ion-label>
+          </ion-segment-button>
+        </ion-segment>
       </ng-container>
     </ng-container>
     <!-- this title tag is for spacing purpose only -->


### PR DESCRIPTION
ion-segment itself already manages a group of buttons (ion-segment-button elements). By removing the redundant <ion-buttons> wrapper, it could simplify the DOM structure, making code cleaner.