### PR TITLE
[Edge] Refactor AC-in setpoint calculation

### DIFF
--- a/io.openems.edge.victron/src/io/openems/edge/victron/ess/VictronEssImpl.java
+++ b/io.openems.edge.victron/src/io/openems/edge/victron/ess/VictronEssImpl.java
@@ -513,23 +513,10 @@ public class VictronEssImpl extends AbstractOpenemsModbusComponent
 			}
 		}
 
-		if (activePowerTarget < 0) {
-			// CHARGE: AC-Out draws power from battery, subtract from target
-			activePowerTarget -= acOutputActivePowerSum;
-			this.logDebug(this.log, "Symm. PowerWanted ChargeMode after subtraction of AC Out: "
-					+ acOutputActivePowerSum + " ->  " + activePowerTarget);
-		} else if (activePowerTarget > 0) {
-			this.logDebug(this.log, "Symm. PowerWanted DischargeMode Target ->  " + activePowerTarget);
-		}
+		activePowerTarget = calculateAcInSetpoint(activePowerTarget, acOutputActivePowerSum, this.maxChargePower,
+				this.maxDischargePower);
 
-		// Clamp power to hardware limits
-
-		if (activePowerTarget < 0 && Math.abs(activePowerTarget) > this.maxChargePower) {
-			activePowerTarget = this.maxChargePower * -1;
-		}
-		if (activePowerTarget > 0 && activePowerTarget > this.maxDischargePower) {
-			activePowerTarget = this.maxDischargePower;
-		}
+		this.logDebug(this.log, "Symm. PowerWanted after clamp and AC-Out adjustment: " + activePowerTarget);
 
 		this._setAllowedChargePower(this.maxChargePower * -1); // Negative for charging
 		this._setAllowedDischargePower(this.maxDischargePower); // Positive for discharging
@@ -572,6 +559,40 @@ public class VictronEssImpl extends AbstractOpenemsModbusComponent
 	@Override
 	public Power getPower() {
 		return this.power;
+	}
+
+	/**
+	 * Calculates the AC-in setpoint by first clamping the battery power to hardware
+	 * limits, then adjusting for AC-out load.
+	 *
+	 * <p>
+	 * Clamping is applied before the AC-out adjustment so that the hardware limits
+	 * constrain the battery charge/discharge power, not the total AC-in power which
+	 * must also cover AC-out loads.
+	 *
+	 * @param activePowerTarget      the requested battery power (negative=charge,
+	 *                               positive=discharge)
+	 * @param acOutputActivePowerSum the total AC-out load (always positive)
+	 * @param maxChargePower         the maximum charge power (positive value)
+	 * @param maxDischargePower      the maximum discharge power (positive value)
+	 * @return the adjusted AC-in setpoint
+	 */
+	protected static int calculateAcInSetpoint(int activePowerTarget, int acOutputActivePowerSum, int maxChargePower,
+			int maxDischargePower) {
+		// Clamp power to hardware limits before AC-Out adjustment
+		if (activePowerTarget < 0 && Math.abs(activePowerTarget) > maxChargePower) {
+			activePowerTarget = maxChargePower * -1;
+		}
+		if (activePowerTarget > 0 && activePowerTarget > maxDischargePower) {
+			activePowerTarget = maxDischargePower;
+		}
+
+		// CHARGE: AC-Out draws power from battery, subtract from target
+		if (activePowerTarget < 0) {
+			activePowerTarget -= acOutputActivePowerSum;
+		}
+
+		return activePowerTarget;
 	}
 
 	/**

--- a/io.openems.edge.victron/test/io/openems/edge/victron/ess/VictronEssImplTest.java
+++ b/io.openems.edge.victron/test/io/openems/edge/victron/ess/VictronEssImplTest.java
@@ -111,4 +111,48 @@ public class VictronEssImplTest {
 		assertEquals(100, victronEss.getPowerPrecision());
 	}
 
+	@Test
+	public void testCalculateAcInSetpoint_chargeWithAcOutLoad() {
+		// Issue #3573: Charge request of 3kW with 5kW AC-out load
+		// Battery should charge at 3kW, so AC-in must be 8kW
+		var result = VictronEssImpl.calculateAcInSetpoint(-3000, 5000, 3000, 3000);
+		assertEquals(-8000, result);
+	}
+
+	@Test
+	public void testCalculateAcInSetpoint_chargeExceedsMaxWithAcOut() {
+		// Charge request of 5kW exceeds maxChargePower of 3kW, with 2kW AC-out
+		// Should clamp to -3kW charge, then subtract 2kW AC-out => -5kW
+		var result = VictronEssImpl.calculateAcInSetpoint(-5000, 2000, 3000, 3000);
+		assertEquals(-5000, result);
+	}
+
+	@Test
+	public void testCalculateAcInSetpoint_chargeWithinLimitsNoAcOut() {
+		// Charge request of 2kW, no AC-out, maxCharge 3kW
+		var result = VictronEssImpl.calculateAcInSetpoint(-2000, 0, 3000, 3000);
+		assertEquals(-2000, result);
+	}
+
+	@Test
+	public void testCalculateAcInSetpoint_dischargeWithinLimits() {
+		// Discharge request of 2kW, maxDischarge 3kW
+		var result = VictronEssImpl.calculateAcInSetpoint(2000, 1000, 3000, 3000);
+		assertEquals(2000, result);
+	}
+
+	@Test
+	public void testCalculateAcInSetpoint_dischargeExceedsMax() {
+		// Discharge request of 5kW, maxDischarge 3kW => clamped to 3kW
+		var result = VictronEssImpl.calculateAcInSetpoint(5000, 0, 3000, 3000);
+		assertEquals(3000, result);
+	}
+
+	@Test
+	public void testCalculateAcInSetpoint_zeroPower() {
+		// Zero power target, should remain zero
+		var result = VictronEssImpl.calculateAcInSetpoint(0, 5000, 3000, 3000);
+		assertEquals(0, result);
+	}
+
 }


### PR DESCRIPTION
This commit refactors the AC-in setpoint calculation logic in VictronEssImpl.java to improve code maintainability and readability. It introduces a new method, calculateAcInSetpoint, which encapsulates the logic for clamping the battery power to hardware limits and adjusting for AC-out load. This change simplifies the main logic flow by abstracting the detailed calculation steps into a separate, well-documented method. Additionally, it fixes potential issues with the previous implementation by ensuring that the hardware limits are applied before adjusting for AC-out load, which prevents the hardware constraints from being bypassed. The accompanying tests in VictronEssImplTest.java have been updated to cover various scenarios, ensuring the new method behaves as expected.

should fix: https://github.com/OpenEMS/openems/issues/3573