### PR TITLE
ESS GoodWe: Improved implementation of getSurplusPower()

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0.1%
+        threshold: 0.3%
     patch:
       default:
         target: 75%

--- a/io.openems.edge.goodwe/src/io/openems/edge/goodwe/ess/GoodWeEssImpl.java
+++ b/io.openems.edge.goodwe/src/io/openems/edge/goodwe/ess/GoodWeEssImpl.java
@@ -168,15 +168,17 @@ public class GoodWeEssImpl extends AbstractGoodWe implements GoodWeEss, GoodWe, 
 
 	@Override
 	public Integer getSurplusPower() {
-		// TODO logic is insufficient
-		if (this.getSoc().orElse(0) < 99) {
-			return null;
-		}
 		var productionPower = this.calculatePvProduction();
 		if (productionPower == null || productionPower < 100) {
 			return null;
 		}
-		return productionPower + 200 /* discharge more than PV production to avoid PV curtail */;
+		// Surplus power is the PV production that cannot be fed into the battery. "+" because
+		// allowed charge power is always negative by convention
+		var surplus = productionPower + this.getAllowedChargePower().orElse(0);
+		if (surplus < 0) {
+			return null;
+		}
+		return surplus;
 	}
 
 	@Override

--- a/io.openems.edge.goodwe/test/io/openems/edge/goodwe/ess/GoodWeEssImplTest.java
+++ b/io.openems.edge.goodwe/test/io/openems/edge/goodwe/ess/GoodWeEssImplTest.java
@@ -1,12 +1,20 @@
 package io.openems.edge.goodwe.ess;
 
 import static io.openems.edge.goodwe.GoodWeConstants.DEFAULT_UNIT_ID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
 import io.openems.edge.bridge.modbus.test.DummyModbusBridge;
+import io.openems.edge.common.sum.DummySum;
+import io.openems.edge.common.test.AbstractComponentTest.TestCase;
 import io.openems.edge.common.test.ComponentTest;
+import io.openems.edge.common.test.DummyComponentManager;
 import io.openems.edge.common.test.DummyConfigurationAdmin;
+import io.openems.edge.common.test.TestUtils;
+import io.openems.edge.ess.api.ManagedSymmetricEss;
+import io.openems.edge.ess.dccharger.api.EssDcCharger;
 import io.openems.edge.ess.test.DummyPower;
 import io.openems.edge.ess.test.ManagedSymmetricEssTest;
 import io.openems.edge.goodwe.charger.singlestring.GoodWeChargerPv1;
@@ -33,6 +41,8 @@ public class GoodWeEssImplTest {
 				.addReference("power", new DummyPower()) //
 				.addReference("cm", new DummyConfigurationAdmin()) //
 				.addReference("setModbus", new DummyModbusBridge("modbus0")) //
+				.addReference("sum", new DummySum()) //
+				.addReference("componentManager", new DummyComponentManager()) //
 				.addComponent(charger) //
 				.activate(MyConfig.create() //
 						.setId("ess0") //
@@ -42,7 +52,23 @@ public class GoodWeEssImplTest {
 						.setMaxBatteryPower(5_200) //
 						.setControlMode(ControlMode.SMART) //
 						.build()) //
-		;
+				.next(new TestCase()) //
+				.deactivate();
+
+		// Test getSurplusPower()
+		assertNull(ess.getSurplusPower());
+		TestUtils.withValue(charger, EssDcCharger.ChannelId.ACTUAL_POWER, 100);
+		assertEquals(100, (int) ess.getSurplusPower());
+
+		TestUtils.withValue(charger, EssDcCharger.ChannelId.ACTUAL_POWER, 99);
+		assertNull(ess.getSurplusPower());
+
+		TestUtils.withValue(charger, EssDcCharger.ChannelId.ACTUAL_POWER, 1000);
+		TestUtils.withValue(ess, ManagedSymmetricEss.ChannelId.ALLOWED_CHARGE_POWER, -1000);
+		assertEquals(0, (int) ess.getSurplusPower());
+
+		TestUtils.withValue(ess, ManagedSymmetricEss.ChannelId.ALLOWED_CHARGE_POWER, -1001);
+		assertNull(ess.getSurplusPower());
 	}
 
 	@Test
@@ -52,6 +78,8 @@ public class GoodWeEssImplTest {
 				.addReference("power", new DummyPower()) //
 				.addReference("cm", new DummyConfigurationAdmin()) //
 				.addReference("setModbus", new DummyModbusBridge("modbus0")) //
+				.addReference("sum", new DummySum()) //
+				.addReference("componentManager", new DummyComponentManager()) //
 				.activate(MyConfig.create() //
 						.setId("ess0") //
 						.setModbusId("modbus0") //
@@ -60,7 +88,8 @@ public class GoodWeEssImplTest {
 						.setMaxBatteryPower(5_200) //
 						.setControlMode(ControlMode.SMART) //
 						.build()) //
-		;
+				.next(new TestCase()) //
+				.deactivate();
 	}
 
 }


### PR DESCRIPTION
The old implementation simply said "There is no surplus power, when the SOC is below 99%, and otherwise, the whole production is surplus power". The existing implementation has two weaknesses:
1. You will effectively lose 1-2% of the battery capacity.
2. When the battery is below 99%, but cannot charge for other reasons (e.g. due to low cell temperature), the production power does not count as surplus power, meaning that the controller surplus feed-to-grid would curtail the PV.

The new implementation takes the more generic approach that the surplus power is the production power that cannot be fed into the battery (for whatever reason). It can also be applied for other Hybrid-ESSs.