### PR TITLE
Adjust large screen widget size based on nav position

### DIFF
--- a/ui/src/app/edge/live/live.component.html
+++ b/ui/src/app/edge/live/live.component.html
@@ -33,7 +33,7 @@
       </ion-col>
 
       <!-- Widgets -->
-      <ion-col size="12" size-md="8" size-lg="6" class="ion-no-padding">
+      <ion-col size="12" size-md="8" [attr.size-lg]="navigationService.position() === 'left' ? 8 : 6" class="ion-no-padding">
         <ion-grid class="ion-no-padding">
           <ion-row>
             <!-- Regular Widgets -->


### PR DESCRIPTION
Changed the size attribute for the `ion-col` element in `live.component.html` to dynamically adjust the widget size on large screens depending on the navigation service's position. This allows for a more flexible layout, accommodating different navigation positions by setting the size to 8 if the navigation is on the left and 6 otherwise (standard).

Before:
<img width="1915" height="873" alt="image" src="https://github.com/user-attachments/assets/030577ec-1cef-452e-8b43-88cea681fb30" />

After:
<img width="1896" height="881" alt="image" src="https://github.com/user-attachments/assets/b91feb0c-fd97-4182-a08d-7ed73db6cc21" />
