### PR TITLE
Fix JSCalendar without recurrence rule

### DIFF
--- a/io.openems.common/src/io/openems/common/jscalendar/JSCalendar.java
+++ b/io.openems.common/src/io/openems/common/jscalendar/JSCalendar.java
@@ -27,6 +27,7 @@ import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -194,10 +195,9 @@ public class JSCalendar<PAYLOAD> {
 						.setStart(json.getString("start")) //
 						.setDuration(json.getStringOrNull("duration")); //
 
-				json.getNullableJsonArrayPath("recurrenceRules") //
-						.getAsOptionalList(RecurrenceRule.serializer()) //
-						.ifPresent(rrs -> rrs.forEach(rr -> b.addRecurrenceRule(rr))); //
-
+				json.getOptionalList("recurrenceRules", RecurrenceRule.serializer()).orElse(Collections.emptyList()) //
+				.forEach(rr -> b.addRecurrenceRule(rr));
+				
 				var payload = json.getObjectOrNull(PROPERTY_PAYLOAD, payloadSerializer);
 				if (payload != null) {
 					b.setPayload(payload);

--- a/io.openems.common/src/io/openems/common/jscalendar/JSCalendar.java
+++ b/io.openems.common/src/io/openems/common/jscalendar/JSCalendar.java
@@ -194,9 +194,9 @@ public class JSCalendar<PAYLOAD> {
 						.setStart(json.getString("start")) //
 						.setDuration(json.getStringOrNull("duration")); //
 
-				json.getNullableJsonArrayPath("recurrenceRules")
-						.mapIfPresent(t -> t.getAsList(RecurrenceRule.serializer()))
-						.forEach(rr -> b.addRecurrenceRule(rr));
+				json.getNullableJsonArrayPath("recurrenceRules") //
+						.getAsOptionalList(RecurrenceRule.serializer()) //
+						.ifPresent(rrs -> rrs.forEach(rr -> b.addRecurrenceRule(rr))); //
 
 				var payload = json.getObjectOrNull(PROPERTY_PAYLOAD, payloadSerializer);
 				if (payload != null) {

--- a/io.openems.common/src/io/openems/common/jscalendar/JSCalendar.java
+++ b/io.openems.common/src/io/openems/common/jscalendar/JSCalendar.java
@@ -18,6 +18,7 @@ import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.temporal.ChronoField.NANO_OF_DAY;
 import static java.time.temporal.TemporalAdjusters.nextOrSame;
 import static java.util.Arrays.stream;
+import static java.util.Collections.emptyList;
 
 import java.time.DayOfWeek;
 import java.time.Duration;
@@ -27,7 +28,6 @@ import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -195,9 +195,10 @@ public class JSCalendar<PAYLOAD> {
 						.setStart(json.getString("start")) //
 						.setDuration(json.getStringOrNull("duration")); //
 
-				json.getOptionalList("recurrenceRules", RecurrenceRule.serializer()).orElse(Collections.emptyList()) //
-				.forEach(rr -> b.addRecurrenceRule(rr));
-				
+				json.getOptionalList("recurrenceRules", RecurrenceRule.serializer()) //
+						.orElse(emptyList()) //
+						.forEach(rr -> b.addRecurrenceRule(rr));
+
 				var payload = json.getObjectOrNull(PROPERTY_PAYLOAD, payloadSerializer);
 				if (payload != null) {
 					b.setPayload(payload);

--- a/io.openems.common/test/io/openems/common/jscalendar/JSCalendarTest.java
+++ b/io.openems.common/test/io/openems/common/jscalendar/JSCalendarTest.java
@@ -55,6 +55,7 @@ public class JSCalendarTest {
 		next = sut.getNextOccurence(next.plusSeconds(1));
 		assertEquals("2020-01-03T07:00Z", next.toString());
 	}
+	
 	@Test
 	public void testParseSingleTask() throws OpenemsNamedException {
 		var sut = JSCalendar.Tasks.fromStringOrEmpty("""
@@ -85,6 +86,7 @@ public class JSCalendarTest {
 				]""");
 		assertEquals(1, sut.size());
 	}
+	
 	@Test
 	public void testSingle() throws OpenemsNamedException {
 		var sut = JSCalendar.Task.<StringPayload>create() //

--- a/io.openems.common/test/io/openems/common/jscalendar/JSCalendarTest.java
+++ b/io.openems.common/test/io/openems/common/jscalendar/JSCalendarTest.java
@@ -55,6 +55,18 @@ public class JSCalendarTest {
 		next = sut.getNextOccurence(next.plusSeconds(1));
 		assertEquals("2020-01-03T07:00Z", next.toString());
 	}
+	@Test
+	public void testParseSingleTask() throws OpenemsNamedException {
+		var sut = JSCalendar.Tasks.fromStringOrEmpty("""
+				[
+				   {
+				      "@type":"Task",
+				      "start":"2025-06-18T15:00:00",
+				      "duration":"PT12H"
+				   }
+				]""");
+		assertEquals(1, sut.size());
+	}
 
 	@Test
 	public void testDailyParse() throws OpenemsNamedException {
@@ -72,6 +84,22 @@ public class JSCalendarTest {
 				   }
 				]""");
 		assertEquals(1, sut.size());
+	}
+	@Test
+	public void testSingle() throws OpenemsNamedException {
+		var sut = JSCalendar.Task.<StringPayload>create() //
+				.setStart("2024-06-17T00:00:00") //
+				.setPayload(new StringPayload("Hello World")) //
+				.build();
+		var json = TASK_SERIALIZER.serialize(sut);
+		assertEquals("""
+				{
+				  "@type": "Task",
+				  "start": "2024-06-17T00:00:00",
+				  "openems.io:payload": {
+				    "value": "Hello World"
+				  }
+				}""", prettyToString(json));
 	}
 
 	@Test


### PR DESCRIPTION
Previously, a `NullPointerException` was thrown when parsing a `JSCalendar`-Entry without a recurrence rule. This is fixed here, and JUnit tests are added.