### PR TITLE
Fixed description typos for some additional channels

### DIFF
--- a/io.openems.edge.battery.fenecon.home/src/io/openems/edge/battery/fenecon/home/BatteryFeneconHome.java
+++ b/io.openems.edge.battery.fenecon.home/src/io/openems/edge/battery/fenecon/home/BatteryFeneconHome.java
@@ -154,7 +154,7 @@ public interface BatteryFeneconHome extends Battery, ModbusComponent, OpenemsCom
 				.text("Rack Under Temperature warning")), //
 		RACK_LEVEL_1_CELL_VOLTAGE_DIFFERENCE(Doc.of(OpenemsType.BOOLEAN) //
 				.accessMode(AccessMode.READ_ONLY) //
-				.text("Rack Cell VOltage Difference warning")), //
+				.text("Rack Cell Voltage Difference warning")), //
 		RACK_LEVEL_1_BCU_TEMP_DIFFERENCE(Doc.of(OpenemsType.BOOLEAN) //
 				.accessMode(AccessMode.READ_ONLY) //
 				.text("Rack BCU Temp Difference warning")), //
@@ -412,7 +412,7 @@ public interface BatteryFeneconHome extends Battery, ModbusComponent, OpenemsCom
 				.text("BCU Status Alarm")),
 		STATUS_WARNING(Doc.of(OpenemsType.BOOLEAN) //
 				.accessMode(AccessMode.READ_ONLY) //
-				.text("BCU Status WARNNG")),
+				.text("BCU Status WARNING")),
 		STATUS_FAULT(Doc.of(OpenemsType.BOOLEAN) //
 				.accessMode(AccessMode.READ_ONLY) //
 				.text("BCU Status BCU Status Fault")),
@@ -573,7 +573,7 @@ public interface BatteryFeneconHome extends Battery, ModbusComponent, OpenemsCom
 				.text("BCU HW Voltage Detect Fault")),
 		HW_TEMPERATURE_DETECT_FAULT(Doc.of(Level.WARNING) //
 				.accessMode(AccessMode.READ_ONLY) //
-				.text("BCU HW Temperaure Detect Fault")),
+				.text("BCU HW Temperature Detect Fault")),
 		HW_CURRENT_DETECT_FAULT(Doc.of(Level.WARNING) //
 				.accessMode(AccessMode.READ_ONLY) //
 				.text("BCU HW Current Detect Fault")),

--- a/io.openems.edge.goodwe/src/io/openems/edge/goodwe/common/GoodWeStateDefinitions.java
+++ b/io.openems.edge.goodwe/src/io/openems/edge/goodwe/common/GoodWeStateDefinitions.java
@@ -188,7 +188,7 @@ public class GoodWeStateDefinitions {
 					new GwState(9, "GFCI Protection (60mA Internal)"), //
 					new GwState(10, "GFCI Protection (150mA Internal)"), //
 					new GwState(11, "GFCI Protection (300mA Internal)"), //
-					new GwState(12, "Parallell I/O Check Failure"), //
+					new GwState(12, "Parallel I/O Check Failure"), //
 					new GwState(13, "BUS (by BAT) Soft Start Failure"), //
 					new GwState(14, "BAT Voltage Low"), //
 					new GwState(15, "BUS Continuous Overvoltage"))),
@@ -218,7 +218,7 @@ public class GoodWeStateDefinitions {
 					new GwState(1, "BAT 1 Software Overcurrent"), //
 					new GwState(2, "BAT 1 Undervoltage Shutdown (Off-grid Mode)"), //
 					new GwState(3, "BAT 1 Abnormal Connection"), //
-					new GwState(4, "BAT 1 Abnormal Disonnection"), //
+					new GwState(4, "BAT 1 Abnormal Disconnection"), //
 					new GwState(5, "BAT 2 Hardware Overcurrent"), //
 					new GwState(6, "BAT 2 Software Overcurrent"), //
 					new GwState(7, "BAT 2 Undervoltage Shutdown (Off-grid Mode)"), //

--- a/io.openems.edge.goodwe/src/io/openems/edge/goodwe/common/enums/BatteryMode.java
+++ b/io.openems.edge.goodwe/src/io/openems/edge/goodwe/common/enums/BatteryMode.java
@@ -5,7 +5,7 @@ import io.openems.common.types.OptionsEnum;
 public enum BatteryMode implements OptionsEnum {
 	UNDEFINED(-1, "Undefined"), //
 	NO_BATTERY(0, "NO Battery,inverter disconnects to Battery"), //
-	STANDBY(1, "Standby,no diacharging and no charging"), //
+	STANDBY(1, "Standby,no discharging and no charging"), //
 	DISCHARGING(2, "Discharging"), //
 	CHARGING(3, "Charging");
 


### PR DESCRIPTION
Two more small typo fixed for channel descriptions of:
- BatteryFeneconHome
- BatteryMode
- GoodWeStateDefinitions