### PR TITLE
fix: remove original translation file and migrate it to exsiting one

### DIFF
--- a/ui/src/app/edge/history/Controller/Io/heatpump/overview/overview.ts
+++ b/ui/src/app/edge/history/Controller/Io/heatpump/overview/overview.ts
@@ -12,7 +12,6 @@ import { PickdateComponentModule } from "src/app/shared/components/pickdate/pick
 import { Service } from "src/app/shared/shared";
 import { Language } from "src/app/shared/type/language";
 import { ChartComponent } from "../chart/chart";
-import tr from "./translation.json";
 @Component({
     selector: "controller-io-heatpump-overview",
     templateUrl: "./overview.html",
@@ -49,9 +48,6 @@ export class OverviewComponent extends AbstractHistoryChartOverview {
         private translate: TranslateService,
     ) {
         super(service, route, modalCtrl);
-        Language.setAdditionalTranslationFile(tr, this.translate).then(({ lang, translations, shouldMerge }) => {
-            this.translate.setTranslation(lang, translations, shouldMerge);
-        });
     }
 
     protected setChartConfig(event: ChartTypes.ChartConfig) {

--- a/ui/src/app/edge/history/Controller/Io/heatpump/overview/translation.json
+++ b/ui/src/app/edge/history/Controller/Io/heatpump/overview/translation.json
@@ -1,8 +1,0 @@
-{
-    "de": {
-        "LEGEND_DESCRIPTION": "Legende Betriebszustand"
-    },
-    "en": {
-        "LEGEND_DESCRIPTION": "Legend operating status"
-    }
-}

--- a/ui/src/assets/i18n/de.json
+++ b/ui/src/assets/i18n/de.json
@@ -720,6 +720,7 @@
       "GRID_OPTIMIZED_CHARGE": "Netzdienliche Beladung",
       "TIME_OF_USE_TARIFF": "Dynamischer Stromtarif",
       "LEGEND": "Legende",
+      "LEGEND_DESCRIPTION": "Legende Betriebszustand",
       "NOT_YET_CONFIGURED": "noch nicht konfiguriert/ausgeführt",
       "PARTIAL_CONFIGURATION": "Es konnten nicht alle Komponenten richtig konfiguriert werden.",
       "PRE_CONFIGURED": "vorkonfiguriert / Warnung",

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -713,6 +713,7 @@
       "GRID_OPTIMIZED_CHARGE": "Grid-optimized charge",
       "TIME_OF_USE_TARIFF": "Time-of-use tariff",
       "LEGEND": "Legend",
+      "LEGEND_DESCRIPTION": "Legend operating status",
       "NOT_YET_CONFIGURED": "Not yet configured/checked",
       "PARTIAL_CONFIGURATION": "Not all components could be configured correctly.",
       "PRE_CONFIGURED": "Preconfigured/Warning",

--- a/ui/src/assets/i18n/ja.json
+++ b/ui/src/assets/i18n/ja.json
@@ -558,6 +558,7 @@
       "GRID_METER": "グリッドメーター",
       "GRID_OPTIMIZED_CHARGE": "グリッドに優しい充電",
       "LEGEND": "伝説",
+      "LEGEND_DESCRIPTION": "運転状態の凡例",
       "NOT_YET_CONFIGURED": "まだ構成 /チェックされていません",
       "PARTIAL_CONFIGURATION": "すべてのコンポーネントを正しく構成できるわけではありません。",
       "PRE_CONFIGURED": "事前に設定された /警告",


### PR DESCRIPTION
This pull request refactors the translation handling in the `OverviewComponent` and consolidates translation strings into centralized files. The most important changes include removing the component-specific translation file and logic, and adding the necessary translations to the global translation files.

### Refactoring translation handling:

* [`ui/src/app/edge/history/Controller/Io/heatpump/overview/overview.ts`](diffhunk://#diff-1001baf79599b929651baf9249063fcb3fe36af60c7b1224c110530211ddf784L15): Removed the import of the component-specific `translation.json` file and the logic for setting additional translations in the `OverviewComponent` constructor. [[1]](diffhunk://#diff-1001baf79599b929651baf9249063fcb3fe36af60c7b1224c110530211ddf784L15) [[2]](diffhunk://#diff-1001baf79599b929651baf9249063fcb3fe36af60c7b1224c110530211ddf784L52-L54)
* [`ui/src/app/edge/history/Controller/Io/heatpump/overview/translation.json`](diffhunk://#diff-5608d58db07865d6d50124050d092824af1bbd5e5a0c3f02b632a4e4cb755731L1-L8): Deleted the component-specific translation file entirely.

### Consolidating translations into global files:

* [`ui/src/assets/i18n/de.json`](diffhunk://#diff-4c00e9ac7a5629a23e077dc4b4d0b857a713fef27c2b20becc6585064794070eR689): Added the `"LEGEND_DESCRIPTION"` key with the German translation `"Legende Betriebszustand"`.
* [`ui/src/assets/i18n/en.json`](diffhunk://#diff-3664d4d898522a2acf844695c45209868e5692e975b1e497dca81400ecccc0a2R683): Added the `"LEGEND_DESCRIPTION"` key with the English translation `"Legend operating status"`.
* [`ui/src/assets/i18n/ja.json`](diffhunk://#diff-328a4a102784442187540086e8cc50d343dfbe95b83be539e1ff501de64dd184R558): Added the `"LEGEND_DESCRIPTION"` key with the Japanese translation `"運転状態の凡例"`.

co-author: @Jasonlee6789 , codex, copilot