### PR TITLE
Fix: Preserve currentEdge and channel subscriptions when navigating to /user to prevent data loss on return to /live page.

### DIFF
--- a/ui/src/app/edge/edge.component.ts
+++ b/ui/src/app/edge/edge.component.ts
@@ -57,6 +57,10 @@ export class EdgeComponent implements OnInit, OnDestroy, ViewWillLeave {
     }
 
     public ngOnDestroy(): void {
+        const nextUrl = this.router.url;
+        if (nextUrl.startsWith("/user")) {
+          return;
+        }
         this.service.currentEdge.set(null);
         if (!this.edge) {
             return;


### PR DESCRIPTION
### Description  
When navigating from the `/user` page back to the `/device/[edgeId]/live` page (e.g., by clicking a back button in the header), the data initially appears for a brief moment, but then disappears. This causes the Live page to show `"-"` placeholders instead of the actual channel data.

When navigating from live page to user page and back, data subscriptions were being lost because EdgeComponent unsubscribed channels during destruction regardless of navigation target.

This fix prevent clearing currentEdge and unsubscribing channels when navigating to /user, as it is not considered exiting Edge context. This fixes the issue where returning to /live would result in missing real-time data due to lost channel subscriptions.

--

### Screenshots
Before
![Image](https://github.com/user-attachments/assets/48bb4be4-de44-407f-a49e-5a058d1e81c1)
After
![chrome-capture-2025-6-19](https://github.com/user-attachments/assets/5ea96c5c-4284-4e82-a939-9f74876dbf2f)

### Operating System

MacOS

### How to reproduce the Error?

1. Use OpenEMS UI version `2025.4.0` or later.  
2. Navigate to `/device/[edgeId]/live` and observe data correctly displayed.  
3. Navigate to the `/user` page.  
4. Click the back button.  
5. Observe:
   - Data on the Live page appears momentarily.
   - Then disappears and only `"-"` placeholders are shown.