### PR TITLE
RestApi: fix handling regex queries

### DIFF
--- a/io.openems.edge.bridge.http/src/io/openems/edge/bridge/http/api/UrlBuilder.java
+++ b/io.openems.edge.bridge.http/src/io/openems/edge/bridge/http/api/UrlBuilder.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -217,7 +218,9 @@ public final class UrlBuilder {
 			if (!this.path.startsWith("/")) {
 				url.append("/");
 			}
-			url.append(this.path);
+			url.append(Arrays.stream(this.path.split("/")) //
+					.map(UrlBuilder::encode) //
+					.collect(joining("/")));
 		}
 
 		if (!this.queryParams.isEmpty()) {

--- a/io.openems.edge.controller.api.rest/bnd.bnd
+++ b/io.openems.edge.controller.api.rest/bnd.bnd
@@ -6,6 +6,7 @@ Bundle-Version: 1.0.0.${tstamp}
 -buildpath: \
 	${buildpath},\
 	io.openems.common,\
+	io.openems.edge.bridge.http,\
 	io.openems.edge.common,\
 	io.openems.edge.controller.api,\
 	io.openems.edge.controller.api.common,\

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/RestHandler.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/RestHandler.java
@@ -60,7 +60,7 @@ public class RestHandler extends Handler.Abstract {
 	public boolean handle(Request request, Response response, Callback callback) throws Exception {
 		try {
 			// Use the new API to extract the target path.
-			var target = request.getHttpURI().getPath();
+			var target = request.getHttpURI().getDecodedPath();
 			if (target == null || target.isEmpty() || "/".equals(target)) {
 				throw new OpenemsException("Missing arguments to handle request");
 			}

--- a/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readonly/ControllerApiRestReadOnlyImplTest.java
+++ b/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readonly/ControllerApiRestReadOnlyImplTest.java
@@ -1,11 +1,31 @@
 package io.openems.edge.controller.api.rest.readonly;
 
 import static io.openems.common.test.TestUtils.findRandomOpenPortOnAllLocalInterfaces;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.util.Base64;
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-import io.openems.common.exceptions.OpenemsException;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+import io.openems.common.jsonrpc.serialization.JsonSerializer;
+import io.openems.common.jsonrpc.serialization.JsonSerializerUtil;
+import io.openems.common.types.HttpStatus;
+import io.openems.common.utils.JsonUtils;
+import io.openems.edge.bridge.http.api.BridgeHttp;
+import io.openems.edge.bridge.http.api.HttpMethod;
+import io.openems.edge.bridge.http.api.UrlBuilder;
+import io.openems.edge.bridge.http.dummy.DummyBridgeHttpFactory;
+import io.openems.edge.common.sum.DummySum;
+import io.openems.edge.common.sum.Sum;
 import io.openems.edge.common.test.DummyComponentManager;
+import io.openems.edge.common.test.DummyUser;
 import io.openems.edge.common.test.DummyUserService;
 import io.openems.edge.controller.api.rest.DummyJsonRpcRestHandlerFactory;
 import io.openems.edge.controller.api.rest.JsonRpcRestHandler;
@@ -13,21 +33,160 @@ import io.openems.edge.controller.test.ControllerTest;
 
 public class ControllerApiRestReadOnlyImplTest {
 
-	@Test
-	public void test() throws OpenemsException, Exception {
-		final var port = findRandomOpenPortOnAllLocalInterfaces();
+	private static final Map<String, String> ADMIN_AUTHENTICATION = Map.of("Authorization",
+			"Basic " + Base64.getEncoder().encodeToString("admin:admin".getBytes()));
 
-		new ControllerTest(new ControllerApiRestReadOnlyImpl()) //
+	private static Sum sum;
+	private static ControllerTest test;
+	private static int port;
+	private static BridgeHttp bridgeHttp;
+
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		sum = new DummySum() //
+				.withEssSoc(69) //
+				.withGridActivePower(300);
+
+		port = findRandomOpenPortOnAllLocalInterfaces();
+
+		test = new ControllerTest(new ControllerApiRestReadOnlyImpl()) //
 				.addReference("componentManager", new DummyComponentManager()) //
-				.addReference("userService", new DummyUserService()) //
+				.addReference("userService", new DummyUserService(DummyUser.DUMMY_ADMIN)) //
 				.addReference("restHandlerFactory", new DummyJsonRpcRestHandlerFactory(JsonRpcRestHandler::new)) //
+				.addComponent(new DummySum() //
+						.withEssSoc(69) //
+						.withGridActivePower(300)) //
 				.activate(MyConfig.create() //
 						.setId("ctrlApiRest0") //
-						.setEnabled(false) // do not actually start server
+						.setEnabled(true) // do not actually start server
 						.setConnectionlimit(5) //
 						.setDebugMode(false) //
 						.setPort(port) //
-						.build()) //
-				.deactivate();
+						.build());
+
+		final var executor = DummyBridgeHttpFactory.dummyBridgeHttpExecutor(true);
+		final var bridgeHttpFactory = DummyBridgeHttpFactory.ofBridgeImpl(DummyBridgeHttpFactory::cycleSubscriber,
+				DummyBridgeHttpFactory::networkEndpointFetcher, () -> executor);
+
+		bridgeHttp = bridgeHttpFactory.get();
 	}
+
+	@AfterClass
+	public static void afterClass() throws Exception {
+		test.deactivate();
+		test = null;
+		bridgeHttp = null;
+		sum = null;
+	}
+
+	@Test(timeout = 5_000)
+	public void testGetChannel() throws Exception {
+		final var result = bridgeHttp
+				.requestJson(new BridgeHttp.Endpoint("http://localhost:" + port + "/rest/channel/_sum/EssSoc",
+						HttpMethod.GET, BridgeHttp.DEFAULT_CONNECT_TIMEOUT, BridgeHttp.DEFAULT_READ_TIMEOUT, null,
+						ADMIN_AUTHENTICATION))
+				.get();
+
+		assertEquals(HttpStatus.OK, result.status());
+		assertEquals(new ChannelRecord("_sum/EssSoc", "INTEGER", "RO", "Range 0..100", "%", new JsonPrimitive(69)),
+				ChannelRecord.serializer().deserialize(result.data()));
+	}
+
+	@Test(timeout = 5_000)
+	public void testGetChannelRegexOr() throws Exception {
+		final var result = bridgeHttp.requestJson(new BridgeHttp.Endpoint(//
+				UrlBuilder.parse("http://localhost") //
+						.withPort(port) //
+						.withPath("/rest/channel/_sum/(EssSoc|GridActivePower)") //
+						.toEncodedString(),
+				HttpMethod.GET, BridgeHttp.DEFAULT_CONNECT_TIMEOUT, BridgeHttp.DEFAULT_READ_TIMEOUT, null,
+				ADMIN_AUTHENTICATION)).get();
+
+		assertEquals(HttpStatus.OK, result.status());
+
+		final var channels = ChannelRecord.serializer().toListSerializer().deserialize(result.data());
+		assertEquals(2, channels.size());
+		assertTrue(channels.contains(
+				new ChannelRecord("_sum/EssSoc", "INTEGER", "RO", "Range 0..100", "%", new JsonPrimitive(69))));
+		assertTrue(channels.contains(new ChannelRecord("_sum/GridActivePower", "INTEGER", "RO",
+				"Grid exchange power. Negative values for sell-to-grid; positive for buy-from-grid", "W",
+				new JsonPrimitive(300))));
+	}
+
+	@Test(timeout = 5_000)
+	public void testGetChannelRegexArea() throws Exception {
+		final var result = bridgeHttp.requestJson(new BridgeHttp.Endpoint(//
+				UrlBuilder.parse("http://localhost") //
+						.withPort(port) //
+						.withPath("/rest/channel/_sum/EssActivePowerL[1-3]") //
+						.toEncodedString(),
+				HttpMethod.GET, BridgeHttp.DEFAULT_CONNECT_TIMEOUT, BridgeHttp.DEFAULT_READ_TIMEOUT, null,
+				ADMIN_AUTHENTICATION)).get();
+
+		assertEquals(HttpStatus.OK, result.status());
+
+		final var channels = ChannelRecord.serializer().toListSerializer().deserialize(result.data());
+		assertEquals(3, channels.size());
+	}
+
+	@Test(timeout = 5_000)
+	public void testGetChannelRegexEscape() throws Exception {
+		final var result = bridgeHttp.requestJson(
+				new BridgeHttp.Endpoint("http://localhost:" + port + "/rest/channel/_sum/EssActivePowerL%5Cd", // "%5C"
+																												// -> \
+						HttpMethod.GET, BridgeHttp.DEFAULT_CONNECT_TIMEOUT, BridgeHttp.DEFAULT_READ_TIMEOUT, null,
+						ADMIN_AUTHENTICATION))
+				.get();
+
+		assertEquals(HttpStatus.OK, result.status());
+
+		final var channels = ChannelRecord.serializer().toListSerializer().deserialize(result.data());
+		assertEquals(3, channels.size());
+	}
+
+	@Test(timeout = 5_000)
+	public void testGetChannelRegexWildcard() throws Exception {
+		final var result = bridgeHttp.requestJson(new BridgeHttp.Endpoint(//
+				UrlBuilder.parse("http://localhost") //
+						.withPort(port) //
+						.withPath("/rest/channel/_sum/.*") //
+						.toEncodedString(),
+				HttpMethod.GET, BridgeHttp.DEFAULT_CONNECT_TIMEOUT, BridgeHttp.DEFAULT_READ_TIMEOUT, null,
+				ADMIN_AUTHENTICATION)).get();
+
+		assertEquals(HttpStatus.OK, result.status());
+
+		final var channels = ChannelRecord.serializer().toListSerializer().deserialize(result.data());
+		assertEquals(sum.channels().size(), channels.size());
+	}
+
+	private record ChannelRecord(//
+			String address, //
+			String type, //
+			String accessMode, //
+			String text, //
+			String unit, //
+			JsonElement value //
+	) {
+
+		public static JsonSerializer<ChannelRecord> serializer() {
+			return JsonSerializerUtil.jsonObjectSerializer(json -> new ChannelRecord(//
+					json.getString("address"), //
+					json.getString("type"), //
+					json.getString("accessMode"), //
+					json.getString("text"), //
+					json.getString("unit"), //
+					json.getJsonElement("value") //
+			), obj -> JsonUtils.buildJsonObject() //
+					.addProperty("address", obj.address()) //
+					.addProperty("type", obj.type()) //
+					.addProperty("accessMode", obj.accessMode()) //
+					.addProperty("text", obj.text()) //
+					.addProperty("unit", obj.unit()) //
+					.add("value", obj.value()) //
+					.build());
+		}
+
+	}
+
 }

--- a/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readonly/ControllerApiRestReadOnlyImplTest.java
+++ b/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readonly/ControllerApiRestReadOnlyImplTest.java
@@ -41,6 +41,11 @@ public class ControllerApiRestReadOnlyImplTest {
 	private static int port;
 	private static BridgeHttp bridgeHttp;
 
+	/**
+	 * Before class.
+	 * 
+	 * @throws Exception on error
+	 */
 	@BeforeClass
 	public static void beforeClass() throws Exception {
 		sum = new DummySum() //
@@ -71,6 +76,11 @@ public class ControllerApiRestReadOnlyImplTest {
 		bridgeHttp = bridgeHttpFactory.get();
 	}
 
+	/**
+	 * After class. Cleanup.
+	 * 
+	 * @throws Exception on error
+	 */
 	@AfterClass
 	public static void afterClass() throws Exception {
 		test.deactivate();
@@ -131,12 +141,10 @@ public class ControllerApiRestReadOnlyImplTest {
 
 	@Test(timeout = 5_000)
 	public void testGetChannelRegexEscape() throws Exception {
-		final var result = bridgeHttp.requestJson(
-				new BridgeHttp.Endpoint("http://localhost:" + port + "/rest/channel/_sum/EssActivePowerL%5Cd", // "%5C"
-																												// -> \
-						HttpMethod.GET, BridgeHttp.DEFAULT_CONNECT_TIMEOUT, BridgeHttp.DEFAULT_READ_TIMEOUT, null,
-						ADMIN_AUTHENTICATION))
-				.get();
+		// "%5C" -> \
+		final var result = bridgeHttp.requestJson(new BridgeHttp.Endpoint(
+				"http://localhost:" + port + "/rest/channel/_sum/EssActivePowerL%5Cd", HttpMethod.GET,
+				BridgeHttp.DEFAULT_CONNECT_TIMEOUT, BridgeHttp.DEFAULT_READ_TIMEOUT, null, ADMIN_AUTHENTICATION)).get();
 
 		assertEquals(HttpStatus.OK, result.status());
 


### PR DESCRIPTION
Fix handling regex patterns in URL

Tested for regex patterns like:
 * "_sum/(EssSoc|GridActivePower)"
 * "_sum/EssActivePowerL[1-3]"
 * "_sum/EssActivePowerL%5Cd" %5C -> \
 * "_sum/.*"