### PR TITLE
fix(backend): display user role as desired by message

### DIFF
--- a/io.openems.backend.common/src/io/openems/backend/common/metadata/User.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/metadata/User.java
@@ -64,7 +64,7 @@ public class User extends AbstractUser {
 		}
 		var thisRole = thisRoleOpt.get();
 		if (!thisRole.isAtLeast(role)) {
-			throw OpenemsError.COMMON_ROLE_ACCESS_DENIED.exception(resource, role.toString());
+			throw OpenemsError.COMMON_ROLE_ACCESS_DENIED.exception(resource, thisRole.toString());
 		}
 		return thisRole;
 	}


### PR DESCRIPTION
When access is denied due to missing role privileges, currently the desired role is added to the error message. However, the error message indicates that the current user role is printed.
