### PR TITLE
change console output format from plan to colored in gradle build of ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,13 @@ jobs:
       - uses: kiancross/checkstyle-annotations-action@v1
 
       - name: Checkstyle
-        run: ./gradlew checkstyleAll --console=plain --warn
+        run: ./gradlew checkstyleAll --console=colored --warn
 
       - name: Build all Java packages
-        run: ./gradlew build --console=plain --warn
+        run: ./gradlew build --console=colored --warn
 
       - name: Resolve OpenEMS bundles
-        run: ./gradlew resolve --console=plain --warn
+        run: ./gradlew resolve --console=colored --warn
 
       - name: Validate BackendApp.bndrun
         run: git diff --exit-code io.openems.backend.application/BackendApp.bndrun


### PR DESCRIPTION
from gradle 9.1, it support colord option (I contributed this). --console=rich break ci output, because it designed rich terminal(VT100). but this option is for ci, not break ci output.