### PR TITLE
Update MyConfig.java: removed import

### DIFF
--- a/io.openems.common/resources/templates/controller/$testSrcDir$/$basePackageDir$/MyConfig.java
+++ b/io.openems.common/resources/templates/controller/$testSrcDir$/$basePackageDir$/MyConfig.java
@@ -1,7 +1,6 @@
 package $basePackageName$;
 
 import io.openems.common.test.AbstractComponentConfig;
-import io.openems.edge.test.Config;
 
 @SuppressWarnings("all")
 public class MyConfig extends AbstractComponentConfig implements Config {


### PR DESCRIPTION
The "import io.openems.edge.test.Config" caused an import not found error. After removing the import, it compiles fine.