### PR TITLE
Edge: Backend Api Controller: Change SendChannelsValueWorker SendAllChannelsAfterSeconds to 4 min

### DIFF
--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/SendChannelValuesWorker.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/SendChannelValuesWorker.java
@@ -54,7 +54,7 @@ import io.openems.edge.common.type.TypeUtils;
 public class SendChannelValuesWorker {
 
 	private static final int AGGREGATION_MINUTES = 5;
-	private static final int SEND_VALUES_OF_ALL_CHANNELS_AFTER_SECONDS = 300; /* 5 minutes */
+	private static final int SEND_VALUES_OF_ALL_CHANNELS_AFTER_SECONDS = 240; /* 4 minutes */
 
 	private final Logger log = LoggerFactory.getLogger(SendChannelValuesWorker.class);
 


### PR DESCRIPTION
Due to resolution request, the UI might display empty values in data charts. (5 min time range)
By reducing the send all channel values time to 4 min on the edge, this can be prevented.

The issue only occurs with components that have the same channel value over a long time period.

E.g. an ess over night, where the ess is neither charging or discharging (look at 1 o clock), this is a reoccuring theme, and the image is a mere example.

![5MinIssue](https://github.com/user-attachments/assets/6191a4f5-c168-4c0b-a924-2a5cd3843da3)


