### PR TITLE
fix: remove redundant unsubscribeFromChannels on component destroy to align with edge signal refactor

### DIFF
--- a/ui/src/app/shared/components/flat/abstract-flat-widget-line.ts
+++ b/ui/src/app/shared/components/flat/abstract-flat-widget-line.ts
@@ -81,10 +81,6 @@ export abstract class AbstractFlatWidgetLine implements OnChanges, OnDestroy {
   }
 
   public ngOnDestroy() {
-    // Unsubscribe from OpenEMS
-    if (this.edge != null && this._channelAddress) {
-      this.edge.unsubscribeFromChannels(this.websocket, [this._channelAddress]);
-    }
 
     // Unsubscribe from CurrentData subject
     this.stopOnDestroy.next();


### PR DESCRIPTION
### Description  

This PR change removes the call to `this.edge.unsubscribeFromChannels()` in `AbstractFlatWidgetLine`'s `ngOnDestroy()` method.

### Reason

OpenEMS has refactored `Edge` into a Signal-based global state (`Service.currentEdge`) after 202504 version edge signal refactor.
Components are now pure consumers of edge Signals, without managing channel lifecycle.
Prevents premature unsubscription leading to data loss and inconsistent UI state.

### How to reproduce the Error?
Use OpenEMS UI version `2025.4.0` or later.  