### PR TITLE
Aggregated coverage report without using codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         run: git diff --exit-code io.openems.edge.application/EdgeApp.bndrun
 
       - name: Generate JaCoCo Code-coverage-report
-        run: ./gradlew jacocoTestReport
+        run: ./gradlew jacocoTestReport jacocoAggregatedReport
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'base'
 	id 'java'
 	id 'com.github.node-gradle.node'
+	id 'org.barfuin.gradle.jacocolog' version '3.1.0'
 }
 
 repositories {


### PR DESCRIPTION
# What does this MR do?
It adds a new Gradle Plugin named JacocoLog. This plugin prints the instruction coverage to stdout.

# Why is this MR needed?
We have a GitLab Pipeline without using codecov Bot. GitLab is able to directly consume the code coverage from the stdout of the build job. As we think this feature is useful for others, we wanted to share this contribution. It also mitigates an eventual future merge conflict in out fork.