### PR TITLE
feat(simulated ess): allow configuration of dis/charge limit

### DIFF
--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/ess/symmetric/reacting/Config.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/ess/symmetric/reacting/Config.java
@@ -22,6 +22,12 @@ import io.openems.edge.common.sum.GridMode;
 	@AttributeDefinition(name = "Max Apparent Power [VA]")
 	int maxApparentPower() default 10000;
 
+	@AttributeDefinition(name = "Max charge power [W]")
+	int maxChargePower() default 10000;
+
+	@AttributeDefinition(name = "Max discharge power [W]")
+	int maxDischargePower() default 10000;
+
 	@AttributeDefinition(name = "Capacity [Wh]")
 	int capacity() default 10000;
 

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/ess/symmetric/reacting/SimulatorEssSymmetricReactingImpl.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/ess/symmetric/reacting/SimulatorEssSymmetricReactingImpl.java
@@ -90,8 +90,8 @@ public class SimulatorEssSymmetricReactingImpl extends AbstractOpenemsComponent
 				/ 100 * this.config.initialSoc() /* [current SoC] */);
 		this._setSoc(config.initialSoc());
 		this._setMaxApparentPower(config.maxApparentPower());
-		this._setAllowedChargePower(config.capacity() * -1);
-		this._setAllowedDischargePower(config.capacity());
+		this._setAllowedChargePower(config.maxChargePower() * -1);
+		this._setAllowedDischargePower(config.maxDischargePower());
 		this._setGridMode(config.gridMode());
 		this._setCapacity(config.capacity());
 	}
@@ -189,12 +189,12 @@ public class SimulatorEssSymmetricReactingImpl extends AbstractOpenemsComponent
 		if (soc == 100) {
 			this._setAllowedChargePower(0);
 		} else {
-			this._setAllowedChargePower(this.config.capacity() * -1);
+			this._setAllowedChargePower(this.config.maxChargePower() * -1);
 		}
 		if (soc == 0) {
 			this._setAllowedDischargePower(0);
 		} else {
-			this._setAllowedDischargePower(this.config.capacity());
+			this._setAllowedDischargePower(this.config.maxDischargePower());
 		}
 	}
 

--- a/io.openems.edge.simulator/src/io/openems/edge/simulator/ess/symmetric/reacting/SimulatorEssSymmetricReactingImpl.java
+++ b/io.openems.edge.simulator/src/io/openems/edge/simulator/ess/symmetric/reacting/SimulatorEssSymmetricReactingImpl.java
@@ -1,5 +1,11 @@
 package io.openems.edge.simulator.ess.symmetric.reacting;
 
+import static io.openems.edge.common.event.EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE;
+import static org.osgi.service.component.annotations.ConfigurationPolicy.REQUIRE;
+import static org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL;
+import static org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC;
+import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
+
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -8,12 +14,8 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventHandler;
 import org.osgi.service.event.propertytypes.EventTopics;
@@ -24,7 +26,6 @@ import io.openems.common.exceptions.OpenemsException;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
 import io.openems.edge.common.component.ComponentManager;
 import io.openems.edge.common.component.OpenemsComponent;
-import io.openems.edge.common.event.EdgeEventConstants;
 import io.openems.edge.common.modbusslave.ModbusSlave;
 import io.openems.edge.common.modbusslave.ModbusSlaveNatureTable;
 import io.openems.edge.common.modbusslave.ModbusSlaveTable;
@@ -41,11 +42,9 @@ import io.openems.edge.timedata.api.utils.CalculateEnergyFromPower;
 @Component(//
 		name = "Simulator.EssSymmetric.Reacting", //
 		immediate = true, //
-		configurationPolicy = ConfigurationPolicy.REQUIRE //
-)
+		configurationPolicy = REQUIRE)
 @EventTopics({ //
-		EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE //
-})
+		TOPIC_CYCLE_AFTER_PROCESS_IMAGE })
 public class SimulatorEssSymmetricReactingImpl extends AbstractOpenemsComponent
 		implements SimulatorEssSymmetricReacting, ManagedSymmetricEss, SymmetricEss, OpenemsComponent, TimedataProvider,
 		EventHandler, StartStoppable, ModbusSlave {
@@ -64,7 +63,7 @@ public class SimulatorEssSymmetricReactingImpl extends AbstractOpenemsComponent
 	@Reference
 	private ComponentManager componentManager;
 
-	@Reference(policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.OPTIONAL)
+	@Reference(policy = DYNAMIC, policyOption = GREEDY, cardinality = OPTIONAL)
 	private volatile Timedata timedata = null;
 
 	/** Current Energy in the battery [Wms], based on SoC. */
@@ -108,9 +107,8 @@ public class SimulatorEssSymmetricReactingImpl extends AbstractOpenemsComponent
 			return;
 		}
 		switch (event.getTopic()) {
-		case EdgeEventConstants.TOPIC_CYCLE_AFTER_PROCESS_IMAGE:
-			this.calculateEnergy();
-			break;
+		case TOPIC_CYCLE_AFTER_PROCESS_IMAGE //
+			-> this.calculateEnergy();
 		}
 	}
 

--- a/io.openems.edge.simulator/test/io/openems/edge/simulator/ess/symmetric/reacting/MyConfig.java
+++ b/io.openems.edge.simulator/test/io/openems/edge/simulator/ess/symmetric/reacting/MyConfig.java
@@ -69,6 +69,16 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	}
 
 	@Override
+	public int maxChargePower() {
+		return this.capacity();
+	}
+
+	@Override
+	public int maxDischargePower() {
+		return this.capacity();
+	}
+
+	@Override
 	public int capacity() {
 		return this.builder.capacity;
 	}

--- a/io.openems.edge.simulator/test/io/openems/edge/simulator/ess/symmetric/reacting/MyConfig.java
+++ b/io.openems.edge.simulator/test/io/openems/edge/simulator/ess/symmetric/reacting/MyConfig.java
@@ -7,11 +7,13 @@ import io.openems.edge.common.sum.GridMode;
 public class MyConfig extends AbstractComponentConfig implements Config {
 
 	protected static class Builder {
-		private String id = null;
-		private Integer maxApparentPower = null;
-		private Integer capacity = null;
-		private Integer initialSoc = null;
-		private GridMode gridMode = null;
+		private String id;
+		private int maxApparentPower;
+		private int maxChargePower;
+		private int maxDischargePower;
+		private int capacity;
+		private int initialSoc;
+		private GridMode gridMode;
 
 		private Builder() {
 

--- a/io.openems.edge.simulator/test/io/openems/edge/simulator/ess/symmetric/reacting/MyConfig.java
+++ b/io.openems.edge.simulator/test/io/openems/edge/simulator/ess/symmetric/reacting/MyConfig.java
@@ -27,6 +27,16 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 			return this;
 		}
 
+		public Builder setMaxChargePower(int maxChargePower) {
+			this.maxChargePower = maxChargePower;
+			return this;
+		}
+		
+		public Builder setMaxDischargePower(int maxDischargePower) {
+			this.maxDischargePower = maxDischargePower;
+			return this;
+		}
+		
 		public Builder setCapacity(int capacity) {
 			this.capacity = capacity;
 			return this;
@@ -70,12 +80,12 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 	@Override
 	public int maxChargePower() {
-		return this.capacity();
+		return this.builder.maxChargePower;
 	}
 
 	@Override
 	public int maxDischargePower() {
-		return this.capacity();
+		return this.builder.maxDischargePower;
 	}
 
 	@Override

--- a/io.openems.edge.simulator/test/io/openems/edge/simulator/ess/symmetric/reacting/SimulatorEssSymmetricReactingImplTest.java
+++ b/io.openems.edge.simulator/test/io/openems/edge/simulator/ess/symmetric/reacting/SimulatorEssSymmetricReactingImplTest.java
@@ -35,6 +35,8 @@ public class SimulatorEssSymmetricReactingImplTest {
 						.setId(ESS_ID) //
 						.setCapacity(10_000) //
 						.setMaxApparentPower(10_000) //
+						.setMaxChargePower(10_000) //
+						.setMaxDischargePower(10_000) //
 						.setInitialSoc(50) //
 						.setGridMode(GridMode.ON_GRID) //
 						.build()) //

--- a/io.openems.edge.simulator/test/io/openems/edge/simulator/ess/symmetric/reacting/SimulatorEssSymmetricReactingImplTest.java
+++ b/io.openems.edge.simulator/test/io/openems/edge/simulator/ess/symmetric/reacting/SimulatorEssSymmetricReactingImplTest.java
@@ -1,12 +1,10 @@
 package io.openems.edge.simulator.ess.symmetric.reacting;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 
 import org.junit.Test;
 
-import io.openems.common.test.TimeLeapClock;
+import io.openems.common.test.TestUtils;
 import io.openems.common.types.ChannelAddress;
 import io.openems.edge.common.sum.GridMode;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
@@ -25,8 +23,7 @@ public class SimulatorEssSymmetricReactingImplTest {
 
 	@Test
 	public void test() throws Exception {
-		final var clock = new TimeLeapClock(Instant.ofEpochSecond(1577836800) /* starts at 1. January 2020 00:00:00 */,
-				ZoneOffset.UTC);
+		final var clock = TestUtils.createDummyClock();
 		new ManagedSymmetricEssTest(new SimulatorEssSymmetricReactingImpl()) //
 				.addReference("cm", new DummyConfigurationAdmin()) //
 				.addReference("componentManager", new DummyComponentManager(clock)) //
@@ -55,8 +52,8 @@ public class SimulatorEssSymmetricReactingImplTest {
 				.next(new TestCase() //
 						.timeleap(clock, 30, ChronoUnit.MINUTES) //
 						.input(ESS_SET_ACTIVE_POWER_EQUALS, 10_000) //
-						.output(ESS_SOC, 25)); //
-
+						.output(ESS_SOC, 25)) //
+				.deactivate();
 	}
 
 }


### PR DESCRIPTION
Currently the dis/charge limit was based on the capacity. With this change it's configurable.

Testing: Executed `java -jar build/openems-edge.jar` and configured simulated ess with custom dis/charge limits and verified them via using the fixed state of charge controller