### PR TITLE
[Edge] EssCore: Fix NPE in "KeepingAllNearEqual" if mergedResult is null (or result.length is 0)

### DIFF
--- a/io.openems.edge.ess.core/src/io/openems/edge/ess/core/power/optimizers/KeepAllNearEqual.java
+++ b/io.openems.edge.ess.core/src/io/openems/edge/ess/core/power/optimizers/KeepAllNearEqual.java
@@ -48,10 +48,16 @@ public class KeepAllNearEqual {
 		var reactivePowerSolved = solvePowerIfNotNaN(setReactivePower, essList, Pwr.REACTIVE, direction);
 
 		var mergedResult = mergeResults(coefficients, esss, activePowerSolved, reactivePowerSolved);
+		if (mergedResult == null) {
+			return null;
+		}
 
 		var result = Arrays.stream(mergedResult)//
 				.map(d -> reverseAbsoluteData(d, direction))//
 				.toArray();
+		if (result.length == 0) {
+			return null;
+		}
 		return new PointValuePair(result, 0);
 	}
 


### PR DESCRIPTION
We experienced NPE with the solver strategy of "KeepingAllNearEqual" when using multiple (2) ESS and put them into a cluster.
("Error during handleEvent(). NullPointerException: null")

When those two ESS were at 0 % no solution could be found and the mergedResult becomes null.

To prevent the NPE we check if the mergedResult is null and if the result.length is greater than 0 (the latter one might be not nec. but I still put this here in case it might occurr)

And return null if either is the case. Same as previously done (like when checking for NaN)

After implementing this change, we did not experience the NPE anymore