### PR TITLE
TimeOfUseTariff: improvements for EVCS

### DIFF
--- a/io.openems.common/src/io/openems/common/utils/JsonUtils.java
+++ b/io.openems.common/src/io/openems/common/utils/JsonUtils.java
@@ -3,6 +3,7 @@ package io.openems.common.utils;
 import static io.openems.common.utils.EnumUtils.toEnum;
 
 import java.net.Inet4Address;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -1721,6 +1722,32 @@ public class JsonUtils {
 		} catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
 			throw OpenemsError.JSON_NO_DATE_MEMBER.exception(memberName, element.toString(), e.getMessage());
 		}
+	}
+
+	/**
+	 * Takes a JSON in the form '2020-01-01T00:00:00' and converts it to a
+	 * {@link LocalDateTime}.
+	 *
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member of the JsonObject
+	 * @return the {@link ZonedDateTime}
+	 */
+	public static LocalDateTime getAsLocalDateTime(JsonElement jElement, String memberName)
+			throws OpenemsNamedException {
+		return DateUtils.parseLocalDateTimeOrError(toString(toPrimitive(toSubElement(jElement, memberName))));
+	}
+
+	/**
+	 * Takes a JSON in the form '2020-01-01T00:00:00Z' and converts it to a
+	 * {@link ZonedDateTime}.
+	 *
+	 * @param jElement   the {@link JsonElement}
+	 * @param memberName the name of the member of the JsonObject
+	 * @return the {@link ZonedDateTime}
+	 */
+	public static ZonedDateTime getAsZonedDateTime(JsonElement jElement, String memberName)
+			throws OpenemsNamedException {
+		return DateUtils.parseZonedDateTimeOrError(toString(toPrimitive(toSubElement(jElement, memberName))));
 	}
 
 	/**

--- a/io.openems.common/src/io/openems/common/utils/JsonUtils.java
+++ b/io.openems.common/src/io/openems/common/utils/JsonUtils.java
@@ -38,7 +38,11 @@ import io.openems.common.exceptions.OpenemsError;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.types.OpenemsType;
 
-public class JsonUtils {
+public final class JsonUtils {
+
+	private JsonUtils() {
+	}
+
 	/**
 	 * Provide a easy way to generate a JsonArray from a list using the given
 	 * convert function to add each element.
@@ -288,6 +292,24 @@ public class JsonUtils {
 		public JsonObjectBuilder addProperty(String property, ZonedDateTime value) {
 			if (value != null) {
 				this.j.addProperty(property, value.format(DateTimeFormatter.ISO_INSTANT));
+			}
+			return this;
+		}
+
+		/**
+		 * Add a {@link LocalDateTime} value to the {@link JsonObject}.
+		 *
+		 * <p>
+		 * The value gets added in the format of
+		 * {@link DateTimeFormatter#ISO_LOCAL_DATE_TIME}.
+		 *
+		 * @param property the key
+		 * @param value    the value
+		 * @return the {@link JsonObjectBuilder}
+		 */
+		public JsonObjectBuilder addProperty(String property, LocalDateTime value) {
+			if (value != null) {
+				this.j.addProperty(property, value.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
 			}
 			return this;
 		}

--- a/io.openems.common/test/io/openems/common/utils/JsonUtilsTest.java
+++ b/io.openems.common/test/io/openems/common/utils/JsonUtilsTest.java
@@ -44,6 +44,7 @@ import static io.openems.common.utils.JsonUtils.getAsInt;
 import static io.openems.common.utils.JsonUtils.getAsJsonArray;
 import static io.openems.common.utils.JsonUtils.getAsJsonElement;
 import static io.openems.common.utils.JsonUtils.getAsJsonObject;
+import static io.openems.common.utils.JsonUtils.getAsLocalDateTime;
 import static io.openems.common.utils.JsonUtils.getAsLong;
 import static io.openems.common.utils.JsonUtils.getAsOptionalBoolean;
 import static io.openems.common.utils.JsonUtils.getAsOptionalDouble;
@@ -64,6 +65,7 @@ import static io.openems.common.utils.JsonUtils.getAsStringArray;
 import static io.openems.common.utils.JsonUtils.getAsStringOrElse;
 import static io.openems.common.utils.JsonUtils.getAsType;
 import static io.openems.common.utils.JsonUtils.getAsUUID;
+import static io.openems.common.utils.JsonUtils.getAsZonedDateTime;
 import static io.openems.common.utils.JsonUtils.getAsZonedDateWithZeroTime;
 import static io.openems.common.utils.JsonUtils.getOptionalSubElement;
 import static io.openems.common.utils.JsonUtils.getSubElement;
@@ -80,11 +82,13 @@ import static java.util.Optional.empty;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -148,6 +152,8 @@ public class JsonUtilsTest {
 			.addProperty("Enum3", (Unit) null) //
 			.addProperty("Inet4Address", "192.168.1.2") //
 			.addProperty("UUID", "c48e2e28-09be-41d5-8e58-260d162991cc") //
+			.addProperty("ZonedDateTime", ZonedDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"))) //
+			.addProperty("LocalDateTime", LocalDateTime.of(1900, 1, 1, 0, 0, 0, 0)) //
 			.addPropertyIfNotNull("Boolean1", (Boolean) null) //
 			.addPropertyIfNotNull("Boolean2", Boolean.FALSE) //
 			.addPropertyIfNotNull("Double1", (Double) null) //
@@ -680,6 +686,13 @@ public class JsonUtilsTest {
 		assertOpenemsError(JSON_NO_DATE_MEMBER, //
 				() -> getAsZonedDateWithZeroTime(j, "foo", ZoneId.of("UTC")) //
 		);
+
+		assertEquals("1900-01-01T00:00Z", getAsZonedDateTime(JSON_OBJECT, "ZonedDateTime").toString());
+	}
+
+	@Test
+	public void testGetAsLocalDateTime() throws OpenemsNamedException {
+		assertEquals("1900-01-01T00:00", getAsLocalDateTime(JSON_OBJECT, "LocalDateTime").toString());
 	}
 
 	@Test
@@ -744,6 +757,9 @@ public class JsonUtilsTest {
 
 	@Test
 	public void testGenerateJsonArray() {
+		assertNull(generateJsonArray(null));
+		assertEquals(JsonNull.INSTANCE, generateJsonArray(List.of(JsonNull.INSTANCE)).get(0));
+
 		var list = List.of("foo", "bar");
 		var r = generateJsonArray(list, v -> new JsonPrimitive(v));
 		assertEquals("foo", r.get(0).getAsString());

--- a/io.openems.edge.controller.ess.fixactivepower/src/io/openems/edge/controller/ess/fixactivepower/ControllerEssFixActivePowerImpl.java
+++ b/io.openems.edge.controller.ess.fixactivepower/src/io/openems/edge/controller/ess/fixactivepower/ControllerEssFixActivePowerImpl.java
@@ -85,7 +85,7 @@ public class ControllerEssFixActivePowerImpl extends AbstractOpenemsComponent
 		if (this.applyConfig(context, config)) {
 			return;
 		}
-		this.energyScheduleHandler.triggerReschedule();
+		this.energyScheduleHandler.triggerReschedule("ControllerEssFixActivePowerImpl::modified()");
 	}
 
 	private boolean applyConfig(ComponentContext context, Config config) {
@@ -165,9 +165,9 @@ public class ControllerEssFixActivePowerImpl extends AbstractOpenemsComponent
 	 * @return a {@link EnergyScheduleHandler}
 	 */
 	public static EnergyScheduleHandler buildEnergyScheduleHandler(Supplier<EshContext> context) {
-		return EnergyScheduleHandler.of(//
-				simContext -> context.get(), //
-				(simContext, period, energyFlow, ctrlContext) -> {
+		return EnergyScheduleHandler.WithOnlyOneState.<EshContext>create() //
+				.setContextFunction(simContext -> context.get()) //
+				.setSimulator((simContext, period, energyFlow, ctrlContext) -> {
 					switch (ctrlContext.mode) {
 					case MANUAL_ON:
 						switch (ctrlContext.relationship) {
@@ -179,7 +179,8 @@ public class ControllerEssFixActivePowerImpl extends AbstractOpenemsComponent
 					case MANUAL_OFF:
 						break;
 					}
-				});
+				}) //
+				.build();
 	}
 
 	public static record EshContext(Mode mode, int energy, Relationship relationship) {

--- a/io.openems.edge.controller.ess.limittotaldischarge/src/io/openems/edge/controller/ess/limittotaldischarge/ControllerEssLimitTotalDischargeImpl.java
+++ b/io.openems.edge.controller.ess.limittotaldischarge/src/io/openems/edge/controller/ess/limittotaldischarge/ControllerEssLimitTotalDischargeImpl.java
@@ -232,11 +232,12 @@ public class ControllerEssLimitTotalDischargeImpl extends AbstractOpenemsCompone
 	 * @return a {@link EnergyScheduleHandler}
 	 */
 	public static EnergyScheduleHandler buildEnergyScheduleHandler(IntSupplier minSoc) {
-		return EnergyScheduleHandler.of(//
-				simContext -> socToEnergy(simContext.ess().totalEnergy(), minSoc.getAsInt()), //
-				(simContext, period, energyFlow, minEnergy) -> {
+		return EnergyScheduleHandler.WithOnlyOneState.<Integer>create() //
+				.setContextFunction(simContext -> socToEnergy(simContext.ess().totalEnergy(), minSoc.getAsInt())) //
+				.setSimulator((simContext, period, energyFlow, minEnergy) -> {
 					energyFlow.setEssMaxDischarge(max(0, simContext.ess.getInitialEnergy() - minEnergy));
-				});
+				}) //
+				.build();
 	}
 
 	@Override

--- a/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/Config.java
+++ b/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/Config.java
@@ -19,6 +19,13 @@ import io.openems.edge.evcs.api.ChargeMode;
 	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
 	boolean enabled() default true;
 
+	// TODO this will change in future
+	@AttributeDefinition(name = "Enable EnergyScheduler SMART-Mode", description = "")
+	boolean smartMode() default false;
+
+	@AttributeDefinition(name = "JSON Configuration for SMART mode", description = "")
+	String smartConfig() default "";
+
 	@AttributeDefinition(name = "Debug Mode", description = "Activates the debug mode")
 	boolean debugMode() default false;
 

--- a/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/ControllerEvcs.java
+++ b/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/ControllerEvcs.java
@@ -13,7 +13,9 @@ public interface ControllerEvcs extends OpenemsComponent {
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
 
 		AWAITING_HYSTERESIS(Doc.of(BOOLEAN) //
-				.persistencePriority(HIGH)),
+				.persistencePriority(HIGH)), //
+		SMART_MODE(Doc.of(SmartMode.values()) //
+				.persistencePriority(HIGH)), //
 		EVCS_IS_READ_ONLY(Doc.of(Level.INFO) //
 				.translationKey(ControllerEvcs.class, "evcsIsReadOnly")); //
 

--- a/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/ControllerEvcsImpl.java
+++ b/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/ControllerEvcsImpl.java
@@ -1,15 +1,17 @@
 package io.openems.edge.controller.evcs;
 
-import static io.openems.edge.energy.api.EnergyUtils.toEnergy;
+import static io.openems.common.utils.FunctionUtils.doNothing;
+import static io.openems.edge.controller.evcs.Utils.FORCE_CHARGE_POWER;
+import static io.openems.edge.controller.evcs.Utils.MIN_CHARGE_POWER;
+import static io.openems.edge.controller.evcs.Utils.buildEshManual;
+import static io.openems.edge.controller.evcs.Utils.buildEshSmart;
 import static java.lang.Math.max;
-import static java.lang.Math.min;
 
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.function.BiConsumer;
-import java.util.function.Supplier;
 
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -30,12 +32,19 @@ import io.openems.common.exceptions.OpenemsException;
 import io.openems.edge.common.channel.value.Value;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
 import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.jsonapi.ComponentJsonApi;
+import io.openems.edge.common.jsonapi.JsonApiBuilder;
 import io.openems.edge.common.modbusslave.ModbusSlave;
 import io.openems.edge.common.modbusslave.ModbusSlaveTable;
 import io.openems.edge.common.sum.Sum;
 import io.openems.edge.controller.api.Controller;
+import io.openems.edge.controller.evcs.Utils.EshContext.EshManualContext;
+import io.openems.edge.controller.evcs.Utils.EshContext.EshSmartContext;
+import io.openems.edge.controller.evcs.jsonrpc.GetScheduleRequest;
+import io.openems.edge.controller.evcs.jsonrpc.GetScheduleResponse;
 import io.openems.edge.energy.api.EnergySchedulable;
 import io.openems.edge.energy.api.EnergyScheduleHandler;
+import io.openems.edge.energy.api.EnergyScheduleHandler.WithDifferentStates.Period;
 import io.openems.edge.evcs.api.ChargeMode;
 import io.openems.edge.evcs.api.ChargeState;
 import io.openems.edge.evcs.api.ManagedEvcs;
@@ -48,7 +57,7 @@ import io.openems.edge.evcs.api.Status;
 		configurationPolicy = ConfigurationPolicy.REQUIRE //
 )
 public class ControllerEvcsImpl extends AbstractOpenemsComponent
-		implements Controller, OpenemsComponent, ModbusSlave, EnergySchedulable, ControllerEvcs {
+		implements Controller, ControllerEvcs, EnergySchedulable, OpenemsComponent, ModbusSlave, ComponentJsonApi {
 
 	private static final int CHARGE_POWER_BUFFER = 200;
 	private static final double DEFAULT_UPPER_TARGET_DIFFERENCE_PERCENT = 0.10; // 10%
@@ -56,8 +65,9 @@ public class ControllerEvcsImpl extends AbstractOpenemsComponent
 	private final Logger log = LoggerFactory.getLogger(ControllerEvcsImpl.class);
 	private final ChargingLowerThanTargetHandler chargingLowerThanTargetHandler;
 	private final Clock clock;
-	private final EnergyScheduleHandler energyScheduleHandler;
-	private final BiConsumer<Value<Status>, Value<Status>> onEvcsStatusChange;
+
+	private EnergyScheduleHandler energyScheduleHandler;
+	private BiConsumer<Value<Status>, Value<Status>> onEvcsStatusChange;
 
 	// Time of last charge power change, used for the hysteresis
 	private Instant lastInitialCharge = Instant.MIN;
@@ -91,16 +101,6 @@ public class ControllerEvcsImpl extends AbstractOpenemsComponent
 		);
 		this.clock = clock;
 		this.chargingLowerThanTargetHandler = new ChargingLowerThanTargetHandler(clock);
-		this.energyScheduleHandler = buildEnergyScheduleHandler(() -> new EshContext(//
-				this.config.evcs_id(), this.config.enabledCharging(), this.config.chargeMode(), this.config.priority(),
-				this.config.defaultChargeMinPower(), this.config.forceChargeMinPower(),
-				this.config.energySessionLimit() > 0 //
-						? this.config.energySessionLimit() //
-						: 30_000 // Apply a default limit
-		));
-		this.onEvcsStatusChange = (oldStatus, newStatus) -> {
-			this.energyScheduleHandler.triggerReschedule(); // Trigger Reschedule on Status change
-		};
 	}
 
 	@Activate
@@ -117,6 +117,16 @@ public class ControllerEvcsImpl extends AbstractOpenemsComponent
 		}
 
 		this.config = config;
+
+		this.energyScheduleHandler = config.smartMode() //
+				? buildEshSmart(() -> EshSmartContext.fromConfig(this.config)) //
+				: buildEshManual(() -> EshManualContext.fromConfig(this.config));
+		this.onEvcsStatusChange = (oldStatus, newStatus) -> {
+			// Trigger Reschedule on Status change
+			this.energyScheduleHandler
+					.triggerReschedule("ControllerEvcsImpl::onEvcsStatusChange from " + oldStatus + " to " + newStatus);
+		};
+
 		this.evcs._setChargeMode(config.chargeMode());
 
 		if (OpenemsComponent.updateReferenceFilter(this.cm, this.servicePid(), "evcs", config.evcs_id())) {
@@ -175,21 +185,44 @@ public class ControllerEvcsImpl extends AbstractOpenemsComponent
 				this.resetMinMaxChannels();
 				return;
 			}
-			case CHARGING_REJECTED, READY_FOR_CHARGING -> {
-				this.evcs._setMaximumPower(null);
-			}
-			case CHARGING -> {
-			}
+			case CHARGING_REJECTED, READY_FOR_CHARGING //
+				-> this.evcs._setMaximumPower(null);
+			case CHARGING //
+				-> doNothing();
 			}
 		}
+
+		// Read parameters from Config or scheduled Period
+		final SmartMode smartMode;
+		final ChargeMode chargeMode;
+		final Priority priority;
+		final int forceChargePower;
+		final int defaultChargeMinPower;
+		var p = getCurrentPeriod(this.energyScheduleHandler);
+		if (p != null) {
+			this.logInfo(this.log, "ESH: " + p);
+			smartMode = p.state();
+			chargeMode = p.state().chargeMode;
+			priority = p.state().priority;
+			forceChargePower = FORCE_CHARGE_POWER;
+			defaultChargeMinPower = MIN_CHARGE_POWER;
+		} else {
+			smartMode = null;
+			chargeMode = this.config.chargeMode();
+			priority = this.config.priority();
+			forceChargePower = this.config.forceChargeMinPower() * this.evcs.getPhasesAsInt();
+			defaultChargeMinPower = this.config.defaultChargeMinPower();
+		}
+		this.channel(ControllerEvcs.ChannelId.SMART_MODE).setNextValue(smartMode);
 
 		/*
 		 * Calculates the next charging power depending on the charge mode and priority
 		 */
-		var nextChargePower = //
-				switch (this.config.chargeMode()) {
+		var nextChargePower = chargeMode == null //
+				? 0 //
+				: switch (chargeMode) {
 				case EXCESS_POWER -> //
-					switch (this.config.priority()) {
+					switch (priority) {
 					case CAR -> calculateChargePowerFromExcessPower(this.sum, this.evcs);
 					case STORAGE -> {
 						// SoC > 97 % or always, when there is no ESS is available
@@ -200,12 +233,13 @@ public class ControllerEvcsImpl extends AbstractOpenemsComponent
 						}
 					}
 					};
-				case FORCE_CHARGE -> this.config.forceChargeMinPower() * this.evcs.getPhasesAsInt();
+				case FORCE_CHARGE -> forceChargePower;
 				};
 
-		var nextMinPower = //
-				switch (this.config.chargeMode()) {
-				case EXCESS_POWER -> this.config.defaultChargeMinPower();
+		var nextMinPower = chargeMode == null //
+				? 0 //
+				: switch (chargeMode) {
+				case EXCESS_POWER -> defaultChargeMinPower;
 				case FORCE_CHARGE -> 0;
 				};
 		this.evcs._setMinimumPower(nextMinPower);
@@ -250,7 +284,7 @@ public class ControllerEvcsImpl extends AbstractOpenemsComponent
 			}
 		}
 
-		if (this.config.chargeMode().equals(ChargeMode.EXCESS_POWER)) {
+		if (chargeMode == ChargeMode.EXCESS_POWER) {
 			// Apply hysteresis
 			nextChargePower = this.applyHysteresis(nextChargePower);
 		}
@@ -453,78 +487,32 @@ public class ControllerEvcsImpl extends AbstractOpenemsComponent
 		}
 	}
 
-	/**
-	 * Builds the {@link EnergyScheduleHandler}.
-	 * 
-	 * <p>
-	 * This is public so that it can be used by the EnergyScheduler integration
-	 * test.
-	 * 
-	 * @param context a supplier for the configured {@link EshContext}
-	 * @return a {@link EnergyScheduleHandler}
-	 */
-	public static EnergyScheduleHandler buildEnergyScheduleHandler(Supplier<EshContext> context) {
-		return EnergyScheduleHandler.of(//
-				simContext -> context.get(), //
-				(simContext, period, energyFlow, ctrlContext) -> {
-					final var evcsGlobal = simContext.global.evcss().get(ctrlContext.evcsId);
-					final var evcsOne = simContext.evcss.get(ctrlContext.evcsId);
-					if (!ctrlContext.enabledCharging || evcsGlobal == null || evcsOne == null) {
-						return;
-					}
-					switch (evcsGlobal.status()) {
-					case CHARGING:
-					case READY_FOR_CHARGING:
-						break;
-					case CHARGING_REJECTED:
-					case ENERGY_LIMIT_REACHED:
-					case ERROR:
-					case NOT_READY_FOR_CHARGING:
-					case STARTING:
-					case UNDEFINED:
-						return;
-					}
-
-					// Evaluate Charge-Energy per mode
-					final var chargeEnergy = switch (ctrlContext.chargeMode) {
-					case EXCESS_POWER //
-						-> switch (ctrlContext.priority) {
-						case CAR //
-							-> toEnergy(//
-									max(ctrlContext.defaultChargeMinPower,
-											energyFlow.production - energyFlow.unmanagedConsumption));
-						case STORAGE -> 0; // TODO not implemented
-						};
-					case FORCE_CHARGE //
-						-> toEnergy(ctrlContext.forceChargeMinPower);
-					};
-
-					if (chargeEnergy <= 0) {
-						return; // stop early
-					}
-
-					// Apply Session Limit
-					final int limitedChargeEnergy;
-					if (ctrlContext.energySessionLimit > 0) {
-						limitedChargeEnergy = min(chargeEnergy,
-								max(0, ctrlContext.energySessionLimit - evcsOne.getInitialEnergySession()));
-					} else {
-						limitedChargeEnergy = chargeEnergy;
-					}
-
-					if (limitedChargeEnergy > 0) {
-						energyFlow.addConsumption(limitedChargeEnergy);
-						evcsOne.calculateInitialEnergySession(limitedChargeEnergy);
-					}
-				});
+	@Override
+	public void buildJsonApiRoutes(JsonApiBuilder builder) {
+		builder.handleRequest(GetScheduleRequest.METHOD, call -> GetScheduleResponse.from(call.getRequest().getId(), //
+				this.energyScheduleHandler));
 	}
 
-	public static record EshContext(String evcsId, boolean enabledCharging, ChargeMode chargeMode, Priority priority,
-			int defaultChargeMinPower, int forceChargeMinPower, int energySessionLimit) {
+	@Override
+	public String debugLog() {
+		var p = getCurrentPeriod(this.energyScheduleHandler);
+		if (p == null) {
+			return null;
+		}
+		return p.state().name();
 	}
 
 	@Override
 	public EnergyScheduleHandler getEnergyScheduleHandler() {
 		return this.energyScheduleHandler;
+	}
+
+	private static Period<SmartMode, ?> getCurrentPeriod(EnergyScheduleHandler esh) {
+		if (esh == null || esh instanceof EnergyScheduleHandler.WithOnlyOneState<?>) {
+			return null;
+		}
+		@SuppressWarnings("unchecked")
+		var e = (EnergyScheduleHandler.WithDifferentStates<SmartMode, ?>) esh;
+		return e.getCurrentPeriod();
 	}
 }

--- a/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/JSCalendar.java
+++ b/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/JSCalendar.java
@@ -1,0 +1,391 @@
+package io.openems.edge.controller.evcs;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;
+import static io.openems.common.utils.JsonUtils.getAsEnum;
+import static io.openems.common.utils.JsonUtils.getAsJsonArray;
+import static io.openems.common.utils.JsonUtils.getAsJsonObject;
+import static io.openems.common.utils.JsonUtils.getAsLocalDateTime;
+import static io.openems.common.utils.JsonUtils.getAsString;
+import static io.openems.common.utils.JsonUtils.getAsUUID;
+import static io.openems.common.utils.JsonUtils.getAsZonedDateTime;
+import static io.openems.common.utils.JsonUtils.stream;
+import static io.openems.common.utils.JsonUtils.toJsonArray;
+import static io.openems.edge.controller.evcs.JSCalendar.RecurrenceFrequency.WEEKLY;
+import static java.time.DayOfWeek.FRIDAY;
+import static java.time.DayOfWeek.MONDAY;
+import static java.time.DayOfWeek.SATURDAY;
+import static java.time.DayOfWeek.SUNDAY;
+import static java.time.DayOfWeek.THURSDAY;
+import static java.time.DayOfWeek.TUESDAY;
+import static java.time.DayOfWeek.WEDNESDAY;
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static java.time.temporal.ChronoField.NANO_OF_DAY;
+import static java.time.temporal.TemporalAdjusters.nextOrSame;
+import static java.util.Arrays.stream;
+import static java.util.UUID.randomUUID;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Ordering;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.function.ThrowingFunction;
+import io.openems.common.utils.JsonUtils;
+
+/**
+ * This implementation is based on RFC 8984 "JSCalendar: A JSON Representation
+ * of Calendar Data".
+ * 
+ * <p>
+ * 
+ * @link <a href=
+ *       "https://www.rfc-editor.org/rfc/rfc8984.html">https://www.rfc-editor.org/rfc/rfc8984.html</a>
+ */
+// CHECKSTYLE:OFF
+public class JSCalendar<PAYLOAD> {
+	// CHECKSTYLE:ON
+
+	public static record Task<PAYLOAD>(UUID uid, ZonedDateTime updated, LocalDateTime start,
+			ImmutableList<RecurrenceRule> recurrenceRules, PAYLOAD payload) {
+
+		/**
+		 * Parse a List of {@link Task}s from a {@link JsonArray}.
+		 * 
+		 * @param <PAYLOAD>     the type of the Payload
+		 * @param json          the {@link JsonArray}
+		 * @param payloadParser a parser for a Payload
+		 * @return the List of {@link Task}s
+		 * @throws OpenemsNamedException on error
+		 */
+		public static <PAYLOAD> ImmutableList<Task<PAYLOAD>> fromJson(JsonArray json,
+				ThrowingFunction<JsonObject, PAYLOAD, OpenemsNamedException> payloadParser)
+				throws OpenemsNamedException {
+			return stream(json) //
+					.map(j -> {
+						try {
+							return fromJson(JsonUtils.getAsJsonObject(j), payloadParser);
+						} catch (OpenemsNamedException e) {
+							e.printStackTrace();
+							throw new NoSuchElementException(e.getMessage());
+						}
+					}) //
+					.collect(toImmutableList());
+		}
+
+		/**
+		 * Parse a {@link Task} from a {@link JsonObject}.
+		 * 
+		 * @param <PAYLOAD>     the type of the Payload
+		 * @param json          the {@link JsonObject}
+		 * @param payloadParser a parser for a Payload
+		 * @return the {@link Task}
+		 * @throws OpenemsNamedException on error
+		 */
+		public static <PAYLOAD> Task<PAYLOAD> fromJson(JsonObject json, Function<JsonObject, PAYLOAD> payloadParser)
+				throws OpenemsNamedException {
+			return fromJson(json, new ThrowingFunction<JsonObject, PAYLOAD, OpenemsNamedException>() {
+
+				@Override
+				public PAYLOAD apply(JsonObject json) throws OpenemsNamedException {
+					return payloadParser.apply(json);
+				}
+			});
+		}
+
+		/**
+		 * Parse a {@link Task} from a {@link JsonObject}.
+		 * 
+		 * @param <PAYLOAD>     the type of the Payload
+		 * @param json          the {@link JsonObject}
+		 * @param payloadParser a parser for a Payload
+		 * @return the {@link Task}
+		 * @throws OpenemsNamedException on error
+		 */
+		public static <PAYLOAD> Task<PAYLOAD> fromJson(JsonObject json,
+				ThrowingFunction<JsonObject, PAYLOAD, OpenemsNamedException> payloadParser)
+				throws OpenemsNamedException {
+			var type = getAsString(json, "@type");
+			if (!type.equalsIgnoreCase("Task")) {
+				throw new OpenemsException("This is not a 'Task': " + type);
+			}
+			try {
+				var uid = getAsUUID(json, "uid");
+				var updated = getAsZonedDateTime(json, "updated");
+				var start = getAsLocalDateTime(json, "start");
+				var recurrenceRules = stream(getAsJsonArray(json, "recurrenceRules")) //
+						.map(r -> {
+							try {
+								return RecurrenceRule.fromJson(r);
+							} catch (OpenemsNamedException e) {
+								e.printStackTrace();
+								throw new NoSuchElementException(e.getMessage());
+							}
+						}) //
+						.collect(toImmutableList());
+				var payload = payloadParser.apply(getAsJsonObject(json, "payload"));
+				return new Task<PAYLOAD>(uid, updated, start, recurrenceRules, payload);
+
+			} catch (NoSuchElementException e) {
+				throw new OpenemsException("NoSuchElementException: " + e.getMessage());
+			}
+		}
+
+		public static class Builder<PAYLOAD> {
+			private final UUID uid;
+			private final ZonedDateTime updated;
+
+			private LocalDateTime start = null;
+			private ImmutableList.Builder<RecurrenceRule> recurrenceRules = ImmutableList.builder();
+			private PAYLOAD payload = null;
+
+			protected Builder() {
+				this(randomUUID(), ZonedDateTime.now());
+			}
+
+			protected Builder(UUID uid, ZonedDateTime updated) {
+				this.uid = uid;
+				this.updated = updated;
+			}
+
+			public Builder<PAYLOAD> setStart(LocalDateTime start) {
+				this.start = start;
+				return this;
+			}
+
+			protected Builder<PAYLOAD> setStart(String start) {
+				this.setStart(LocalDateTime.parse(start));
+				return this;
+			}
+
+			/**
+			 * Adds a {@link RecurrenceRule}.
+			 * 
+			 * @param recurrenceRule the {@link RecurrenceRule}
+			 * @return myself
+			 */
+			public Builder<PAYLOAD> addRecurrenceRule(RecurrenceRule recurrenceRule) {
+				this.recurrenceRules.add(recurrenceRule);
+				return this;
+			}
+
+			/**
+			 * Adds a {@link RecurrenceRule}.
+			 * 
+			 * @param consumer a RecurrenceRule Builder
+			 * @return myself
+			 */
+			public Builder<PAYLOAD> addRecurrenceRule(Consumer<RecurrenceRule.Builder> consumer) {
+				var builder = RecurrenceRule.create();
+				consumer.accept(builder);
+				this.recurrenceRules.add(builder.build());
+				return this;
+			}
+
+			public Builder<PAYLOAD> setPayload(PAYLOAD payload) {
+				this.payload = payload;
+				return this;
+			}
+
+			public Task<PAYLOAD> build() {
+				return new Task<PAYLOAD>(this.uid, this.updated, this.start, this.recurrenceRules.build(),
+						this.payload);
+			}
+		}
+
+		/**
+		 * Create a {@link CalendarEvent} {@link Builder}.
+		 * 
+		 * @param <PAYLOAD> the type of the Payload
+		 * @return a {@link Builder}
+		 */
+		public static <PAYLOAD> Builder<PAYLOAD> create() {
+			return new Builder<PAYLOAD>();
+		}
+
+		/**
+		 * Convert to {@link JsonObject}.
+		 * 
+		 * @param payloadConverter a converter for a Payload
+		 * @return a {@link JsonObject}
+		 */
+		public JsonObject toJson(Function<PAYLOAD, JsonObject> payloadConverter) {
+			var j = JsonUtils.buildJsonObject() //
+					.addProperty("@type", "Task") //
+					.addProperty("uid", this.uid.toString()) //
+					.addProperty("updated", this.updated.format(ISO_INSTANT));
+			if (this.start != null) {
+				j.addProperty("start", this.start.format(ISO_LOCAL_DATE_TIME));
+			}
+			if (!this.recurrenceRules.isEmpty()) {
+				j.add("recurrenceRules", this.recurrenceRules.stream() //
+						.map(RecurrenceRule::toJson) //
+						.collect(toJsonArray()));
+			}
+			if (this.payload != null) {
+				j.add("payload", payloadConverter.apply(this.payload));
+			}
+			return j.build();
+		}
+
+		/**
+		 * Gets the next occurence of the {@link Task} at or after a date.
+		 * 
+		 * @param from the from timestamp
+		 * @return a {@link ZonedDateTime}
+		 */
+		public ZonedDateTime getNextOccurence(ZonedDateTime from) {
+			var start = this.start.atZone(from.getZone());
+			return this.recurrenceRules.stream() //
+					.map(rr -> rr.getNextOccurence(from.isBefore(start) ? start : from, start)) //
+					.min((o1, o2) -> o1.toInstant().compareTo(o2.toInstant())) //
+					.orElse(null);
+		}
+	}
+
+	public enum RecurrenceFrequency {
+		// SECONDLY("secondly"),
+		// MINUTELY("minutely"),
+		// HOURLY("hourly"),
+		DAILY("daily"), //
+		WEEKLY("weekly"), //
+		MONTHLY("monthly"), //
+		YEARLY("yearly");
+
+		public final String name;
+
+		private RecurrenceFrequency(String name) {
+			this.name = name;
+		}
+	}
+
+	public record RecurrenceRule(RecurrenceFrequency frequency, ImmutableSortedSet<DayOfWeek> byDay) {
+
+		/**
+		 * Parse a {@link RecurrenceRule} from a {@link JsonObject}.
+		 * 
+		 * @param json the {@link JsonObject}
+		 * @return the {@link RecurrenceRule}
+		 * @throws OpenemsNamedException on error
+		 */
+		public static RecurrenceRule fromJson(JsonElement json) throws OpenemsNamedException, NoSuchElementException {
+			var frequency = getAsEnum(RecurrenceFrequency.class, json, "frequency");
+			var byDay = stream(getAsJsonArray(json, "byDay")) //
+					.map(j -> switch (JsonUtils.getAsOptionalString(j).orElseThrow()) {
+					case "mo" -> MONDAY;
+					case "tu" -> TUESDAY;
+					case "we" -> WEDNESDAY;
+					case "th" -> THURSDAY;
+					case "fr" -> FRIDAY;
+					case "sa" -> SATURDAY;
+					case "su" -> SUNDAY;
+					default -> throw new NoSuchElementException("");
+					}) //
+					.collect(toImmutableSortedSet(Ordering.natural()));
+			return new RecurrenceRule(frequency, byDay);
+		}
+
+		public static class Builder {
+			private RecurrenceFrequency frequency;
+			private ImmutableSortedSet.Builder<DayOfWeek> byDay = ImmutableSortedSet.naturalOrder();
+
+			public Builder() {
+			}
+
+			public Builder setFrequency(RecurrenceFrequency frequency) {
+				this.frequency = frequency;
+				return this;
+			}
+
+			/**
+			 * Adds a `byDay`rule.
+			 * 
+			 * @param byDay the {@link DayOfWeek}s
+			 * @return myself
+			 */
+			public Builder addByDay(DayOfWeek... byDay) {
+				stream(byDay).forEach(this.byDay::add);
+				return this;
+			}
+
+			public RecurrenceRule build() {
+				return new RecurrenceRule(this.frequency, this.byDay.build());
+			}
+		}
+
+		/**
+		 * Create a {@link RecurrenceRule} {@link Builder}.
+		 * 
+		 * @return a {@link Builder}
+		 */
+		public static Builder create() {
+			return new Builder();
+		}
+
+		/**
+		 * Gets the next occurence of the {@link RecurrenceRule} at or after a date.
+		 * 
+		 * @param from  the from date
+		 * @param start the start timestamp of the {@link Task}
+		 * @return a {@link ZonedDateTime}
+		 */
+		public ZonedDateTime getNextOccurence(ZonedDateTime from, ZonedDateTime start) {
+			if (this.frequency == WEEKLY) {
+				if (!this.byDay.isEmpty()) {
+					var startTime = start.toLocalTime();
+					var nextByDay = this.byDay.ceiling(from.toLocalTime().isAfter(startTime) //
+							? from.getDayOfWeek().plus(1) // next day
+							: from.getDayOfWeek()); // same day
+					if (nextByDay == null) {
+						nextByDay = this.byDay.first();
+					}
+					return from //
+							.with(nextOrSame(nextByDay)) //
+							.with(NANO_OF_DAY, startTime.toNanoOfDay());
+				}
+			}
+			return null;
+		}
+
+		/**
+		 * Convert to {@link JsonObject}.
+		 * 
+		 * @return a {@link JsonObject}
+		 */
+		public JsonObject toJson() {
+			var j = JsonUtils.buildJsonObject();
+			if (this.frequency != null) {
+				j.addProperty("frequency", this.frequency.name);
+			}
+			if (!this.byDay.isEmpty()) {
+				j.add("byDay", this.byDay.stream() //
+						.map(d -> switch (d) {
+						case MONDAY -> "mo";
+						case TUESDAY -> "tu";
+						case WEDNESDAY -> "we";
+						case THURSDAY -> "th";
+						case FRIDAY -> "fr";
+						case SATURDAY -> "sa";
+						case SUNDAY -> "su";
+						}) //
+						.map(JsonUtils::toJson) //
+						.collect(toJsonArray()));
+			}
+			return j.build();
+		}
+	}
+
+}

--- a/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/SmartMode.java
+++ b/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/SmartMode.java
@@ -1,0 +1,42 @@
+package io.openems.edge.controller.evcs;
+
+import io.openems.common.types.OptionsEnum;
+import io.openems.edge.evcs.api.ChargeMode;
+
+public enum SmartMode implements OptionsEnum {
+	ZERO(0, "Zero", null, null), //
+	// TODO SURPLUS_PV without min-charge power and only if there is predicted
+	// surplus power
+	// SURPLUS_PV(1, "Surplus PV with Min charge power", ChargeMode.EXCESS_POWER,
+	// Priority.CAR), //
+	FORCE(3, "Force charge", ChargeMode.FORCE_CHARGE, null) //
+	;
+
+	private final int value;
+	private final String name;
+
+	public final ChargeMode chargeMode;
+	public final Priority priority;
+
+	private SmartMode(int value, String name, ChargeMode chargeMode, Priority priority) {
+		this.value = value;
+		this.name = name;
+		this.chargeMode = chargeMode;
+		this.priority = priority;
+	}
+
+	@Override
+	public int getValue() {
+		return this.value;
+	}
+
+	@Override
+	public String getName() {
+		return this.name;
+	}
+
+	@Override
+	public OptionsEnum getUndefined() {
+		return ZERO;
+	}
+}

--- a/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/Utils.java
+++ b/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/Utils.java
@@ -1,0 +1,271 @@
+package io.openems.edge.controller.evcs;
+
+import static io.openems.common.utils.FunctionUtils.doNothing;
+import static io.openems.common.utils.JsonUtils.getAsInt;
+import static io.openems.common.utils.JsonUtils.parseToJsonArray;
+import static io.openems.edge.energy.api.EnergyUtils.toEnergy;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+import java.time.Clock;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.function.Supplier;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.math.Quantiles;
+import com.google.gson.JsonObject;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.edge.controller.evcs.JSCalendar.Task;
+import io.openems.edge.controller.evcs.Utils.EshContext.EshManualContext;
+import io.openems.edge.controller.evcs.Utils.EshContext.EshSmartContext;
+import io.openems.edge.energy.api.EnergyScheduleHandler;
+import io.openems.edge.energy.api.EnergyScheduleHandler.WithDifferentStates.InitialPopulation;
+import io.openems.edge.energy.api.simulation.EnergyFlow;
+import io.openems.edge.energy.api.simulation.OneSimulationContext;
+import io.openems.edge.energy.api.simulation.OneSimulationContext.Evcs;
+import io.openems.edge.evcs.api.ChargeMode;
+
+public final class Utils {
+
+	protected static final int FORCE_CHARGE_POWER = 11000; // [W]
+	protected static final int MIN_CHARGE_POWER = 4600; // [W]
+
+	private static int TARGET_HOUR = 7;
+
+	private Utils() {
+	}
+
+	/**
+	 * Builds an {@link EnergyScheduleHandler} for SMART mode.
+	 * 
+	 * @param context a supplier for {@link EshSmartContext}
+	 * @return the {@link EnergyScheduleHandler.WithDifferentStates}
+	 */
+	public static EnergyScheduleHandler.WithDifferentStates<SmartMode, EshSmartContext> buildEshSmart(
+			Supplier<EshSmartContext> context) {
+		return EnergyScheduleHandler.WithDifferentStates.<SmartMode, EshSmartContext>create() //
+				.setDefaultState(SmartMode.ZERO) //
+				// TODO if there is no surplus power, SmartMode.SURPLUS_PV should not be an
+				// option
+				.setAvailableStates(() -> SmartMode.values()) //
+				.setContextFunction(simContext -> context.get()) //
+				.setInitialPopulationsFunction(gsc -> {
+					// Sets initial population to FORCE charge during cheapest periods
+					var targetDateTime = getTargetDateTime(gsc.startTime(), TARGET_HOUR);
+					var threshold = Quantiles.percentiles() //
+							.index(5) //
+							.compute(gsc.periods().stream() //
+									.takeWhile(p -> !p.time().isAfter(targetDateTime)) //
+									.mapToDouble(p -> p.price()) //
+									.toArray());
+					var times = gsc.periods().stream() //
+							.filter(p -> p.price() < threshold) //
+							.map(p -> p.time()) //
+							.toList();
+					return List.of(//
+							InitialPopulation.of(times, SmartMode.FORCE));
+				}) //
+				.setSimulator((simContext, period, energyFlow, ctrlContext, mode) -> {
+					final var evcsOne = simContext.evcss.get(ctrlContext.evcsId);
+					switch (mode) {
+					case FORCE -> applyChargeEnergy(energyFlow, ctrlContext, evcsOne, mode.chargeMode, mode.priority,
+							MIN_CHARGE_POWER, FORCE_CHARGE_POWER);
+					case ZERO -> doNothing();
+					}
+
+					if (period.time().isAfter(getTargetDateTime(simContext.global.startTime(), TARGET_HOUR))
+							&& evcsOne.getInitialEnergySession() < ctrlContext.energySessionLimit) {
+						// TODO apply JSCalendar SmartConfig
+						// Charged less than EnergySessionLimit till next 7am.
+						return 1_000_000; // add high cost
+					}
+					return 0.;
+				}) //
+				.setPostProcessor(Utils::postprocessSimulatorState) //
+				.build();
+	}
+
+	/**
+	 * Builds an {@link EnergyScheduleHandler} for MANUL mode.
+	 * 
+	 * @param context a supplier for {@link EshManualContext}
+	 * @return the {@link EnergyScheduleHandler.WithOnlyOneState}
+	 */
+	public static EnergyScheduleHandler.WithOnlyOneState<EshManualContext> buildEshManual(
+			Supplier<EshManualContext> context) {
+		return EnergyScheduleHandler.WithOnlyOneState.<EshManualContext>create() //
+				.setContextFunction(simContext -> context.get()) //
+				.setSimulator((simContext, period, energyFlow, ctrlContext) -> {
+					final var evcsGlobal = simContext.global.evcss().get(ctrlContext.evcsId);
+					if (!ctrlContext.enabledCharging || evcsGlobal == null) {
+						return;
+					}
+					switch (evcsGlobal.status()) {
+					case CHARGING:
+					case READY_FOR_CHARGING:
+						break;
+					case CHARGING_REJECTED:
+					case ENERGY_LIMIT_REACHED:
+					case ERROR:
+					case NOT_READY_FOR_CHARGING:
+					case STARTING:
+					case UNDEFINED:
+						return;
+					}
+
+					final var evcsOne = simContext.evcss.get(ctrlContext.evcsId);
+					applyChargeEnergy(energyFlow, ctrlContext, evcsOne, ctrlContext.chargeMode, ctrlContext.priority,
+							ctrlContext.defaultChargeMinPower, ctrlContext.forceChargeMinPower);
+				}) //
+				.build();
+	}
+
+	public static sealed interface EshContext {
+
+		/**
+		 * Gets the configured Energy-Session-Limit.
+		 * 
+		 * @return the value
+		 */
+		public int energySessionLimit();
+
+		public static record EshManualContext(boolean enabledCharging, ChargeMode chargeMode, int forceChargeMinPower,
+				int defaultChargeMinPower, Priority priority, String evcsId, int energySessionLimit)
+				implements EshContext {
+
+			/**
+			 * Factory for {@link EshManualContext} from {@link Config}.
+			 * 
+			 * @param config the {@link Config}
+			 * @return the {@link EshManualContext}
+			 */
+			public static EshManualContext fromConfig(Config config) {
+				return new EshManualContext(config.enabledCharging(), config.chargeMode(), config.forceChargeMinPower(),
+						config.defaultChargeMinPower(), config.priority(), config.evcs_id(),
+						config.energySessionLimit());
+			}
+		}
+
+		public static record EshSmartContext(String evcsId, int energySessionLimit /* TODO required */,
+				ImmutableList<JSCalendar.Task<Payload>> tasks) implements EshContext {
+
+			/**
+			 * Factory for {@link EshSmartContext} from {@link Config}.
+			 * 
+			 * @param config the {@link Config}
+			 * @return the {@link EshSmartContext}
+			 */
+			public static EshSmartContext fromConfig(Config config) {
+				return new EshSmartContext(config.evcs_id(), config.energySessionLimit(),
+						Payload.fromJson(config.smartConfig()));
+			}
+
+			public static record Payload(int energySessionLimit) {
+				/**
+				 * Parses the String configuration to {@link Payload} objects.
+				 * 
+				 * @param smartConfig the configuration
+				 * @return the result
+				 */
+				public static ImmutableList<Task<Payload>> fromJson(String smartConfig) {
+					if (smartConfig == null || smartConfig.isBlank()) {
+						return ImmutableList.of();
+					}
+
+					try {
+						return JSCalendar.Task.<Payload>fromJson(parseToJsonArray(smartConfig), Payload::fromJson);
+					} catch (OpenemsNamedException e) {
+						e.printStackTrace();
+						return ImmutableList.of();
+					}
+				}
+
+				/**
+				 * Parses one {@link JsonObject} to a {@link Payload} object.
+				 * 
+				 * @param j the {@link JsonObject}
+				 * @return the {@link Payload} object
+				 * @throws OpenemsNamedException on error
+				 */
+				public static Payload fromJson(JsonObject j) throws OpenemsNamedException {
+					var sessionEnergy = getAsInt(j, "sessionEnergy");
+					return new Payload(sessionEnergy);
+				}
+			}
+		}
+	}
+
+	protected static ZonedDateTime getTargetDateTime(ZonedDateTime startTime, int hour) {
+		var localTime = startTime.withZoneSameInstant(Clock.systemDefaultZone().getZone());
+		var targetDate = localTime.getHour() > hour //
+				? startTime.plusDays(1) //
+				: startTime;
+		return targetDate.truncatedTo(ChronoUnit.DAYS).withHour(hour);
+	}
+
+	private static void applyChargeEnergy(EnergyFlow.Model energyFlow, EshContext ctrlContext, Evcs evcsOne,
+			ChargeMode chargeMode, Priority priority, int chargeMinPower, int forceChargePower) {
+		if (evcsOne == null) {
+			return;
+		}
+
+		// Evaluate Charge-Energy per mode
+		final var chargeEnergy = switch (chargeMode) {
+		case EXCESS_POWER //
+			-> switch (priority) {
+			case CAR //
+				-> toEnergy(//
+						max(chargeMinPower, energyFlow.production - energyFlow.unmanagedConsumption));
+			case STORAGE -> 0; // TODO not implemented
+			};
+		case FORCE_CHARGE //
+			-> toEnergy(forceChargePower);
+		};
+
+		if (chargeEnergy <= 0) {
+			return; // stop early
+		}
+
+		// Apply Session Limit
+		final int limitedChargeEnergy;
+		if (ctrlContext.energySessionLimit() > 0) {
+			limitedChargeEnergy = min(chargeEnergy,
+					max(0, ctrlContext.energySessionLimit() - evcsOne.getInitialEnergySession()));
+		} else {
+			limitedChargeEnergy = chargeEnergy;
+		}
+
+		if (limitedChargeEnergy > 0) {
+			energyFlow.addConsumption(limitedChargeEnergy);
+			evcsOne.calculateInitialEnergySession(limitedChargeEnergy);
+		}
+	}
+
+	/**
+	 * Post-Process a state of a Period during Simulation, i.e. replace with
+	 * 'better' state with the same behaviour.
+	 * 
+	 * <p>
+	 * NOTE: heavy computation is ok here, because this method is called only at the
+	 * end with the best Schedule.
+	 * 
+	 * @param osc     the {@link OneSimulationContext}
+	 * @param ef      the {@link EnergyFlow} for the state
+	 * @param context the {@link EshContext}
+	 * @param mode    the initial {@link SmartMode}
+	 * @return the new state
+	 */
+	protected static SmartMode postprocessSimulatorState(OneSimulationContext osc, EnergyFlow ef, EshContext context,
+			SmartMode mode) {
+		if (mode == SmartMode.ZERO) {
+			return mode;
+		}
+		if (ef.getManagedCons() == 0) { // TODO this works only reliably with one ControllerEvcs
+			return SmartMode.ZERO;
+		}
+		return mode;
+	}
+}

--- a/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/jsonrpc/GetScheduleRequest.java
+++ b/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/jsonrpc/GetScheduleRequest.java
@@ -1,0 +1,49 @@
+package io.openems.edge.controller.evcs.jsonrpc;
+
+import com.google.gson.JsonObject;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.jsonrpc.base.JsonrpcRequest;
+
+/**
+ * Represents a JSON-RPC Request for 'getSchedule'.
+ *
+ * <pre>
+ * {
+ *   "jsonrpc": "2.0",
+ *   "id": "UUID",
+ *   "method": "getSchedule",
+ *   "params": {}
+ * }
+ * </pre>
+ */
+public class GetScheduleRequest extends JsonrpcRequest {
+
+	public static final String METHOD = "getSchedule";
+
+	/**
+	 * Create {@link GetScheduleRequest} from a template {@link JsonrpcRequest}.
+	 *
+	 * @param r the template {@link JsonrpcRequest}
+	 * @return the {@link GetScheduleRequest}
+	 * @throws OpenemsNamedException on parse error
+	 */
+	public static GetScheduleRequest from(JsonrpcRequest r) throws OpenemsException {
+		return new GetScheduleRequest(r);
+	}
+
+	public GetScheduleRequest() {
+		super(METHOD);
+	}
+
+	private GetScheduleRequest(JsonrpcRequest request) {
+		super(request, METHOD);
+	}
+
+	@Override
+	public JsonObject getParams() {
+		return new JsonObject();
+	}
+
+}

--- a/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/jsonrpc/GetScheduleResponse.java
+++ b/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/jsonrpc/GetScheduleResponse.java
@@ -1,0 +1,136 @@
+package io.openems.edge.controller.evcs.jsonrpc;
+
+import static io.openems.common.utils.JsonUtils.buildJsonObject;
+import static io.openems.common.utils.JsonUtils.toJsonArray;
+import static io.openems.common.utils.StringUtils.toShortString;
+
+import java.time.Clock;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+
+import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
+import io.openems.edge.controller.evcs.SmartMode;
+import io.openems.edge.controller.evcs.Utils.EshContext.EshSmartContext;
+import io.openems.edge.energy.api.EnergyScheduleHandler;
+import io.openems.edge.energy.api.EnergyScheduleHandler.WithDifferentStates.Period;
+
+/**
+ * Represents a JSON-RPC Response for 'getSchedule'.
+ *
+ * <pre>
+ * {
+ *   "jsonrpc": "2.0",
+ *   "id": "UUID",
+ *   "result": {
+ *     'schedule': [{
+ *      'timestamp':...,
+ *      'price':...,
+ *      'state':...
+ *     }]
+ *   }
+ * }
+ * </pre>
+ */
+public class GetScheduleResponse extends JsonrpcResponseSuccess {
+
+	private static final Logger LOG = LoggerFactory.getLogger(GetScheduleResponse.class);
+
+	private final JsonObject result;
+
+	public GetScheduleResponse(UUID id, JsonObject result) {
+		super(id);
+		this.result = result;
+	}
+
+	@Override
+	public JsonObject getResult() {
+		return this.result;
+	}
+
+	/**
+	 * Builds a {@link GetScheduleResponse} with last three hours data and current
+	 * Schedule.
+	 * 
+	 * @param requestId             the JSON-RPC request-id
+	 * @param energyScheduleHandler the {@link EnergyScheduleHandler}
+	 * @return the {@link GetScheduleResponse}
+	 */
+	public static GetScheduleResponse from(UUID requestId, EnergyScheduleHandler energyScheduleHandler) {
+		LOG.info("OPTIMIZER JSONRPC start");
+		if (energyScheduleHandler == null
+				|| energyScheduleHandler instanceof EnergyScheduleHandler.WithOnlyOneState<?>) {
+			return null;
+		}
+		@SuppressWarnings("unchecked")
+		var esh = (EnergyScheduleHandler.WithDifferentStates<SmartMode, EshSmartContext>) energyScheduleHandler;
+		final var schedule = esh.getSchedule();
+		final JsonArray result;
+		if (schedule.isEmpty()) {
+			result = new JsonArray();
+		} else {
+			final var historic = Stream.<JsonObject>of(); // TODO
+			final var future = fromSchedule(schedule);
+			result = Stream.concat(historic, future) //
+					.collect(toJsonArray());
+		}
+		LOG.info("OPTIMIZER JSONRPC finished. " + toShortString(result, 100));
+
+		return new GetScheduleResponse(requestId, //
+				buildJsonObject() //
+						.add("schedule", result) //
+						.build());
+	}
+
+	/**
+	 * Converts the Schedule to a {@link Stream} of {@link JsonObject}s suitable for
+	 * a {@link GetScheduleResponse}.
+	 * 
+	 * @param schedule the {@link EnergyScheduleHandler} schedule
+	 * @return {@link Stream} of {@link JsonObject}s
+	 */
+	protected static Stream<JsonObject> fromSchedule(
+			ImmutableSortedMap<ZonedDateTime, Period<SmartMode, EshSmartContext>> schedule) {
+		return schedule.entrySet().stream() //
+				.map(e -> {
+					var p = e.getValue();
+
+					return buildJsonObject() //
+							.addProperty("timestamp", e.getKey()) //
+							.addProperty("price", p.price()) //
+							.addProperty("state", p.state().getValue()) //
+							.build();
+				});
+	}
+
+	/**
+	 * Creates an empty default Schedule in case no Schedule is available.
+	 * 
+	 * @param clock       the {@link Clock}
+	 * @param defaultMode the default {@link SmartMode}
+	 * @return {@link Stream} of {@link JsonObject}s
+	 */
+	protected static Stream<JsonObject> empty(Clock clock, SmartMode defaultMode) {
+		final var now = ZonedDateTime.now(clock);
+		final var numberOfPeriods = 96;
+
+		return IntStream.range(0, numberOfPeriods) //
+				.mapToObj(i -> {
+					return buildJsonObject() //
+							.addProperty("timestamp", now.plusMinutes(i * 15)) //
+							.add("price", JsonNull.INSTANCE) //
+							.addProperty("state", defaultMode.getValue()) //
+							.build();
+				});
+	}
+
+}

--- a/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/jsonrpc/package-info.java
+++ b/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/jsonrpc/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package io.openems.edge.controller.evcs.jsonrpc;

--- a/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/package-info.java
+++ b/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package io.openems.edge.controller.evcs;

--- a/io.openems.edge.controller.evcs/test/io/openems/edge/controller/evcs/JSCalendarTest.java
+++ b/io.openems.edge.controller.evcs/test/io/openems/edge/controller/evcs/JSCalendarTest.java
@@ -1,0 +1,133 @@
+package io.openems.edge.controller.evcs;
+
+import static io.openems.common.utils.JsonUtils.buildJsonObject;
+import static io.openems.common.utils.JsonUtils.prettyToString;
+import static io.openems.common.utils.UuidUtils.getNilUuid;
+import static io.openems.edge.common.test.TestUtils.createDummyClock;
+import static io.openems.edge.controller.evcs.JSCalendar.RecurrenceFrequency.WEEKLY;
+import static java.time.DayOfWeek.FRIDAY;
+import static java.time.DayOfWeek.MONDAY;
+import static java.time.DayOfWeek.SATURDAY;
+import static java.time.DayOfWeek.SUNDAY;
+import static java.time.DayOfWeek.THURSDAY;
+import static java.time.DayOfWeek.TUESDAY;
+import static java.time.DayOfWeek.WEDNESDAY;
+import static java.util.function.Function.identity;
+import static org.junit.Assert.assertEquals;
+
+import java.time.ZonedDateTime;
+
+import org.junit.Test;
+
+import com.google.gson.JsonObject;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+
+//CHECKSTYLE:OFF
+public class JSCalendarTest {
+	// CHECKSTYLE:ON
+
+	@Test
+	public void testWeekday() throws OpenemsNamedException {
+		var clock = createDummyClock();
+		var sut = new JSCalendar.Task.Builder<JsonObject>(getNilUuid(), ZonedDateTime.now(clock)) //
+				.setStart("2024-06-17T07:00:00") //
+				.addRecurrenceRule(b -> b //
+						.setFrequency(WEEKLY) //
+						.addByDay(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)) //
+				.setPayload(buildJsonObject() //
+						.addProperty("sessionEnergy", 10000) //
+						.build()) //
+				.build();
+		assertEquals("""
+				{
+				  "@type": "Task",
+				  "uid": "00000000-0000-0000-0000-000000000000",
+				  "updated": "2020-01-01T00:00:00Z",
+				  "start": "2024-06-17T07:00:00",
+				  "recurrenceRules": [
+				    {
+				      "frequency": "weekly",
+				      "byDay": [
+				        "mo",
+				        "tu",
+				        "we",
+				        "th",
+				        "fr"
+				      ]
+				    }
+				  ],
+				  "payload": {
+				    "sessionEnergy": 10000
+				  }
+				}""", prettyToString(sut.toJson(identity())));
+
+		var next = sut.getNextOccurence(ZonedDateTime.now(clock));
+		assertEquals("2024-06-17T07:00Z", next.toString());
+		next = sut.getNextOccurence(next.plusSeconds(1));
+		assertEquals("2024-06-18T07:00Z", next.toString());
+		next = sut.getNextOccurence(next.plusSeconds(1));
+		assertEquals("2024-06-19T07:00Z", next.toString());
+		next = sut.getNextOccurence(next.plusSeconds(1));
+		assertEquals("2024-06-20T07:00Z", next.toString());
+		next = sut.getNextOccurence(next.plusSeconds(1));
+		assertEquals("2024-06-21T07:00Z", next.toString());
+		next = sut.getNextOccurence(next.plusSeconds(1)); // next week
+		assertEquals("2024-06-24T07:00Z", next.toString());
+		next = sut.getNextOccurence(next);
+		assertEquals("2024-06-24T07:00Z", next.toString()); // same
+
+		// Parse JSON
+		var fromJson = JSCalendar.Task.fromJson(sut.toJson(identity()), identity());
+		assertEquals(sut.toJson(identity()), fromJson.toJson(identity()));
+	}
+
+	@Test
+	public void testWeekend() throws OpenemsNamedException {
+		var clock = createDummyClock();
+		var sut = new JSCalendar.Task.Builder<JsonObject>(getNilUuid(), ZonedDateTime.now(clock)) //
+				.setStart("2024-06-17T00:00:00") //
+				.addRecurrenceRule(b -> b //
+						.setFrequency(WEEKLY) //
+						.addByDay(SATURDAY, SUNDAY)) //
+				.setPayload(buildJsonObject() //
+						.addProperty("sessionEnergy", 10001) //
+						.build()) //
+				.build();
+		assertEquals("""
+				{
+				  "@type": "Task",
+				  "uid": "00000000-0000-0000-0000-000000000000",
+				  "updated": "2020-01-01T00:00:00Z",
+				  "start": "2024-06-17T00:00:00",
+				  "recurrenceRules": [
+				    {
+				      "frequency": "weekly",
+				      "byDay": [
+				        "sa",
+				        "su"
+				      ]
+				    }
+				  ],
+				  "payload": {
+				    "sessionEnergy": 10001
+				  }
+				}""", prettyToString(sut.toJson(identity())));
+
+		var next = sut.getNextOccurence(ZonedDateTime.now(clock));
+		assertEquals("2024-06-22T00:00Z", next.toString());
+		next = sut.getNextOccurence(next.plusSeconds(1));
+		assertEquals("2024-06-23T00:00Z", next.toString());
+		next = sut.getNextOccurence(next.plusSeconds(1));
+		assertEquals("2024-06-29T00:00Z", next.toString());
+		next = sut.getNextOccurence(next.plusSeconds(1));
+		assertEquals("2024-06-30T00:00Z", next.toString());
+		next = sut.getNextOccurence(next.plusSeconds(1));
+		assertEquals("2024-07-06T00:00Z", next.toString());
+
+		// Parse JSON
+		var fromJson = JSCalendar.Task.fromJson(sut.toJson(identity()), identity());
+		assertEquals(sut.toJson(identity()), fromJson.toJson(identity()));
+	}
+
+}

--- a/io.openems.edge.controller.evcs/test/io/openems/edge/controller/evcs/MyConfig.java
+++ b/io.openems.edge.controller.evcs/test/io/openems/edge/controller/evcs/MyConfig.java
@@ -12,6 +12,8 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 		private boolean debugMode = false;
 		private String evcsId = "evcs0";
 		private boolean enabledCharging = true;
+		private boolean smartMode = false;
+		private String smartConfig = "";
 		private ChargeMode chargeMode = ChargeMode.FORCE_CHARGE;
 		private int forceChargeMinPower = 7560;
 		private int defaultChargeMinPower = 0;
@@ -35,6 +37,16 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 		public Builder setDebugMode(boolean debugMode) {
 			this.debugMode = debugMode;
+			return this;
+		}
+
+		public Builder setSmartMode(boolean smartMode) {
+			this.smartMode = smartMode;
+			return this;
+		}
+
+		public Builder setSmartConfig(String smartConfig) {
+			this.smartConfig = smartConfig;
 			return this;
 		}
 
@@ -117,6 +129,16 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	@Override
 	public boolean enabledCharging() {
 		return this.builder.enabledCharging;
+	}
+
+	@Override
+	public boolean smartMode() {
+		return this.builder.smartMode;
+	}
+
+	@Override
+	public String smartConfig() {
+		return this.builder.smartConfig;
 	}
 
 	@Override

--- a/io.openems.edge.energy.api/src/io/openems/edge/energy/api/EnergySchedulable.java
+++ b/io.openems.edge.energy.api/src/io/openems/edge/energy/api/EnergySchedulable.java
@@ -1,8 +1,8 @@
 package io.openems.edge.energy.api;
 
-import io.openems.edge.controller.api.Controller;
+import io.openems.edge.common.component.OpenemsComponent;
 
-public interface EnergySchedulable extends Controller {
+public interface EnergySchedulable extends OpenemsComponent {
 
 	/**
 	 * Get the {@link EnergyScheduleHandler}.

--- a/io.openems.edge.energy.api/src/io/openems/edge/energy/api/EnergyScheduleHandler.java
+++ b/io.openems.edge.energy.api/src/io/openems/edge/energy/api/EnergyScheduleHandler.java
@@ -6,8 +6,10 @@ import static io.openems.common.utils.DateUtils.roundDownToQuarter;
 import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
@@ -17,7 +19,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSortedMap;
 
 import io.openems.edge.controller.api.Controller;
-import io.openems.edge.energy.api.EnergyScheduleHandler.WithDifferentStates.PostProcessor;
 import io.openems.edge.energy.api.simulation.EnergyFlow;
 import io.openems.edge.energy.api.simulation.GlobalSimulationsContext;
 import io.openems.edge.energy.api.simulation.OneSimulationContext;
@@ -25,68 +26,11 @@ import io.openems.edge.energy.api.simulation.OneSimulationContext;
 public sealed interface EnergyScheduleHandler {
 
 	/**
-	 * Creates an {@link EnergyScheduleHandler} for a {@link Controller} with
-	 * different states that can be evaluated.
-	 * 
-	 * @param <STATE>         the type of the State
-	 * @param <CONTEXT>       the type of the Context
-	 * @param defaultState    the default State if no other is explicitly scheduled
-	 * @param statesSupplier  a {@link Supplier} for available States
-	 * @param contextFunction a {@link Function} to create a Context
-	 * @param simulator       a simulator that modifies a given {@link EnergyFlow}
-	 * @return an {@link EnergyScheduleHandler}
-	 */
-	public static <STATE, CONTEXT> EnergyScheduleHandler.WithDifferentStates<STATE, CONTEXT> of(//
-			STATE defaultState, //
-			Supplier<STATE[]> statesSupplier, //
-			Function<GlobalSimulationsContext, CONTEXT> contextFunction, //
-			WithDifferentStates.Simulator<STATE, CONTEXT> simulator) {
-		return new EnergyScheduleHandler.WithDifferentStates<STATE, CONTEXT>(defaultState, statesSupplier,
-				contextFunction, simulator, EnergyScheduleHandler.WithDifferentStates.PostProcessor.doNothing());
-	}
-
-	/**
-	 * Creates an {@link EnergyScheduleHandler} for a {@link Controller} with
-	 * different states that can be evaluated.
-	 * 
-	 * @param <STATE>         the type of the State
-	 * @param <CONTEXT>       the type of the Context
-	 * @param defaultState    the default State if no other is explicitly scheduled
-	 * @param statesSupplier  a {@link Supplier} for available States
-	 * @param contextFunction a {@link Function} to create a Context
-	 * @param simulator       a simulator that modifies a given {@link EnergyFlow}
-	 * @param postProcessor   a {@link PostProcessor}
-	 * @return an {@link EnergyScheduleHandler}
-	 */
-	public static <STATE, CONTEXT> EnergyScheduleHandler.WithDifferentStates<STATE, CONTEXT> of(//
-			STATE defaultState, //
-			Supplier<STATE[]> statesSupplier, //
-			Function<GlobalSimulationsContext, CONTEXT> contextFunction, //
-			WithDifferentStates.Simulator<STATE, CONTEXT> simulator, //
-			WithDifferentStates.PostProcessor<STATE, CONTEXT> postProcessor) {
-		return new EnergyScheduleHandler.WithDifferentStates<STATE, CONTEXT>(defaultState, statesSupplier,
-				contextFunction, simulator, postProcessor);
-	}
-
-	/**
-	 * Creates an {@link EnergyScheduleHandler} for a {@link Controller} with only a
-	 * single state.
-	 * 
-	 * @param <CONTEXT>       the type of the Context
-	 * @param contextFunction a {@link Function} to create a Context
-	 * @param simulator       a simulator that modifies a given {@link EnergyFlow}
-	 * @return an {@link EnergyScheduleHandler}
-	 */
-	public static <CONTEXT> EnergyScheduleHandler.WithOnlyOneState<CONTEXT> of(//
-			Function<GlobalSimulationsContext, CONTEXT> contextFunction, //
-			WithOnlyOneState.Simulator<CONTEXT> simulator) {
-		return new EnergyScheduleHandler.WithOnlyOneState<CONTEXT>(contextFunction, simulator);
-	}
-
-	/**
 	 * Triggers Rescheduling by the Energy Scheduler.
+	 * 
+	 * @param reason a reason
 	 */
-	public void triggerReschedule();
+	public void triggerReschedule(String reason);
 
 	public abstract static sealed class AbstractEnergyScheduleHandler<CONTEXT> implements EnergyScheduleHandler {
 
@@ -94,7 +38,7 @@ public sealed interface EnergyScheduleHandler {
 
 		protected Clock clock;
 		protected CONTEXT context;
-		private Runnable onRescheduleCallback;
+		private Consumer<String> onRescheduleCallback;
 
 		public AbstractEnergyScheduleHandler(Function<GlobalSimulationsContext, CONTEXT> contextFunction) {
 			this.contextFunction = contextFunction;
@@ -116,9 +60,9 @@ public sealed interface EnergyScheduleHandler {
 		/**
 		 * This method sets the callback for events that require Rescheduling.
 		 * 
-		 * @param callback the {@link Runnable} callback
+		 * @param callback the {@link Consumer} callback with a reason
 		 */
-		public synchronized void setOnRescheduleCallback(Runnable callback) {
+		public synchronized void setOnRescheduleCallback(Consumer<String> callback) {
 			this.onRescheduleCallback = callback;
 		}
 
@@ -130,10 +74,10 @@ public sealed interface EnergyScheduleHandler {
 		}
 
 		@Override
-		public void triggerReschedule() {
+		public void triggerReschedule(String reason) {
 			var onRescheduleCallback = this.onRescheduleCallback;
 			if (onRescheduleCallback != null) {
-				onRescheduleCallback.run();
+				onRescheduleCallback.accept(reason);
 			}
 		}
 
@@ -155,6 +99,110 @@ public sealed interface EnergyScheduleHandler {
 
 	public static final class WithDifferentStates<STATE, CONTEXT> extends AbstractEnergyScheduleHandler<CONTEXT> {
 
+		public static final class Builder<STATE, CONTEXT> {
+
+			private STATE defaultState;
+			private Supplier<STATE[]> availableStatesSupplier;
+			private Function<GlobalSimulationsContext, CONTEXT> contextFunction;
+			private Function<GlobalSimulationsContext, List<InitialPopulation<STATE>>> initialPopulationsFunction = gsc -> List
+					.of();
+			private WithDifferentStates.Simulator<STATE, CONTEXT> simulator;
+			private WithDifferentStates.PostProcessor<STATE, CONTEXT> postProcessor = PostProcessor.doNothing();
+
+			/**
+			 * Sets the default State if no other is explicitly scheduled.
+			 * 
+			 * @param state a state
+			 * @return myself
+			 */
+			public Builder<STATE, CONTEXT> setDefaultState(STATE state) {
+				this.defaultState = state;
+				return this;
+			}
+
+			/**
+			 * Sets a {@link Function} to create a {@link GlobalSimulationsContext}.
+			 * 
+			 * @param contextFunction the context function
+			 * @return myself
+			 */
+			public Builder<STATE, CONTEXT> setContextFunction(
+					Function<GlobalSimulationsContext, CONTEXT> contextFunction) {
+				this.contextFunction = contextFunction;
+				return this;
+			}
+
+			/**
+			 * Sets a {@link Function} to provide {@link InitialPopulation}s.
+			 * 
+			 * @param initialPopulationsFunction the function
+			 * @return myself
+			 */
+			public Builder<STATE, CONTEXT> setInitialPopulationsFunction(
+					Function<GlobalSimulationsContext, List<InitialPopulation<STATE>>> initialPopulationsFunction) {
+				this.initialPopulationsFunction = initialPopulationsFunction;
+				return this;
+			}
+
+			/**
+			 * Sets a {@link Supplier} for available States.
+			 * 
+			 * @param supplier a states supplier
+			 * @return myself
+			 */
+			public Builder<STATE, CONTEXT> setAvailableStates(Supplier<STATE[]> supplier) {
+				this.availableStatesSupplier = supplier;
+				return this;
+			}
+
+			/**
+			 * Sets a {@link WithDifferentStates.Simulator} that modifies a given
+			 * {@link EnergyFlow}.
+			 * 
+			 * @param simulator a simulator
+			 * @return myself
+			 */
+			public Builder<STATE, CONTEXT> setSimulator(WithDifferentStates.Simulator<STATE, CONTEXT> simulator) {
+				this.simulator = simulator;
+				return this;
+			}
+
+			/**
+			 * Sets a {@link PostProcessor}.
+			 * 
+			 * @param postProcessor a {@link PostProcessor}
+			 * @return myself
+			 */
+			public Builder<STATE, CONTEXT> setPostProcessor(
+					WithDifferentStates.PostProcessor<STATE, CONTEXT> postProcessor) {
+				this.postProcessor = postProcessor;
+				return this;
+			}
+
+			/**
+			 * Builds the {@link EnergyScheduleHandler.WithDifferentStates} instance.
+			 *
+			 * @return a {@link EnergyScheduleHandler.WithDifferentStates}
+			 */
+			public WithDifferentStates<STATE, CONTEXT> build() {
+				return new EnergyScheduleHandler.WithDifferentStates<STATE, CONTEXT>(this.defaultState,
+						this.availableStatesSupplier, this.contextFunction, this.initialPopulationsFunction,
+						this.simulator, this.postProcessor);
+			}
+		}
+
+		/**
+		 * Create a {@link EnergyScheduleHandler.WithDifferentStates} for a
+		 * {@link Controller} with different states that can be evaluated.
+		 *
+		 * @param <STATE>   the type of the State
+		 * @param <CONTEXT> the type of the Context
+		 * @return a {@link Builder}
+		 */
+		public static <STATE, CONTEXT> Builder<STATE, CONTEXT> create() {
+			return new Builder<STATE, CONTEXT>();
+		}
+
 		public static interface Simulator<STATE, CONTEXT> {
 			/**
 			 * Simulates a Period.
@@ -164,8 +212,9 @@ public sealed interface EnergyScheduleHandler {
 			 * @param model   the {@link EnergyFlow.Model}
 			 * @param context the Controller Context
 			 * @param state   the simulated State
+			 * @return additional cost to be considered by the cost function
 			 */
-			public void simulate(OneSimulationContext osc, GlobalSimulationsContext.Period period,
+			public double simulate(OneSimulationContext osc, GlobalSimulationsContext.Period period,
 					EnergyFlow.Model model, CONTEXT context, STATE state);
 		}
 
@@ -201,6 +250,7 @@ public sealed interface EnergyScheduleHandler {
 
 		private final STATE defaultState;
 		private final Supplier<STATE[]> availableStatesSupplier;
+		private final Function<GlobalSimulationsContext, List<InitialPopulation<STATE>>> initialPopulationsFunction;
 		private final Simulator<STATE, CONTEXT> simulator;
 		private final WithDifferentStates.PostProcessor<STATE, CONTEXT> postProcessor;
 		private final SortedMap<ZonedDateTime, Period<STATE, CONTEXT>> schedule = new TreeMap<>();
@@ -211,11 +261,13 @@ public sealed interface EnergyScheduleHandler {
 				STATE defaultState, //
 				Supplier<STATE[]> availableStatesSupplier, //
 				Function<GlobalSimulationsContext, CONTEXT> contextFunction, //
+				Function<GlobalSimulationsContext, List<InitialPopulation<STATE>>> initialPopulationsFunction, //
 				Simulator<STATE, CONTEXT> simulator, //
 				WithDifferentStates.PostProcessor<STATE, CONTEXT> postProcessor) {
 			super(contextFunction);
 			this.defaultState = defaultState;
 			this.availableStatesSupplier = availableStatesSupplier;
+			this.initialPopulationsFunction = initialPopulationsFunction;
 			this.simulator = simulator;
 			this.postProcessor = postProcessor;
 		}
@@ -224,6 +276,32 @@ public sealed interface EnergyScheduleHandler {
 		public void initialize(GlobalSimulationsContext asc) {
 			super.initialize(asc);
 			this.availableStates = this.availableStatesSupplier.get();
+		}
+
+		public static record InitialPopulation<STATE>(List<ZonedDateTime> periods, STATE state) {
+
+			/**
+			 * Creates a {@link InitialPopulation} record.
+			 * 
+			 * @param <STATE> the type of the State
+			 * @param periods a List of {@link ZonedDateTime}s
+			 * @param state   the state
+			 * @return a {@link InitialPopulation} record
+			 */
+			public static <STATE> InitialPopulation<STATE> of(List<ZonedDateTime> periods, STATE state) {
+				return new InitialPopulation<STATE>(periods, state);
+			}
+		}
+
+		/**
+		 * Generates {@link InitialPopulation}s for this
+		 * {@link EnergyScheduleHandler.WithDifferentStates}.
+		 * 
+		 * @param gsc the {@link GlobalSimulationsContext}
+		 * @return a List of {@link InitialPopulation}s
+		 */
+		public List<InitialPopulation<STATE>> getInitialPopulations(GlobalSimulationsContext gsc) {
+			return this.initialPopulationsFunction.apply(gsc);
 		}
 
 		/**
@@ -268,10 +346,11 @@ public sealed interface EnergyScheduleHandler {
 		 * @param period     the simulated {@link GlobalSimulationsContext.Period}
 		 * @param model      the {@link EnergyFlow.Model}
 		 * @param stateIndex the index of the simulated state
+		 * @return additional cost to be considered by the cost function
 		 */
-		public void simulatePeriod(OneSimulationContext osc, GlobalSimulationsContext.Period period,
+		public double simulatePeriod(OneSimulationContext osc, GlobalSimulationsContext.Period period,
 				EnergyFlow.Model model, int stateIndex) {
-			this.simulator.simulate(osc, period, model, this.context, this.availableStates[stateIndex]);
+			return this.simulator.simulate(osc, period, model, this.context, this.availableStates[stateIndex]);
 		}
 
 		/**
@@ -436,6 +515,55 @@ public sealed interface EnergyScheduleHandler {
 	}
 
 	public static final class WithOnlyOneState<CONTEXT> extends AbstractEnergyScheduleHandler<CONTEXT> {
+
+		public static final class Builder<CONTEXT> {
+
+			private Function<GlobalSimulationsContext, CONTEXT> contextFunction;
+			private WithOnlyOneState.Simulator<CONTEXT> simulator;
+
+			/**
+			 * Sets a {@link Function} to create a {@link GlobalSimulationsContext}.
+			 * 
+			 * @param contextFunction the context function
+			 * @return myself
+			 */
+			public Builder<CONTEXT> setContextFunction(Function<GlobalSimulationsContext, CONTEXT> contextFunction) {
+				this.contextFunction = contextFunction;
+				return this;
+			}
+
+			/**
+			 * Sets a {@link WithDifferentStates.Simulator} that modifies a given
+			 * {@link EnergyFlow}.
+			 * 
+			 * @param simulator a simulator
+			 * @return myself
+			 */
+			public Builder<CONTEXT> setSimulator(WithOnlyOneState.Simulator<CONTEXT> simulator) {
+				this.simulator = simulator;
+				return this;
+			}
+
+			/**
+			 * Builds the {@link EnergyScheduleHandler.WithDifferentStates} instance.
+			 *
+			 * @return a {@link EnergyScheduleHandler.WithDifferentStates}
+			 */
+			public WithOnlyOneState<CONTEXT> build() {
+				return new EnergyScheduleHandler.WithOnlyOneState<CONTEXT>(this.contextFunction, this.simulator);
+			}
+		}
+
+		/**
+		 * Create a {@link EnergyScheduleHandler.WithOnlyOneState} for a
+		 * {@link Controller} with only a single state.
+		 *
+		 * @param <CONTEXT> the type of the Context
+		 * @return a {@link Builder}
+		 */
+		public static <CONTEXT> Builder<CONTEXT> create() {
+			return new Builder<CONTEXT>();
+		}
 
 		public static interface Simulator<CONTEXT> {
 			/**

--- a/io.openems.edge.energy.api/src/io/openems/edge/energy/api/test/DummyEnergySchedulable.java
+++ b/io.openems.edge.energy.api/src/io/openems/edge/energy/api/test/DummyEnergySchedulable.java
@@ -1,6 +1,5 @@
 package io.openems.edge.energy.api.test;
 
-import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.energy.api.EnergySchedulable;
 import io.openems.edge.energy.api.EnergyScheduleHandler;
@@ -24,10 +23,6 @@ public class DummyEnergySchedulable extends AbstractDummyEnergySchedulable<Dummy
 	@Override
 	protected final DummyEnergySchedulable self() {
 		return this;
-	}
-
-	@Override
-	public void run() throws OpenemsNamedException {
 	}
 
 	@Override

--- a/io.openems.edge.energy/bnd.bnd
+++ b/io.openems.edge.energy/bnd.bnd
@@ -29,6 +29,7 @@ Bundle-Version: 1.0.0.${tstamp}
 	io.openems.edge.controller.ess.gridoptimizedcharge,\
 	io.openems.edge.controller.ess.limittotaldischarge,\
 	io.openems.edge.controller.ess.timeofusetariff,\
+	io.openems.edge.controller.evcs,\
 	io.openems.edge.evcs.api,\
 	io.openems.edge.meter.api,\
 	org.apache.commons.math3,\

--- a/io.openems.edge.energy/src/io/openems/edge/energy/optimizer/EshCodec.java
+++ b/io.openems.edge.energy/src/io/openems/edge/energy/optimizer/EshCodec.java
@@ -78,6 +78,8 @@ public class EshCodec implements InvertibleCodec<int[][], IntegerGene> {
 						for (var eshIndex = 0; eshIndex < numberOfEshs; eshIndex++) {
 							final int value = gt.get(eshIndex).get(periodIndex).intValue();
 							final int state;
+							// TODO Valid States per Period should be read from ESH here.
+							// Example: might be limited by a SmartConfig with JSCalendar payload
 							if (isFirstPeriodFixed && periodIndex == 0) {
 								final var time = gsc.periods().get(periodIndex).time();
 								final var esh = gsc.eshsWithDifferentStates().get(eshIndex);

--- a/io.openems.edge.energy/src/io/openems/edge/energy/optimizer/InitialPopulation.java
+++ b/io.openems.edge.energy/src/io/openems/edge/energy/optimizer/InitialPopulation.java
@@ -38,6 +38,8 @@ public class InitialPopulation {
 	 */
 	public static ISeq<Genotype<IntegerGene>> generateInitialPopulation(GlobalSimulationsContext gsc, EshCodec codec,
 			SimulationResult previousResult, boolean isCurrentPeriodFixed) {
+		// TODO read good variations from ESHs.
+		// Example: force charge car during cheapest hours
 		return Stream //
 				.concat(//
 						variationsOfAllStatesDefault(gsc, previousResult, isCurrentPeriodFixed), //

--- a/io.openems.edge.energy/src/io/openems/edge/energy/optimizer/Optimizer.java
+++ b/io.openems.edge.energy/src/io/openems/edge/energy/optimizer/Optimizer.java
@@ -62,7 +62,10 @@ public class Optimizer implements Runnable {
 		initializeRandomRegistryForProduction();
 	}
 
-	private synchronized void interruptTask() {
+	/**
+	 * Interrupts the {@link Optimizer} Task.
+	 */
+	public synchronized void interruptTask() {
 		if (this.future != null) {
 			this.future.cancel(true);
 		}
@@ -86,22 +89,32 @@ public class Optimizer implements Runnable {
 
 	/**
 	 * Triggers Rescheduling.
+	 * 
+	 * @param reason a reason
 	 */
-	public void triggerReschedule() {
-		this.traceLog(() -> "Trigger Reschedule");
-		this.activate(); // interrupt + reschedule
+	public void triggerReschedule(String reason) {
+		// NOTE: This is what happens here:
+		// [_cycle  ] INFO  [dge.energy.optimizer.Optimizer] OPTIMIZER Trigger Reschedule. Reason: ControllerEvcsImpl::onEvcsStatusChange from 6:The charging limit reached to 1:Not ready for Charging
+		// [thread-1] INFO  [dge.energy.optimizer.Optimizer] OPTIMIZER Optimizer::run() InterruptedException: null
+		// [thread-1] INFO  [dge.energy.optimizer.Optimizer] OPTIMIZER Simulation gave no result!
+		// [thread-1] INFO  [dge.energy.optimizer.Optimizer] OPTIMIZER Run Quick Optimization...
+		// [thread-1] INFO  [dge.energy.optimizer.Optimizer] OPTIMIZER updateSimulator()...
+		
+		// TODO On interrupt: keep best "regularOptimization" up till now as input for next InitialPopulation
+		this.traceLog(() -> "Trigger Reschedule. Reason: " + reason);
 		this.rescheduleCurrentPeriod.set(true);
+		this.activate(); // interrupt + reschedule
 	}
 
 	@Override
 	public void run() {
-		SimulationResult simulationResult = SimulationResult.EMPTY;
+		var simulationResult = SimulationResult.EMPTY;
 		try {
-			this.traceLog(() -> "Run...");
-
 			if (this.rescheduleCurrentPeriod.getAndSet(false) || this.simulationResult == EMPTY) {
+				this.traceLog(() -> "Run Quick Optimization...");
 				simulationResult = this.runQuickOptimization();
 			} else {
+				this.traceLog(() -> "Run Regular Optimization...");
 				simulationResult = this.runRegularOptimization();
 			}
 
@@ -120,20 +133,26 @@ public class Optimizer implements Runnable {
 	 * @throws InterruptedException on interrupted sleep
 	 */
 	private Simulator updateSimulator() throws InterruptedException {
-		// Create the Simulator with GlobalSimulationsContext
-		createSimulator(this.gscSupplier, //
-				simulator -> this.simulator = simulator, //
-				error -> {
-					this.traceLog(error);
-					this.applySimulationResult(EMPTY);
-				});
-		final var simulator = this.simulator;
-		if (simulator == null) {
-			this.traceLog(() -> "Simulator is null");
-		} else {
-			this.traceLog(() -> "Simulator is " + simulator.toLogString(""));
+		try {
+			// Create the Simulator with GlobalSimulationsContext
+			this.traceLog(() -> "updateSimulator()...");
+			createSimulator(this.gscSupplier, //
+					simulator -> this.simulator = simulator, //
+					error -> {
+						this.traceLog(error);
+						this.applySimulationResult(EMPTY);
+					});
+			final var simulator = this.simulator;
+			if (simulator == null) {
+				this.traceLog(() -> "Simulator is null");
+			} else {
+				this.traceLog(() -> "Simulator is " + simulator.toLogString(""));
+			}
+			return simulator;
+		} catch (Exception e) {
+			e.printStackTrace(); // TODO remove
+			throw e;
 		}
-		return simulator;
 	}
 
 	/**

--- a/io.openems.edge.energy/src/io/openems/edge/energy/optimizer/SimulationResult.java
+++ b/io.openems.edge.energy/src/io/openems/edge/energy/optimizer/SimulationResult.java
@@ -145,7 +145,7 @@ public record SimulationResult(//
 	 */
 	public String toLogString(String prefix) {
 		var b = new StringBuilder(prefix) //
-				.append("Time   Price Production Consumption   Ess   Grid ProdToCons ProdToGrid ProdToEss GridToCons GridToEss EssToCons EssInitial\n");
+				.append("Time   Price Production Consumption ManagedCons    Ess   Grid ProdToCons ProdToGrid ProdToEss GridToCons GridToEss EssToCons EssInitial\n");
 		this.periods.entrySet().forEach(e -> {
 			final var time = e.getKey();
 			final var p = e.getValue();
@@ -155,7 +155,8 @@ public record SimulationResult(//
 			log(b, "%s ", time.format(TIME_FORMATTER));
 			log(b, "%6.2f ", c.price());
 			log(b, "%10d ", ef.getProd());
-			log(b, "%10d ", ef.getCons());
+			log(b, "%11d ", ef.getCons());
+			log(b, "%11d ", ef.getManagedCons());
 			log(b, "%6d ", ef.getEss());
 			log(b, "%6d ", ef.getGrid());
 			log(b, "%10d ", ef.getProdToCons());
@@ -170,6 +171,7 @@ public record SimulationResult(//
 			});
 			b.append("\n");
 		});
+		b.append(prefix).append("cost=").append(this.cost);
 		return b.toString();
 	}
 }

--- a/io.openems.edge.energy/test/io/openems/edge/energy/optimizer/app/AppUtils.java
+++ b/io.openems.edge.energy/test/io/openems/edge/energy/optimizer/app/AppUtils.java
@@ -1,6 +1,7 @@
 package io.openems.edge.energy.optimizer.app;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.openems.edge.energy.api.EnergyUtils.filterEshsWithDifferentStates;
 import static java.lang.Double.parseDouble;
 import static java.lang.Integer.parseInt;
@@ -9,12 +10,12 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import io.openems.common.test.TimeLeapClock;
 import io.openems.edge.energy.api.EnergyScheduleHandler;
@@ -22,6 +23,7 @@ import io.openems.edge.energy.api.RiskLevel;
 import io.openems.edge.energy.api.simulation.GlobalSimulationsContext;
 import io.openems.edge.energy.api.simulation.GlobalSimulationsContext.Period;
 import io.openems.edge.energy.optimizer.SimulationResult;
+import io.openems.edge.evcs.api.Status;
 
 public class AppUtils {
 
@@ -57,8 +59,13 @@ public class AppUtils {
 				parseInt(essMatcher.group("maxChargeEnergy")), //
 				parseInt(essMatcher.group("maxDischargeEnergy")));
 
-		// TODO Evcs
-		final var evcss =  ImmutableMap.<String, GlobalSimulationsContext.Evcs>of();
+		final var evcss = Arrays.stream(headerMatcher.group("evcss").split("], ")) //
+				.map(evcs -> applyPattern(EVCS_PATTERN, evcs)) //
+				.collect(toImmutableMap(//
+						m -> m.group("componentId"), //
+						m -> new GlobalSimulationsContext.Evcs(//
+								Status.valueOf(m.group("status")), //
+								parseInt(m.group("energySession"))))); //
 
 		var nextTime = new AtomicReference<>(startDateTime);
 		var periods = log.lines() //
@@ -95,7 +102,9 @@ public class AppUtils {
 	private static final Pattern HEADER_PATTERN = Pattern.compile("" //
 			+ "startTime=(?<startTime>\\S*), " //
 			+ "Grid\\[(?<grid>.*)\\], " //
-			+ "Ess\\[(?<ess>.*)\\]");
+			+ "Ess\\[(?<ess>.*)\\], " //
+			+ "evcss=\\{(?<evcss>.*)\\}, " //
+			+ "eshs=\\[");
 
 	private static final Pattern GRID_PATTERN = Pattern.compile("" //
 			+ "maxBuy=(?<maxBuy>\\d+), " //
@@ -106,6 +115,11 @@ public class AppUtils {
 			+ "totalEnergy=(?<totalEnergy>\\d+), " //
 			+ "maxChargeEnergy=(?<maxChargeEnergy>\\d+), " //
 			+ "maxDischargeEnergy=(?<maxDischargeEnergy>\\d+)");
+
+	private static final Pattern EVCS_PATTERN = Pattern.compile("" //
+			+ "(?<componentId>\\S+)=Evcs\\[" //
+			+ "status=(?<status>\\S+), " //
+			+ "energySession=(?<energySession>\\d+)");
 
 	private static final Pattern PERIOD_PATTERN = Pattern.compile("" //
 			+ "(?<time>\\d{2}:\\d{2})" //

--- a/io.openems.edge.energy/test/io/openems/edge/energy/optimizer/app/RunOptimizerFromLogApp.java
+++ b/io.openems.edge.energy/test/io/openems/edge/energy/optimizer/app/RunOptimizerFromLogApp.java
@@ -1,10 +1,17 @@
 package io.openems.edge.energy.optimizer.app;
 
 import static io.jenetics.engine.Limits.byExecutionTime;
+import static io.openems.edge.controller.evcs.JSCalendar.RecurrenceFrequency.WEEKLY;
 import static io.openems.edge.energy.optimizer.SimulationResult.EMPTY;
 import static io.openems.edge.energy.optimizer.app.AppUtils.parseGlobalSimulationsContextFromLogString;
+import static java.time.DayOfWeek.FRIDAY;
+import static java.time.DayOfWeek.MONDAY;
+import static java.time.DayOfWeek.THURSDAY;
+import static java.time.DayOfWeek.TUESDAY;
+import static java.time.DayOfWeek.WEDNESDAY;
 import static java.time.Duration.ofSeconds;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import com.google.common.collect.ImmutableList;
@@ -16,6 +23,8 @@ import io.openems.edge.controller.ess.gridoptimizedcharge.Mode;
 import io.openems.edge.controller.ess.limittotaldischarge.ControllerEssLimitTotalDischargeImpl;
 import io.openems.edge.controller.ess.timeofusetariff.ControlMode;
 import io.openems.edge.controller.ess.timeofusetariff.TimeOfUseTariffControllerImpl;
+import io.openems.edge.controller.evcs.JSCalendar;
+import io.openems.edge.controller.evcs.Utils.EshContext.EshSmartContext;
 import io.openems.edge.energy.api.EnergyScheduleHandler;
 import io.openems.edge.energy.api.EnergyUtils;
 import io.openems.edge.energy.optimizer.Simulator;
@@ -53,13 +62,31 @@ public class RunOptimizerFromLogApp {
 					() -> new ControllerEssFixActivePowerImpl.EshContext(
 							io.openems.edge.controller.ess.fixactivepower.Mode.MANUAL_ON, //
 							EnergyUtils.toEnergy(-1000), Relationship.GREATER_OR_EQUALS)), //
+			io.openems.edge.controller.evcs.Utils.buildEshSmart(//
+					() -> new EshSmartContext("evcs1", 30000, ImmutableList.of(//
+							JSCalendar.Task.<EshSmartContext.Payload>create() //
+									.setStart(LocalDateTime.of(2024, 28, 12, 7, 0, 0)) //
+									.addRecurrenceRule(b -> b //
+											.setFrequency(WEEKLY) //
+											.addByDay(TUESDAY, WEDNESDAY, THURSDAY, FRIDAY)) //
+									.setPayload(new EshSmartContext.Payload(10000)) //
+									.build(), //
+							JSCalendar.Task.<EshSmartContext.Payload>create() //
+									.setStart(LocalDateTime.of(2024, 28, 12, 7, 0, 0)) //
+									.addRecurrenceRule(b -> b //
+											.setFrequency(WEEKLY) //
+											.addByDay(MONDAY)) //
+									.setPayload(new EshSmartContext.Payload(40000)) //
+									.build()))), //
 			ControllerEssGridOptimizedChargeImpl.buildEnergyScheduleHandler(//
 					() -> Mode.MANUAL, //
 					() -> LocalTime.of(10, 00)), //
+			// TODO EssLimiter
 			TimeOfUseTariffControllerImpl.buildEnergyScheduleHandler(//
 					() -> ESS, //
 					() -> ControlMode.CHARGE_CONSUMPTION, //
-					() -> /* maxChargePowerFromGrid */ 20_000));
+					() -> /* maxChargePowerFromGrid */ 20_000) //
+	);
 
 	/** Insert the full log lines including GlobalSimulationsContext header. */
 	private static final String LOG = """

--- a/ui/src/app/edge/live/Controller/Evcs/Evcs.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/Evcs.ts
@@ -1,8 +1,12 @@
 import { NgModule } from "@angular/core";
 import { BrowserModule } from "@angular/platform-browser";
+import { TranslateService } from "@ngx-translate/core";
+import { ChartDataset } from "chart.js";
+import { TimeOfUseTariffUtils } from "src/app/shared/service/utils";
 import { SharedModule } from "src/app/shared/shared.module";
 import { FlatComponent } from "./flat/flat";
 import { ModalComponent } from "./modal/modal";
+import { ScheduleChartComponent } from "./modal/scheduleChart";
 import { PopoverComponent } from "./popover/popover";
 
 @NgModule({
@@ -14,6 +18,7 @@ import { PopoverComponent } from "./popover/popover";
     FlatComponent,
     ModalComponent,
     PopoverComponent,
+    ScheduleChartComponent,
   ],
   exports: [
     FlatComponent,
@@ -21,4 +26,106 @@ import { PopoverComponent } from "./popover/popover";
 })
 export class Controller_Evcs { }
 
+export namespace Controller_Evcs {
 
+  export type ScheduleChartData = {
+    datasets: ChartDataset[],
+    colors: any[],
+    labels: Date[]
+  };
+
+  export enum SmartMode {
+    ZERO = 0,
+    SURPLUS_PV = 1,
+    FORCE = 3,
+  }
+
+  /**
+   * Gets the schedule chart data containing datasets, colors and labels.
+   *
+   * @param size The length of the dataset
+   * @param prices The Time-of-Use-Tariff quarterly price array
+   * @param states The Time-of-Use-Tariff state array
+   * @param timestamps The Time-of-Use-Tariff timestamps array
+   * @param translate The Translate service
+   * @returns The ScheduleChartData.
+   */
+  export function getScheduleChartData(size: number, prices: number[], states: number[], timestamps: string[], translate: TranslateService): Controller_Evcs.ScheduleChartData {
+
+    const datasets: ChartDataset[] = [];
+    const colors: any[] = [];
+    const labels: Date[] = [];
+
+    // Initializing States.
+    const barZero = Array(size).fill(null);
+    const barSurplusPv = Array(size).fill(null);
+    const barForce = Array(size).fill(null);
+
+    for (let index = 0; index < size; index++) {
+      const quarterlyPrice = TimeOfUseTariffUtils.formatPrice(prices[index]);
+      const state = states[index];
+      labels.push(new Date(timestamps[index]));
+
+      if (state !== null) {
+        switch (state) {
+          case Controller_Evcs.SmartMode.ZERO:
+            barZero[index] = quarterlyPrice;
+            break;
+          case Controller_Evcs.SmartMode.SURPLUS_PV:
+            barSurplusPv[index] = quarterlyPrice;
+            break;
+          case Controller_Evcs.SmartMode.FORCE:
+            barForce[index] = quarterlyPrice;
+            break;
+        }
+      }
+    }
+
+    // Set datasets
+    datasets.push({
+      type: "bar",
+      label: "No Charge",
+      data: barZero,
+      order: 1,
+    });
+    colors.push({
+      // Dark Green
+      backgroundColor: "rgba(51,102,0,0.8)",
+      borderColor: "rgba(51,102,0,1)",
+    });
+
+    // Set dataset for ChargeGrid.
+    datasets.push({
+      type: "bar",
+      label: "Surplus PV",
+      data: barSurplusPv,
+      order: 1,
+    });
+    colors.push({
+      // Sky blue
+      backgroundColor: "rgba(0, 204, 204,0.5)",
+      borderColor: "rgba(0, 204, 204,0.7)",
+    });
+
+    // Set dataset for buy from grid
+    datasets.push({
+      type: "bar",
+      label: "Force Charge",
+      data: barForce,
+      order: 1,
+    });
+    colors.push({
+      // Black
+      backgroundColor: "rgba(0,0,0,0.8)",
+      borderColor: "rgba(0,0,0,0.9)",
+    });
+
+    const scheduleChartData: Controller_Evcs.ScheduleChartData = {
+      colors: colors,
+      datasets: datasets,
+      labels: labels,
+    };
+
+    return scheduleChartData;
+  }
+}

--- a/ui/src/app/edge/live/Controller/Evcs/jsonrpc/getScheduleRequest.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/jsonrpc/getScheduleRequest.ts
@@ -1,0 +1,24 @@
+import { JsonrpcRequest } from "src/app/shared/jsonrpc/base";
+
+/**
+ * Wraps a JSON-RPC Request for an OpenEMS Component that implements JsonApi
+ *
+ * <pre>
+ * {
+ *   "jsonrpc": "2.0",
+ *   "id": "UUID",
+ *   "method": "getSchedule",
+ *   "params": {}
+ * }
+ * </pre>
+ */
+export class GetScheduleRequest extends JsonrpcRequest {
+
+    private static METHOD: string = "getSchedule";
+
+    public constructor(
+    ) {
+        super(GetScheduleRequest.METHOD, {});
+    }
+
+}

--- a/ui/src/app/edge/live/Controller/Evcs/jsonrpc/getScheduleResponse.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/jsonrpc/getScheduleResponse.ts
@@ -1,0 +1,36 @@
+import { JsonrpcResponseSuccess } from "src/app/shared/jsonrpc/base";
+
+/**
+ * Wraps a JSON-RPC Response for a GetScheduleRequest.
+ *
+ * <pre>
+ * {
+ *   "jsonrpc": "2.0",
+ *   "id": UUID,
+ *   "result": {
+ *     "schedule": [{
+ *     	"timestamp": string,
+ *      "price": number,
+ *      "state": number,
+ *     }]
+ *   }
+ * }
+ * </pre>
+ */
+export class GetScheduleResponse extends JsonrpcResponseSuccess {
+
+
+    public constructor(
+        public override readonly id: string,
+        public override readonly result: {
+            schedule: {
+                timestamp: string;
+                price: number;
+                state: number;
+            }[]
+        },
+    ) {
+        super(id, result);
+    }
+
+}

--- a/ui/src/app/edge/live/Controller/Evcs/modal/modal.html
+++ b/ui/src/app/edge/live/Controller/Evcs/modal/modal.html
@@ -70,6 +70,15 @@
     <oe-modal-horizontal-line></oe-modal-horizontal-line>
     <ng-container *ngIf="controller">
 
+      <ng-container *ngIf="edge.roleIsAtLeast('admin') && controller['properties']['smartMode'] === true">
+        <oe-modal-info-line [info]="'Edge.Index.Widgets.SCHEDULE.CHART_TITLE_ADMIN'| translate"></oe-modal-info-line>
+
+        <scheduleChart class="ion-padding" [refresh]="refreshChart" [component]="component" [edge]="edge">
+        </scheduleChart>
+
+        <oe-modal-horizontal-line></oe-modal-horizontal-line>
+      </ng-container>
+
       <!--Force Charge settings-->
       <ng-container *ngIf="formGroup.value.chargeMode === 'FORCE_CHARGE'">
         <ng-container>

--- a/ui/src/app/edge/live/Controller/Evcs/modal/scheduleChart.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/modal/scheduleChart.ts
@@ -1,0 +1,164 @@
+// @ts-strict-ignore
+import { Component, Input, OnChanges, OnDestroy, OnInit } from "@angular/core";
+import { TranslateService } from "@ngx-translate/core";
+import * as Chart from "chart.js";
+import { filter, take } from "rxjs/operators";
+import { AbstractHistoryChart } from "src/app/edge/history/abstracthistorychart";
+import { calculateResolution } from "src/app/edge/history/shared";
+import { ChartConstants } from "src/app/shared/components/chart/chart.constants";
+import { ComponentJsonApiRequest } from "src/app/shared/jsonrpc/request/componentJsonApiRequest";
+import { ChartAxis, HistoryUtils, TimeOfUseTariffUtils, YAxisType } from "src/app/shared/service/utils";
+import { ChannelAddress, Currency, Edge, EdgeConfig, Service, Websocket } from "src/app/shared/shared";
+import { ColorUtils } from "src/app/shared/utils/color/color.utils";
+import { Controller_Evcs } from "../Evcs";
+import { GetScheduleRequest } from "../jsonrpc/getScheduleRequest";
+import { GetScheduleResponse } from "../jsonrpc/getScheduleResponse";
+
+@Component({
+    selector: "scheduleChart",
+    templateUrl: "../../../../history/abstracthistorychart.html",
+    standalone: false,
+})
+export class ScheduleChartComponent extends AbstractHistoryChart implements OnInit, OnChanges, OnDestroy {
+
+    @Input({ required: true }) public refresh!: boolean;
+    @Input({ required: true }) public override edge!: Edge;
+    @Input({ required: true }) public component!: EdgeConfig.Component;
+
+    protected evcsComponent: EdgeConfig.Component;
+    private currencyLabel: Currency.Label; // Default
+    private currencyUnit: Currency.Unit; // Default
+
+    constructor(
+        protected override service: Service,
+        protected override translate: TranslateService,
+        private websocket: Websocket,
+    ) {
+        super("schedule-chart", service, translate);
+    }
+
+    public getChartHeight(): number {
+        return TimeOfUseTariffUtils.getChartHeight(this.service.isSmartphoneResolution);
+    }
+
+    public async ngOnChanges() {
+        this.edge.getConfig(this.websocket).pipe(filter(config => !!config), take(1)).subscribe(config => {
+            this.evcsComponent = config?.getComponentsByFactory("Controller.Evcs")
+                .find(element => "evcs.id" in element.properties && element.properties["evcs.id"] == this.component.id);
+            const meta: EdgeConfig.Component = config?.getComponent("_meta");
+            const currency: string = config?.getPropertyFromComponent<string>(meta, "currency");
+            this.currencyLabel = Currency.getCurrencyLabelByCurrency(currency);
+            this.currencyUnit = Currency.getChartCurrencyUnitLabel(currency);
+        });
+        this.updateChart();
+    }
+
+    public ngOnInit() {
+        this.service.startSpinner(this.spinnerId);
+    }
+
+    public ngOnDestroy() {
+        this.unsubscribeChartRefresh();
+    }
+
+    protected override updateChart() {
+        this.autoSubscribeChartRefresh();
+        this.service.startSpinner(this.spinnerId);
+        this.loading = true;
+
+        this.edge.sendRequest(
+            this.websocket,
+            new ComponentJsonApiRequest({ componentId: this.evcsComponent.id, payload: new GetScheduleRequest() }),
+        ).then(response => {
+            const result = (response as GetScheduleResponse).result;
+            const schedule = result.schedule;
+
+            // Extracting prices, states, timestamps from the schedule array
+            const { priceArray, stateArray, timestampArray } = {
+                priceArray: schedule.map(entry => entry.price),
+                stateArray: schedule.map(entry => entry.state),
+                timestampArray: schedule.map(entry => entry.timestamp),
+            };
+
+            const scheduleChartData = Controller_Evcs.getScheduleChartData(schedule.length, priceArray,
+                stateArray, timestampArray, this.translate);
+
+            this.colors = scheduleChartData.colors;
+            this.labels = scheduleChartData.labels;
+
+            this.datasets = scheduleChartData.datasets;
+            this.loading = false;
+            this.setLabel();
+            this.stopSpinner();
+
+        }).catch((reason) => {
+            console.error(reason);
+            this.initializeChart();
+            return;
+
+        }).finally(async () => {
+            this.unit = YAxisType.CURRENCY;
+            await this.setOptions(this.options);
+            this.applyControllerSpecificOptions();
+        });
+    }
+
+    protected setLabel() {
+        this.options = this.createDefaultChartOptions();
+    }
+
+    protected getChannelAddresses(): Promise<ChannelAddress[]> {
+        return new Promise(() => { []; });
+    }
+
+    private applyControllerSpecificOptions() {
+
+        this.options.scales.x["time"].unit = calculateResolution(this.service, this.service.historyPeriod.value.from, this.service.historyPeriod.value.to).timeFormat;
+        this.options.scales.x["ticks"] = { source: "auto", autoSkip: false };
+        this.options.scales.x.ticks.maxTicksLimit = 30;
+        this.options.scales.x["offset"] = false;
+        this.options.scales.x.ticks.callback = function (value) {
+            const date = new Date(value);
+
+            // Display the label only if the minutes are zero (full hour)
+            return date.getMinutes() === 0 ? date.getHours() + ":00" : "";
+        };
+
+        // options.plugins.
+        this.options.plugins.tooltip.mode = "index";
+        this.options.plugins.tooltip.callbacks.labelColor = (item: Chart.TooltipItem<any>) => {
+            if (!item) {
+                return;
+            }
+            return {
+                borderColor: ColorUtils.changeOpacityFromRGBA(item.dataset.borderColor, 1),
+                backgroundColor: item.dataset.backgroundColor,
+            };
+        };
+
+        this.options.plugins.tooltip.callbacks.label = (item: Chart.TooltipItem<any>) => {
+
+            const label = item.dataset.label;
+            const value = item.dataset.data[item.dataIndex];
+
+            return TimeOfUseTariffUtils.getLabel(value, label, this.translate, this.currencyLabel);
+        };
+
+        this.datasets = this.datasets.map((el) => {
+            const opacity = el.type === "line" ? 0.2 : 0.5;
+
+            if (el.backgroundColor && el.borderColor) {
+                el.backgroundColor = ColorUtils.changeOpacityFromRGBA(el.backgroundColor.toString(), opacity);
+                el.borderColor = ColorUtils.changeOpacityFromRGBA(el.borderColor.toString(), 1);
+            }
+            return el;
+        });
+
+        const leftYAxis: HistoryUtils.yAxes = { position: "left", unit: this.unit, yAxisId: ChartAxis.LEFT, customTitle: this.currencyUnit, scale: { dynamicScale: true } };
+
+        this.options.scales[ChartAxis.LEFT] = {
+            ...this.options.scales[ChartAxis.LEFT],
+            ...ChartConstants.DEFAULT_Y_SCALE_OPTIONS(leftYAxis, this.translate, "bar", this.datasets.filter(el => el["yAxisID"] === ChartAxis.LEFT), true),
+        };
+    }
+}


### PR DESCRIPTION
- Add JsonUtils for LocalDateTime
- Add DEBUG context to `triggerReschedule()` (temporary)
- Add Bulider for EnergyScheduleHandlers
- EvcsController
  - Add temporary configs for SmartMode
  - Apply smart config in `run()`
  - Add simple JSONRPC request/response
- EnergyFlow: handle managedConsumption
- Add first implementation of JSCalendar

Open TODOs
- Fix EnergySession bugs with KEBA
- EshCodec: valid states should be read from ESH (e.g. JSCalendar payload)
- InitialPopulation: read good variations from ESHs (e.g. suggest force charge car during cheapest hour)
- on interrupt: keep best "regularOptimization" up till now as input for next InitialPopulation