### PR TITLE
Feature/Dummy MacOS Support

### DIFF
--- a/io.openems.edge.core/src/io/openems/edge/core/host/HostImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/host/HostImpl.java
@@ -78,8 +78,6 @@ public class HostImpl extends AbstractOpenemsComponent implements Host, OpenemsC
 				OpenemsComponent.ChannelId.values(), //
 				Host.ChannelId.values() //
 		);
-		
-		log.info(System.getProperty("os.name"));
 
 		// Initialize correct Operating System handler
 		if (System.getProperty("os.name").startsWith("Windows")) {

--- a/io.openems.edge.core/src/io/openems/edge/core/host/HostImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/host/HostImpl.java
@@ -78,10 +78,14 @@ public class HostImpl extends AbstractOpenemsComponent implements Host, OpenemsC
 				OpenemsComponent.ChannelId.values(), //
 				Host.ChannelId.values() //
 		);
+		
+		log.info(System.getProperty("os.name"));
 
 		// Initialize correct Operating System handler
 		if (System.getProperty("os.name").startsWith("Windows")) {
 			this.operatingSystem = new OperatingSystemWindows();
+		} else if (System.getProperty("os.name").startsWith("Mac")) {
+			this.operatingSystem = new OperatingSystemMac();
 		} else {
 			this.operatingSystem = new OperatingSystemDebianSystemd(this);
 		}

--- a/io.openems.edge.core/src/io/openems/edge/core/host/OperatingSystemMac.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/host/OperatingSystemMac.java
@@ -1,0 +1,60 @@
+package io.openems.edge.core.host;
+
+import java.net.Inet4Address;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+
+import io.openems.common.exceptions.NotImplementedException;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
+import io.openems.edge.common.user.User;
+import io.openems.edge.core.host.jsonrpc.ExecuteSystemCommandRequest;
+import io.openems.edge.core.host.jsonrpc.ExecuteSystemCommandResponse;
+import io.openems.edge.core.host.jsonrpc.ExecuteSystemRestartRequest;
+import io.openems.edge.core.host.jsonrpc.SetNetworkConfigRequest;
+
+public class OperatingSystemMac implements OperatingSystem {
+
+	@Override
+	public NetworkConfiguration getNetworkConfiguration() throws OpenemsNamedException {
+		return new NetworkConfiguration(new TreeMap<>());
+	}
+
+	@Override
+	public void handleSetNetworkConfigRequest(User user, NetworkConfiguration oldNetworkConfiguration,
+			SetNetworkConfigRequest request) throws OpenemsNamedException {
+		throw new NotImplementedException("SetNetworkConfigRequest is not implemented for Mac");
+		
+	}
+
+	@Override
+	public String getUsbConfiguration() throws OpenemsNamedException {
+		// not implemented
+		return "";
+	}
+
+	@Override
+	public CompletableFuture<ExecuteSystemCommandResponse> handleExecuteSystemCommandRequest(
+			ExecuteSystemCommandRequest request) throws OpenemsNamedException {
+		throw new NotImplementedException("ExecuteSystemCommandRequest is not implemented for Mac");
+	}
+
+	@Override
+	public CompletableFuture<? extends JsonrpcResponseSuccess> handleExecuteSystemRestartRequest(
+			ExecuteSystemRestartRequest request) throws NotImplementedException {
+		throw new NotImplementedException("ExecuteSystemRestartRequest is not implemented for Mac");
+	}
+
+	@Override
+	public List<Inet4Address> getSystemIPs() throws OpenemsNamedException {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public CompletableFuture<String> getOperatingSystemVersion() {
+		return CompletableFuture.completedFuture(System.getProperty("os.name"));
+	}
+
+}


### PR DESCRIPTION
Added the ability for OpenEMS edge to run on MacOS. Purely to be used for development purposes. The implementation of OperatingSystemMacOS is based on the Windows version.