### PR TITLE
Websocket: WSS instead of WS if page is accessed via HTTPS

### DIFF
--- a/ui/src/environments/index.ts
+++ b/ui/src/environments/index.ts
@@ -96,3 +96,10 @@ export interface Environment {
     },
     readonly PRODUCT_TYPES: (translate: TranslateService) => Filter | null
 }
+
+/*
+ * Return the proper websocket scheme (WS or WSS) depending on whether the page is accessed via HTTP or HTTPS.
+*/
+export function getWebsocketScheme() : string {
+  return window.location.protocol === "https:" ? "wss://" : "ws://";
+}

--- a/ui/src/environments/index.ts
+++ b/ui/src/environments/index.ts
@@ -99,7 +99,7 @@ export interface Environment {
 
 /*
  * Return the proper websocket scheme (WS or WSS) depending on whether the page is accessed via HTTP or HTTPS.
-*/
-export function getWebsocketScheme() : string {
-  return window.location.protocol === "https:" ? "wss://" : "ws://";
+ */
+export function getWebsocketScheme(): string {
+    return window.location.protocol === "https:" ? "wss://" : "ws://";
 }

--- a/ui/src/themes/openems/environments/backend-dev.ts
+++ b/ui/src/themes/openems/environments/backend-dev.ts
@@ -1,11 +1,12 @@
 import { Environment } from "src/environments";
+import { getWebsocketScheme } from "src/environments";
 import { theme } from "./theme";
 
 export const environment: Environment = {
     ...theme, ...{
 
         backend: "OpenEMS Backend",
-        url: "ws://" + location.hostname + ":8082",
+        url: getWebsocketScheme() + location.hostname + ":8082",
 
         production: false,
         debugMode: true,

--- a/ui/src/themes/openems/environments/backend-prod.ts
+++ b/ui/src/themes/openems/environments/backend-prod.ts
@@ -1,11 +1,12 @@
 import { Environment } from "src/environments";
+import { getWebsocketScheme } from "src/environments";
 import { theme } from "./theme";
 
 export const environment: Environment = {
     ...theme, ...{
 
         backend: "OpenEMS Backend",
-        url: "ws://" + location.hostname + ":8082",
+        url: getWebsocketScheme() + location.hostname + ":8082",
 
         production: true,
         debugMode: false,

--- a/ui/src/themes/openems/environments/edge-dev.ts
+++ b/ui/src/themes/openems/environments/edge-dev.ts
@@ -1,11 +1,12 @@
 import { Environment } from "src/environments";
+import { getWebsocketScheme } from "src/environments";
 import { theme } from "./theme";
 
 export const environment: Environment = {
     ...theme, ...{
 
         backend: "OpenEMS Edge",
-        url: "ws://" + location.hostname + ":8085",
+        url: getWebsocketScheme() + location.hostname + ":8085",
 
         production: false,
         debugMode: true,

--- a/ui/src/themes/openems/environments/edge-prod.ts
+++ b/ui/src/themes/openems/environments/edge-prod.ts
@@ -1,11 +1,12 @@
 import { Environment } from "src/environments";
+import { getWebsocketScheme } from "src/environments";
 import { theme } from "./theme";
 
 export const environment: Environment = {
     ...theme, ...{
 
         backend: "OpenEMS Edge",
-        url: "ws://" + location.hostname + ":8075",
+        url: getWebsocketScheme() + location.hostname + ":8075",
 
         production: true,
         debugMode: false,


### PR DESCRIPTION
Prevents mixed content errors in the browser by selecting WSS or WS for the websocket depending on the page's scheme (HTTPS or HTTP).

This fixes the problem described in [issue 2396](https://github.com/OpenEMS/openems/issues/2936).