### PR TITLE
feat: add listen ip parameter to components that have socket and set 127.0.0.1 as default

### DIFF
--- a/io.openems.backend.b2brest/src/io/openems/backend/b2brest/Backend2BackendRest.java
+++ b/io.openems.backend.b2brest/src/io/openems/backend/b2brest/Backend2BackendRest.java
@@ -1,5 +1,6 @@
 package io.openems.backend.b2brest;
 
+import java.net.InetSocketAddress;
 import org.eclipse.jetty.server.Server;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -26,6 +27,7 @@ import io.openems.common.exceptions.OpenemsException;
 public class Backend2BackendRest extends AbstractOpenemsBackendComponent {
 
 	public static final int DEFAULT_PORT = 8075;
+	public static final String DEFAULT_IP = "127.0.0.1";
 
 	private final Logger log = LoggerFactory.getLogger(Backend2BackendRest.class);
 
@@ -43,7 +45,7 @@ public class Backend2BackendRest extends AbstractOpenemsBackendComponent {
 
 	@Activate
 	private void activate(Config config) throws OpenemsException {
-		this.startServer(config.port());
+		this.startServer(config.ip(), config.port());
 	}
 
 	@Deactivate
@@ -57,14 +59,14 @@ public class Backend2BackendRest extends AbstractOpenemsBackendComponent {
 	 * @param port the port
 	 * @throws OpenemsException on error
 	 */
-	private synchronized void startServer(int port) throws OpenemsException {
+	private synchronized void startServer(String ip, int port) throws OpenemsException {
 		try {
-			this.server = new Server(port);
+			this.server = new Server(new InetSocketAddress(ip, port));
 			this.server.setHandler(new RestHandler(this));
 			this.server.start();
-			this.logInfo(this.log, "Backend2Backend.Rest started on port [" + port + "].");
+			this.logInfo(this.log, "Backend2Backend.Rest started on [" + ip + ":" + port + "].");
 		} catch (Exception e) {
-			throw new OpenemsException("Backend2Backend.Rest failed on port [" + port + "].", e);
+			throw new OpenemsException("Backend2Backend.Rest failed on [" + ip + ":" + port + "].", e);
 		}
 	}
 

--- a/io.openems.backend.b2brest/src/io/openems/backend/b2brest/Config.java
+++ b/io.openems.backend.b2brest/src/io/openems/backend/b2brest/Config.java
@@ -11,6 +11,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Port", description = "The port of the REST server.")
 	int port() default Backend2BackendRest.DEFAULT_PORT;
 
+	@AttributeDefinition(name = "IP Address", description = "The IP address to listen on.")
+	String ip() default Backend2BackendRest.DEFAULT_IP;
+
 	String webconsole_configurationFactory_nameHint() default "Backend2Backend Rest";
 
 }

--- a/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/Backend2BackendWebsocket.java
+++ b/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/Backend2BackendWebsocket.java
@@ -45,6 +45,7 @@ public class Backend2BackendWebsocket extends AbstractOpenemsBackendComponent im
 	private static final String COMPONENT_ID = "b2bwebsocket0";
 
 	public static final int DEFAULT_PORT = 8076;
+	public static final String DEFAULT_IP = io.openems.common.websocket.AbstractWebsocketServer.DEFAULT_IP;
 
 	protected final ScheduledExecutorService executor = Executors.newScheduledThreadPool(10,
 			new ThreadFactoryBuilder().setNameFormat("B2bWebsocket-%d").build());
@@ -88,7 +89,7 @@ public class Backend2BackendWebsocket extends AbstractOpenemsBackendComponent im
 	 */
 	private synchronized void startServer() {
 		if (this.server == null) {
-			this.server = new WebsocketServer(this, this.getName(), this.config.port(), this.config.poolSize());
+			this.server = new WebsocketServer(this, this.getName(), this.config.ip(), this.config.port(), this.config.poolSize());
 			this.server.start();
 		}
 	}

--- a/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/Config.java
+++ b/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/Config.java
@@ -11,6 +11,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Port", description = "The port of the websocket server.")
 	int port() default Backend2BackendWebsocket.DEFAULT_PORT;
 
+	@AttributeDefinition(name = "IP Address", description = "The IP address to listen on.")
+	String ip() default io.openems.common.websocket.AbstractWebsocketServer.DEFAULT_IP;
+
 	@AttributeDefinition(name = "Number of Threads", description = "Pool-Size: the number of threads dedicated to handle the tasks")
 	int poolSize() default 10;
 

--- a/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/WebsocketServer.java
+++ b/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/WebsocketServer.java
@@ -14,8 +14,8 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 	private final OnError onError;
 	private final OnClose onClose;
 
-	public WebsocketServer(Backend2BackendWebsocket parent, String name, int port, int poolSize) {
-		super(name, port, poolSize);
+	public WebsocketServer(Backend2BackendWebsocket parent, String name, String ip, int port, int poolSize) {
+		super(name, ip, port, poolSize);
 		this.parent = parent;
 		this.onOpen = new OnOpen(//
 				() -> parent.metadata, //

--- a/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/Config.java
+++ b/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/Config.java
@@ -11,6 +11,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Port", description = "The port of the websocket server.")
 	int port() default 8081;
 
+	@AttributeDefinition(name = "IP Address", description = "The IP address to listen on.")
+	String ip() default io.openems.common.websocket.AbstractWebsocketServer.DEFAULT_IP;
+
 	@AttributeDefinition(name = "Number of Threads", description = "Pool-Size: the number of threads dedicated to handle the tasks")
 	int poolSize() default 10;
 

--- a/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/EdgeWebsocketImpl.java
+++ b/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/EdgeWebsocketImpl.java
@@ -112,7 +112,7 @@ public class EdgeWebsocketImpl extends AbstractOpenemsBackendComponent
 	 */
 	private synchronized void startServer() {
 		if (this.server == null) {
-			this.server = new WebsocketServer(this, this.getName(), this.config.port(), this.config.poolSize());
+			this.server = new WebsocketServer(this, this.getName(), this.config.ip(), this.config.port(), this.config.poolSize());
 			this.server.start();
 		}
 	}

--- a/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/WebsocketServer.java
+++ b/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/WebsocketServer.java
@@ -24,8 +24,8 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 	private final OnError onError;
 	private final OnClose onClose;
 
-	public WebsocketServer(EdgeWebsocketImpl parent, String name, int port, int poolSize) {
-		super(name, port, poolSize);
+	public WebsocketServer(EdgeWebsocketImpl parent, String name, String ip, int port, int poolSize) {
+		super(name, ip, port, poolSize);
 		this.parent = parent;
 		this.onOpen = new OnOpen(parent);
 		this.onRequest = new OnRequest(//

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/Config.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/Config.java
@@ -11,6 +11,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Port", description = "The port of the websocket server.")
 	int port() default 8082;
 
+	@AttributeDefinition(name = "IP Address", description = "The IP address to listen on.")
+	String ip() default io.openems.common.websocket.AbstractWebsocketServer.DEFAULT_IP;
+
 	@AttributeDefinition(name = "Number of Threads", description = "Pool-Size: the number of threads dedicated to handle the tasks")
 	int poolSize() default 10;
 

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/UiWebsocketImpl.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/UiWebsocketImpl.java
@@ -100,7 +100,7 @@ public class UiWebsocketImpl extends AbstractOpenemsBackendComponent
 	 */
 	private synchronized void startServer() {
 		if (this.server == null) {
-			this.server = new WebsocketServer(this, this.getName(), this.config.port(), this.config.poolSize());
+			this.server = new WebsocketServer(this, this.getName(), this.config.ip(), this.config.port(), this.config.poolSize());
 			this.server.start();
 			this.uiWebsocketValidator.start(this.server);
 		}

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/WebsocketServer.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/WebsocketServer.java
@@ -14,8 +14,8 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 	private final OnNotification onNotification;
 	private final OnError onError;
 
-	public WebsocketServer(UiWebsocketImpl parent, String name, int port, int poolSize) {
-		super(name, port, poolSize);
+	public WebsocketServer(UiWebsocketImpl parent, String name, String ip, int port, int poolSize) {
+		super(name, ip, port, poolSize);
 		this.parent = parent;
 		this.onRequest = new OnRequest(parent);
 		this.onNotification = new OnNotification(parent);

--- a/io.openems.common/src/io/openems/common/websocket/AbstractWebsocketServer.java
+++ b/io.openems.common/src/io/openems/common/websocket/AbstractWebsocketServer.java
@@ -27,6 +27,8 @@ import io.openems.common.utils.ThreadPoolUtils;
 
 public abstract class AbstractWebsocketServer<T extends WsData> extends AbstractWebsocket<T> {
 
+    public static final String DEFAULT_IP = "127.0.0.1";
+
 	/**
 	 * Shared {@link ExecutorService}.
 	 */
@@ -34,6 +36,7 @@ public abstract class AbstractWebsocketServer<T extends WsData> extends Abstract
 
 	private final Logger log = LoggerFactory.getLogger(AbstractWebsocketServer.class);
 	private final int port;
+	private final String ip;
 	private final WebSocketServer ws;
 	private final Collection<WebSocket> connections = ConcurrentHashMap.newKeySet();
 
@@ -46,13 +49,14 @@ public abstract class AbstractWebsocketServer<T extends WsData> extends Abstract
 	 * @param port     to listen on
 	 * @param poolSize number of threads dedicated to handle the tasks
 	 */
-	protected AbstractWebsocketServer(String name, int port, int poolSize) {
+	protected AbstractWebsocketServer(String name, String ip, int port, int poolSize) {
 		super(name);
 		this.executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(poolSize,
 				new ThreadFactoryBuilder().setNameFormat(name + "-%d").build());
 
 		this.port = port;
-		this.ws = new WebSocketServer(new InetSocketAddress(port),
+		this.ip = ip;
+		this.ws = new WebSocketServer(new InetSocketAddress(ip, port),
 				/* AVAILABLE_PROCESSORS */ Runtime.getRuntime().availableProcessors(), //
 				/* drafts, no filter */ List.of(new MyDraft6455()), //
 				this.connections) {
@@ -172,7 +176,7 @@ public abstract class AbstractWebsocketServer<T extends WsData> extends Abstract
 		return (t, wsDataString) -> {
 			switch (t) {
 			case BindException be //
-				-> this.logError(this.log, "Unable to Bind to port [" + this.port + "]");
+				-> this.logError(this.log, "Unable to Bind to [" + this.ip + ":" + this.port + "]");
 			default //
 				-> this.logError(this.log, new StringBuilder() //
 						.append("OnInternalError for ").append(wsDataString).append(". ") //
@@ -223,6 +227,10 @@ public abstract class AbstractWebsocketServer<T extends WsData> extends Abstract
 	public int getPort() {
 		return this.ws.getPort();
 	}
+	
+	public String getIp() {
+		return this.ip;
+	}
 
 	/**
 	 * Starts the {@link WebSocketServer}.
@@ -234,7 +242,7 @@ public abstract class AbstractWebsocketServer<T extends WsData> extends Abstract
 		}
 		this.isStarted = true;
 		super.start();
-		this.logInfo(this.log, "Starting websocket server [port=" + this.port + "]");
+		this.logInfo(this.log, "Starting websocket server [" + this.ip + ":" + this.port + "]");
 		this.ws.start();
 	}
 

--- a/io.openems.common/src/io/openems/common/websocket/DummyWebsocketServer.java
+++ b/io.openems.common/src/io/openems/common/websocket/DummyWebsocketServer.java
@@ -87,7 +87,7 @@ public class DummyWebsocketServer extends AbstractWebsocketServer<WsData> implem
 	private final DummyWebsocketServer.Builder builder;
 
 	private DummyWebsocketServer(DummyWebsocketServer.Builder builder) {
-		super("DummyWebsocketServer", 0 /* auto-select port */, 1 /* pool size */);
+		super("DummyWebsocketServer", "127.0.0.1", 0 /* auto-select port */, 1 /* pool size */);
 		this.builder = builder;
 	}
 

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/AbstractRestApi.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/AbstractRestApi.java
@@ -59,7 +59,7 @@ public abstract class AbstractRestApi extends AbstractOpenemsComponent
 	 * @param connectionlimit    the connection limit
 	 */
 	protected void activate(ComponentContext context, String id, String alias, boolean enabled,
-			boolean isDebugModeEnabled, int apiTimeout, int port, int connectionlimit) {
+			boolean isDebugModeEnabled, int apiTimeout, String ip, int port, int connectionlimit) {
 		super.activate(context, id, alias, enabled);
 		this.isDebugModeEnabled = isDebugModeEnabled;
 
@@ -78,18 +78,18 @@ public abstract class AbstractRestApi extends AbstractOpenemsComponent
 					UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS, //
 					UriCompliance.Violation.ILLEGAL_PATH_CHARACTERS)));
 			final var connector = new ServerConnector(this.server, new HttpConnectionFactory(httpConfig));
+			connector.setHost(ip);
 			connector.setPort(port);
 			this.server.addConnector(connector);
 			this.server.setHandler(new RestHandler(this));
 			this.server.addBean(new AcceptRateLimit(10, 5, TimeUnit.SECONDS, this.server));
 			this.server.addBean(new ConnectionLimit(connectionlimit, this.server));
 			this.server.start();
-			this.logInfo(this.log, this.implementationName + " started on port [" + port + "].");
+			this.logInfo(this.log, this.implementationName + " started on [" + ip + ":" + port + "].");
 			this._setUnableToStart(false);
-
 		} catch (Exception e) {
 			this.logError(this.log,
-					"Unable to start " + this.implementationName + " on port [" + port + "]: " + e.getMessage());
+					"Unable to start " + this.implementationName + " on [" + ip + ":" + port + "]: " + e.getMessage());
 			this._setUnableToStart(true);
 		}
 		this.getRpcRestHandler().setOnCall(call -> {

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readonly/Config.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readonly/Config.java
@@ -22,6 +22,9 @@ import io.openems.edge.controller.api.rest.AbstractRestApi;
 	@AttributeDefinition(name = "Port", description = "Port on which the webserver should listen.")
 	int port() default 8084;
 
+	@AttributeDefinition(name = "IP Address", description = "The IP address to listen on.")
+	String ip() default io.openems.common.websocket.AbstractWebsocketServer.DEFAULT_IP;
+
 	@AttributeDefinition(name = "Connection limit", description = "Maximum number of connections")
 	int connectionlimit() default 5;
 

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readonly/ControllerApiRestReadOnlyImpl.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readonly/ControllerApiRestReadOnlyImpl.java
@@ -51,7 +51,7 @@ public class ControllerApiRestReadOnlyImpl extends AbstractRestApi
 		this.restHandler = this.restHandlerFactory.get();
 
 		super.activate(context, config.id(), config.alias(), config.enabled(), config.debugMode(), 0, /* no timeout */
-				config.port(), config.connectionlimit());
+				config.ip(), config.port(), config.connectionlimit());
 	}
 
 	@Override

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readwrite/Config.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readwrite/Config.java
@@ -22,6 +22,9 @@ import io.openems.edge.controller.api.rest.AbstractRestApi;
 	@AttributeDefinition(name = "Port", description = "Port on which the webserver should listen.")
 	int port() default 8084;
 
+	@AttributeDefinition(name = "IP Address", description = "The IP address to listen on.")
+	String ip() default io.openems.common.websocket.AbstractWebsocketServer.DEFAULT_IP;
+
 	@AttributeDefinition(name = "Connection limit", description = "Maximum number of connections")
 	int connectionlimit() default 5;
 

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readwrite/ControllerApiRestReadWriteImpl.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readwrite/ControllerApiRestReadWriteImpl.java
@@ -51,8 +51,8 @@ public class ControllerApiRestReadWriteImpl extends AbstractRestApi
 	private void activate(ComponentContext context, Config config) throws OpenemsException {
 		this.restHandler = this.restHandlerFactory.get();
 
-		super.activate(context, config.id(), config.alias(), config.enabled(), config.debugMode(), config.apiTimeout(),
-				config.port(), config.connectionlimit());
+		super.activate(context, config.id(), config.alias(), config.enabled(), config.debugMode(),
+				config.apiTimeout(), config.ip(), config.port(), config.connectionlimit());
 	}
 
 	@Override

--- a/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readonly/ControllerApiRestReadOnlyImplTest.java
+++ b/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readonly/ControllerApiRestReadOnlyImplTest.java
@@ -69,6 +69,7 @@ public class ControllerApiRestReadOnlyImplTest {
 						.setEnabled(true) //
 						.setConnectionlimit(5) //
 						.setDebugMode(false) //
+						.setIp("127.0.0.1") //
 						.setPort(port) //
 						.build());
 

--- a/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readonly/MyConfig.java
+++ b/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readonly/MyConfig.java
@@ -11,6 +11,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 		private int port;
 		private int connectionlimit;
 		private boolean debugMode;
+		private String ip;
 
 		private Builder() {
 		}
@@ -37,6 +38,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 		public Builder setDebugMode(boolean debugMode) {
 			this.debugMode = debugMode;
+			return this;
+		}
+		
+		public Builder setIp(String ip) {
+			this.ip = ip;
 			return this;
 		}
 
@@ -74,6 +80,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	@Override
 	public boolean debugMode() {
 		return this.builder.debugMode;
+	}
+	
+	@Override
+	public String ip() {
+		return this.builder.ip;
 	}
 
 }

--- a/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readwrite/ControllerApiRestReadWriteImplTest.java
+++ b/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readwrite/ControllerApiRestReadWriteImplTest.java
@@ -87,6 +87,7 @@ public class ControllerApiRestReadWriteImplTest {
 						.setApiTimeout(60) //
 						.setConnectionlimit(5) //
 						.setDebugMode(false) //
+						.setIp("127.0.0.1") //
 						.setPort(port) //
 						.build());
 

--- a/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readwrite/MyConfig.java
+++ b/io.openems.edge.controller.api.rest/test/io/openems/edge/controller/api/rest/readwrite/MyConfig.java
@@ -11,6 +11,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 		private int connectionlimit;
 		private int apiTimeout;
 		private boolean debugMode;
+		private String ip;
 
 		private Builder() {
 		}
@@ -37,6 +38,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 		public Builder setDebugMode(boolean debugMode) {
 			this.debugMode = debugMode;
+			return this;
+		}
+
+		public Builder setIp(String ip) {
+			this.ip = ip;
 			return this;
 		}
 
@@ -74,6 +80,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	@Override
 	public boolean debugMode() {
 		return this.builder.debugMode;
+	}
+	
+	@Override
+	public String ip() {
+		return this.builder.ip;
 	}
 
 }

--- a/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/Config.java
+++ b/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/Config.java
@@ -20,6 +20,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Port", description = "Port on which the Websocket server should listen.")
 	int port() default 8085;
 
+	@AttributeDefinition(name = "IP Address", description = "The IP address to listen on.")
+	String ip() default io.openems.common.websocket.AbstractWebsocketServer.DEFAULT_IP;
+
 	@AttributeDefinition(name = "Api-Timeout", description = "Sets the timeout in seconds for updates on Channels set by this Api.")
 	int apiTimeout() default 60;
 

--- a/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/ControllerApiWebsocketImpl.java
+++ b/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/ControllerApiWebsocketImpl.java
@@ -92,7 +92,7 @@ public class ControllerApiWebsocketImpl extends AbstractOpenemsComponent
 			call.put(ComponentConfigRequestHandler.API_WORKER_KEY, this.apiWorker);
 		});
 		this.onRequest.setDebug(config.debugMode());
-		this.startServer(config.port(), POOL_SIZE);
+		this.startServer(config.ip(), config.port(), POOL_SIZE);
 
 	}
 
@@ -111,8 +111,8 @@ public class ControllerApiWebsocketImpl extends AbstractOpenemsComponent
 	 * @param port     the port
 	 * @param poolSize number of threads dedicated to handle the tasks
 	 */
-	private synchronized void startServer(int port, int poolSize) {
-		this.server = new WebsocketServer(this, "Websocket Api", port, poolSize);
+	private synchronized void startServer(String ip, int port, int poolSize) {
+		this.server = new WebsocketServer(this, "Websocket Api", ip, port, poolSize);
 		this.server.start();
 	}
 

--- a/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/WebsocketServer.java
+++ b/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/WebsocketServer.java
@@ -16,8 +16,8 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 	private final OnError onError;
 	private final OnClose onClose;
 
-	public WebsocketServer(ControllerApiWebsocketImpl parent, String name, int port, int poolSize) {
-		super(name, port, poolSize);
+	public WebsocketServer(ControllerApiWebsocketImpl parent, String name, String ip, int port, int poolSize) {
+		super(name, ip, port, poolSize);
 		this.parent = parent;
 		this.onNotification = new OnNotification(parent);
 		this.onError = new OnError(parent);

--- a/io.openems.edge.controller.api.websocket/test/io/openems/edge/controller/api/websocket/ControllerApiWebsocketImplTest.java
+++ b/io.openems.edge.controller.api.websocket/test/io/openems/edge/controller/api/websocket/ControllerApiWebsocketImplTest.java
@@ -18,6 +18,7 @@ public class ControllerApiWebsocketImplTest {
 				.activate(MyConfig.create() //
 						.setId("ctrl0") //
 						.setApiTimeout(60) //
+						.setIp("127.0.0.1") //
 						.setPort(DEFAULT_PORT) //
 						.build()) //
 				.next(new TestCase()) //

--- a/io.openems.edge.controller.api.websocket/test/io/openems/edge/controller/api/websocket/MyConfig.java
+++ b/io.openems.edge.controller.api.websocket/test/io/openems/edge/controller/api/websocket/MyConfig.java
@@ -10,6 +10,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 		private int port;
 		private int apiTimeout;
 		private boolean debugMode;
+		private String ip;
 
 		private Builder() {
 		}
@@ -32,6 +33,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 		public Builder setDebugMode(boolean debugMode) {
 			this.debugMode = debugMode;
 			return this;
+		}
+
+		public Builder setIp(String ip) {
+		        this.ip = ip;
+		        return this;
 		}
 
 		public MyConfig build() {
@@ -68,6 +74,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	@Override
 	public boolean debugMode() {
 		return this.builder.debugMode;
+	}
+	
+	@Override
+	public String ip() {
+		return this.builder.ip;
 	}
 
 }


### PR DESCRIPTION
Current implementation has no parameter of bind ip address and So openems listen 0.0.0.0 (all interface of the computer). This will be problem in usecase of using in global network that can be acceced by anyone. Because some component doesn't provide authentication/authorization/encryption, So if these component is used without IP Firewall in global network, vulnerable endpoint will be exposed.

Therefore this PR introduce bind ip address parameter to these components and provide option of lisning interface.

Today, HTTP/TLS become very complex protocol, So implementing this by application-side itself is very very difficut. Almost case, HTTP/TLS server in global network is provided by combination application and reverse proxy server(like apache, nginx). This PR is mainly targeting lisning localhost in application and lisning 0.0.0.0 in reverse proxy use.

Co-Author: @cvabc, chagpt codex