### PR TITLE
GoodWe: Fix battery charging with PV when constraint is active

### DIFF
--- a/io.openems.edge.goodwe/src/io/openems/edge/goodwe/common/ApplyPowerHandler.java
+++ b/io.openems.edge.goodwe/src/io/openems/edge/goodwe/common/ApplyPowerHandler.java
@@ -138,6 +138,12 @@ public final class ApplyPowerHandler {
 	private static Result handleRemoteMode(int activePowerSetPoint, int pvProduction) {
 		// TODO PV curtail: (surplus power == setpoint && battery soc == 100% => PV
 		// curtail)
+
+		// Constraint case: keep battery neutral (e.g., external controller constraint)
+		if (activePowerSetPoint == 0) {
+			return new Result(EmsPowerMode.DISCHARGE_BAT, 0);
+		}
+
 		if (activePowerSetPoint < 0) {
 			return new Result(EmsPowerMode.CHARGE_BAT, activePowerSetPoint * -1 + pvProduction);
 		}

--- a/io.openems.edge.goodwe/test/io/openems/edge/goodwe/common/ApplyPowerHandlerTest.java
+++ b/io.openems.edge.goodwe/test/io/openems/edge/goodwe/common/ApplyPowerHandlerTest.java
@@ -96,9 +96,9 @@ public class ApplyPowerHandlerTest {
 				/* maxAcExport */ 5000, //
 				/* surplusPower */ 105));
 
-		// SMART - CHARGE_BAT
-		assertResult(EmsPowerMode.CHARGE_BAT, 300, ApplyPowerHandler.calculate(//
-				/* activePowerSetPoint */ 0, //
+		// SMART - Surplus: activePowerSetPoint == surplusPower → AUTO (balanced)
+		assertResult(EmsPowerMode.AUTO, 0, ApplyPowerHandler.calculate(//
+				/* activePowerSetPoint */ 105,
 				/* pvProduction */ 300, //
 				ControlMode.SMART, //
 				/* gridActivePower */ 250, //
@@ -107,7 +107,29 @@ public class ApplyPowerHandlerTest {
 				/* maxAcExport */ 5000, //
 				/* surplusPower */ 105));
 
-		// SMART - null
+		// SMART - CHARGE_BAT: Battery charges with PV surplus
+		assertResult(EmsPowerMode.CHARGE_BAT, 2000, ApplyPowerHandler.calculate(//
+				/* activePowerSetPoint */ 1000,
+				/* pvProduction */ 3000,
+				ControlMode.SMART, //
+				/* gridActivePower */ 500,
+				/* essActivePower */ 300, //
+				/* maxAcImport */ 5000, //
+				/* maxAcExport */ 5000, //
+				/* surplusPower */ 0));
+
+		// SMART - Constraint: activePowerSetPoint == 0 → battery neutral
+		assertResult(EmsPowerMode.DISCHARGE_BAT, 0, ApplyPowerHandler.calculate(//
+				/* activePowerSetPoint */ 0,
+				/* pvProduction */ 300, //
+				ControlMode.SMART, //
+				/* gridActivePower */ 350, //
+				/* essActivePower */ 420, //
+				/* maxAcImport */ 5000, //
+				/* maxAcExport */ 5000, //
+				/* surplusPower */ 0));
+
+		// SMART - Missing data falls back to AUTO
 		assertResult(EmsPowerMode.AUTO, 0, ApplyPowerHandler.calculate(//
 				/* activePowerSetPoint */ 1000, //
 				/* pvProduction */ 300, //
@@ -236,5 +258,33 @@ public class ApplyPowerHandlerTest {
 		assertTrue(noSmartMeterDetected.get());
 		assertEquals(5300, emsPowerSet.get());
 		assertEquals(EmsPowerMode.CHARGE_BAT, emsPowerMode.get());
+	}
+
+	@Test
+	public void testConstraintedRealWorldScenario() throws OpenemsNamedException {
+		// Real-world scenario: evcc storage lock with EV charging (GitHub evcc-io/evcc #22827)
+		// PV: 5000W, Consumption: 12200W, Loadpoint-Consumption: 7200, Constraint: battery not discharging
+
+		// REMOTE mode: battery stays neutral
+		assertResult(EmsPowerMode.DISCHARGE_BAT, 0, ApplyPowerHandler.calculate(//
+				/* activePowerSetPoint */ 0,
+				/* pvProduction */ 5000, //
+				ControlMode.REMOTE, //
+				/* gridActivePower */ 12200, //
+				/* essActivePower */ -5000, //
+				/* maxAcImport */ 20000, //
+				/* maxAcExport */ 20000, //
+				/* surplusPower */ 0));
+
+		// SMART mode: falls through to REMOTE, same result
+		assertResult(EmsPowerMode.DISCHARGE_BAT, 0, ApplyPowerHandler.calculate(//
+				/* activePowerSetPoint */ 0,
+				/* pvProduction */ 5000, //
+				ControlMode.SMART, //
+				/* gridActivePower */ 12200, //
+				/* essActivePower */ -5000, //
+				/* maxAcImport */ 20000, //
+				/* maxAcExport */ 20000, //
+				/* surplusPower */ 0));
 	}
 }


### PR DESCRIPTION
  **Problem**

  When an external controller (e.g., evcc) sets a discharge constraint via setActivePowerLessOrEquals(0) to keep the battery neutral, the GoodWe handler incorrectly charged the battery with available PV power instead of allowing PV to supply household consumption first.

  **Root Cause**

  In handleRemoteMode(), when activePowerSetPoint == 0 and PV was available, the condition pvProduction >= activePowerSetPoint (e.g., 300 >= 0) triggered CHARGE_BAT mode, routing PV to battery instead of household loads.

  **Fix**

  Added explicit handling for constraint case (activePowerSetPoint == 0) to return DISCHARGE_BAT, 0 (neutral), allowing PV to serve household consumption before any battery interaction.

  **Test Coverage**

  - Fixed semantically incorrect test case
  - Added CHARGE_BAT test with proper PV surplus calculation
  - Added constraint test case (activePowerSetPoint == 0)
  - Added real-world evcc scenario test (GitHub evcc#22827)

  **Reference**

  - evcc GitHub Discussion: https://github.com/evcc-io/evcc/discussions/22827
