### PR TITLE
Update docker-compose.yml: removed "version" attribute

### DIFF
--- a/tools/docker/backend/docker-compose.yml
+++ b/tools/docker/backend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   openems_backend:
     image: openems/backend:latest


### PR DESCRIPTION
As docker was complaining:
# docker compose up -d
WARN[0000] docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

cf: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete