### PR TITLE
add shelly em 1

### DIFF
--- a/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyem/Config.java
+++ b/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyem/Config.java
@@ -1,0 +1,39 @@
+package io.openems.edge.io.shelly.shellyem;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+import io.openems.common.types.MeterType;
+import io.openems.edge.meter.api.SinglePhase;
+
+@ObjectClassDefinition(//
+		name = "IO Shelly EM (Gen.1)", //
+		description = "Implements the Shelly EM (Gen.1)")
+@interface Config {
+
+	@AttributeDefinition(name = "Component-ID", description = "Unique ID of this Component")
+	String id() default "io0";
+
+	@AttributeDefinition(name = "Alias", description = "Human-readable name of this Component; defaults to Component-ID")
+	String alias() default "";
+
+	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
+	boolean enabled() default true;
+
+	@AttributeDefinition(name = "IP-Address", description = "The IP address of the Shelly device.")
+	String ip();
+
+	@AttributeDefinition(name = "Meter-Type", description = "What is measured by this meter?")
+	MeterType type() default MeterType.CONSUMPTION_METERED;
+
+	@AttributeDefinition(name = "Summarize energy meters", description = "Whether to sum the values from first and second energy meter.")
+	boolean sumEmeter1AndEmeter2() default false;
+
+	@AttributeDefinition(name = "Measuring channel", description = "Which channel should be measured? Only relevant if sum is set to false")
+	int channel() default 0;
+
+	@AttributeDefinition(name = "Phase", description = "Which phase is the Shelly EM connected?")
+	SinglePhase phase() default SinglePhase.L1;
+
+	String webconsole_configurationFactory_nameHint() default "IO Shelly EM [{id}]";
+}

--- a/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyem/IoShellyEm.java
+++ b/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyem/IoShellyEm.java
@@ -1,0 +1,183 @@
+package io.openems.edge.io.shelly.shellyem;
+
+import org.osgi.service.event.EventHandler;
+
+import io.openems.common.channel.AccessMode;
+import io.openems.common.channel.Level;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.types.OpenemsType;
+import io.openems.edge.common.channel.BooleanDoc;
+import io.openems.edge.common.channel.BooleanWriteChannel;
+import io.openems.edge.common.channel.Doc;
+import io.openems.edge.common.channel.StateChannel;
+import io.openems.edge.common.channel.value.Value;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.io.api.DigitalOutput;
+import io.openems.edge.meter.api.ElectricityMeter;
+
+public interface IoShellyEm extends DigitalOutput, ElectricityMeter, OpenemsComponent, EventHandler {
+
+	public static enum ChannelId implements io.openems.edge.common.channel.ChannelId {
+		
+		/**
+		 * Holds writes to Relay Output for debugging.
+		 *
+		 * <ul>
+		 * <li>Interface: ShellyPlug
+		 * <li>Type: Boolean
+		 * <li>Range: On/Off
+		 * </ul>
+		 */
+		DEBUG_RELAY(Doc.of(OpenemsType.BOOLEAN)), //
+		
+		/**
+		 * Relay Output.
+		 *
+		 * <ul>
+		 * <li>Interface: ShellyPlug
+		 * <li>Type: Boolean
+		 * <li>Range: On/Off
+		 * </ul>
+		 */
+		RELAY(new BooleanDoc() //
+				.accessMode(AccessMode.READ_WRITE) //
+				.onChannelSetNextWriteMirrorToDebugChannel(ChannelId.DEBUG_RELAY)),
+		
+		/**
+		 * Indicates whether the associated meter is functioning properly.
+		 *
+		 * <ul>
+		 * <li>Interface: ShellyPlug
+		 * <li>Type: Boolean
+		 * <li>Level: WARN
+		 * </ul>
+		 */
+		EMETER1_EXCEPTION(Doc.of(Level.WARNING) //
+				.text("E-Meter Phase 1 is not valid.")),
+		
+		/**
+		 * Indicates whether the associated meter is functioning properly.
+		 *
+		 * <ul>
+		 * <li>Interface: ShellyPlug
+		 * <li>Type: Boolean
+		 * <li>Level: WARN
+		 * </ul>
+		 */
+		EMETER2_EXCEPTION(Doc.of(Level.WARNING) //
+				.text("E-Meter Phase 2 is not valid.")),
+		
+		/**
+		 * Indicates whether the associated meter is functioning properly.
+		 *
+		 * <ul>
+		 * <li>Interface: ShellyPlug
+		 * <li>Type: Boolean
+		 * <li>Level: WARN
+		 * </ul>
+		 */
+
+		EMETERN_EXCEPTION(Doc.of(Level.WARNING) //
+				.text("E-Meter Phase N is not valid.")),
+		
+		/**
+		 * Indicates whether the Relay is in an Overpower Condition.
+		 *
+		 * <ul>
+		 * <li>Interface: ShellyPlug
+		 * <li>Type: Boolean
+		 * <li>Level: WARN
+		 * </ul>
+		 */
+		RELAY_OVERPOWER_EXCEPTION(Doc.of(Level.WARNING) //
+				.text("Relay is in overpower condition.")),
+		
+		/**
+		 * Slave Communication Failed Fault.
+		 *
+		 * <ul>
+		 * <li>Interface: ShellyPlug
+		 * <li>Type: State
+		 * </ul>
+		 */
+		SLAVE_COMMUNICATION_FAILED(Doc.of(Level.FAULT)); //
+
+		private final Doc doc;
+
+		private ChannelId(Doc doc) {
+			this.doc = doc;
+		}
+
+		@Override
+		public Doc doc() {
+			return this.doc;
+		}
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#RELAY}.
+	 *
+	 * @return the Channel
+	 */
+	public default BooleanWriteChannel getRelayChannel() {
+		return this.channel(ChannelId.RELAY);
+	}
+
+	/**
+	 * Gets the Relay Output 1. See {@link ChannelId#RELAY}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Boolean> getRelay() {
+		return this.getRelayChannel().value();
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on {@link ChannelId#RELAY} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setRelay(Boolean value) {
+		this.getRelayChannel().setNextValue(value);
+	}
+
+	/**
+	 * Sets the Relay Output. See {@link ChannelId#RELAY}.
+	 *
+	 * @param value the next write value
+	 * @throws OpenemsNamedException on error
+	 */
+	public default void setRelay(boolean value) throws OpenemsNamedException {
+		this.getRelayChannel().setNextWriteValue(value);
+	}
+
+	/**
+	 * Gets the Channel for {@link ChannelId#SLAVE_COMMUNICATION_FAILED}.
+	 *
+	 * @return the Channel
+	 */
+	public default StateChannel getSlaveCommunicationFailedChannel() {
+		return this.channel(ChannelId.SLAVE_COMMUNICATION_FAILED);
+	}
+
+	/**
+	 * Gets the Slave Communication Failed State. See
+	 * {@link ChannelId#SLAVE_COMMUNICATION_FAILED}.
+	 *
+	 * @return the Channel {@link Value}
+	 */
+	public default Value<Boolean> getSlaveCommunicationFailed() {
+		return this.getSlaveCommunicationFailedChannel().value();
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link ChannelId#SLAVE_COMMUNICATION_FAILED} Channel.
+	 *
+	 * @param value the next value
+	 */
+	public default void _setSlaveCommunicationFailed(boolean value) {
+		this.getSlaveCommunicationFailedChannel().setNextValue(value);
+	}
+
+}

--- a/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyem/IoShellyEmImpl.java
+++ b/io.openems.edge.io.shelly/src/io/openems/edge/io/shelly/shellyem/IoShellyEmImpl.java
@@ -1,0 +1,257 @@
+package io.openems.edge.io.shelly.shellyem;
+
+import static io.openems.common.utils.JsonUtils.getAsBoolean;
+import static io.openems.common.utils.JsonUtils.getAsFloat;
+import static io.openems.common.utils.JsonUtils.getAsJsonArray;
+import static io.openems.common.utils.JsonUtils.getAsJsonObject;
+import static io.openems.edge.io.shelly.common.Utils.executeWrite;
+import static io.openems.edge.io.shelly.common.Utils.generateDebugLog;
+import static java.lang.Math.round;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.event.propertytypes.EventTopics;
+import org.osgi.service.metatype.annotations.Designate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonElement;
+
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.types.MeterType;
+import io.openems.edge.bridge.http.api.BridgeHttp;
+import io.openems.edge.bridge.http.api.BridgeHttpFactory;
+import io.openems.edge.bridge.http.api.HttpResponse;
+import io.openems.edge.common.channel.BooleanWriteChannel;
+import io.openems.edge.common.component.AbstractOpenemsComponent;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.event.EdgeEventConstants;
+import io.openems.edge.io.api.DigitalOutput;
+import io.openems.edge.meter.api.ElectricityMeter;
+import io.openems.edge.meter.api.SinglePhase;
+import io.openems.edge.meter.api.SinglePhaseMeter;
+import io.openems.edge.timedata.api.Timedata;
+import io.openems.edge.timedata.api.TimedataProvider;
+import io.openems.edge.timedata.api.utils.CalculateEnergyFromPower;
+
+@Designate(ocd = Config.class, factory = true)
+@Component(//
+		name = "IO.Shelly.EM", //
+		immediate = true, //
+		configurationPolicy = ConfigurationPolicy.REQUIRE //
+)
+@EventTopics({ //
+		EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE, //
+		EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE //
+})
+public class IoShellyEmImpl extends AbstractOpenemsComponent implements IoShellyEm, DigitalOutput, ElectricityMeter,
+		OpenemsComponent, TimedataProvider, EventHandler, SinglePhaseMeter {
+
+	private final CalculateEnergyFromPower calculateProductionEnergy = new CalculateEnergyFromPower(this,
+			ElectricityMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY);
+	private final CalculateEnergyFromPower calculateConsumptionEnergy = new CalculateEnergyFromPower(this,
+			ElectricityMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY);
+
+	private final Logger log = LoggerFactory.getLogger(IoShellyEmImpl.class);
+	private final BooleanWriteChannel[] digitalOutputChannels;
+
+	private MeterType meterType;
+	private SinglePhase phase;
+	private String baseUrl;
+	private Boolean sumEMeter1AndEMeter2;
+	private int channel = 0;
+
+	@Reference(policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.OPTIONAL)
+	private volatile Timedata timedata;
+
+	@Reference()
+	private BridgeHttpFactory httpBridgeFactory;
+	private BridgeHttp httpBridge;
+
+	public IoShellyEmImpl() {
+		super(//
+				OpenemsComponent.ChannelId.values(), //
+				ElectricityMeter.ChannelId.values(), //
+				DigitalOutput.ChannelId.values(), //
+				SinglePhaseMeter.ChannelId.values(), //
+				IoShellyEm.ChannelId.values() //
+		);
+		this.digitalOutputChannels = new BooleanWriteChannel[] { this.channel(IoShellyEm.ChannelId.RELAY) };
+	}
+
+	@Activate
+	protected void activate(ComponentContext context, Config config) {
+		super.activate(context, config.id(), config.alias(), config.enabled());
+		this.meterType = config.type();
+		this.baseUrl = "http://" + config.ip();
+		this.httpBridge = this.httpBridgeFactory.get();
+		this.phase = config.phase();
+		this.sumEMeter1AndEMeter2 = config.sumEmeter1AndEmeter2();
+		this.channel = config.channel();
+
+		if (this.isEnabled()) {
+			this.httpBridge.subscribeJsonEveryCycle(this.baseUrl + "/status", this::processHttpResult);
+		}
+
+		SinglePhaseMeter.calculateSinglePhaseFromActivePower(this);
+		SinglePhaseMeter.calculateSinglePhaseFromCurrent(this);
+		SinglePhaseMeter.calculateSinglePhaseFromVoltage(this);
+		SinglePhaseMeter.calculateSinglePhaseFromReactivePower(this);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		this.httpBridgeFactory.unget(this.httpBridge);
+		this.httpBridge = null;
+		super.deactivate();
+	}
+
+	@Override
+	public BooleanWriteChannel[] digitalOutputChannels() {
+		return this.digitalOutputChannels;
+	}
+
+	@Override
+	public String debugLog() {
+		return generateDebugLog(this.digitalOutputChannels, this.getActivePowerChannel());
+	}
+
+	@Override
+	public void handleEvent(Event event) {
+		if (!this.isEnabled()) {
+			return;
+		}
+
+		switch (event.getTopic()) {
+		case EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE //
+			-> this.calculateEnergy();
+		case EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE //
+			-> executeWrite(this.getRelayChannel(), this.baseUrl, this.httpBridge, 0);
+		}
+	}
+
+	private void processHttpResult(HttpResponse<JsonElement> result, Throwable error) {
+		this._setSlaveCommunicationFailed(result == null);
+
+		Boolean relay0 = null;
+		Integer activePower = null;
+		Integer reactivePower = null;
+		Integer voltage = null;
+		Integer current = null;
+		boolean overpower = false;
+
+		if (error != null) {
+			this.logDebug(this.log, error.getMessage());
+
+		} else {
+			try {
+				var response = getAsJsonObject(result.data());
+
+				var relays = getAsJsonArray(response, "relays");
+				if (!relays.isEmpty()) {
+					var relay = getAsJsonObject(relays.get(0));
+					relay0 = getAsBoolean(relay, "ison");
+					overpower = getAsBoolean(relay, "overpower");
+				}
+
+				int totalPower = 0;
+				int totalVoltage = 0;
+				int validEmeterCount = 0;
+				int totalReactivePower = 0;
+
+				var emeters = getAsJsonArray(response, "emeters");
+				for (int i = 0; i < emeters.size(); i++) {
+					var emeter = getAsJsonObject(emeters.get(i));
+					var power = round(getAsFloat(emeter, "power"));
+					var singleReactivePower = round(getAsFloat(emeter, "reactive"));
+					var emeterVoltage = round(getAsFloat(emeter, "voltage") * 1000);
+					var isValid = getAsBoolean(emeter, "is_valid");
+
+					if (isValid) {
+						if (this.sumEMeter1AndEMeter2) {
+							totalPower += power;
+							totalReactivePower += singleReactivePower;
+							totalVoltage += emeterVoltage;
+							validEmeterCount++;
+						} else if (i == this.channel) {
+							totalPower = power;
+							totalReactivePower = singleReactivePower;
+							totalVoltage = emeterVoltage;
+							validEmeterCount++;
+						}
+
+						if (i == 0) {
+							this.channel(IoShellyEm.ChannelId.EMETER1_EXCEPTION).setNextValue(false);
+						} else if (i == 1) {
+							this.channel(IoShellyEm.ChannelId.EMETER2_EXCEPTION).setNextValue(false);
+						}
+					} else {
+						if (i == 0) {
+							this.channel(IoShellyEm.ChannelId.EMETER1_EXCEPTION).setNextValue(true);
+						} else if (i == 1) {
+							this.channel(IoShellyEm.ChannelId.EMETER2_EXCEPTION).setNextValue(true);
+						}
+					}
+				}
+
+				if (validEmeterCount > 0) {
+					voltage = totalVoltage / validEmeterCount;
+					if (voltage > 0) {
+						current = Math.round((float) (totalPower * 1000 / voltage) * 1000);
+					}
+					activePower = totalPower;
+					reactivePower = totalReactivePower;
+				}
+
+			} catch (OpenemsNamedException e) {
+				this.logDebug(this.log, e.getMessage());
+			}
+		}
+
+		this._setRelay(relay0);
+		this.channel(IoShellyEm.ChannelId.RELAY_OVERPOWER_EXCEPTION).setNextValue(overpower);
+		this._setActivePower(activePower);
+		this._setReactivePower(reactivePower);
+		this._setVoltage(voltage);
+		this._setCurrent(current);
+
+	}
+
+	private void calculateEnergy() {
+		final var activePower = this.getActivePower().get();
+		if (activePower == null) {
+			this.calculateProductionEnergy.update(null);
+			this.calculateConsumptionEnergy.update(null);
+		} else if (activePower <= 0) {
+			this.calculateProductionEnergy.update(activePower);
+			this.calculateConsumptionEnergy.update(0);
+		} else {
+			this.calculateProductionEnergy.update(0);
+			this.calculateConsumptionEnergy.update(-activePower);
+		}
+	}
+
+	@Override
+	public Timedata getTimedata() {
+		return this.timedata;
+	}
+
+	@Override
+	public MeterType getMeterType() {
+		return this.meterType;
+	}
+
+	@Override
+	public SinglePhase getPhase() {
+		return this.phase;
+	}
+}


### PR DESCRIPTION
Sorry, third try. Git, pr and branches are relatively new to me. I have now removed the superfluous comments and `hasUpdate`

The Shelly EM has two measurement channels, but only on one phase.

The Gen1 also didn't provide amperage via the API, so the existing implementations can't be used.

This PR gives the user the ability to select the measured phase (SinglePhaseMeter) and also the option to sum the two channels.
