### PR TITLE
Fix:  prevent energy flow arrow backgrounds from disappearing

### DIFF
--- a/ui/src/app/edge/live/energymonitor/chart/section/abstractsection.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/abstractsection.component.ts
@@ -1,6 +1,7 @@
 // @ts-strict-ignore
 import { TranslateService } from "@ngx-translate/core";
 import * as d3 from "d3";
+import { v4 as uuidv4 } from "uuid";
 import { GridMode, Service } from "src/app/shared/shared";
 import { DefaultTypes } from "../../../../../shared/type/defaulttypes";
 
@@ -146,7 +147,7 @@ export abstract class AbstractSection {
         protected service: Service,
         widgetClass: string,
     ) {
-        this.sectionId = translateName;
+        this.sectionId = translateName + "-" + uuidv4();
         this.name = translate.instant(translateName);
         this.energyFlow = this.initEnergyFlow(0);
         service.getConfig().then(config => {


### PR DESCRIPTION
  **Problem:**
Intermittent disappearance of energy flow arrows (background color) when navigating between tabs. The 
white animated arrow would remain visible, but the colored background would vanish. A page refresh would temporarily resolve the issue.

**Root Cause:**
SVG element IDs must be unique across the entire DOM. 
When Ionic’s router reuses components (without destroying them), multiple elements with the same fillRef/id can persist in the DOM. As a result, browsers were unable to reliably resolve which gradient to use, leading to intermittent  disappearance of the background color for the energy flow arrows.

**Solution:**
The sectionId used for the SVG gradient definition in AbstractSection is now guaranteed to be unique for each component instance by appending a UUID to the translateName. This ensures that each fillRef references a distinct ID. As a result, rendering conflicts in reused components are eliminated, and the background color for all energy flow arrows is always displayed as expected.
Resolves the intermittent disappearance of energy flow arrow background colors.
Ensures robust and correct SVG gradient rendering in all component reuse scenarios.