### PR TITLE
SimilarDayPredictor: Fix ArrayIndexOutOfBoundsException due to time changeover

### DIFF
--- a/io.openems.edge.predictor.similardaymodel/readme.adoc
+++ b/io.openems.edge.predictor.similardaymodel/readme.adoc
@@ -2,15 +2,12 @@
 
 This predictor uses "Similar day technique" for prediction. 
 This particular implementation requires mainly two inputs, which are
+
 * Num of past weeks (n)
 * The channels address data, which needs to predicted.
 
 
- 
- 
-The similar-day models predicts by calculating the average of a 'n' number of previous period values.
-
-_example_: the next monday predictions values is equal to average of past n = 4 monday values.
+The Similarday-Model Predictor predicts same values as on same day in the previous weeks, e.g. the prediction for coming monday calculates the average of (n) previous monday's. 
 
 This predictor is mainly used for predicting the Consumption power and energy. And the Accuracy of the model is scientifically verified within https://openems.io/research/emsig/[EMSIG project^].
 

--- a/io.openems.edge.predictor.similardaymodel/readme.adoc
+++ b/io.openems.edge.predictor.similardaymodel/readme.adoc
@@ -11,5 +11,6 @@ The Similarday-Model Predictor predicts same values as on same day in the previo
 
 This predictor is mainly used for predicting the Consumption power and energy. And the Accuracy of the model is scientifically verified within https://openems.io/research/emsig/[EMSIG project^].
 
+**Note:** This predictor adds one hour offset for (n) weeks during time changeover (summertime -> wintertime and wintertime -> summertime). 
 
 https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.predictor.similardaymodel[Source Code icon:github[]]

--- a/io.openems.edge.predictor.similardaymodel/src/io/openems/edge/predictor/similardaymodel/Config.java
+++ b/io.openems.edge.predictor.similardaymodel/src/io/openems/edge/predictor/similardaymodel/Config.java
@@ -7,7 +7,7 @@ import io.openems.edge.predictor.api.prediction.LogVerbosity;
 
 @ObjectClassDefinition(//
 		name = "Predictor Similarday-Model", //
-		description = "Implements Similarday-Model predictor")
+		description = "Predicts same values as on same day in the previous weeks (e.g. on Monday the average of previous monday's will be returned)")
 @interface Config {
 
 	@AttributeDefinition(name = "Component-ID", description = "Unique ID of this Component")
@@ -23,7 +23,10 @@ import io.openems.edge.predictor.api.prediction.LogVerbosity;
 	int numOfWeeks() default 4;
 
 	@AttributeDefinition(name = "Channel-Addresses", description = "List of Channel-Addresses this Predictor is used for, e.g. '*/ActivePower', '*/ActualPower'")
-	String[] channelAddresses() default { "_sum/ProductionActivePower", "_sum/UnmanagedConsumptionActivePower" };
+	String[] channelAddresses() default { //
+			"_sum/ProductionActivePower", //
+			"_sum/UnmanagedConsumptionActivePower", //
+			"_sum/ConsumptionActivePower" };
 
 	@AttributeDefinition(name = "Log-Verbosity", description = "The log verbosity.")
 	LogVerbosity logVerbosity() default LogVerbosity.NONE;

--- a/io.openems.edge.predictor.similardaymodel/src/io/openems/edge/predictor/similardaymodel/PredictorSimilardayModelImpl.java
+++ b/io.openems.edge.predictor.similardaymodel/src/io/openems/edge/predictor/similardaymodel/PredictorSimilardayModelImpl.java
@@ -120,8 +120,8 @@ public class PredictorSimilardayModelImpl extends AbstractPredictor implements P
 				.toList();
 
 		var mainData = this.getSlicedArrayList(result, NUM_OF_DATA_PER_DAY);
-		var lastSimilarDays = this.getLastSimilarDays(mainData); // oEMS
-		var nextOneDayPredictions = this.getAveragePrediction(lastSimilarDays); // oEMS
+		var lastSimilarDays = this.getLastSimilarDays(mainData);
+		var nextOneDayPredictions = this.getAveragePrediction(lastSimilarDays);
 		return Prediction.from(this.sum, channelAddress, now, nextOneDayPredictions.stream().toArray(Integer[]::new));
 	}
 
@@ -179,7 +179,7 @@ public class PredictorSimilardayModelImpl extends AbstractPredictor implements P
 		List<List<Integer>> days = new ArrayList<>();
 		// get correct index
 		for (var i = 0; i < mainData.size(); i++) {
-			if (this.isMember(i)) { // oEMS
+			if (this.isMember(i)) {
 				indexes.add(i);
 			}
 		}

--- a/io.openems.edge.predictor.similardaymodel/test/io/openems/edge/predictor/similardaymodel/PredictorSimilardayModelImplTest.java
+++ b/io.openems.edge.predictor.similardaymodel/test/io/openems/edge/predictor/similardaymodel/PredictorSimilardayModelImplTest.java
@@ -22,12 +22,31 @@ public class PredictorSimilardayModelImplTest {
 
 	@Test
 	public void test() throws Exception {
+		this.runPredictionTest(Data.data, Data.predictedData);
+	}
 
+	@Test
+	public void testTimeChangeoverWinterToSummerTime() throws Exception {
+		// due to time changeover the db array may have 4 entries less
+		var values = new Integer[Data.data.length - 4];
+		System.arraycopy(Data.data, 0, values, 0, values.length);
+		var predictedValues = Data.predictedData;
+		this.runPredictionTest(values, predictedValues);
+	}
+
+	@Test
+	public void testTimeChangeoverSummerToWinterTime() throws Exception {
+		// due to time changeover the db array may have 4 entries more
+		var values = new Integer[Data.data.length + 4];
+		System.arraycopy(Data.data, 0, values, 0, values.length - 4);
+		System.arraycopy(Data.data, 0, values, values.length - 4, 4);
+		var predictedValues = Data.predictedData;
+		this.runPredictionTest(values, predictedValues);
+	}
+
+	private void runPredictionTest(Integer[] values, Integer[] predictedValues) throws Exception {
 		final var clock = new TimeLeapClock(Instant.ofEpochSecond(1577836800) /* starts at 1. January 2020 00:00:00 */,
 				ZoneOffset.UTC);
-
-		var values = Data.data;
-		var predictedValues = Data.predictedData;
 
 		var timedata = new DummyTimedata("timedata0");
 		var start = ZonedDateTime.of(2019, 12, 1, 0, 0, 0, 0, ZoneId.of("UTC"));


### PR DESCRIPTION
Fix `ArrayIndexOutOfBoundsException` in SimilarDayPredictor on summer/winter time changeover. Due to time changeover the array of data includes either 4 entries more (summer-> wintertime) or 4 entries less (winter-> summertime).

Cleanup Code for better readability.

Note that I would prefer to remove `_sum/ProductionActivePower` from the default configuration as this predictor is not useful for PV production. On the other hand, this configuration makes it easier for new users to get started.