### PR TITLE
Max active and reactive power on ManagedSymmetricPvInverter

### DIFF
--- a/io.openems.edge.pvinverter.api/src/io/openems/edge/pvinverter/api/ManagedSymmetricPvInverter.java
+++ b/io.openems.edge.pvinverter.api/src/io/openems/edge/pvinverter/api/ManagedSymmetricPvInverter.java
@@ -46,6 +46,20 @@ public interface ManagedSymmetricPvInverter extends ElectricityMeter, OpenemsCom
 		 * <li>Range: zero or positive value
 		 * </ul>
 		 */
+		MAX_REACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.VOLT_AMPERE_REACTIVE) //
+				.persistencePriority(PersistencePriority.MEDIUM)), //
+		/**
+		 * Holds the maximum possible apparent power. This value is defined by the
+		 * inverter limitations.
+		 *
+		 * <ul>
+		 * <li>Interface: SymmetricPvInverter
+		 * <li>Type: Integer
+		 * <li>Unit: VA
+		 * <li>Range: zero or positive value
+		 * </ul>
+		 */
 		MAX_APPARENT_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.VOLT_AMPERE) //
 				.persistencePriority(PersistencePriority.MEDIUM)), //
@@ -128,6 +142,45 @@ public interface ManagedSymmetricPvInverter extends ElectricityMeter, OpenemsCom
 	 */
 	public default void _setMaxActivePower(int value) {
 		this.getMaxActivePowerChannel().setNextValue(value);
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#MAX_REACTIVE_POWER}.
+	 *
+	 * @return the Channel
+	 */
+	public default IntegerReadChannel getMaxReactivePowerChannel() {
+		return this.channel(ChannelId.MAX_REACTIVE_POWER);
+	}
+
+	/**
+	 * Gets the Maximum Reactive Power in [VAR], range "&gt;= 0". See
+	 * {@link ChannelId#MAX_REACTIVE_POWER}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Integer> getMaxReactivePower() {
+		return this.getMaxReactivePowerChannel().value();
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#MAX_REACTIVE_POWER} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setMaxReactivePower(Integer value) {
+		this.getMaxReactivePowerChannel().setNextValue(value);
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#MAX_REACTIVE_POWER} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setMaxReactivePower(int value) {
+		this.getMaxReactivePowerChannel().setNextValue(value);
 	}
 
 	/**

--- a/io.openems.edge.pvinverter.api/src/io/openems/edge/pvinverter/api/ManagedSymmetricPvInverter.java
+++ b/io.openems.edge.pvinverter.api/src/io/openems/edge/pvinverter/api/ManagedSymmetricPvInverter.java
@@ -32,6 +32,20 @@ public interface ManagedSymmetricPvInverter extends ElectricityMeter, OpenemsCom
 		 * <li>Range: zero or positive value
 		 * </ul>
 		 */
+		MAX_ACTIVE_POWER(Doc.of(OpenemsType.INTEGER) //
+				.unit(Unit.WATT) //
+				.persistencePriority(PersistencePriority.MEDIUM)), //
+		/**
+		 * Holds the maximum possible apparent power. This value is defined by the
+		 * inverter limitations.
+		 *
+		 * <ul>
+		 * <li>Interface: SymmetricPvInverter
+		 * <li>Type: Integer
+		 * <li>Unit: VA
+		 * <li>Range: zero or positive value
+		 * </ul>
+		 */
 		MAX_APPARENT_POWER(Doc.of(OpenemsType.INTEGER) //
 				.unit(Unit.VOLT_AMPERE) //
 				.persistencePriority(PersistencePriority.MEDIUM)), //
@@ -75,6 +89,45 @@ public interface ManagedSymmetricPvInverter extends ElectricityMeter, OpenemsCom
 	@Override
 	default MeterType getMeterType() {
 		return MeterType.PRODUCTION;
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#MAX_ACTIVE_POWER}.
+	 *
+	 * @return the Channel
+	 */
+	public default IntegerReadChannel getMaxActivePowerChannel() {
+		return this.channel(ChannelId.MAX_ACTIVE_POWER);
+	}
+
+	/**
+	 * Gets the Maximum Active Power in [WATT], range "&gt;= 0". See
+	 * {@link ChannelId#MAX_ACTIVE_POWER}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Integer> getMaxActivePower() {
+		return this.getMaxActivePowerChannel().value();
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#MAX_ACTIVE_POWER} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setMaxActivePower(Integer value) {
+		this.getMaxActivePowerChannel().setNextValue(value);
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#MAX_ACTIVE_POWER} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setMaxActivePower(int value) {
+		this.getMaxActivePowerChannel().setNextValue(value);
 	}
 
 	/**

--- a/io.openems.edge.pvinverter.cluster/src/io/openems/edge/pvinverter/cluster/PvInverterClusterImpl.java
+++ b/io.openems.edge.pvinverter.cluster/src/io/openems/edge/pvinverter/cluster/PvInverterClusterImpl.java
@@ -178,7 +178,7 @@ public class PvInverterClusterImpl extends AbstractOpenemsComponent implements P
 		Map<ManagedSymmetricPvInverter, Integer> values = new HashMap<>();
 		var toBeDistributed = 0;
 		for (ManagedSymmetricPvInverter pvInverter : pvInverters) {
-			int maxPower = pvInverter.getMaxApparentPower().getOrError();
+			int maxPower = pvInverter.getMaxActivePower().getOrError();
 			var power = averageActivePowerLimit;
 			if (maxPower < power) {
 				toBeDistributed += power - maxPower;
@@ -189,7 +189,7 @@ public class PvInverterClusterImpl extends AbstractOpenemsComponent implements P
 
 		for (Entry<ManagedSymmetricPvInverter, Integer> entry : values.entrySet()) {
 			if (toBeDistributed > 0) {
-				int maxPower = entry.getKey().getMaxApparentPower().getOrError();
+				int maxPower = entry.getKey().getMaxActivePower().getOrError();
 				int power = entry.getValue();
 				if (maxPower > power) {
 					toBeDistributed -= maxPower - power;

--- a/io.openems.edge.pvinverter.cluster/src/io/openems/edge/pvinverter/cluster/PvInverterClusterImpl.java
+++ b/io.openems.edge.pvinverter.cluster/src/io/openems/edge/pvinverter/cluster/PvInverterClusterImpl.java
@@ -120,6 +120,8 @@ public class PvInverterClusterImpl extends AbstractOpenemsComponent implements P
 		final var voltage = new CalculateAverage();
 		final var current = new CalculateIntegerSum();
 		// SymmetricPvInverter
+		final var maxActivePower = new CalculateIntegerSum();
+		final var maxReactivePower = new CalculateIntegerSum();
 		final var maxApparentPower = new CalculateIntegerSum();
 		final var activePowerLimit = new CalculateIntegerSum();
 
@@ -133,6 +135,8 @@ public class PvInverterClusterImpl extends AbstractOpenemsComponent implements P
 			voltage.addValue(pvInverter.getVoltageChannel());
 			current.addValue(pvInverter.getCurrentChannel());
 			// SymmetricPvInverter
+			maxActivePower.addValue(pvInverter.getMaxActivePowerChannel());
+			maxReactivePower.addValue(pvInverter.getMaxReactivePowerChannel());
 			maxApparentPower.addValue(pvInverter.getMaxApparentPowerChannel());
 			activePowerLimit.addValue(pvInverter.getActivePowerLimitChannel());
 		}
@@ -146,6 +150,8 @@ public class PvInverterClusterImpl extends AbstractOpenemsComponent implements P
 		this.getVoltageChannel().setNextValue(voltage.calculate());
 		this._setCurrent(current.calculate());
 		// SymmetricPvInverter
+		this._setMaxActivePower(maxActivePower.calculate());
+		this._setMaxReactivePower(maxReactivePower.calculate());
 		this._setMaxApparentPower(maxApparentPower.calculate());
 		this._setActivePowerLimit(activePowerLimit.calculate());
 	}

--- a/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/AbstractSunSpecPvInverter.java
+++ b/io.openems.edge.pvinverter.sunspec/src/io/openems/edge/pvinverter/sunspec/AbstractSunSpecPvInverter.java
@@ -290,10 +290,21 @@ public abstract class AbstractSunSpecPvInverter extends AbstractOpenemsSunSpecCo
 					S701.TOT_WH_INJ_L3);
 		}
 
+		// max power
+		this.mapFirstPointToChannel(
+				ManagedSymmetricPvInverter.ChannelId.MAX_ACTIVE_POWER, //
+				DIRECT_1_TO_1, //
+				S702.W_MAX_RTG, S120.W_RTG);
+
+		this.mapFirstPointToChannel(
+				ManagedSymmetricPvInverter.ChannelId.MAX_REACTIVE_POWER, //
+				DIRECT_1_TO_1, //
+				S702.VAR_MAX_INJ_RTG, S120.V_AR_RTG_Q1);
+
 		this.mapFirstPointToChannel(//
 				ManagedSymmetricPvInverter.ChannelId.MAX_APPARENT_POWER, //
 				DIRECT_1_TO_1, //
-				S702.V_A_MAX_RTG, S120.W_RTG);
+				S702.V_A_MAX_RTG, S120.V_A_RTG);
 
 		// Voltage
 		this.mapFirstPointToChannel(ElectricityMeter.ChannelId.VOLTAGE_L1, //


### PR DESCRIPTION
Adds two channels on ManagedSymmetricPvInverter: MAX_ACTIVE_POWER and MAX_REACTIVE_POWER. I also implemented maintaining these values on PvInverterCluster and SunSpec inverters.

Note: there is already a channel MAX_APPARENT_POWER on ManagedSymmetricPvInverter, which seems to be used for max active power. I swapped its usage to MAX_ACTIVE_POWER for distribution the pv limit in PvInverterCluster and also adopted the mapping in SunSpec (W_RTG -> V_A_RTG) ... unfortunately my SolarEdge does not support S120 or S702 and uses some other registers for all three MAX ACTIVE/REACTIVE/APPARENT POWER but maybe there is a background for the current implementation?