### PR TITLE
Add active charge energy and active discharge energy to modbus table

### DIFF
--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/api/SymmetricEss.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/api/SymmetricEss.java
@@ -225,6 +225,8 @@ public interface SymmetricEss extends OpenemsComponent {
 				.channel(10, ChannelId.MIN_CELL_TEMPERATURE, ModbusType.FLOAT32) //
 				.channel(12, ChannelId.MAX_CELL_TEMPERATURE, ModbusType.FLOAT32) //
 				.channel(14, ChannelId.CAPACITY, ModbusType.FLOAT32) //
+				.channel(16, ChannelId.ACTIVE_CHARGE_ENERGY, ModbusType.FLOAT64) //
+				.channel(20, ChannelId.ACTIVE_DISCHARGE_ENERGY, ModbusType.FLOAT64) //
 				.build();
 	}
 


### PR DESCRIPTION
Add active charge energy and active discharge energy to modbus nature table of SymmetricEss

This will allow the Edge2EdgeEss to read those channels and export correct historical data.

Since this change is intended to work with a FEMS, I would love to see this PR accepted and imported into FEMS soon :-)