### PR TITLE
Update Checkstyle to 10.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ subprojects {
 		}
 	
 		checkstyle {
-			toolVersion = '10.11.0'
+			toolVersion = '10.18.2'
 			configFile = file("${rootDir}/cnf/checkstyle.xml")
 			maxWarnings = 0
 			ignoreFailures = false

--- a/cnf/checkstyle.xml
+++ b/cnf/checkstyle.xml
@@ -23,8 +23,8 @@
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
     </module>
     <module name="AvoidEscapedUnicodeCharacters">
-      <property name="allowEscapesForControlCharacters" value="true"/>
       <property name="allowByTailComment" value="true"/>
+      <property name="allowEscapesForControlCharacters" value="true"/>
       <property name="allowNonPrintableEscapes" value="true"/>
     </module>
     <module name="AvoidStarImport"/>
@@ -47,9 +47,9 @@
     </module>
     <module name="WhitespaceAround">
       <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyLoops" value="true"/>
       <property name="allowEmptyMethods" value="true"/>
       <property name="allowEmptyTypes" value="true"/>
-      <property name="allowEmptyLoops" value="true"/>
       <property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV,DIV_ASSIGN,DO_WHILE,EQUAL,GE,GT,LAMBDA,LAND,LCURLY,LE,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,LOR,LT,MINUS,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS,PLUS_ASSIGN,QUESTION,RCURLY,SL,SLIST,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN,LITERAL_ASSERT,TYPE_EXTENSION_AND"/>
       <message key="ws.notPreceded" value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
       <message key="ws.notFollowed" value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
@@ -107,8 +107,8 @@
       <message key="name.invalidPattern" value="Member name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="ParameterName">
-      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
       <property name="accessModifiers" value="public"/>
+      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern" value="Parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LambdaParameterName">
@@ -144,9 +144,9 @@
     </module>
     <module name="Indentation">
       <property name="severity" value="ignore"/>
+      <property name="arrayInitIndent" value="2"/>
       <property name="basicOffset" value="2"/>
       <property name="caseIndent" value="2"/>
-      <property name="arrayInitIndent" value="2"/>
       <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
     </module>
     <module name="AbbreviationAsWordInName">
@@ -179,12 +179,10 @@
     <module name="SummaryJavadoc">
       <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
     </module>
-    <module name="JavadocParagraph">
-      <property name="allowNewlineParagraph" value="false"/>
-    </module>
+    <module name="JavadocParagraph"/>
     <module name="AtclauseOrder">
-      <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
       <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+      <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="MethodName">
       <property name="format" value="^[a-z_][a-zA-Z0-9_]*$"/>
@@ -206,15 +204,15 @@
       <property name="tokens" value="ANNOTATION_DEF,ANNOTATION_FIELD_DEF,CLASS_DEF,CTOR_DEF,ENUM_CONSTANT_DEF,ENUM_DEF,INTERFACE_DEF,METHOD_DEF,VARIABLE_DEF"/>
     </module>
     <module name="MissingJavadocMethod">
-      <property name="allowedAnnotations" value="Before,Test,After,Override"/>
       <property name="allowMissingPropertyJavadoc" value="true"/>
+      <property name="allowedAnnotations" value="Before,Test,After,Override"/>
       <property name="ignoreMethodNamesRegex" value="doc|set.+|build"/>
       <property name="tokens" value="METHOD_DEF"/>
     </module>
     <module name="VisibilityModifier">
-      <property name="protectedAllowed" value="true"/>
       <property name="allowPublicFinalFields" value="true"/>
       <property name="allowPublicImmutableFields" value="true"/>
+      <property name="protectedAllowed" value="true"/>
     </module>
   </module>
   <module name="LineLength">

--- a/io.openems.edge.controller.ess.gridoptimizedcharge/test/io/openems/edge/controller/ess/gridoptimizedcharge/ControllerEssGridOptimizedChargeImplTest.java
+++ b/io.openems.edge.controller.ess.gridoptimizedcharge/test/io/openems/edge/controller/ess/gridoptimizedcharge/ControllerEssGridOptimizedChargeImplTest.java
@@ -1444,80 +1444,6 @@ public class ControllerEssGridOptimizedChargeImplTest {
 		});
 	}
 
-	private DelayChargeResultState testOneDay(String testDescription, Integer[] productionPrediction,
-			Integer[] consumptionPrediction, int soc, Optional<Integer> targetMinuteOpt, int capacity,
-			int maxApparentPower, int allowedChargePower, DelayChargeRiskLevel riskLevel, Integer[] productionActual,
-			Integer[] consumptionActual, float resultBuffer) {
-		DelayChargeResultState resultState;
-		DelayChargeResult newLogic = ControllerEssGridOptimizedChargeImplTest.testOneDay(testDescription,
-				productionPrediction, consumptionPrediction, soc, targetMinuteOpt, capacity, maxApparentPower,
-				allowedChargePower, riskLevel, productionActual, consumptionActual, false);
-
-		DelayChargeResult oldLogic = ControllerEssGridOptimizedChargeImplTest.testOneDay(testDescription,
-				productionPrediction, consumptionPrediction, soc, targetMinuteOpt, capacity, maxApparentPower,
-				allowedChargePower, riskLevel, productionActual, consumptionActual, true);
-
-		if (newLogic.getFinalSoc() + resultBuffer < oldLogic.getFinalSoc()) {
-			resultState = DelayChargeResultState.WARNING;
-		} else if (newLogic.getFinalSoc() - resultBuffer > oldLogic.getFinalSoc()) {
-			resultState = DelayChargeResultState.PERFECT;
-		} else {
-			resultState = DelayChargeResultState.OK;
-		}
-
-		float unefficientEnergy = Math
-				.round(newLogic.getChargedEnergyWithLowPower() / newLogic.getChargedEnergy() * 1000) / 10.0f;
-		float unefficientEnergyOld = Math
-				.round(oldLogic.getChargedEnergyWithLowPower() / oldLogic.getChargedEnergy() * 1000) / 10.0f;
-		System.out.println(resultState.text + "\t" + testDescription + "     \t(New: "
-				+ Math.round(newLogic.getFinalSoc() * 100) / 100.0 + " | Old: "
-				+ Math.round(oldLogic.getFinalSoc() * 100) / 100.0 + ") \t   Energy: (New: "
-				+ newLogic.getChargedEnergy() + "[" + newLogic.getChargedEnergyWithLowPower() + " -> "
-				+ unefficientEnergy + "%] | Old: " + oldLogic.getChargedEnergy() + "["
-				+ oldLogic.getChargedEnergyWithLowPower() + " -> " + unefficientEnergyOld + "%])");
-
-		// fail("New logic results in a lower SoC (New: " + newLogic.getFinalSoc() + " |
-		// Old: "+ oldLogic.getFinalSoc() + ") - " + testDescription);
-		return resultState;
-	}
-
-	private static class DelayChargeResult {
-
-		private float finalSoc;
-		private float chargedEnergy;
-		private float chargedEnergyWithLowPower;
-
-		public DelayChargeResult(float finalSoc, float chargedEnergy, float chargedEnergyWithLowPower) {
-			this.finalSoc = finalSoc;
-			this.chargedEnergy = chargedEnergy;
-			this.chargedEnergyWithLowPower = chargedEnergyWithLowPower;
-		}
-
-		public float getFinalSoc() {
-			return this.finalSoc;
-		}
-
-		public float getChargedEnergy() {
-			return this.chargedEnergy;
-		}
-
-		public float getChargedEnergyWithLowPower() {
-			return this.chargedEnergyWithLowPower;
-		}
-	}
-
-	private static enum DelayChargeResultState {
-		OK("OK - SoC as bevore"), //
-		WARNING("WARNING - Lower SoC"), //
-		PERFECT("PERFECT - Higher SoC");
-
-		private String text;
-
-		DelayChargeResultState(String text) {
-			this.text = text;
-		}
-	}
-
 	@SuppressWarnings("deprecation")
 	private static DelayChargeResult testOneDay(String testDescription, Integer[] productionPrediction,
 			Integer[] consumptionPrediction, int soc, Optional<Integer> targetMinuteOpt, int capacity,
@@ -1656,6 +1582,80 @@ public class ControllerEssGridOptimizedChargeImplTest {
 			e.printStackTrace();
 		}
 		return new DelayChargeResult(socFloat, totoalActivePower * 0.25f, totoalActivePowerLessEfficiency * 0.25f);
+	}
+
+	private DelayChargeResultState testOneDay(String testDescription, Integer[] productionPrediction,
+			Integer[] consumptionPrediction, int soc, Optional<Integer> targetMinuteOpt, int capacity,
+			int maxApparentPower, int allowedChargePower, DelayChargeRiskLevel riskLevel, Integer[] productionActual,
+			Integer[] consumptionActual, float resultBuffer) {
+		DelayChargeResultState resultState;
+		DelayChargeResult newLogic = ControllerEssGridOptimizedChargeImplTest.testOneDay(testDescription,
+				productionPrediction, consumptionPrediction, soc, targetMinuteOpt, capacity, maxApparentPower,
+				allowedChargePower, riskLevel, productionActual, consumptionActual, false);
+
+		DelayChargeResult oldLogic = ControllerEssGridOptimizedChargeImplTest.testOneDay(testDescription,
+				productionPrediction, consumptionPrediction, soc, targetMinuteOpt, capacity, maxApparentPower,
+				allowedChargePower, riskLevel, productionActual, consumptionActual, true);
+
+		if (newLogic.getFinalSoc() + resultBuffer < oldLogic.getFinalSoc()) {
+			resultState = DelayChargeResultState.WARNING;
+		} else if (newLogic.getFinalSoc() - resultBuffer > oldLogic.getFinalSoc()) {
+			resultState = DelayChargeResultState.PERFECT;
+		} else {
+			resultState = DelayChargeResultState.OK;
+		}
+
+		float unefficientEnergy = Math
+				.round(newLogic.getChargedEnergyWithLowPower() / newLogic.getChargedEnergy() * 1000) / 10.0f;
+		float unefficientEnergyOld = Math
+				.round(oldLogic.getChargedEnergyWithLowPower() / oldLogic.getChargedEnergy() * 1000) / 10.0f;
+		System.out.println(resultState.text + "\t" + testDescription + "     \t(New: "
+				+ Math.round(newLogic.getFinalSoc() * 100) / 100.0 + " | Old: "
+				+ Math.round(oldLogic.getFinalSoc() * 100) / 100.0 + ") \t   Energy: (New: "
+				+ newLogic.getChargedEnergy() + "[" + newLogic.getChargedEnergyWithLowPower() + " -> "
+				+ unefficientEnergy + "%] | Old: " + oldLogic.getChargedEnergy() + "["
+				+ oldLogic.getChargedEnergyWithLowPower() + " -> " + unefficientEnergyOld + "%])");
+
+		// fail("New logic results in a lower SoC (New: " + newLogic.getFinalSoc() + " |
+		// Old: "+ oldLogic.getFinalSoc() + ") - " + testDescription);
+		return resultState;
+	}
+
+	private static class DelayChargeResult {
+
+		private float finalSoc;
+		private float chargedEnergy;
+		private float chargedEnergyWithLowPower;
+
+		public DelayChargeResult(float finalSoc, float chargedEnergy, float chargedEnergyWithLowPower) {
+			this.finalSoc = finalSoc;
+			this.chargedEnergy = chargedEnergy;
+			this.chargedEnergyWithLowPower = chargedEnergyWithLowPower;
+		}
+
+		public float getFinalSoc() {
+			return this.finalSoc;
+		}
+
+		public float getChargedEnergy() {
+			return this.chargedEnergy;
+		}
+
+		public float getChargedEnergyWithLowPower() {
+			return this.chargedEnergyWithLowPower;
+		}
+	}
+
+	private static enum DelayChargeResultState {
+		OK("OK - SoC as bevore"), //
+		WARNING("WARNING - Lower SoC"), //
+		PERFECT("PERFECT - Higher SoC");
+
+		private String text;
+
+		DelayChargeResultState(String text) {
+			this.text = text;
+		}
 	}
 
 	@Test


### PR DESCRIPTION
See https://github.com/checkstyle/checkstyle/releases/tag/checkstyle-10.18.2 for details.

Unfortunately Checkstyle by default requires _no_ newline after `<p>` in JavaDoc, whereas Eclipse IDE automatically adds one by default. This is PR disables this check.