### PR TITLE
improve formatting in nature.adoc

### DIFF
--- a/doc/modules/ROOT/pages/edge/nature.adoc
+++ b/doc/modules/ROOT/pages/edge/nature.adoc
@@ -12,12 +12,13 @@ Physical hardware is abstracted in OpenEMS Edge using _Natures_. A Nature define
 
 Technically Natures are implemented as OSGi API Bundles.
 
-Each .api bundle contains the nature interfaces that device implementations must implement. For example, io.openems.edge.ess.api defines interfaces like SymmetricEss, AsymmetricEss, ManagedSymmetricEss, etc. These are sub-natures of the Ess nature.
+Each .api bundle contains the nature interfaces that device implementations must implement. For example, `io.openems.edge.ess.api` defines interfaces like `SymmetricEss`, `AsymmetricEss`, `ManagedSymmetricEss`, etc. These are sub-natures of the `Ess` nature.
 
 OpenEMS Edge provides the following types of Natures:
 
 == Device Natures
 e.g.:
+
 - io.openems.edge.battery.api - Battery interfaces
 - io.openems.edge.batteryinverter.api - Battery inverter interfaces
 - io.openems.edge.ess.api - Energy Storage System interfaces
@@ -31,6 +32,7 @@ e.g.:
 
 == Service/Support Natures
 e.g.:
+
 - io.openems.edge.controller.api - Controller interfaces
 - io.openems.edge.scheduler.api - Scheduler interfaces
 - io.openems.edge.timedata.api - Time-series data interfaces
@@ -39,7 +41,7 @@ e.g.:
 - io.openems.edge.weather.api - Weather service interfaces
 - io.openems.edge.energy.api - Energy management interfaces
 
-
+---
 Following you find all natures currently defined in OpenEMS Edge:
 
 include::nature.adoc.d/_include.adoc[leveloffset=+0]


### PR DESCRIPTION
improve formatting in nature.adoc:
* fix lists (adding empty line in front)
* added more inline code blocks to improve readability
* separator line to separate pre-text from documention of the natures.