### PR TITLE
[UI] Only apply additional filter when filter values are selected

### DIFF
--- a/ui/src/app/index/filter/filter.component.ts
+++ b/ui/src/app/index/filter/filter.component.ts
@@ -190,9 +190,9 @@ export class FilterComponent {
         } else {
             this.searchParams.set(filter.category, values);
 
-          if (additionalFilter) {
-              this.searchParams.set(additionalFilter.key, additionalFilter.value);
-          }
+            if (additionalFilter) {
+                this.searchParams.set(additionalFilter.key, additionalFilter.value);
+            }
         }
 
         this.persistSelection(filter);


### PR DESCRIPTION
Previously, when opening and closing the SumState filter dropdown without selecting any values, the `isOnline: true` additional filter was still being applied. This caused the device list to show only online devices even when no SumState filter was selected.

The issue was in `filter.component.ts` where `additionalFilter` was set unconditionally after the if/else block. Now it's only set when actual filter values are selected.

Fixes: Opening SumState filter and closing it without selection no longer filters to online-only devices.