### PR TITLE
Improve querylimit handling to avoid unintended increment due to type conflicts

### DIFF
--- a/io.openems.backend.timedata.aggregatedinflux/src/io/openems/backend/timedata/aggregatedinflux/AggregatedInflux.java
+++ b/io.openems.backend.timedata.aggregatedinflux/src/io/openems/backend/timedata/aggregatedinflux/AggregatedInflux.java
@@ -125,6 +125,7 @@ public class AggregatedInflux extends AbstractOpenemsBackendComponent implements
 				(throwable) -> {
 					this.logError(this.log, "Unable to write to InfluxDB. " + throwable.getClass().getSimpleName()
 							+ ": " + throwable.getMessage());
+					return false;
 				}, true /* enable safe write */, this.writeParametersAvgPoints, this.writeParametersMaxPoints);
 
 		// load available since for edges which already wrote in the new database

--- a/io.openems.backend.timedata.influx/src/io/openems/backend/timedata/influx/FieldTypeConflictHandler.java
+++ b/io.openems.backend.timedata.influx/src/io/openems/backend/timedata/influx/FieldTypeConflictHandler.java
@@ -37,9 +37,10 @@ public class FieldTypeConflictHandler {
 	 * fields that already exist in the database.
 	 *
 	 * @param e the {@link FieldTypeConflictException}
+	 * @return true means handled successfully (data written to influxdb)
 	 */
-	public synchronized void handleException(InfluxException e) throws IllegalStateException, IllegalArgumentException {
-		this.handleExceptionMessage(e.getMessage());
+	public synchronized boolean handleException(InfluxException e) throws IllegalStateException, IllegalArgumentException {
+		return this.handleExceptionMessage(e.getMessage());
 	}
 
 	protected synchronized boolean handleExceptionMessage(String message)

--- a/io.openems.backend.timedata.influx/src/io/openems/backend/timedata/influx/TimedataInfluxDb.java
+++ b/io.openems.backend.timedata.influx/src/io/openems/backend/timedata/influx/TimedataInfluxDb.java
@@ -97,7 +97,7 @@ public class TimedataInfluxDb extends AbstractOpenemsBackendComponent implements
 				config.org(), config.apiKey(), config.bucket(), this.oem.getInfluxdbTag(), config.isReadOnly(),
 				config.poolSize(), config.maxQueueSize(), //
 				(e) -> {
-					this.fieldTypeConflictHandler.handleException(e);
+					return this.fieldTypeConflictHandler.handleException(e);
 				});
 	}
 

--- a/io.openems.edge.timedata.influxdb/src/io/openems/edge/timedata/influxdb/TimedataInfluxDbImpl.java
+++ b/io.openems.edge.timedata.influxdb/src/io/openems/edge/timedata/influxdb/TimedataInfluxDbImpl.java
@@ -95,6 +95,7 @@ public class TimedataInfluxDbImpl extends AbstractOpenemsComponent
 				config.maxQueueSize(), //
 				(e) -> {
 					// ignore
+					return false;
 				});
 	}
 

--- a/io.openems.shared.influxdb/src/io/openems/shared/influxdb/ForceMergePointsWorker.java
+++ b/io.openems.shared.influxdb/src/io/openems/shared/influxdb/ForceMergePointsWorker.java
@@ -1,7 +1,7 @@
 package io.openems.shared.influxdb;
 
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import com.influxdb.client.write.Point;
 import com.influxdb.client.write.WriteParameters;
@@ -10,7 +10,7 @@ import com.influxdb.exceptions.BadRequestException;
 public class ForceMergePointsWorker extends AbstractMergePointsWorker<Point> implements MergePointsWorker {
 
 	public ForceMergePointsWorker(InfluxConnector parent, String name, WriteParameters writeParameters,
-			Consumer<BadRequestException> onWriteError) {
+			Predicate<BadRequestException> onWriteError) {
 		super(parent, name, writeParameters, onWriteError);
 	}
 

--- a/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnector.java
+++ b/io.openems.shared.influxdb/src/io/openems/shared/influxdb/InfluxConnector.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
-import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -87,7 +87,7 @@ public class InfluxConnector {
 	 */
 	public InfluxConnector(String componentId, QueryLanguageConfig queryLanguage, URI url, String org, String apiKey,
 			String bucket, String tag, boolean isReadOnly, int poolSize, int maxQueueSize,
-			Consumer<BadRequestException> onWriteError, boolean safeWrite, WriteParameters... parameters) {
+			Predicate<BadRequestException> onWriteError, boolean safeWrite, WriteParameters... parameters) {
 		this.queryProxy = QueryProxy.from(queryLanguage, tag);
 		this.url = url;
 		this.org = org;
@@ -136,7 +136,7 @@ public class InfluxConnector {
 
 	public InfluxConnector(String componentId, QueryLanguageConfig queryLanguage, URI url, String org, String apiKey,
 			String bucket, String tag, boolean isReadOnly, int poolSize, int maxQueueSize,
-			Consumer<BadRequestException> onWriteError, WriteParameters... parameters) {
+			Predicate<BadRequestException> onWriteError, WriteParameters... parameters) {
 		this(componentId, queryLanguage, url, org, apiKey, bucket, tag, isReadOnly, poolSize, maxQueueSize,
 				onWriteError, false, parameters);
 	}


### PR DESCRIPTION
Previously, the backend incremented querylimit even for type conflicts in InfluxDB queries. Since querylimit should only reflect actual overload cases, this change modifies the handling logic to prevent increments caused solely by type conflicts.

I have tested this PR, and it appears to be working as expected. However, since this affects a core part of the backend functionality, I'm opening it initially as a Draft PR for further review and discussion.