### PR TITLE
Bugfix: V1 ScheduleData: Systems with no Production results in Null for History Data

### DIFF
--- a/io.openems.edge.energy/src/io/openems/edge/energy/v1/optimizer/ScheduleDatas.java
+++ b/io.openems.edge.energy/src/io/openems/edge/energy/v1/optimizer/ScheduleDatas.java
@@ -6,6 +6,7 @@ import static io.openems.common.types.OptionsEnum.getOption;
 import static io.openems.common.utils.JsonUtils.buildJsonObject;
 import static io.openems.common.utils.JsonUtils.getAsDouble;
 import static io.openems.common.utils.JsonUtils.getAsInt;
+import static io.openems.common.utils.JsonUtils.getAsOptionalInt;
 import static io.openems.common.utils.JsonUtils.toJson;
 import static io.openems.edge.controller.ess.timeofusetariff.Utils.SUM_PRODUCTION;
 import static io.openems.edge.energy.optimizer.Utils.SUM_ESS_DISCHARGE_POWER;
@@ -233,7 +234,7 @@ public record ScheduleDatas(int essTotalEnergy, ImmutableList<ScheduleData> entr
 									0 /* ignore */, //
 									0 /* ignore */, //
 									round(getAsInt(getter.apply(SUM_ESS_SOC)) / 100F * essTotalEnergy), //
-									toEnergy(getAsInt(getter.apply(SUM_PRODUCTION))), //
+									toEnergy(getAsOptionalInt(getter.apply(SUM_PRODUCTION)).orElse(0)), //
 									toEnergy(getAsInt(getter.apply(SUM_CONSUMPTION))), //
 									getAsDouble(getter.apply(channelQuarterlyPrices)), //
 									ofNullable(getOption(StateMachine.class, //


### PR DESCRIPTION
This fixes a Bug in the Optimizer V1 Schedule Request, when the System does not have a ProductionActivePower.

## Description

The following issue occured:

We have a System useing V1 of the optimization (ctrlEssTimeOfUseController). 

However, the system does not have any Production (resulting in ProductionActivePower in Sum is always null).

Resulting in a NPE when requesting the Schedule History Data (used by e.g. UI) Since no Production is available (null)

Therefor I used the getOptionalInt method and used orElse(0) in case of the SUM_PRODUCTION.

I specifically used .orElse(0) since the current/future schedule uses ParamsV1, where the production variable is a primitive int.

I provided a section of the Request result from my demo/testing system in the PR

## Demo Data before fix

(null values == past, after that data from Optimizer)

<img width="573" height="170" alt="Schedule_response_b4" src="https://github.com/user-attachments/assets/acd07ef8-de4d-410f-91ff-1a13181147b3" />


## Demo Data After fix

<img width="503" height="172" alt="WithBugFix" src="https://github.com/user-attachments/assets/7c0db874-643c-4d2c-bb71-8e4ff646d68c" />


