### PR TITLE
Update readme.adoc: added link to documentation

### DIFF
--- a/io.openems.edge.controller.io.channelsinglethreshold/readme.adoc
+++ b/io.openems.edge.controller.io.channelsinglethreshold/readme.adoc
@@ -1,5 +1,7 @@
 = IO Channel-Single-Threshold
 
-Generic Controller that sets a digital output according to the value of given Channel - e.g. turn a Relay on or off, when configured input channel/SoC is above or below a given threshold respectively.
+Generic Controller that sets a digital output according to the value of given Channel -- e.g., turn a relay on or off, when configured input channel/SoC is above or below a given threshold respectively.
+
+Documentation: https://docs.fenecon.de/en/fems/fems-app/App_Schwellwertsteuerung.html
 
 https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.controller.io.channelsinglethreshold[Source Code icon:github[]]


### PR DESCRIPTION
Not sure if it is intended to *mix* OpenEMS and FEMS, but seems easiest to me to just add a link (and not duplicate contents).