### PR TITLE
Controller Timeslot Peakshaving: Avoid endless while loop

### DIFF
--- a/io.openems.edge.controller.symmetric.timeslotpeakshaving/src/io/openems/edge/controller/timeslotpeakshaving/ControllerEssTimeslotPeakshavingImpl.java
+++ b/io.openems.edge.controller.symmetric.timeslotpeakshaving/src/io/openems/edge/controller/timeslotpeakshaving/ControllerEssTimeslotPeakshavingImpl.java
@@ -117,8 +117,8 @@ public class ControllerEssTimeslotPeakshavingImpl extends AbstractOpenemsCompone
 	private void applyPower(ManagedSymmetricEss ess, Integer activePower) throws OpenemsNamedException {
 		if (activePower != null) {
 			ess.setActivePowerEqualsWithPid(activePower);
-			this.channel(ControllerEssTimeslotPeakshaving.ChannelId.CALCULATED_POWER).setNextValue(activePower);
 		}
+		this.channel(ControllerEssTimeslotPeakshaving.ChannelId.CALCULATED_POWER).setNextValue(activePower);
 	}
 
 	/**


### PR DESCRIPTION
In the previous implementation, if the min power of the ess is 0 (e.g. if the battery has an error), and the SOC is below the hysteresis SOC while being in state slowcharge, the while loop would toggle between the states `SLOWCHARGE` and `HYSTERESIS` endlessly. This is critical, as the method runs inside the core cycle, therefore the whole system would stop.
One can reproduce the bug with a simulated ess, a controller fix active power setting the ess to 0, and a controller timeslot peakshaving running afterwards in state `SLOWCHARGE`.
The new implementation leaves out the while loop altogether and does not check the min power.

When going through the code, I saw that there is more room for improvement, namely:
1. The ess and the meter could be referenced via OSGi (breaking configurations, as `ess()` would need to be renamed to `ess_id()`)
2. When restarting the system in state `SLOWCHARGE`, the controller will not get back into the state, but remain in state `NORMAL`. 
This will be done in separate PRs.
