### PR TITLE
Implementation: Variant of ShellyPlus1PM for more than one Shelly model

### DIFF
--- a/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/common/Utils.java
+++ b/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/common/Utils.java
@@ -15,7 +15,48 @@ import io.openems.edge.common.component.OpenemsComponent;
 
 public class Utils {
 
+	public enum ShellyModel {
+		/**
+		 * Defines a Shelly Plus 1 PM with relay
+		 * power can be read from the object "switch:0"
+		 */
+
+		Plus1PM("switch:0",true),
+		/**
+		 * Defines a Shelly Plus PM Mini. Power can be read from the channel pm1:0 
+		 */
+		PlusPMMini("pm1:0",false);
+		
+		String channel;
+		Boolean hasRelay;
+		ShellyModel (String channel, Boolean hasRelay) {
+			this.channel = channel;
+			this.hasRelay = hasRelay;
+		}
+		
+		public Boolean hasRelay() {
+			return this.hasRelay;
+		}
+		
+		public String channel() {
+			return this.channel;
+		}
+		
+	}
+	
+	
 	private Utils() {
+	}
+
+	/**
+	 * Generates a standard Debug-Log string for Shellys with power
+	 * meter.
+	 * 
+	 * @param activePowerChannel the ActivePower-Channel
+	 * @return suitable for {@link OpenemsComponent#debugLog()}
+	 */
+	public static String generateDebugLog(Channel<Integer> activePowerChannel) {
+		return activePowerChannel.value().asString();
 	}
 
 	/**

--- a/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyplus1pm/Config.java
+++ b/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyplus1pm/Config.java
@@ -6,6 +6,8 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import io.openems.common.types.MeterType;
 import io.openems.edge.meter.api.SinglePhase;
 
+import io.openems.edge.io.shelly.common.Utils;
+
 @ObjectClassDefinition(//
 		name = "IO Shelly Plus 1PM", //
 		description = "Implements the Shelly 2ndGen / Plug WiFi Switch.")
@@ -26,6 +28,10 @@ import io.openems.edge.meter.api.SinglePhase;
 	@AttributeDefinition(name = "IP-Address", description = "The IP address of the Shelly device.")
 	String ip();
 
+	@AttributeDefinition(name = "Shelly-Type", description = "Which type of shelly?")
+	Utils.ShellyModel shellyModel() default Utils.ShellyModel.Plus1PM;
+
+	
 	@AttributeDefinition(name = "Meter-Type", description = "What is measured by this Meter?")
 	MeterType type() default MeterType.CONSUMPTION_METERED;
 

--- a/io.openems.edge.io.shelly/test/io/openems/edge/io/shelly/shellyplus1pm/MyConfig.java
+++ b/io.openems.edge.io.shelly/test/io/openems/edge/io/shelly/shellyplus1pm/MyConfig.java
@@ -2,6 +2,7 @@ package io.openems.edge.io.shelly.shellyplus1pm;
 
 import io.openems.common.test.AbstractComponentConfig;
 import io.openems.common.types.MeterType;
+import io.openems.edge.io.shelly.common.Utils.ShellyModel;
 import io.openems.edge.meter.api.SinglePhase;
 
 @SuppressWarnings("all")
@@ -12,6 +13,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 		private String ip;
 		private MeterType type;
 		private SinglePhase phase;
+		private ShellyModel shellyModel;
 
 		private Builder() {
 		}
@@ -33,6 +35,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 		public Builder setType(MeterType type) {
 			this.type = type;
+			return this;
+		}
+
+		public Builder setShellyModel(ShellyModel shellyModel) {
+			this.shellyModel = shellyModel;
 			return this;
 		}
 
@@ -70,5 +77,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	@Override
 	public SinglePhase phase() {
 		return this.builder.phase;
+	}
+
+	@Override
+	public ShellyModel shellyModel() {
+		// TODO Auto-generated method stub
+		return this.builder.shellyModel;
 	}
 }


### PR DESCRIPTION
This variant of the ShellyPlus1PM component is capable of covering more than one Shelly model.
The Shelly models can be defined in the enum io.openems.edge.io.shelly.common.Utils.ShellyModel with name, power channel and a flag indicating if it has a relay.
Tested with the Shelly Plus PM Mini and Shelly Plus 1 PM..