### PR TITLE
Fixed HW_AFE_COMMUNICATION_FAULT channel name

### DIFF
--- a/io.openems.edge.battery.fenecon.home/src/io/openems/edge/battery/fenecon/home/BatteryFeneconHome.java
+++ b/io.openems.edge.battery.fenecon.home/src/io/openems/edge/battery/fenecon/home/BatteryFeneconHome.java
@@ -559,7 +559,7 @@ public interface BatteryFeneconHome extends Battery, ModbusComponent, OpenemsCom
 				.text("BCU Fault Hardware Fault")),
 
 		// Bcu HW Fault Detail
-		HW_AFE_COMMUNICAITON_FAULT(Doc.of(Level.WARNING) //
+		HW_AFE_COMMUNICATION_FAULT(Doc.of(Level.WARNING) //
 				.accessMode(AccessMode.READ_ONLY) //
 				.text("BCU HW AFE Communication Fault")),
 		HW_ACTOR_DRIVER_FAULT(Doc.of(Level.WARNING) //

--- a/io.openems.edge.battery.fenecon.home/src/io/openems/edge/battery/fenecon/home/BatteryFeneconHomeImpl.java
+++ b/io.openems.edge.battery.fenecon.home/src/io/openems/edge/battery/fenecon/home/BatteryFeneconHomeImpl.java
@@ -648,7 +648,7 @@ public class BatteryFeneconHomeImpl extends AbstractOpenemsModbusComponent imple
 										.bit(14, this.generateTowerChannel(tower, "LEVEL_2_BAT_UNDER_VOLTAGE",
 												Level.WARNING))), //
 								m(new BitsWordElement(towerOffset + 6, this)
-										.bit(0, this.generateTowerChannel(tower, "HW_AFE_COMMUNICAITON_FAULT",
+										.bit(0, this.generateTowerChannel(tower, "HW_AFE_COMMUNICATION_FAULT",
 												Level.WARNING)) //
 										.bit(1, this.generateTowerChannel(tower, "HW_ACTOR_DRIVER_FAULT",
 												Level.WARNING)) //

--- a/io.openems.edge.goodwe/src/io/openems/edge/goodwe/common/AbstractGoodWe.java
+++ b/io.openems.edge.goodwe/src/io/openems/edge/goodwe/common/AbstractGoodWe.java
@@ -2028,7 +2028,7 @@ public abstract class AbstractGoodWe extends AbstractOpenemsModbusComponent
 						// Only for Australia, Refer to Table 8-22
 						m(GoodWe.ChannelId.DRED_CMD, new UnsignedWordElement(47007)), //
 						new DummyRegisterElement(47008), //
-						// For wifi+Lan module, to switch to LAN or WiFi communicaiton
+						// For wifi+Lan module, to switch to LAN or WiFi communication
 						m(GoodWe.ChannelId.WIFI_OR_LAN_SWITCH, new UnsignedWordElement(47009)), //
 						// Ripple Control Receiver on/off
 						m(GoodWe.ChannelId.DRED_REMOTE_SHUTDOWN_RCR_FUNCTIONS_ENABLE, new UnsignedWordElement(47010)), //


### PR DESCRIPTION
Fixed a typo in the HW_AFE_COMMUNICATION_FAULT channel name. Since this a channel name, not sure if it is easy enough to be fixed and what potential external dependencies are.

Feel free to close this PR if a fix would be able to break external code.