### PR TITLE
Do not bind felix http host to localhost in docker backend

### DIFF
--- a/tools/docker/backend/root/etc/s6-overlay/s6-rc.d/svc-openems-backend/run
+++ b/tools/docker/backend/root/etc/s6-overlay/s6-rc.d/svc-openems-backend/run
@@ -7,7 +7,6 @@ exec \
              /usr/bin/java \
                 -Dosgi.clean=true \
                 -Dorg.apache.felix.eventadmin.Timeout=0 \
-                -Dorg.apache.felix.http.host=localhost \
                 -Dfelix.cm.dir=/var/opt/openems/config \
                 -Dopenems.data.dir=/var/opt/openems/data \
                 -XX:+ExitOnOutOfMemoryError \


### PR DESCRIPTION
Binding to localhost when running on Docker means the Apache Felix web console will only be accessible from inside the docker container, not from the host machine or other containers. This is almost certainly unintended and also conflicts with the provided docker-compose.yml, which suggests exposing the web console port. However, this will not work with the current configuration of felix.