### PR TITLE
Fix translation key of changeComponentHint used in ModbusApiProps

### DIFF
--- a/io.openems.edge.core/src/io/openems/edge/core/appmanager/translation_en.properties
+++ b/io.openems.edge.core/src/io/openems/edge/core/appmanager/translation_en.properties
@@ -92,7 +92,7 @@ App.Cloud.CleverPv.url.description = Full API URL. See https://support.clever-pv
 
 App.Api.Modbus.componentIds.description = Components that should be made available via Modbus.
 App.Api.Modbus.componentIds.label = Component-IDs
-App.Api.ModbusTcp.changeComponentHint = <a class=\"warning\">Note</a>: When inserting a component, the Modbus table also changes!
+App.Api.Modbus.changeComponentHint = <a class=\"warning\">Note</a>: When inserting a component, the Modbus table also changes!
 
 App.Api.ModbusRtu.ReadOnly.Name = Modbus/RTU reading
 App.Api.ModbusRtu.ReadOnly.Name.short = Modbus/RTU reading


### PR DESCRIPTION
The Key used in ModbusApiProps for translation of message: `<a class=\"warning\">Note</a>: When inserting a component, the Modbus table also changes!` is `App.Api.Modbus.changeComponentHint`

https://github.com/OpenEMS/openems/blob/develop/io.openems.edge.core/src/io/openems/edge/app/api/ModbusApiProps.java#L51

I encountered this discrepancy while running unit tests — the testEnglishTranslation under TestTranslations failed with the following message:

`java.util.MissingResourceException: Can't find resource for bundle java.util.PropertyResourceBundle, key App.Api.Modbus.changeComponentHint
	at java.base/java.util.ResourceBundle.getObject(ResourceBundle.java:567)
	at java.base/java.util.ResourceBundle.getString(ResourceBundle.java:523)
	at io.openems.edge.core.appmanager.TranslationUtil.getNullableTranslation(TranslationUtil.java:119)
	at io.openems.edge.core.appmanager.TranslationUtil$DebugTranslator.getTranslation(TranslationUtil.java:45)
	at io.openems.edge.core.appmanager.TranslationUtil.getTranslation(TranslationUtil.java:85)`

Interestingly, I didn’t observe this failure in the openems-fork repository. However, it appears that the key is  mismatched in the translation_en.properties file. I believe the correct key (App.Api.Modbus.changeComponentHint) should be updated there to resolve the issue.