### PR TITLE
Fixed typo in CONSUMPTION_MAX_ACTIVE_POWER

### DIFF
--- a/io.openems.edge.common/src/io/openems/edge/common/sum/Sum.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/sum/Sum.java
@@ -493,7 +493,7 @@ public interface Sum extends OpenemsComponent {
 		CONSUMPTION_MAX_ACTIVE_POWER(Doc.of(INTEGER) //
 				.unit(WATT) //
 				.persistencePriority(VERY_HIGH) //
-				.text("Maximum measured active power of the electrical consumpton")), //
+				.text("Maximum measured active power of the electrical consumption")), //
 		/**
 		 * Unmanaged Consumption: Active Power.
 		 *


### PR DESCRIPTION
Fixed a small typo on CONSUMPTION_MAX_ACTIVE_POWER (consumpton instead of consumption).