### PR TITLE
fixed Kostal Piko HTML parsing bug: kWh for Total Energy in HTML, instead of expected Wh in ActiveProductionEnergy

### DIFF
--- a/io.openems.edge.pvinverter.kostal/src/io/openems/edge/pvinverter/kostal/piko/PvInverterKostalPikoImpl.java
+++ b/io.openems.edge.pvinverter.kostal/src/io/openems/edge/pvinverter/kostal/piko/PvInverterKostalPikoImpl.java
@@ -193,10 +193,13 @@ public class PvInverterKostalPikoImpl extends AbstractOpenemsComponent
 			acPower = value != null ? value : 0;
 		}
 
-		// Total Energy - second value
+		// Total Energy - second value (HTML provides kWh, need to convert to Wh)
 		Long totalYield = null;
 		if (index < valueCells.size()) {
 			totalYield = this.parseLongValue(valueCells.get(index++).text());
+			if (totalYield != null) {
+          		totalYield = totalYield * 1000; // Convert kWh to Wh
+      		}
 		}
 
 		// Day Energy - third value


### PR DESCRIPTION
As the parsed HTML from the Kostal Piko delivers kWh, the value should be multiplied by 1000 before it is stored into ActiveProductionEnergy, that expects Wh, by `this._setActiveProductionEnergy(totalYield);` (line 321)
This PR adds exactly this adjustment.