### PR TITLE
Supply allowed string values of @AttributeDefinition channels

### DIFF
--- a/io.openems.common/src/io/openems/common/jsonrpc/request/GetChannelsOfComponent.java
+++ b/io.openems.common/src/io/openems/common/jsonrpc/request/GetChannelsOfComponent.java
@@ -6,7 +6,9 @@ import static io.openems.common.utils.JsonUtils.toJsonObject;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 
+import java.lang.reflect.Type;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -14,7 +16,11 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
+import com.google.gson.reflect.TypeToken;
 
 import io.openems.common.channel.AccessMode;
 import io.openems.common.channel.ChannelCategory;
@@ -109,6 +115,10 @@ public class GetChannelsOfComponent implements EndpointRequestType<Request, Resp
 			// category = ChannelCategory.STATE
 			Level level, //
 
+			// category = ChannelCategory.OPENEMS_TYPE
+			// type = OpenemsType.STRING
+			List<String> stringOptions,
+
 			// category = ChannelCategory.ENUM
 			List<OptionsEnumEntry> options //
 	) {
@@ -135,6 +145,22 @@ public class GetChannelsOfComponent implements EndpointRequestType<Request, Resp
 		 */
 		public static JsonSerializer<GetChannelsOfComponent.ChannelRecord> serializer() {
 			return jsonObjectSerializer(GetChannelsOfComponent.ChannelRecord.class, json -> {
+				ChannelCategory jsonCategory = json.getEnum("category", ChannelCategory.class);
+				List<String> stringOptions = null;
+				List<OptionsEnumEntry> options = null;
+				if (jsonCategory == ChannelCategory.ENUM) {
+					options = json.getNullableJsonObjectPath("options").mapIfPresent(o -> o.collectStringKeys(
+							mapping(t -> new OptionsEnumEntry(t.getKey(), t.getValue().getAsInt()), toList())));
+				} else if (jsonCategory == ChannelCategory.OPENEMS_TYPE) {
+					JsonArray jsonArray = json.getJsonArrayOrNull("options");
+					if (jsonArray != null) {
+						Gson googleJson = new Gson();
+						Type listType = new TypeToken<List<String>>() {
+						}.getType();
+						stringOptions = googleJson.fromJson(jsonArray, listType);
+					}
+				}
+
 				return new GetChannelsOfComponent.ChannelRecord(//
 						json.getString("id"), //
 						json.getObject("accessMode", accessModeSerializer()), //
@@ -142,12 +168,26 @@ public class GetChannelsOfComponent implements EndpointRequestType<Request, Resp
 						json.getString("text"), //
 						json.getEnum("type", OpenemsType.class), //
 						json.getObject("unit", unitSerializer()), //
-						json.getEnum("category", ChannelCategory.class), //
+						jsonCategory, //
 						json.getEnumOrNull("level", Level.class), //
-						json.getNullableJsonObjectPath("options").mapIfPresent(o -> o.collectStringKeys(
-								mapping(t -> new OptionsEnumEntry(t.getKey(), t.getValue().getAsInt()), toList()))) //
+						stringOptions, //
+						options //
 				);
 			}, obj -> {
+				JsonElement optionsJson = null;
+				if (obj.options() != null) {
+					optionsJson = obj.options().stream() //
+							.collect(toJsonObject(OptionsEnumEntry::name, i -> new JsonPrimitive(i.value())));
+				} else if (obj.stringOptions() != null) {
+					JsonArray optionsArray = new JsonArray();
+					ListIterator<String> it = obj.stringOptions().listIterator();
+					while (it.hasNext()) {
+						optionsArray.add(it.next());
+					}
+					optionsJson = optionsArray;
+				}
+				final JsonElement optionsJsonFinal = optionsJson;
+
 				return JsonUtils.buildJsonObject() //
 						.addProperty("id", obj.id()) //
 						.add("accessMode", accessModeSerializer().serialize(obj.accessMode())) //
@@ -157,8 +197,7 @@ public class GetChannelsOfComponent implements EndpointRequestType<Request, Resp
 						.add("unit", unitSerializer().serialize(obj.unit())) //
 						.addProperty("category", obj.category()) //
 						.onlyIf(obj.level() != null, t -> t.addProperty("level", obj.level())) //
-						.onlyIf(obj.options() != null, t -> t.add("options", obj.options().stream() //
-								.collect(toJsonObject(OptionsEnumEntry::name, i -> new JsonPrimitive(i.value()))))) //
+						.onlyIf(optionsJsonFinal != null, t -> t.add("options", optionsJsonFinal)) //
 						.build();
 			});
 		}

--- a/io.openems.common/test/io/openems/common/jsonrpc/request/GetChannelsOfComponentTest.java
+++ b/io.openems.common/test/io/openems/common/jsonrpc/request/GetChannelsOfComponentTest.java
@@ -2,8 +2,19 @@ package io.openems.common.jsonrpc.request;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import io.openems.common.channel.AccessMode;
+import io.openems.common.channel.ChannelCategory;
+import io.openems.common.channel.PersistencePriority;
+import io.openems.common.channel.Unit;
+import io.openems.common.types.OpenemsType;
 import io.openems.common.utils.JsonUtils;
 
 public class GetChannelsOfComponentTest {
@@ -14,6 +25,60 @@ public class GetChannelsOfComponentTest {
 				.addProperty("componentId", "ess0") //
 				.build());
 		assertEquals(new GetChannelsOfComponent.Request("ess0", false), result);
+	}
+
+	@Test
+	public void testResponseSerializer() {
+		// Create a sample channel record with string options
+		List<GetChannelsOfComponent.ChannelRecord.OptionsEnumEntry> options = Arrays.asList(//
+				new GetChannelsOfComponent.ChannelRecord.OptionsEnumEntry("Ok", 0), //
+				new GetChannelsOfComponent.ChannelRecord.OptionsEnumEntry("Info", 1), //
+				new GetChannelsOfComponent.ChannelRecord.OptionsEnumEntry("Warning", 2), //
+				new GetChannelsOfComponent.ChannelRecord.OptionsEnumEntry("Fault", 3)//
+		);
+		var plainChannelRecord = new GetChannelsOfComponent.ChannelRecord(//
+				"State", //
+				AccessMode.READ_ONLY, //
+				PersistencePriority.VERY_HIGH, //
+				"0:Ok, 1:Info, 2:Warning, 3:Fault", //
+				OpenemsType.INTEGER, //
+				Unit.NONE, //
+				ChannelCategory.ENUM, //
+				null, // level
+				null, // stringOptions
+				options //
+		);
+		List<String> stringOptions = Arrays.asList("NONE", "DEBUG_LOG", "TRACE");
+		var attributedefinitionRecord = new GetChannelsOfComponent.ChannelRecord(//
+				"_PropertyLogVerbosity", //
+				AccessMode.READ_WRITE, //
+				PersistencePriority.HIGH, //
+				"", //
+				OpenemsType.STRING, //
+				Unit.NONE, //
+				ChannelCategory.OPENEMS_TYPE, //
+				null, // level
+				stringOptions, //
+				null // options
+		);
+
+		// Create a response with the channel record
+		var originalResponse = new GetChannelsOfComponent.Response(
+				Arrays.asList(plainChannelRecord, attributedefinitionRecord));
+
+		// Serialize to JSON string
+		var json = GetChannelsOfComponent.Response.serializer().serialize(originalResponse);
+		String jsonString = json.toString();
+
+		// Deserialize back from JSON string
+		JsonElement stringJson = JsonParser.parseString(jsonString);
+		var result = GetChannelsOfComponent.Response.serializer().deserialize(stringJson);
+
+		// Verify the deserialized response matches the original
+		assertEquals(originalResponse, result);
+		assertEquals(2, result.channels().size());
+		assertEquals("State", result.channels().get(0).id());
+		assertEquals(stringOptions, result.channels().get(1).stringOptions());
 	}
 
 }

--- a/io.openems.common/test/io/openems/common/jsonrpc/request/GetChannelsOfComponentTest.java
+++ b/io.openems.common/test/io/openems/common/jsonrpc/request/GetChannelsOfComponentTest.java
@@ -45,7 +45,7 @@ public class GetChannelsOfComponentTest {
 				Unit.NONE, //
 				ChannelCategory.ENUM, //
 				null, // level
-				null, //stringOptions
+				null, // stringOptions
 				options //
 		);
 		List<String> stringOptions = Arrays.asList("NONE", "DEBUG_LOG", "TRACE");
@@ -63,7 +63,8 @@ public class GetChannelsOfComponentTest {
 		);
 
 		// Create a response with the channel record
-		var originalResponse = new GetChannelsOfComponent.Response(Arrays.asList(plainChannelRecord, attributedefinitionRecord));
+		var originalResponse = new GetChannelsOfComponent.Response(
+				Arrays.asList(plainChannelRecord, attributedefinitionRecord));
 
 		// Serialize to JSON string
 		var json = GetChannelsOfComponent.Response.serializer().serialize(originalResponse);

--- a/io.openems.common/test/io/openems/common/jsonrpc/request/GetChannelsOfComponentTest.java
+++ b/io.openems.common/test/io/openems/common/jsonrpc/request/GetChannelsOfComponentTest.java
@@ -7,6 +7,9 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
 import io.openems.common.channel.AccessMode;
 import io.openems.common.channel.ChannelCategory;
 import io.openems.common.channel.PersistencePriority;
@@ -27,12 +30,30 @@ public class GetChannelsOfComponentTest {
 	@Test
 	public void testResponseSerializer() {
 		// Create a sample channel record with string options
-		List<String> stringOptions = Arrays.asList("VERY_LOW", "LOW", "MEDIUM", "HIGH", "VERY_HIGH");
-		var channelRecord = new GetChannelsOfComponent.ChannelRecord(//
-				"priority", //
+		List<GetChannelsOfComponent.ChannelRecord.OptionsEnumEntry> options = Arrays.asList(//
+				new GetChannelsOfComponent.ChannelRecord.OptionsEnumEntry("Ok", 0), //
+				new GetChannelsOfComponent.ChannelRecord.OptionsEnumEntry("Info", 1), //
+				new GetChannelsOfComponent.ChannelRecord.OptionsEnumEntry("Warning", 2), //
+				new GetChannelsOfComponent.ChannelRecord.OptionsEnumEntry("Fault", 3)//
+		);
+		var plainChannelRecord = new GetChannelsOfComponent.ChannelRecord(//
+				"State", //
+				AccessMode.READ_ONLY, //
+				PersistencePriority.VERY_HIGH, //
+				"0:Ok, 1:Info, 2:Warning, 3:Fault", //
+				OpenemsType.INTEGER, //
+				Unit.NONE, //
+				ChannelCategory.ENUM, //
+				null, // level
+				null, //stringOptions
+				options //
+		);
+		List<String> stringOptions = Arrays.asList("NONE", "DEBUG_LOG", "TRACE");
+		var attributedefinitionRecord = new GetChannelsOfComponent.ChannelRecord(//
+				"_PropertyLogVerbosity", //
 				AccessMode.READ_WRITE, //
 				PersistencePriority.HIGH, //
-				"Priority Level", //
+				"", //
 				OpenemsType.STRING, //
 				Unit.NONE, //
 				ChannelCategory.OPENEMS_TYPE, //
@@ -42,19 +63,21 @@ public class GetChannelsOfComponentTest {
 		);
 
 		// Create a response with the channel record
-		var originalResponse = new GetChannelsOfComponent.Response(Arrays.asList(channelRecord));
+		var originalResponse = new GetChannelsOfComponent.Response(Arrays.asList(plainChannelRecord, attributedefinitionRecord));
 
-		// Serialize to JSON
+		// Serialize to JSON string
 		var json = GetChannelsOfComponent.Response.serializer().serialize(originalResponse);
+		String jsonString = json.toString();
 
-		// Deserialize back from JSON
-		var result = GetChannelsOfComponent.Response.serializer().deserialize(json);
+		// Deserialize back from JSON string
+		JsonElement stringJson = JsonParser.parseString(jsonString);
+		var result = GetChannelsOfComponent.Response.serializer().deserialize(stringJson);
 
 		// Verify the deserialized response matches the original
 		assertEquals(originalResponse, result);
-		assertEquals(1, result.channels().size());
-		assertEquals("priority", result.channels().get(0).id());
-		assertEquals(stringOptions, result.channels().get(0).stringOptions());
+		assertEquals(2, result.channels().size());
+		assertEquals("State", result.channels().get(0).id());
+		assertEquals(stringOptions, result.channels().get(1).stringOptions());
 	}
 
 }

--- a/io.openems.common/test/io/openems/common/jsonrpc/request/GetChannelsOfComponentTest.java
+++ b/io.openems.common/test/io/openems/common/jsonrpc/request/GetChannelsOfComponentTest.java
@@ -2,8 +2,16 @@ package io.openems.common.jsonrpc.request;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
 
+import io.openems.common.channel.AccessMode;
+import io.openems.common.channel.ChannelCategory;
+import io.openems.common.channel.PersistencePriority;
+import io.openems.common.channel.Unit;
+import io.openems.common.types.OpenemsType;
 import io.openems.common.utils.JsonUtils;
 
 public class GetChannelsOfComponentTest {
@@ -14,6 +22,39 @@ public class GetChannelsOfComponentTest {
 				.addProperty("componentId", "ess0") //
 				.build());
 		assertEquals(new GetChannelsOfComponent.Request("ess0", false), result);
+	}
+
+	@Test
+	public void testResponseSerializer() {
+		// Create a sample channel record with string options
+		List<String> stringOptions = Arrays.asList("VERY_LOW", "LOW", "MEDIUM", "HIGH", "VERY_HIGH");
+		var channelRecord = new GetChannelsOfComponent.ChannelRecord(//
+				"priority", //
+				AccessMode.READ_WRITE, //
+				PersistencePriority.HIGH, //
+				"Priority Level", //
+				OpenemsType.STRING, //
+				Unit.NONE, //
+				ChannelCategory.OPENEMS_TYPE, //
+				null, // level
+				stringOptions, //
+				null // options
+		);
+
+		// Create a response with the channel record
+		var originalResponse = new GetChannelsOfComponent.Response(Arrays.asList(channelRecord));
+
+		// Serialize to JSON
+		var json = GetChannelsOfComponent.Response.serializer().serialize(originalResponse);
+
+		// Deserialize back from JSON
+		var result = GetChannelsOfComponent.Response.serializer().deserialize(json);
+
+		// Verify the deserialized response matches the original
+		assertEquals(originalResponse, result);
+		assertEquals(1, result.channels().size());
+		assertEquals("priority", result.channels().get(0).id());
+		assertEquals(stringOptions, result.channels().get(0).stringOptions());
 	}
 
 }

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/Doc.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/Doc.java
@@ -1,5 +1,7 @@
 package io.openems.edge.common.channel;
 
+import java.util.List;
+
 import io.openems.common.channel.AccessMode;
 import io.openems.common.channel.ChannelCategory;
 import io.openems.common.channel.Level;
@@ -163,6 +165,13 @@ public interface Doc {
 	 * @return myself
 	 */
 	public Doc translationKey(Class<?> clazz, String channelKey);
+
+	/**
+	 * Gets the allowed string values.
+	 *
+	 * @return the options
+	 */
+	public List<String> getStringOptions();
 
 	/**
 	 * Is the more verbose debug mode activated?.

--- a/io.openems.edge.common/src/io/openems/edge/common/channel/internal/AbstractDoc.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/channel/internal/AbstractDoc.java
@@ -31,6 +31,8 @@ public abstract class AbstractDoc<T> implements Doc {
 
 	protected Function<Language, String> getTextFunction;
 
+	private List<String> stringOptions;
+
 	protected AbstractDoc(OpenemsType type) {
 		this.type = type;
 	}
@@ -70,6 +72,26 @@ public abstract class AbstractDoc<T> implements Doc {
 	@Override
 	public AccessMode getAccessMode() {
 		return this.accessMode;
+	}
+
+	/**
+	 * Set the allowed string values.
+	 * 
+	 * @param stringOptions the list of allowed string options
+	 * @return myself
+	 */
+	public AbstractDoc<T> stringOptions(List<String> stringOptions) {
+		this.stringOptions = stringOptions;
+		return this.self();
+	}
+
+	/**
+	 * Get the allowed string values.
+	 *
+	 * @return the options
+	 */
+	public List<String> getStringOptions() {
+		return this.stringOptions;
 	}
 
 	/**

--- a/io.openems.edge.common/src/io/openems/edge/common/component/AbstractOpenemsComponent.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/AbstractOpenemsComponent.java
@@ -3,8 +3,11 @@ package io.openems.edge.common.component;
 import static io.openems.edge.common.channel.ChannelId.channelIdUpperToCamel;
 
 import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Dictionary;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -19,6 +22,8 @@ import org.slf4j.Logger;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CaseFormat;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 
 import io.openems.common.channel.PersistencePriority;
 import io.openems.common.channel.PropertyChannel;
@@ -335,6 +340,19 @@ public abstract class AbstractOpenemsComponent implements OpenemsComponent {
 		final var doc = Doc.of(channelType) //
 				.remotePersistencePriority(PersistencePriority.HIGH) //
 				.localPersistencePriority(PersistencePriority.LOW);
+
+		try {
+			JsonArray jsonOptions = property.toJson().getAsJsonObject("schema")
+					.getAsJsonObject("templateOptions").getAsJsonArray("options");
+			List<String> options = new ArrayList<String>();
+			Iterator<JsonElement> it = jsonOptions.iterator();
+			while (it.hasNext()) {
+				options.add(it.next().getAsJsonObject().get("value").getAsString());
+			}
+			doc.stringOptions(options);
+		} catch (Exception e) {
+			// errors can be ignored, as optional property
+		}
 
 		try {
 			final var method = configClass.getMethod(methodName, (Class<?>[]) null);

--- a/io.openems.edge.common/src/io/openems/edge/common/component/AbstractOpenemsComponent.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/component/AbstractOpenemsComponent.java
@@ -1,8 +1,11 @@
 package io.openems.edge.common.component;
 
 import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Dictionary;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -17,6 +20,8 @@ import org.slf4j.Logger;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CaseFormat;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 
 import io.openems.common.OpenemsConstants;
 import io.openems.common.channel.PersistencePriority;
@@ -349,6 +354,19 @@ public abstract class AbstractOpenemsComponent implements OpenemsComponent {
 		final var doc = Doc.of(channelType) //
 				.remotePersistencePriority(PersistencePriority.HIGH) //
 				.localPersistencePriority(PersistencePriority.LOW);
+
+		try {
+			JsonArray jsonOptions = property.toJson().getAsJsonObject("schema")
+					.getAsJsonObject("templateOptions").getAsJsonArray("options");
+			List<String> options = new ArrayList<String>();
+			Iterator<JsonElement> it = jsonOptions.iterator();
+			while (it.hasNext()) {
+				options.add(it.next().getAsJsonObject().get("value").getAsString());
+			}
+			doc.stringOptions(options);
+		} catch (Exception e) {
+			// errors can be ignored, as optional property
+		}
 
 		try {
 			final var method = configClass.getMethod(methodName, (Class<?>[]) null);

--- a/io.openems.edge.common/test/io/openems/edge/common/component/AbstractOpenemsComponentTest.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/component/AbstractOpenemsComponentTest.java
@@ -1,12 +1,38 @@
 package io.openems.edge.common.component;
 
 import static io.openems.edge.common.component.AbstractOpenemsComponent.propertyIdToMethodName;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonArray;
+
+import io.openems.common.channel.PropertyChannel;
+import io.openems.common.types.EdgeConfig;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
 public class AbstractOpenemsComponentTest {
+
+	/**
+	 * Test configuration interface with select property.
+	 */
+	@ObjectClassDefinition(name = "Test Component with Select Property", description = "A test component configuration with a select property")
+	@interface TestConfig {
+		@AttributeDefinition(name = "Priority", description = "Priority level")
+		@PropertyChannel
+		String priority();
+	}
 
 	@Test
 	public void testPropertyIdToMethodName() {
@@ -29,6 +55,74 @@ public class AbstractOpenemsComponentTest {
 	@Test
 	public void test() {
 		assertThrows(IllegalArgumentException.class, () -> new DummyComponent(null));
+	}
+
+	@Test
+	public void testAddChannelsForProperties() throws Exception {
+		// This test verifies that getOrCreateChannel correctly parses select schema
+		// (templateOptions.options) and adds channels with string options
+
+		// Create a property with select schema
+		JsonObject schemaJson = new JsonObject();
+		schemaJson.addProperty("type", "select");
+
+		JsonObject templateOptions = new JsonObject();
+		JsonArray options = new JsonArray();
+
+		// Add the select options
+		List<String> optionValues = Arrays.asList("VERY_LOW", "LOW", "MEDIUM", "HIGH", "VERY_HIGH");
+		List<String> optionLabels = Arrays.asList("Very Low", "Low", "Medium", "High", "Very High");
+
+		for (int i = 0; i < optionValues.size(); i++) {
+			JsonObject option = new JsonObject();
+			option.addProperty("value", optionValues.get(i));
+			option.addProperty("label", optionLabels.get(i));
+			options.add(option);
+		}
+
+		templateOptions.add("options", options);
+		schemaJson.add("templateOptions", templateOptions);
+
+		// Create a mock Property with select schema
+		EdgeConfig.Factory.Property property = mock(EdgeConfig.Factory.Property.class);
+		when(property.getId()).thenReturn("priority");
+		when(property.isPassword()).thenReturn(false);
+		when(property.getType()).thenReturn(io.openems.common.types.OpenemsType.STRING);
+		when(property.getDefaultValue()).thenReturn(null);
+		JsonObject propertyJson = new JsonObject();
+		propertyJson.add("schema", schemaJson);
+		when(property.toJson()).thenReturn(propertyJson);
+
+		// Create component
+		DummyComponent comp = new DummyComponent("selectTest");
+
+		// Get the getOrCreateChannel method and invoke it
+		Method method = AbstractOpenemsComponent.class.getDeclaredMethod("getOrCreateChannel",
+				EdgeConfig.Factory.Property.class, io.openems.common.types.OpenemsType.class, Class.class);
+		method.setAccessible(true);
+
+		// Invoke getOrCreateChannel with our test property
+		Object result = method.invoke(comp, property, io.openems.common.types.OpenemsType.STRING, TestConfig.class);
+
+		// Verify that the channel was created successfully
+		assertNotNull("Channel should be created", result);
+
+		// Verify that it's actually a Channel
+		assertTrue("Result should be a Channel instance", result instanceof io.openems.edge.common.channel.Channel);
+
+		io.openems.edge.common.channel.Channel<?> channel = (io.openems.edge.common.channel.Channel<?>) result;
+
+		// Verify the channel has the correct ID
+		assertNotNull("Channel ID should not be null", channel.channelId());
+
+		// Verify that the channel was added to the component
+		// Validate channel structure, especially stringOptions via reflection
+		io.openems.edge.common.channel.Doc doc = channel.channelId().doc();
+		assertNotNull("Channel Doc should not be null", doc);
+
+		// Verify the option values match what we defined in the schema
+		List<String> stringOptions = doc.getStringOptions();
+		assertTrue("String options should be equal to initial values", optionValues.equals(stringOptions));
 	}
 
 }

--- a/io.openems.edge.common/test/io/openems/edge/common/component/AbstractOpenemsComponentTest.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/component/AbstractOpenemsComponentTest.java
@@ -8,11 +8,8 @@ import static org.mockito.Mockito.*;
 import org.junit.jupiter.api.Test;
 import static org.junit.Assert.*;
 
-import org.osgi.service.metatype.ObjectClassDefinition;
-
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Dictionary;
 import java.util.List;
 
 import com.google.gson.JsonObject;
@@ -59,29 +56,6 @@ public class AbstractOpenemsComponentTest {
 
 	@Test
 	public void testAddChannelsForProperties() throws Exception {
-		// This test verifies that the addChannelsForProperties method exists and is accessible
-		// It's a simple check to ensure the method signature and basic functionality are present
-
-		// Verify that the private method exists
-		Method method = AbstractOpenemsComponent.class.getDeclaredMethod("addChannelsForProperties",
-				ObjectClassDefinition.class, Dictionary.class);
-		assertNotNull("addChannelsForProperties method should exist", method);
-
-		// Verify method is private
-		method.setAccessible(true);
-
-		// The method processes properties and skips password properties
-		// The actual invocation would require complex mocking of OSGi components
-		// For now, we verify that the method:
-		// 1. Exists (above check)
-		// 2. Is properly defined with correct parameters (above check)
-		// 3. Can be invoked via reflection (accessibility check)
-		assertEquals("Method should be declared in AbstractOpenemsComponent",
-				AbstractOpenemsComponent.class, method.getDeclaringClass());
-	}
-
-	@Test
-	public void testAddChannelsForPropertiesWithSelectSchema() throws Exception {
 		// This test verifies that getOrCreateChannel correctly parses select schema
 		// (templateOptions.options) and adds channels with string options
 

--- a/io.openems.edge.common/test/io/openems/edge/common/component/AbstractOpenemsComponentTest.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/component/AbstractOpenemsComponentTest.java
@@ -1,12 +1,14 @@
 package io.openems.edge.common.component;
 
 import static io.openems.edge.common.component.AbstractOpenemsComponent.propertyIdToMethodName;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -18,14 +20,15 @@ import com.google.gson.JsonArray;
 import io.openems.common.channel.PropertyChannel;
 import io.openems.common.types.EdgeConfig;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 public class AbstractOpenemsComponentTest {
 
 	/**
 	 * Test configuration interface with select property
 	 */
-	@org.osgi.service.metatype.annotations.ObjectClassDefinition(name = "Test Component with Select Property")
-	public interface TestConfig {
+	@ObjectClassDefinition(name = "Test Component with Select Property", description = "A test component configuration with a select property")
+	@interface TestConfig {
 		@AttributeDefinition(name = "Priority", description = "Priority level")
 		@PropertyChannel
 		String priority();

--- a/io.openems.edge.common/test/io/openems/edge/common/component/AbstractOpenemsComponentTest.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/component/AbstractOpenemsComponentTest.java
@@ -3,10 +3,36 @@ package io.openems.edge.common.component;
 import static io.openems.edge.common.component.AbstractOpenemsComponent.propertyIdToMethodName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.Test;
+import static org.junit.Assert.*;
+
+import org.osgi.service.metatype.ObjectClassDefinition;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.List;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonArray;
+
+import io.openems.common.channel.PropertyChannel;
+import io.openems.common.types.EdgeConfig;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
 
 public class AbstractOpenemsComponentTest {
+
+	/**
+	 * Test configuration interface with select property
+	 */
+	@org.osgi.service.metatype.annotations.ObjectClassDefinition(name = "Test Component with Select Property")
+	public interface TestConfig {
+		@AttributeDefinition(name = "Priority", description = "Priority level")
+		@PropertyChannel
+		String priority();
+	}
 
 	@Test
 	public void testPropertyIdToMethodName() {
@@ -29,6 +55,97 @@ public class AbstractOpenemsComponentTest {
 	@Test
 	public void test() {
 		assertThrows(IllegalArgumentException.class, () -> new DummyComponent(null));
+	}
+
+	@Test
+	public void testAddChannelsForProperties() throws Exception {
+		// This test verifies that the addChannelsForProperties method exists and is accessible
+		// It's a simple check to ensure the method signature and basic functionality are present
+
+		// Verify that the private method exists
+		Method method = AbstractOpenemsComponent.class.getDeclaredMethod("addChannelsForProperties",
+				ObjectClassDefinition.class, Dictionary.class);
+		assertNotNull("addChannelsForProperties method should exist", method);
+
+		// Verify method is private
+		method.setAccessible(true);
+
+		// The method processes properties and skips password properties
+		// The actual invocation would require complex mocking of OSGi components
+		// For now, we verify that the method:
+		// 1. Exists (above check)
+		// 2. Is properly defined with correct parameters (above check)
+		// 3. Can be invoked via reflection (accessibility check)
+		assertEquals("Method should be declared in AbstractOpenemsComponent",
+				AbstractOpenemsComponent.class, method.getDeclaringClass());
+	}
+
+	@Test
+	public void testAddChannelsForPropertiesWithSelectSchema() throws Exception {
+		// This test verifies that getOrCreateChannel correctly parses select schema
+		// (templateOptions.options) and adds channels with string options
+
+		// Create a property with select schema
+		JsonObject schemaJson = new JsonObject();
+		schemaJson.addProperty("type", "select");
+
+		JsonObject templateOptions = new JsonObject();
+		JsonArray options = new JsonArray();
+
+		// Add the select options
+		List<String> optionValues = Arrays.asList("VERY_LOW", "LOW", "MEDIUM", "HIGH", "VERY_HIGH");
+		List<String> optionLabels = Arrays.asList("Very Low", "Low", "Medium", "High", "Very High");
+
+		for (int i = 0; i < optionValues.size(); i++) {
+			JsonObject option = new JsonObject();
+			option.addProperty("value", optionValues.get(i));
+			option.addProperty("label", optionLabels.get(i));
+			options.add(option);
+		}
+
+		templateOptions.add("options", options);
+		schemaJson.add("templateOptions", templateOptions);
+
+		// Create a mock Property with select schema
+		EdgeConfig.Factory.Property property = mock(EdgeConfig.Factory.Property.class);
+		when(property.getId()).thenReturn("priority");
+		when(property.isPassword()).thenReturn(false);
+		when(property.getType()).thenReturn(io.openems.common.types.OpenemsType.STRING);
+		when(property.getDefaultValue()).thenReturn(null);
+		JsonObject propertyJson = new JsonObject();
+		propertyJson.add("schema", schemaJson);
+		when(property.toJson()).thenReturn(propertyJson);
+
+		// Create component
+		DummyComponent comp = new DummyComponent("selectTest");
+
+		// Get the getOrCreateChannel method and invoke it
+		Method method = AbstractOpenemsComponent.class.getDeclaredMethod("getOrCreateChannel",
+				EdgeConfig.Factory.Property.class, io.openems.common.types.OpenemsType.class, Class.class);
+		method.setAccessible(true);
+
+		// Invoke getOrCreateChannel with our test property
+		Object result = method.invoke(comp, property, io.openems.common.types.OpenemsType.STRING, TestConfig.class);
+
+		// Verify that the channel was created successfully
+		assertNotNull("Channel should be created", result);
+
+		// Verify that it's actually a Channel
+		assertTrue("Result should be a Channel instance", result instanceof io.openems.edge.common.channel.Channel);
+
+		io.openems.edge.common.channel.Channel<?> channel = (io.openems.edge.common.channel.Channel<?>) result;
+
+		// Verify the channel has the correct ID
+		assertNotNull("Channel ID should not be null", channel.channelId());
+
+		// Verify that the channel was added to the component
+		// Validate channel structure, especially stringOptions via reflection
+		io.openems.edge.common.channel.Doc doc = channel.channelId().doc();
+		assertNotNull("Channel Doc should not be null", doc);
+
+		// Verify the option values match what we defined in the schema
+		List<String> stringOptions = doc.getStringOptions();		
+		assertEquals("String options should be equal to initial values", optionValues, stringOptions);
 	}
 
 }

--- a/io.openems.edge.common/test/io/openems/edge/common/component/AbstractOpenemsComponentTest.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/component/AbstractOpenemsComponentTest.java
@@ -118,8 +118,8 @@ public class AbstractOpenemsComponentTest {
 		assertNotNull("Channel Doc should not be null", doc);
 
 		// Verify the option values match what we defined in the schema
-		List<String> stringOptions = doc.getStringOptions();		
-		assertEquals("String options should be equal to initial values", optionValues, stringOptions);
+		List<String> stringOptions = doc.getStringOptions();
+		assertTrue("String options should be equal to initial values", optionValues.equals(stringOptions));
 	}
 
 }

--- a/io.openems.edge.common/test/io/openems/edge/common/component/AbstractOpenemsComponentTest.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/component/AbstractOpenemsComponentTest.java
@@ -25,7 +25,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 public class AbstractOpenemsComponentTest {
 
 	/**
-	 * Test configuration interface with select property
+	 * Test configuration interface with select property.
 	 */
 	@ObjectClassDefinition(name = "Test Component with Select Property", description = "A test component configuration with a select property")
 	@interface TestConfig {

--- a/io.openems.edge.core/src/io/openems/edge/core/componentmanager/ComponentManagerImpl.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/componentmanager/ComponentManagerImpl.java
@@ -408,6 +408,7 @@ public class ComponentManagerImpl extends AbstractOpenemsComponent
 				channel.channelDoc().getUnit(), //
 				channel.channelDoc().getChannelCategory(), //
 				channel.channelDoc() instanceof StateChannelDoc c ? c.getLevel() : null, //
+				channel.channelDoc().getStringOptions(), //
 				channel.channelDoc() instanceof EnumDoc c ? Stream.of(c.getOptions()) //
 						.map(OptionsEnumEntry::from) //
 						.toList() : null);


### PR DESCRIPTION
Until now, AttributeDefinition channels (channels, whose names start with _Property) which are based on Enums do not provide the allowed values in their type defintions retrieved via edge call `getChannelsOfComponent()`.

For example the channel ctrlEvcs0/_PropertyChargeMode provides:
```
    {
        "id": "_PropertyChargeMode",
        "accessMode": "RO",
        "persistencePriority": "HIGH",
        "text": "",
        "type": "STRING",
        "unit": "",
        "category": "OPENEMS_TYPE"
    },
```

With this pull request, the allowed enum values (which were stored internally already previously) are published correctly:

```
    {
        "id": "_PropertyChargeMode",
        "accessMode": "RO",
        "persistencePriority": "HIGH",
        "text": "",
        "type": "STRING",
        "unit": "",
        "category": "OPENEMS_TYPE",
        "options": [
            "FORCE_CHARGE",
            "EXCESS_POWER"
        ]
    },
```
