### PR TITLE
CI: Increase coverage report threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0.3%
+        threshold: 0.4%
         branches:
           - "!main"
           - "!develop"
@@ -35,7 +35,7 @@ component_management:
     statuses:
       - type: project
         target: auto
-        threshold: 0.1%
+        threshold: 0.3%
         branches:
           - "!main"
           - "!develop"
@@ -60,3 +60,7 @@ component_management:
       name: "OpenEMS UI"
       paths:
         - ui/**
+      statuses:
+        - type: project
+          target: auto
+          threshold: 0.5%  


### PR DESCRIPTION
Increase coverage thresholds, especially for the UI, to reduce false failures from flaky coverage reports.