### PR TITLE
Fix high and low price description for Octopus Heat TOU Tariff

### DIFF
--- a/io.openems.edge.timeofusetariff.manual/src/io/openems/edge/timeofusetariff/manual/octopus/heat/Config.java
+++ b/io.openems.edge.timeofusetariff.manual/src/io/openems/edge/timeofusetariff/manual/octopus/heat/Config.java
@@ -17,13 +17,13 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
 	boolean enabled() default true;
 
-	@AttributeDefinition(name = "High Price", description = "The High price [Cent/kWh]")
+	@AttributeDefinition(name = "High Price", description = "The high price, active from 06 to 09 pm [Cent/kWh]")
 	double highPrice();
 
 	@AttributeDefinition(name = "Standard Price", description = "The standard price [Cent/kWh]")
 	double standardPrice();
 
-	@AttributeDefinition(name = "Low Price", description = "The low price, active between 00 and 05 am [Cent/kWh]")
+	@AttributeDefinition(name = "Low Price", description = "The low price, active from 02 to 06 am and 12 am to 16 pm [Cent/kWh]")
 	double lowPrice();
 
 	String webconsole_configurationFactory_nameHint() default "Time-Of-Use Tariff Octopus Heat [{id}]";


### PR DESCRIPTION
The active hours in the description of the low price config of the Octopus Heat TOU Tariff were wrong and in the description of the high price they were missing.