### PR TITLE
Fix WebSocket backend URL when running UI via openems-edge-dev configuration

### DIFF
--- a/ui/src/themes/openems/environments/edge-dev.ts
+++ b/ui/src/themes/openems/environments/edge-dev.ts
@@ -5,7 +5,7 @@ export const environment: Environment = {
     ...theme, ...{
 
         backend: "OpenEMS Edge",
-        url: `${getWebsocketScheme()}://${location.host}/backend`,
+        url: `${getWebsocketScheme()}://${location.hostname}:8085`,
 
         production: false,
         debugMode: true,


### PR DESCRIPTION
### Description
This PR fixes a WebSocket connection issue encountered when following the Getting Started documentation to run the UI with:
`ng serve -c openems-edge-dev`

### Problem
The current environment.openems-edge-dev.ts uses:
`` url: `${getWebsocketScheme()}://${location.host}/backend`, ``

When running the UI dev server, location.host resolves to localhost:4200, so the UI tries to connect to:
ws://localhost:4200/backend
However, the OpenEMS Edge WebSocket Bridge runs on port 8085, not 4200.
This results in a failed WebSocket handshake and the UI does not connect to Edge:
<img width="740" height="49" alt="image" src="https://github.com/user-attachments/assets/7468b446-0d42-47dc-bf9e-062bcf6e5968" />

### Solution
Explicitly point the WebSocket URL to port 8085 while keeping hostname dynamic:
`` url: `${getWebsocketScheme()}://${location.hostname}:8085`, ``