### PR TITLE
Kostal Plenticore: correct and simplify smartmode

### DIFF
--- a/io.openems.edge.kostal/src/io/openems/edge/kostal/plenticore/ess/Config.java
+++ b/io.openems.edge.kostal/src/io/openems/edge/kostal/plenticore/ess/Config.java
@@ -30,8 +30,8 @@ import io.openems.edge.kostal.plenticore.enums.ControlMode;
 	@AttributeDefinition(name = "Watchdog", description = "The watchdog configured at the inverter to return into internal operation mode.")
 	int watchdog() default 30;
 
-	@AttributeDefinition(name = "Tolerance", description = "The tolerance value in watts to skip the modbus writing if the timer is not yet elapsed (smart-mode).")
-	int tolerance() default 20;
+	@AttributeDefinition(name = "Tolerance", description = "The tolerance value in watts to skip the modbus writing if the timer is not yet elapsed (smart-mode), small power values are set to 0 (idle zone).")
+	int tolerance() default 50;
 
 	@AttributeDefinition(name = "Modbus-ID", description = "ID of Modbus bridge.")
 	String modbus_id() default "modbus0";


### PR DESCRIPTION
- Correction for the smart-mode skip logic: Modbus writes are skipped if the power change is within the tolerance or unchanged, unless the watchdog interval is exceeded.
- Implemented an idle zone: any power within tolerance (i.e. ±50 W per default) is set to 0 to reduce unnecessary battery cycling and inverter wear.
