### PR TITLE
[Edge] Time-of-Use Tariff ENTSO-E: update link to API documentation

### DIFF
--- a/io.openems.edge.timeofusetariff.entsoe/readme.adoc
+++ b/io.openems.edge.timeofusetariff.entsoe/readme.adoc
@@ -2,7 +2,7 @@
 
 This implementation uses the ENTSO-E transparency platform to receive day-ahead prices in European power grids.
 
-To request a (free) authentication token, please see chapter "1.5. How to get security token" in the official API documentation: https://transparencyplatform.zendesk.com/hc/en-us/articles/12845911031188-How-to-get-security-token
+To request a (free) authentication token, please see chapter "How to get security token?" in the official API documentation: https://transparencyplatform.zendesk.com/hc/en-us/articles/12845911031188-How-to-get-security-token
 
 Prices retrieved from ENTSO-E are subsequently converted to the user's currency (defined in Core.Meta Component) using the Exchange Rates API.
 


### PR DESCRIPTION
The location of the API doc has changed. Updated to new link.