### PR TITLE
fix: add translation text for technicalName, category, cardinality

### DIFF
--- a/ui/src/app/edge/settings/app/index.component.html
+++ b/ui/src/app/edge/settings/app/index.component.html
@@ -27,12 +27,12 @@
           </div>
         </div>
         <p *ngIf="false">
-          <small>Technischer Name: {{ app.appId }}</small><br />
-          <small>Kategorie:
+          <small>{{ 'Edge.Config.App.technicalName' | translate }}: {{ app.appId }}</small><br />
+          <small>{{ 'Edge.Config.App.category' | translate }}:
             <a *ngFor="let c of app.categorys">
               {{ c.readableName }}
             </a></small><br />
-          <small>Cardinality: {{ app.cardinality }}</small>
+          <small>{{ 'Edge.Config.App.cardinality' | translate }}: {{ app.cardinality }}</small>
         </p>
       </ion-card-content>
       <ion-accordion-group>

--- a/ui/src/assets/i18n/de.json
+++ b/ui/src/assets/i18n/de.json
@@ -455,7 +455,10 @@
         "successDelete": "App erfolgreich entfernt",
         "failDelete": "Entfernen der App fehlgeschlagen: {{error}}",
         "DELETE_CONFIRM_HEADLINE": "Sind Sie sicher, dass die App entfernt werden soll?",
-        "DELETE_CONFIRM_DESCRIPTION": "Beim Entfernen werden alle Komponenten und Einstellungen gelöscht, die von dieser App angelegt wurden."
+        "DELETE_CONFIRM_DESCRIPTION": "Beim Entfernen werden alle Komponenten und Einstellungen gelöscht, die von dieser App angelegt wurden.",
+        "technicalName": "Technischer Name",
+        "category": "Kategorie",
+        "cardinality": "Kardinalität"
       }
     },
     "Service": {

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -457,7 +457,10 @@
         "successDelete": "Successfully deleted App",
         "failDelete": "Error deleting App '{{error}}'",
         "DELETE_CONFIRM_HEADLINE": "Are you sure you wish to uninstall the app?",
-        "DELETE_CONFIRM_DESCRIPTION": "Uninstalling the app will remove all of its components and delete all settings made by it."
+        "DELETE_CONFIRM_DESCRIPTION": "Uninstalling the app will remove all of its components and delete all settings made by it.",
+        "technicalName": "Technical name",
+        "category": "Category",
+        "cardinality": "Cardinality"
       }
     },
     "Service": {

--- a/ui/src/assets/i18n/ja.json
+++ b/ui/src/assets/i18n/ja.json
@@ -374,7 +374,10 @@
         "deleteApp": "アプリを削除します",
         "updateApp": "アプリを更新します",
         "errorInstallable": "インストールエラー",
-        "errorCompatible": "互換性エラー"
+        "errorCompatible": "互換性エラー",
+        "technicalName": "技術名",
+        "category": "カテゴリ",
+        "cardinality": "カーディナリティ"
       }
     },
     "Service": {


### PR DESCRIPTION
This pull request introduces localization improvements to the app settings UI by replacing hardcoded strings with translatable keys and updating language files to include the necessary translations.

### Localization improvements:

* [`ui/src/app/edge/settings/app/index.component.html`](diffhunk://#diff-d2dbe22f15c096bfcc109781249a4dc0ff8ead8ada83b3e33afa2cc801453fc1L30-R35): Replaced hardcoded labels like "Technischer Name," "Kategorie," and "Cardinality" with translatable keys (`Edge.Config.App.technicalName`, `Edge.Config.App.category`, and `Edge.Config.App.cardinality`) to support internationalization.

### Language file updates:

* [`ui/src/assets/i18n/de.json`](diffhunk://#diff-4c00e9ac7a5629a23e077dc4b4d0b857a713fef27c2b20becc6585064794070eL458-R461): Added translations for "technicalName," "category," and "cardinality" in German.
* [`ui/src/assets/i18n/en.json`](diffhunk://#diff-3664d4d898522a2acf844695c45209868e5692e975b1e497dca81400ecccc0a2L460-R463): Added translations for "technicalName," "category," and "cardinality" in English.
* [`ui/src/assets/i18n/ja.json`](diffhunk://#diff-328a4a102784442187540086e8cc50d343dfbe95b83be539e1ff501de64dd184L377-R380): Added translations for "technicalName," "category," and "cardinality" in Japanese.

co-author: @Jasonlee6789 , codex, copilot