### PR TITLE
Add missing channels to Generic ESS modbus table

### DIFF
--- a/io.openems.edge.ess.generic/src/io/openems/edge/ess/generic/common/AbstractGenericManagedEss.java
+++ b/io.openems.edge.ess.generic/src/io/openems/edge/ess/generic/common/AbstractGenericManagedEss.java
@@ -199,7 +199,9 @@ public abstract class AbstractGenericManagedEss<ESS extends SymmetricEss & Cycle
 		return new ModbusSlaveTable(//
 				OpenemsComponent.getModbusSlaveNatureTable(accessMode), //
 				SymmetricEss.getModbusSlaveNatureTable(accessMode), //
-				ManagedSymmetricEss.getModbusSlaveNatureTable(accessMode) //
+				ManagedSymmetricEss.getModbusSlaveNatureTable(accessMode), //
+				HybridEss.getModbusSlaveNatureTable(accessMode), //
+				StartStoppable.getModbusSlaveNatureTable(accessMode) //
 		);
 	}
 


### PR DESCRIPTION
The modbus interface of the generic ESS is missing the HybridEss and StartStoppable channels. This PR adds them.