### PR TITLE
levl: set LevlControlRequest method as expected rpc method

### DIFF
--- a/io.openems.edge.controller.levl/src/io/openems/edge/controller/levl/balancing/ControllerLevlEssBalancingImpl.java
+++ b/io.openems.edge.controller.levl/src/io/openems/edge/controller/levl/balancing/ControllerLevlEssBalancingImpl.java
@@ -212,7 +212,7 @@ public class ControllerLevlEssBalancingImpl extends AbstractOpenemsComponent
 
 	@Override
 	public void buildJsonApiRoutes(JsonApiBuilder builder) {
-		builder.handleRequest("sendLevlControlRequest", call -> {
+		builder.handleRequest(LevlControlRequest.METHOD, call -> {
 			return this.handleRequest(call);
 		});
 	}


### PR DESCRIPTION
# Minor Bug Fix Following Review Feedback
During the review of [PR #2873](https://github.com/OpenEMS/openems/pull/2873), the naming of the published JSON-RPC method was refactored. While this adjustment was correctly applied to the new LevlControlRequest class, the corresponding update in the request handler event listener was overlooked.

This commit ensures consistency by aligning the naming across all relevant components.