### PR TITLE
fix(near equals power solver): Invalid behavior for limits

### DIFF
--- a/io.openems.edge.ess.core/src/io/openems/edge/ess/core/power/optimizers/KeepAllNearEqual.java
+++ b/io.openems.edge.ess.core/src/io/openems/edge/ess/core/power/optimizers/KeepAllNearEqual.java
@@ -48,17 +48,10 @@ public class KeepAllNearEqual {
 		var reactivePowerSolved = solvePowerIfNotNaN(setReactivePower, essList, Pwr.REACTIVE, direction);
 
 		var mergedResult = mergeResults(coefficients, esss, activePowerSolved, reactivePowerSolved);
-		if (mergedResult == null) {
+		if (mergedResult == null || mergedResult.length == 0) {
 			return null;
 		}
-
-		var result = Arrays.stream(mergedResult)//
-				.map(d -> reverseAbsoluteData(d, direction))//
-				.toArray();
-		if (result.length == 0) {
-			return null;
-		}
-		return new PointValuePair(result, 0);
+		return new PointValuePair(mergedResult, 0);
 	}
 
 	/**
@@ -188,7 +181,6 @@ public class KeepAllNearEqual {
 				.filter(constraint -> clusterEssId.equals(constraint.getCoefficients()[0].getCoefficient().getEssId()))
 				.filter(constraint -> constraint.getCoefficients()[0].getCoefficient().getPwr() == pwr)
 				.mapToDouble(constraint -> constraint.getValue().get())//
-				.map(c -> absoluteData(c, direction))//
 				.findFirst()//
 				.orElse(noPowerSetPoint);
 	}
@@ -197,36 +189,6 @@ public class KeepAllNearEqual {
 		return esss.stream()//
 				.filter(e -> !(e instanceof MetaEss))//
 				.toList();
-	}
-
-	/**
-	 * Calculate absolute value or zero based on the TargetDirection.
-	 * 
-	 * @param d         the input value to be processed
-	 * @param direction the {@link TargetDirection}
-	 * @return the processed value based on the direction
-	 */
-	private static double absoluteData(double d, TargetDirection direction) {
-		return switch (direction) {
-		case CHARGE -> Math.abs(d);
-		case DISCHARGE -> d;
-		case KEEP_ZERO -> 0.0;
-		};
-	}
-
-	/**
-	 * Calculate reverse absolute value or zero based on the TargetDirection.
-	 * 
-	 * @param d         the input value to be processed
-	 * @param direction the {@link TargetDirection}
-	 * @return the processed value based on the direction
-	 */
-	private static double reverseAbsoluteData(double d, TargetDirection direction) {
-		return switch (direction) {
-		case CHARGE -> -d;
-		case DISCHARGE -> d;
-		case KEEP_ZERO -> 0.0;
-		};
 	}
 
 	/**

--- a/io.openems.edge.ess.core/test/io/openems/edge/ess/core/power/PowerComponentTest.java
+++ b/io.openems.edge.ess.core/test/io/openems/edge/ess/core/power/PowerComponentTest.java
@@ -575,7 +575,7 @@ public class PowerComponentTest {
 	 * 
 	 * @throws Exception on exception
 	 */
-	// @Test
+	@Test
 	public void testNearEqualDistribution() throws Exception {
 		EssPower powerComponent = new EssPowerImpl();
 
@@ -647,10 +647,10 @@ public class PowerComponentTest {
 		ess4.withAllowedDischargePower(1900);
 
 		// Should be
-		expect("#3.1", ess1, 2701, 0);
-		expect("#3.2", ess2, 2701, 0);
-		expect("#3.3", ess3, 2701, 0);
-		expect("#3.4", ess4, 1897, 0);
+		expect("#3.1", ess1, 3240, 0);
+		expect("#3.2", ess2, 3240, 0);
+		expect("#3.3", ess3, 1620, 0);
+		expect("#3.4", ess4, 1900, 0);
 
 		ess0.addPowerConstraint("SetActivePowerEquals", ALL, ACTIVE, EQUALS, 10000);
 		componentTest.next(new TestCase("#3"));
@@ -659,10 +659,10 @@ public class PowerComponentTest {
 		ess4.withAllowedDischargePower(12000);
 		ess4.withAllowedChargePower(-1900);
 
-		expect("#4.1", ess1, -9899, 0);
-		expect("#4.2", ess2, -9899, 0);
-		expect("#4.3", ess3, -9900, 0);
-		expect("#4.4", ess4, -1881, 0);
+		expect("#4.1", ess1, -2160, 0);
+		expect("#4.2", ess2, -2160, 0);
+		expect("#4.3", ess3, -3780, 0);
+		expect("#4.4", ess4, -1900, 0);
 
 		ess0.addPowerConstraint("SetActivePowerEquals", ALL, ACTIVE, EQUALS, -10000);
 		componentTest.next(new TestCase("#4"));

--- a/io.openems.edge.ess.core/test/io/openems/edge/ess/core/power/SolverBySocOptimizationTest.java
+++ b/io.openems.edge.ess.core/test/io/openems/edge/ess/core/power/SolverBySocOptimizationTest.java
@@ -1,5 +1,6 @@
 package io.openems.edge.ess.core.power;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -179,6 +180,23 @@ public class SolverBySocOptimizationTest {
 		printing(socDistribution, upperBound, solution, lowerBound, powerSetValue);
 
 		assertEquals(-30000.0, Arrays.stream(solution).sum(), 1e-6);
+	}
+
+	@Test
+	public void testLowerBoundsForLowSoc() {
+
+		double[] upperBound = { 12_000, 12_000, 12_000, 12_000 };
+		double[] lowerBound = { -12_000, -12_000, -12_000, -1_900 };
+		double[] socDistribution = { 60, 60, 30, 60 };
+		double powerSetValue = -10000;
+
+		double[] solution = SolverBySocOptimization.solveDistribution(upperBound, lowerBound, socDistribution,
+				powerSetValue, getDirection(powerSetValue));
+		// Print this if test fails
+		printing(socDistribution, upperBound, solution, lowerBound, powerSetValue);
+
+		assertEquals(-10000, Arrays.stream(solution).sum(), 1e-6);
+		assertArrayEquals(new double[] {-2160, -2160, -3779.9, -1900}, solution, 0.1);
 	}
 
 	private static String formatArray(String label, double[] array) {


### PR DESCRIPTION
This fixes an error where a charge limit was set for a single ess inside a cluster. The power solver disrespected this, and set a value outside of the limit. For details see unit test part `#4` of `testNearEqualDistribution in io.openems.edge.ess.core/test/io/openems/edge/ess/core/power/PowerComponentTest.java. Without this fix, this test fails and charges higher than the allowed -1900.

Testing: Unit tests, also tested in a setup with a power plant with 12 ESS in total stacked in two layers of ESS clusters. First layer is an cluster of 3 Edge2Edge ESS, second layer is a Cluster of 4 EssGenericManagedSymmetric each.