### PR TITLE
Implement Shelly Plus Add-On

### DIFF
--- a/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyplus1pmaddon/AddOnEnums.java
+++ b/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyplus1pmaddon/AddOnEnums.java
@@ -1,0 +1,32 @@
+package io.openems.edge.io.shelly.shellyplus1pmaddon;
+
+public class AddOnInputType {
+	
+	public enum InputType {
+		TEMPERATURE,
+		TEMPERATURE_AND_HUMIDITY,
+		VOLTAGE,
+		DIGITAL_INPUT,
+		ANALOG_INPUT,
+		NONE;
+	}
+
+
+	public enum InputIndex {
+		Index100 (100),
+		Index101 (101),
+		Index102 (102),
+		Index103 (103),
+		Index104 (104);
+
+		int index;
+		InputIndex(int index) {
+			this.index = index;
+		}
+		
+
+
+	}
+	
+}
+

--- a/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyplus1pmaddon/Config.java
+++ b/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyplus1pmaddon/Config.java
@@ -1,0 +1,35 @@
+package io.openems.edge.io.shelly.shellyplus1pmaddon;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+
+
+
+
+@ObjectClassDefinition(//
+		name = "IO Shelly Plus 1PM AddOn Input", //
+		description = "Implements the Shelly AddOn Channel")
+@interface Config {
+
+	@AttributeDefinition(name = "Component-ID", description = "Unique ID of this Component")
+	String id() default "ioShellyInput0";
+
+	@AttributeDefinition(name = "Alias", description = "Human-readable name of this Component; defaults to Component-ID")
+	String alias() default "";
+
+	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
+	boolean enabled() default true;
+
+	@AttributeDefinition(name = "IP-Address", description = "The IP address of the Shelly device.")
+	String ip();
+
+	@AttributeDefinition(name = "Channel-Type", description = "What type of sensor is attached to this channel?")
+	AddOnInputType.InputType type() default AddOnInputType.InputType.TEMPERATURE;
+
+	@AttributeDefinition(name = "Channel-Index", description = "Index of this channel?")
+	AddOnInputType.InputIndex index() default AddOnInputType.InputIndex.Index100;
+	
+
+	String webconsole_configurationFactory_nameHint() default "IO Shelly Plus 1PM AddOn Channel[{id}]";
+}

--- a/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyplus1pmaddon/IoShellyPlus1PmAddOn.java
+++ b/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyplus1pmaddon/IoShellyPlus1PmAddOn.java
@@ -1,0 +1,88 @@
+package io.openems.edge.io.shelly.shellyplus1pmaddon;
+
+import org.osgi.service.event.EventHandler;
+
+import io.openems.common.channel.Level;
+import io.openems.common.channel.Unit;
+import io.openems.common.types.OpenemsType;
+import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.StateChannel;
+import io.openems.edge.common.channel.value.Value;
+import io.openems.edge.common.component.OpenemsComponent;
+//import io.openems.edge.thermometer.api.Thermometer;
+
+public interface IoShellyPlus1PmAddOn
+		extends  OpenemsComponent, EventHandler {
+
+	public static enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+		
+		Add_On_Humidity(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.PERCENT) //
+				.text("Range: 0 ~ 100")),  //
+
+		Add_On_Temperature(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.DEZIDEGREE_CELSIUS) //
+				.text("Range: -550 ~ 1250")),  //
+
+		Add_On_Voltmeter(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.MILLIVOLT)),  //
+
+		Add_On_Digital_Input(Doc.of(OpenemsType.BOOLEAN) //
+				),  //
+
+		Add_On_Analog_Input(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.PERCENT)),  //
+
+		/**
+		 * Slave Communication Failed Fault.
+		 *
+		 * <ul>
+		 * <li>Interface: ShellyPlus1PM
+		 * <li>Type: State
+		 * </ul>
+		 */
+		SLAVE_COMMUNICATION_FAILED(Doc.of(Level.FAULT)); //
+
+		private final Doc doc;
+
+		private ChannelId(Doc doc) {
+			this.doc = doc;
+		}
+
+		@Override
+		public Doc doc() {
+			return this.doc;
+		}
+	}
+
+
+	/**
+	 * Gets the Channel for {@link ChannelId#SLAVE_COMMUNICATION_FAILED}.
+	 *
+	 * @return the Channel
+	 */
+	public default StateChannel getSlaveCommunicationFailedChannel() {
+		return this.channel(ChannelId.SLAVE_COMMUNICATION_FAILED);
+	}
+
+	/**
+	 * Gets the Slave Communication Failed State. See
+	 * {@link ChannelId#SLAVE_COMMUNICATION_FAILED}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Boolean> getSlaveCommunicationFailed() {
+		return this.getSlaveCommunicationFailedChannel().value();
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#SLAVE_COMMUNICATION_FAILED} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setSlaveCommunicationFailed(boolean value) {
+		this.getSlaveCommunicationFailedChannel().setNextValue(value);
+	}
+
+}

--- a/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyplus1pmaddon/IoShellyPlus1PmAddOnImpl.java
+++ b/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyplus1pmaddon/IoShellyPlus1PmAddOnImpl.java
@@ -1,0 +1,248 @@
+package io.openems.edge.io.shelly.shellyplus1pmaddon;
+
+
+import static io.openems.common.utils.JsonUtils.getAsOptionalFloat;
+import static io.openems.common.utils.JsonUtils.getAsOptionalBoolean;
+import static io.openems.common.utils.JsonUtils.getAsJsonObject;
+import static java.lang.Math.round;
+
+import com.google.gson.JsonObject;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.event.propertytypes.EventTopics;
+import org.osgi.service.metatype.annotations.Designate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonElement;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.edge.bridge.http.api.BridgeHttp;
+import io.openems.edge.bridge.http.api.BridgeHttpFactory;
+import io.openems.edge.bridge.http.api.HttpResponse;
+import io.openems.edge.common.channel.BooleanReadChannel;
+import io.openems.edge.common.channel.IntegerReadChannel;
+import io.openems.edge.common.component.AbstractOpenemsComponent;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.event.EdgeEventConstants;
+import io.openems.edge.timedata.api.Timedata;
+import io.openems.edge.timedata.api.TimedataProvider;
+//import io.openems.edge.io.shelly.shellyplus1pmaddon.AddOnInputType;
+
+@Designate(ocd = Config.class, factory = true)
+@Component(//
+		name = "IO.Shelly.Plus1PMAddOnChannel", //
+		immediate = true, //
+		configurationPolicy = ConfigurationPolicy.REQUIRE//
+)
+@EventTopics({ //
+		EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE, //
+		EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE //
+})
+public class IoShellyPlus1PmAddOnImpl extends AbstractOpenemsComponent implements IoShellyPlus1PmAddOn,
+		OpenemsComponent, TimedataProvider, EventHandler {
+
+
+	private final Logger log = LoggerFactory.getLogger(IoShellyPlus1PmAddOnImpl.class);
+	
+	private String baseUrl;
+	private AddOnInputType.InputType inputType;
+	private AddOnInputType.InputIndex inputIndex;
+
+	@Reference(policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.OPTIONAL)
+	private volatile Timedata timedata;
+
+	@Reference(cardinality = ReferenceCardinality.MANDATORY)
+	private BridgeHttpFactory httpBridgeFactory;
+	private BridgeHttp httpBridge;
+
+	public IoShellyPlus1PmAddOnImpl() {
+		super(//
+				OpenemsComponent.ChannelId.values(), //
+				IoShellyPlus1PmAddOn.ChannelId.values()
+		);
+	}
+
+	@Activate
+	protected void activate(ComponentContext context, Config config) {
+		super.activate(context, config.id(), config.alias(), config.enabled());
+		this.baseUrl = "http://" + config.ip();
+		this.httpBridge = this.httpBridgeFactory.get();
+		this.inputType = config.type();
+		this.inputIndex = config.index();
+		if (!this.isEnabled()) {
+			return;
+		}
+
+		this.httpBridge.subscribeJsonCycle(2, this.baseUrl + "/rpc/Shelly.GetStatus", this::processHttpResult);
+//		this.httpBridge.subscribeJsonEveryCycle(this.baseUrl + "/rpc/Shelly.GetStatus", this::processHttpResult);
+		
+		
+	}
+
+	@Override
+	@Deactivate
+	protected void deactivate() {
+		if (this.httpBridge != null) {
+			this.httpBridgeFactory.unget(this.httpBridge);
+			this.httpBridge = null;
+		}
+		super.deactivate();
+	}
+
+
+	@Override
+	public String debugLog() {
+		var b = new StringBuilder();
+
+		switch (this.inputType) {
+		case ANALOG_INPUT:
+			b.append(this.channel(IoShellyPlus1PmAddOn.ChannelId.Add_On_Analog_Input).value().asString());
+			break;
+		case DIGITAL_INPUT:
+			b.append(this.channel(IoShellyPlus1PmAddOn.ChannelId.Add_On_Digital_Input).value().asString());
+			break;
+		case TEMPERATURE:
+			b.append(this.channel(IoShellyPlus1PmAddOn.ChannelId.Add_On_Temperature).value().asString());
+			break;
+		case TEMPERATURE_AND_HUMIDITY:
+			b.append(this.channel(IoShellyPlus1PmAddOn.ChannelId.Add_On_Temperature).value().asString());
+			b.append("|").append(this.channel(IoShellyPlus1PmAddOn.ChannelId.Add_On_Humidity).value().asString());
+			break;
+		case VOLTAGE:
+			b.append(this.channel(IoShellyPlus1PmAddOn.ChannelId.Add_On_Voltmeter).value().asString());
+			break;
+		default:
+			break;
+		}
+		return b.toString();
+
+//		return generateDebugLog(this.digitalOutputChannels, this.getActivePowerChannel(), this.inputChannels());
+//		return generateDebugLog(this.digitalOutputChannels, this.getActivePowerChannel());
+	}
+
+	@Override
+	public void handleEvent(Event event) {
+		if (!this.isEnabled()) {
+			return;
+		}
+	}
+
+	private void processHttpResult(HttpResponse<JsonElement> result, Throwable error) {
+		this._setSlaveCommunicationFailed(result == null);
+
+		//boolean restartRequired = false;
+		
+
+		if (error != null) {
+			this.logDebug(this.log, error.getMessage());
+
+		} else {
+			try {
+				var jsonResponse = getAsJsonObject(result.data());
+
+				getInput(jsonResponse, this.inputType, this.inputIndex);
+				
+				//var sys = getAsJsonObject(jsonResponse, "sys");
+				//restartRequired = getAsBoolean(sys, "restart_required");
+
+			} catch (OpenemsNamedException e) {
+				this.logDebug(this.log, e.getMessage());
+			}
+		}
+
+		//this.channel(IoShellyPlus1PmAddOn.ChannelId.NEEDS_RESTART).setNextValue(restartRequired);
+	}
+
+
+	/**
+	 * Extract values from JSON 
+	 */
+
+	private void getInput(JsonObject json, AddOnInputType.InputType inputType, AddOnInputType.InputIndex inputIndex) {
+	
+		
+			switch (inputType) {
+			case ANALOG_INPUT:
+				getInputValue(json, "input:"+ inputIndex.index, (IntegerReadChannel) this.channel(IoShellyPlus1PmAddOn.ChannelId.Add_On_Analog_Input));
+				break;
+			case DIGITAL_INPUT:
+				getInputValue(json, "input:"+ inputIndex.index,  (BooleanReadChannel) this.channel(IoShellyPlus1PmAddOn.ChannelId.Add_On_Digital_Input));
+				break;
+			case TEMPERATURE:
+				getInputValue(json, "temperature:"+ inputIndex.index,  (IntegerReadChannel) this.channel(IoShellyPlus1PmAddOn.ChannelId.Add_On_Temperature));
+				break;
+			case TEMPERATURE_AND_HUMIDITY:
+				getInputValue(json, "temperature:"+ inputIndex.index,  (IntegerReadChannel) this.channel(IoShellyPlus1PmAddOn.ChannelId.Add_On_Temperature));
+				getInputValue(json, "humidity:"+ inputIndex.index,  (IntegerReadChannel) this.channel(IoShellyPlus1PmAddOn.ChannelId.Add_On_Humidity));
+				break;
+			case VOLTAGE:
+				getInputValue(json, "voltmeter:"+ inputIndex.index,  (IntegerReadChannel) this.channel(IoShellyPlus1PmAddOn.ChannelId.Add_On_Voltmeter));
+				break;
+			default:
+				break;
+		}
+	}
+	
+ 	private void getInputValue(JsonObject json, String inputName, IntegerReadChannel ch) {
+		try {
+			if (json.has(inputName)) {
+				final var input = getAsJsonObject(json, inputName);
+				
+				if (input.has("tC")) {//Temperature
+					getAsOptionalFloat(input, "tC").ifPresent(v -> ch.setNextValue(round(v * 10)));
+				} else if (input.has("rh")) {//Humidity
+					getAsOptionalFloat(input, "rh").ifPresent(v -> ch.setNextValue(round(v)));
+				} else if (input.has("voltage")) {
+					getAsOptionalFloat(input, "voltage").ifPresent(v -> ch.setNextValue(round(v * 1000)));
+				} else if (input.has("percent")) {
+					getAsOptionalFloat(input, "percent").ifPresent(v -> ch.setNextValue(round(v)));
+				} else {
+					ch.setNextValue(null);
+				}
+			} else {
+				ch.setNextValue(null);
+			}
+			
+		} catch (OpenemsNamedException e) {
+			this.logDebug(this.log, e.getMessage());
+		}
+	}
+ 	
+ 	private void getInputValue(JsonObject json, String inputName, BooleanReadChannel ch) {
+		try {
+			if (json.has(inputName)) {
+				final var input = getAsJsonObject(json, inputName);
+				
+				if (input.has("state"))  {
+					getAsOptionalBoolean(input, "state").ifPresent(v -> ch.setNextValue(v));
+				} else {
+					ch.setNextValue(null);
+				}
+			} else {
+				ch.setNextValue(null);
+			}
+			
+		} catch (OpenemsNamedException e) {
+			this.logDebug(this.log, e.getMessage());
+		}
+	}
+
+
+
+	@Override
+	public Timedata getTimedata() {
+		return this.timedata;
+	}
+
+}

--- a/io.openems.edge.io.shelly/test/io/openems/edge/io/shelly/shellyplus1pm/MyConfig.java
+++ b/io.openems.edge.io.shelly/test/io/openems/edge/io/shelly/shellyplus1pm/MyConfig.java
@@ -71,4 +71,5 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	public SinglePhase phase() {
 		return this.builder.phase;
 	}
+
 }


### PR DESCRIPTION
Implementation of requesting the input values from a Shelly Plus Add-On.
There are different input types:

- Temperature
- Humidity (always in combination with temperature)
- Voltage
- Analog
- Digital

Each input is configured as a separate component. The type and index (100 - 104) have to correspond with the ones for this input in the Shelly configuration page.
For avoiding errors, the type and the index can only be selected by drop down menus.

The request is the same as of the io.openems.edge.io.shelly.shellyplus1pm component: http://ip-address/rpc/Shelly.GetStatus
In the resulting JSON the corresponding objects are evaluated:

`,
"input:100": {
  "id": 100,
  "state": false
},
"temperature:100": {
  "id": 100,
  "tC": 48.2,
  "tF": 118.9
},
  "input:100": {
    "id": 100,
    "percent": 47.1
},
"voltmeter:100": {
  "id": 100,
  "voltage": 4.71
},
`
For temperature only the Celsius value ("tC") is  read.
The channels are of type Integer, except for the input type "Digital", which is of type Boolean.

The values are stores as mV (voltage), dC (temperature), percent (humidity and analog) and true/false (digital).

The corresponding console output looks like this:
`ioShellyInput101[516 dC] ioShellyInput3100[271 dC] ioShellyInput3101[411 dC] ioShellyInput3102[321 dC] ioShellyInput3103[445 dC] ioShellyInput3104[401 dC] ioShellyInput4100[487 dC] ioShellyInputDigital100[false] ioShellyInputVolt100[4710 mV]
`


