### PR TITLE
Gradle: Fix `buildBackend`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
 		ext.isEdge = true
 	}
 	
-	if (name ==~ /io.openems.(backend|common|shared|wrapper).*/) {
+	if (name ==~ /io.openems.(backend|common|oem|shared|wrapper).*/) {
 		ext.isBackend = true
 	}
 


### PR DESCRIPTION
Fix
```
#19 128.4 > Task :assembleBackend
#19 129.4 
#19 129.4 Resolution failed. Summary:
#19 129.4 > Task :io.openems.backend.application:resolve.BackendApp FAILED
#19 129.4       ⇒ Bundle: io.openems.backend.metadata.odoo cannot be resolved
#19 129.4               ⇒ Service: objectClass=io.openems.common.oem.OpenemsBackendOem cannot be resolved
#19 129.4 
#19 129.4 Note: The summary above may be incomplete. Please check the full output below for more hints.
#19 129.4 Resolution failed. Capabilities satisfying the following requirements could not be found:
```

https://github.com/OpenEMS/openems/actions/runs/19413070591/job/55537254934#step:9:1265