### PR TITLE
Implements VirtualMeter on PvInverterCluster

### DIFF
--- a/io.openems.edge.pvinverter.cluster/src/io/openems/edge/pvinverter/cluster/Config.java
+++ b/io.openems.edge.pvinverter.cluster/src/io/openems/edge/pvinverter/cluster/Config.java
@@ -3,6 +3,8 @@ package io.openems.edge.pvinverter.cluster;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
+import io.openems.common.types.MeterType;
+
 @ObjectClassDefinition(//
 		name = "PV-Inverter Cluster", //
 		description = "Combines several PV-Inverters to one.")
@@ -16,6 +18,12 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
 	boolean enabled() default true;
+
+	@AttributeDefinition(name = "Meter-Type", description = "Production meter (=default)")
+	MeterType meterType() default MeterType.PRODUCTION;
+
+	@AttributeDefinition(name = "Add to Sum?", description = "Should the data of this cluster be added to the Sum?")
+	boolean addToSum() default true;
 
 	@AttributeDefinition(name = "PV-Inverter-IDs", description = "IDs of PvInverter devices.")
 	String[] pvInverter_ids();

--- a/io.openems.edge.pvinverter.cluster/src/io/openems/edge/pvinverter/cluster/PvInverterClusterImpl.java
+++ b/io.openems.edge.pvinverter.cluster/src/io/openems/edge/pvinverter/cluster/PvInverterClusterImpl.java
@@ -219,11 +219,11 @@ public class PvInverterClusterImpl extends AbstractOpenemsComponent implements P
 
 	@Override
 	public boolean addToSum() {
-		return config.addToSum();
+		return this.config.addToSum();
 	}
 
 	@Override
 	public MeterType getMeterType() {
-		return config.meterType();
+		return this.config.meterType();
 	}
 }

--- a/io.openems.edge.pvinverter.cluster/src/io/openems/edge/pvinverter/cluster/PvInverterClusterImpl.java
+++ b/io.openems.edge.pvinverter.cluster/src/io/openems/edge/pvinverter/cluster/PvInverterClusterImpl.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import io.openems.common.channel.AccessMode;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
+import io.openems.common.types.MeterType;
 import io.openems.edge.common.channel.calculate.CalculateAverage;
 import io.openems.edge.common.channel.calculate.CalculateIntegerSum;
 import io.openems.edge.common.channel.calculate.CalculateLongSum;
@@ -32,6 +33,7 @@ import io.openems.edge.common.event.EdgeEventConstants;
 import io.openems.edge.common.modbusslave.ModbusSlave;
 import io.openems.edge.common.modbusslave.ModbusSlaveTable;
 import io.openems.edge.meter.api.ElectricityMeter;
+import io.openems.edge.meter.api.VirtualMeter;
 import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 
 @Designate(ocd = Config.class, factory = true)
@@ -47,7 +49,7 @@ import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 		EdgeEventConstants.TOPIC_CYCLE_AFTER_CONTROLLERS //
 })
 public class PvInverterClusterImpl extends AbstractOpenemsComponent implements PvInverterCluster,
-		ManagedSymmetricPvInverter, ElectricityMeter, OpenemsComponent, EventHandler, ModbusSlave {
+		ManagedSymmetricPvInverter, VirtualMeter, ElectricityMeter, OpenemsComponent, EventHandler, ModbusSlave {
 
 	private final Logger log = LoggerFactory.getLogger(PvInverterClusterImpl.class);
 
@@ -213,5 +215,15 @@ public class PvInverterClusterImpl extends AbstractOpenemsComponent implements P
 				OpenemsComponent.getModbusSlaveNatureTable(accessMode), //
 				ElectricityMeter.getModbusSlaveNatureTable(accessMode), //
 				ManagedSymmetricPvInverter.getModbusSlaveNatureTable(accessMode));
+	}
+
+	@Override
+	public boolean addToSum() {
+		return config.addToSum();
+	}
+
+	@Override
+	public MeterType getMeterType() {
+		return config.meterType();
 	}
 }

--- a/io.openems.edge.pvinverter.cluster/test/io/openems/edge/pvinverter/cluster/MyConfig.java
+++ b/io.openems.edge.pvinverter.cluster/test/io/openems/edge/pvinverter/cluster/MyConfig.java
@@ -1,6 +1,7 @@
 package io.openems.edge.pvinverter.cluster;
 
 import io.openems.common.test.AbstractComponentConfig;
+import io.openems.common.types.MeterType;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {
@@ -8,6 +9,8 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	protected static class Builder {
 		private String id;
 		private String[] pvInverterIds;
+		private MeterType meterType = MeterType.PRODUCTION;
+		private boolean addToSum = true;
 
 		private Builder() {
 		}
@@ -19,6 +22,16 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 		public Builder setPvInverterIds(String... pvInverterIds) {
 			this.pvInverterIds = pvInverterIds;
+			return this;
+		}
+
+		public Builder setMeterType(MeterType meterType) {
+			this.meterType = meterType;
+			return this;
+		}
+
+		public Builder setAddToSum(boolean addToSum) {
+			this.addToSum = addToSum;
 			return this;
 		}
 
@@ -46,5 +59,15 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	@Override
 	public String[] pvInverter_ids() {
 		return this.builder.pvInverterIds;
+	}
+
+	@Override
+	public MeterType meterType() {
+		return this.builder.meterType;
+	}
+
+	@Override
+	public boolean addToSum() {
+		return this.builder.addToSum;
 	}
 }


### PR DESCRIPTION
Added VirtualMeter interface to PvInverterCluster. This allows to configure, if values are added to the sum. Otherwise you end up with doubled values, as the sum will take the cluster as a normal pvInverter.

Made MeterType on the way configurable ... maybe useful for something.