### PR TITLE
Fixed _appManager/HardwareMissmatch channel name

### DIFF
--- a/io.openems.edge.core/src/io/openems/edge/core/appmanager/AppManager.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/appmanager/AppManager.java
@@ -19,7 +19,7 @@ public interface AppManager extends OpenemsComponent {
 				.translationKey(AppManager.class, "AppManager.DefectiveApp")), //
 		APPS_NOT_SYNCED_WITH_BACKEND(Doc.of(Level.INFO) //
 				.translationKey(AppManager.class, "AppManager.AppsNotSynced")), //
-		HARDWARE_MISSMATCH(Doc.of(Level.INFO) //
+		HARDWARE_MISMATCH(Doc.of(Level.INFO) //
 				.text("The current installed hardware app is not the same as defined in 'hardware.conf'")), //
 		;
 
@@ -71,12 +71,12 @@ public interface AppManager extends OpenemsComponent {
 
 	/**
 	 * Internal method to set the 'nextValue' on
-	 * {@link ChannelId#HARDWARE_MISSMATCH} Channel.
+	 * {@link ChannelId#HARDWARE_MISMATCH} Channel.
 	 * 
 	 * @param value the next value
 	 */
-	public default void _setHardwareMissmatch(boolean value) {
-		this.getHardwareMissmatchChannel().setNextValue(value);
+	public default void _setHardwareMismatch(boolean value) {
+		this.getHardwareMismatchChannel().setNextValue(value);
 	}
 
 	/**
@@ -136,22 +136,22 @@ public interface AppManager extends OpenemsComponent {
 	}
 
 	/**
-	 * Gets the Hardware-Missmatch info State. See
-	 * {@link ChannelId#HARDWARE_MISSMATCH}.
+	 * Gets the Hardware-Mismatch info State. See
+	 * {@link ChannelId#HARDWARE_MISMATCH}.
 	 * 
 	 * @return the Channel {@link Value}
 	 */
-	public default Value<Boolean> getHardwareMissmatch() {
+	public default Value<Boolean> getHardwareMismatch() {
 		return this.getAppsNotSyncedWithBackendChannel().value();
 	}
 
 	/**
-	 * Gets the channel for {@link ChannelId#HARDWARE_MISSMATCH}.
+	 * Gets the channel for {@link ChannelId#HARDWARE_MISMATCH}.
 	 * 
 	 * @return the Channel
 	 */
-	public default StateChannel getHardwareMissmatchChannel() {
-		return this.channel(ChannelId.HARDWARE_MISSMATCH);
+	public default StateChannel getHardwareMismatchChannel() {
+		return this.channel(ChannelId.HARDWARE_MISMATCH);
 	}
 
 }

--- a/io.openems.edge.core/src/io/openems/edge/core/appmanager/ResolveOpenemsHardware.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/appmanager/ResolveOpenemsHardware.java
@@ -132,18 +132,18 @@ public class ResolveOpenemsHardware implements Runnable {
 			// validate
 			if (hardwareApps.size() > 1) {
 				// more than 1 installed => impossible
-				this.appManagerImpl._setHardwareMissmatch(true);
+				this.appManagerImpl._setHardwareMismatch(true);
 				return;
 			}
 
 			final var installedHardwareApp = hardwareApps.get(0);
 			if (installedHardwareApp.appId.equals(this.requireApp)) {
 				// installed hardware app matches the on in the properties file
-				this.appManagerImpl._setHardwareMissmatch(false);
+				this.appManagerImpl._setHardwareMismatch(false);
 				return;
 			}
 
-			this.appManagerImpl._setHardwareMissmatch(true);
+			this.appManagerImpl._setHardwareMismatch(true);
 			return;
 		}
 
@@ -155,10 +155,10 @@ public class ResolveOpenemsHardware implements Runnable {
 					true);
 
 			this.log.trace("Installed '" + this.requireApp + "' successfully");
-			this.appManagerImpl._setHardwareMissmatch(false);
+			this.appManagerImpl._setHardwareMismatch(false);
 		} catch (Exception e) {
 			this.log.error("Installation of '" + this.requireApp + "' failed", e);
-			this.appManagerImpl._setHardwareMissmatch(true);
+			this.appManagerImpl._setHardwareMismatch(true);
 		}
 
 	}

--- a/io.openems.edge.core/test/io/openems/edge/core/appmanager/ResolveOpenemsHardwareTest.java
+++ b/io.openems.edge.core/test/io/openems/edge/core/appmanager/ResolveOpenemsHardwareTest.java
@@ -66,7 +66,7 @@ public class ResolveOpenemsHardwareTest {
 		completed.join();
 
 		assertEquals(1, this.appManagerTestBundle.sut.getInstantiatedApps().size());
-		assertFalse(this.appManagerTestBundle.sut.getHardwareMissmatchChannel().getNextValue().get());
+		assertFalse(this.appManagerTestBundle.sut.getHardwareMismatchChannel().getNextValue().get());
 	}
 
 	@Test
@@ -89,7 +89,7 @@ public class ResolveOpenemsHardwareTest {
 		completed.join();
 
 		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
-		assertTrue(this.appManagerTestBundle.sut.getHardwareMissmatchChannel().getNextValue().get());
+		assertTrue(this.appManagerTestBundle.sut.getHardwareMismatchChannel().getNextValue().get());
 	}
 
 	@Test
@@ -110,7 +110,7 @@ public class ResolveOpenemsHardwareTest {
 		completed.join();
 
 		assertEquals(0, this.appManagerTestBundle.sut.getInstantiatedApps().size());
-		assertFalse(this.appManagerTestBundle.sut.getHardwareMissmatchChannel().getNextValue().get());
+		assertFalse(this.appManagerTestBundle.sut.getHardwareMismatchChannel().getNextValue().get());
 	}
 
 	@Test
@@ -136,7 +136,7 @@ public class ResolveOpenemsHardwareTest {
 		completed.join();
 
 		assertEquals(1, this.appManagerTestBundle.sut.getInstantiatedApps().size());
-		assertTrue(this.appManagerTestBundle.sut.getHardwareMissmatchChannel().getNextValue().get());
+		assertTrue(this.appManagerTestBundle.sut.getHardwareMismatchChannel().getNextValue().get());
 	}
 
 	private void setHardwareApp(String appId) throws Exception {


### PR DESCRIPTION
Fixed a typo in the _appManager/HardwareMissmatch (mismatch instead of missmatch) channel name. Since this a channel name, not sure if it is easy enough to be fixed and what potential external dependencies are.

Feel free to close this PR if a fix would be able to break external code.