### PR TITLE
Fix missing ReactiveFormsModule import in AliasUpdateComponent

### DIFF
--- a/ui/src/app/edge/settings/profile/aliasupdate.component.ts
+++ b/ui/src/app/edge/settings/profile/aliasupdate.component.ts
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import { Component, OnInit } from "@angular/core";
-import { FormBuilder, FormControl, FormGroup } from "@angular/forms";
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, RouterModule } from "@angular/router";
 import { TranslateService } from "@ngx-translate/core";
 import { Edge, EdgeConfig, Service, Websocket } from "src/app/shared/shared";
@@ -13,6 +13,7 @@ import { CommonUiModule } from "../../../shared/common-ui.module";
     imports: [
         CommonUiModule,
         RouterModule,
+        ReactiveFormsModule,
     ],
 })
 export class AliasUpdateComponent implements OnInit {


### PR DESCRIPTION
## Description
The `AliasUpdateComponent` is a standalone component that uses `FormGroup`, but it did not import the `ReactiveFormsModule`.

## Changes
1. Added `ReactiveFormsModule` import (line 3).  
2. Added `ReactiveFormsModule` to the `imports` array in the `@Component` decorator (line 16).

## Result
The component now properly supports reactive form bindings without runtime errors.
