### PR TITLE
[Edge] Only allow stagnant/rising _sum energy channel values

### DIFF
--- a/io.openems.edge.core/src/io/openems/edge/core/sum/EnergyValuesHandler.java
+++ b/io.openems.edge.core/src/io/openems/edge/core/sum/EnergyValuesHandler.java
@@ -110,10 +110,15 @@ public class EnergyValuesHandler {
 			// lastValue was not initialized yet -> ignore value
 			value = null;
 
-		} else if (value == null) {
-			// if value is null, replace it by last value
+		} else {
 			var lastValue = this.lastEnergyValues.get(channelId);
-			value = lastValue;
+			if (value == null) {
+				// 	if value is null, replace it by last value
+				value = lastValue;
+			} else if (lastValue != null && value < lastValue) {
+				// if value is less than last value ignore it
+				value = lastValue;
+			}
 		}
 
 		this.parent.channel(channelId).setNextValue(value);


### PR DESCRIPTION
This change ensures that new values for energy channels of the _sum component can only be greater or equal. The function description of setValue() says that, but the function didn't check for it. Having decreasing energy channel values can be problematic because it breaks for example the calculation of the consumption in the history.

---

## Simulation

To verify this I created a simple simulation which can be run in the simulator app.
[simulation_request.json](https://github.com/user-attachments/files/22046969/simulation_request.json)

The simulation runs a constant 10kW pv inverter and a meter that switches between 2kW and 10kW
I plotted the results using a simple python script.

### Result without fix
[simulation_result_error.json](https://github.com/user-attachments/files/22046971/simulation_result_error.json)
<img width="1399" height="670" alt="simulation_result_error" src="https://github.com/user-attachments/assets/cdcc69d7-ee26-49c4-bfa7-cf810cebd037" />

We can see that the ConsumptionActiveEnergy channel value does sometimes decrease when we have a higher production than usage.

### Result with fix
[simulation_result_fixed.json](https://github.com/user-attachments/files/22046973/simulation_result_fixed.json)
<img width="1397" height="666" alt="simulation_result_fixed" src="https://github.com/user-attachments/assets/71e3afee-db5a-4026-abff-1138cc4882c6" />

With this fix the channel values can never drop but only increase.