### PR TITLE
fix: fix use getEditButtonText; add ja text

### DIFF
--- a/ui/src/app/user/user.component.html
+++ b/ui/src/app/user/user.component.html
@@ -81,8 +81,7 @@
             <ion-item lines="none">
               <ion-button style="padding-top: 0.3em" slot="start" (click)="enableAndDisableEditMode()"
                 [disabled]="!isEditModeDisabled && !this.form?.formGroup?.dirty">
-                <ion-label>{{isEditModeDisabled ? ('General.EDIT' | translate) :('General.RESET' |
-                  translate)}}</ion-label>
+                <ion-label>{{ getEditButtonText() | translate }}</ion-label>
                 <ion-icon name="pencil-outline" slot="end"></ion-icon>
               </ion-button>
               <ion-button [disabled]="!form?.formGroup?.dirty" slot="end" (click)="applyChanges()">

--- a/ui/src/assets/i18n/ja.json
+++ b/ui/src/assets/i18n/ja.json
@@ -400,6 +400,8 @@
     "title": "OpenEMS"
   },
   "General": {
+    "EDIT": "編集",
+    "RESET": "リセット",
     "active": "有効",
     "actualPower": "e-car充電",
     "apply": "適用",


### PR DESCRIPTION
This pull request introduces a small but meaningful improvement to the user interface by refactoring the logic for determining the edit button text and adding missing translations for Japanese localization.

### UI Improvements:
* [`ui/src/app/user/user.component.html`](diffhunk://#diff-64722e19657f10da2ee773c705e92107f6464616acc1a0101eb5cbea7975a7a8L84-R84): Replaced inline conditional logic for the edit button label with a call to the new `getEditButtonText()` method, improving readability and maintainability.

### Localization Enhancements:
* [`ui/src/assets/i18n/ja.json`](diffhunk://#diff-328a4a102784442187540086e8cc50d343dfbe95b83be539e1ff501de64dd184R403-R404): Added missing Japanese translations for "EDIT" ("編集") and "RESET" ("リセット") to ensure proper localization.