### PR TITLE
[EDGE] Handle UNDEFINED_VALUE as null in ModbusRecordChannel

### DIFF
--- a/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordChannel.java
@@ -179,40 +179,15 @@ public class ModbusRecordChannel extends ModbusRecord {
 			}
 		}
 
-		// yes, it is full -> Prepare ByteBuffer
-		var buff = ByteBuffer.allocate(this.writeValueBuffer.length);
-		for (Byte element : this.writeValueBuffer) {
-			buff.put(element);
+		// Copy buffer to byte array and clear buffer
+		var raw = new byte[this.writeValueBuffer.length];
+		for (var i = 0; i < raw.length; i++) {
+			raw[i] = this.writeValueBuffer[i];
 		}
-		buff.rewind();
-
-		// clear buffer
 		Arrays.fill(this.writeValueBuffer, null);
 
-		// Get Value-Object from ByteBuffer, interpreting UNDEFINED_VALUE as null
-		var value = switch (this.getType()) {
-		case FLOAT64 -> {
-			var v = buff.getDouble();
-			yield Double.isNaN(v) ? null : v;
-		}
-		case FLOAT32 -> {
-			var v = buff.getFloat();
-			yield Float.isNaN(v) ? null : v;
-		}
-		case STRING16 -> ""; // TODO implement String conversion
-		case ENUM16, UINT16 -> {
-			var v = buff.getShort();
-			yield v == (short) ModbusRecordUint16.UNDEFINED_VALUE ? null : v;
-		}
-		case UINT32 -> {
-			var v = buff.getInt();
-			yield v == (int) ModbusRecordUint32.UNDEFINED_VALUE ? null : v;
-		}
-		case UINT64 -> {
-			var v = buff.getLong();
-			yield v == ModbusRecordUint64.UNDEFINED_VALUE ? null : v;
-		}
-		};
+		// Get Value-Object from byte array, interpreting UNDEFINED_VALUE as null
+		var value = parseValue(this.getType(), raw);
 
 		// Forward Value to ApiWorker
 		if (this.onWriteValueCallback != null) {
@@ -220,6 +195,41 @@ public class ModbusRecordChannel extends ModbusRecord {
 		} else {
 			this.log.error("No onWriteValueCallback registered. What should I do with [" + value + "]?");
 		}
+	}
+
+	/**
+	 * Parses a value from the given raw byte array according to the
+	 * {@link ModbusType}. Returns null if the bytes match the type's
+	 * UNDEFINED_BYTE_ARRAY.
+	 *
+	 * @param type the {@link ModbusType}
+	 * @param raw  the raw byte array
+	 * @return the parsed value, or null for UNDEFINED
+	 */
+	protected static Object parseValue(ModbusType type, byte[] raw) {
+		// Check for UNDEFINED_VALUE by comparing the raw bytes
+		var undefinedBytes = switch (type) {
+		case FLOAT32 -> ModbusRecordFloat32.UNDEFINED_BYTE_ARRAY;
+		case FLOAT64 -> ModbusRecordFloat64.UNDEFINED_BYTE_ARRAY;
+		case STRING16 -> ModbusRecordString16.UNDEFINED_BYTE_ARRAY;
+		case ENUM16, UINT16 -> ModbusRecordUint16.UNDEFINED_BYTE_ARRAY;
+		case UINT32 -> ModbusRecordUint32.UNDEFINED_BYTE_ARRAY;
+		case UINT64 -> ModbusRecordUint64.UNDEFINED_BYTE_ARRAY;
+		};
+		if (Arrays.equals(raw, undefinedBytes)) {
+			return null;
+		}
+
+		// Parse the value from the byte array
+		var buff = ByteBuffer.wrap(raw);
+		return switch (type) {
+		case FLOAT64 -> buff.getDouble();
+		case FLOAT32 -> buff.getFloat();
+		case STRING16 -> new String(raw, java.nio.charset.StandardCharsets.US_ASCII).trim();
+		case ENUM16, UINT16 -> buff.getShort();
+		case UINT32 -> buff.getInt();
+		case UINT64 -> buff.getLong();
+		};
 	}
 
 	@Override

--- a/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordChannel.java
+++ b/io.openems.edge.common/src/io/openems/edge/common/modbusslave/ModbusRecordChannel.java
@@ -189,14 +189,29 @@ public class ModbusRecordChannel extends ModbusRecord {
 		// clear buffer
 		Arrays.fill(this.writeValueBuffer, null);
 
-		// Get Value-Object from ByteBuffer
+		// Get Value-Object from ByteBuffer, interpreting UNDEFINED_VALUE as null
 		var value = switch (this.getType()) {
-		case FLOAT64 -> buff.getDouble();
-		case FLOAT32 -> buff.getFloat();
+		case FLOAT64 -> {
+			var v = buff.getDouble();
+			yield Double.isNaN(v) ? null : v;
+		}
+		case FLOAT32 -> {
+			var v = buff.getFloat();
+			yield Float.isNaN(v) ? null : v;
+		}
 		case STRING16 -> ""; // TODO implement String conversion
-		case ENUM16, UINT16 -> buff.getShort();
-		case UINT32 -> buff.getInt();
-		case UINT64 -> buff.getLong();
+		case ENUM16, UINT16 -> {
+			var v = buff.getShort();
+			yield v == (short) ModbusRecordUint16.UNDEFINED_VALUE ? null : v;
+		}
+		case UINT32 -> {
+			var v = buff.getInt();
+			yield v == (int) ModbusRecordUint32.UNDEFINED_VALUE ? null : v;
+		}
+		case UINT64 -> {
+			var v = buff.getLong();
+			yield v == ModbusRecordUint64.UNDEFINED_VALUE ? null : v;
+		}
 		};
 
 		// Forward Value to ApiWorker

--- a/io.openems.edge.common/test/io/openems/edge/common/modbusslave/ModbusRecordChannelTest.java
+++ b/io.openems.edge.common/test/io/openems/edge/common/modbusslave/ModbusRecordChannelTest.java
@@ -2,8 +2,21 @@ package io.openems.edge.common.modbusslave;
 
 import static io.openems.common.channel.AccessMode.READ_WRITE;
 import static io.openems.common.channel.AccessMode.WRITE_ONLY;
+import static io.openems.edge.common.modbusslave.ModbusRecordChannel.parseValue;
+import static io.openems.edge.common.modbusslave.ModbusType.ENUM16;
+import static io.openems.edge.common.modbusslave.ModbusType.FLOAT32;
+import static io.openems.edge.common.modbusslave.ModbusType.FLOAT64;
+import static io.openems.edge.common.modbusslave.ModbusType.STRING16;
 import static io.openems.edge.common.modbusslave.ModbusType.UINT16;
+import static io.openems.edge.common.modbusslave.ModbusType.UINT32;
+import static io.openems.edge.common.modbusslave.ModbusType.UINT64;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 
@@ -71,6 +84,115 @@ public class ModbusRecordChannelTest {
 		assertArrayEquals(ModbusRecordUint16.toByteArray(100),
 				new ModbusRecordChannel(0, UINT16, DummyComponent.ChannelId.READ_ONLY_CHANNEL, READ_WRITE)
 						.getValue(component));
+	}
+
+
+	@Test
+	public void testParseValueUint16() {
+		assertEquals((short) 42, parseValue(UINT16, ByteBuffer.allocate(2).putShort((short) 42).array()));
+	}
+
+	@Test
+	public void testParseValueUint16Undefined() {
+		assertNull(parseValue(UINT16, ModbusRecordUint16.UNDEFINED_BYTE_ARRAY));
+	}
+
+
+	@Test
+	public void testParseValueEnum16() {
+		assertEquals((short) 3, parseValue(ENUM16, ByteBuffer.allocate(2).putShort((short) 3).array()));
+	}
+
+	@Test
+	public void testParseValueEnum16Undefined() {
+		assertNull(parseValue(ENUM16, ModbusRecordUint16.UNDEFINED_BYTE_ARRAY));
+	}
+
+
+	@Test
+	public void testParseValueUint32() {
+		assertEquals(42, parseValue(UINT32, ByteBuffer.allocate(4).putInt(42).array()));
+	}
+
+	@Test
+	public void testParseValueUint32Undefined() {
+		assertNull(parseValue(UINT32, ModbusRecordUint32.UNDEFINED_BYTE_ARRAY));
+	}
+
+
+	@Test
+	public void testParseValueUint64() {
+		assertEquals(42L, parseValue(UINT64, ByteBuffer.allocate(8).putLong(42L).array()));
+	}
+
+	@Test
+	public void testParseValueUint64Undefined() {
+		assertNull(parseValue(UINT64, ModbusRecordUint64.UNDEFINED_BYTE_ARRAY));
+	}
+
+
+	@Test
+	public void testParseValueFloat32() {
+		assertEquals(42.5f, parseValue(FLOAT32, ByteBuffer.allocate(4).putFloat(42.5f).array()));
+	}
+
+	@Test
+	public void testParseValueFloat32Undefined() {
+		assertNull(parseValue(FLOAT32, ModbusRecordFloat32.UNDEFINED_BYTE_ARRAY));
+	}
+
+
+	@Test
+	public void testParseValueFloat64() {
+		assertEquals(42.5, parseValue(FLOAT64, ByteBuffer.allocate(8).putDouble(42.5).array()));
+	}
+
+	@Test
+	public void testParseValueFloat64Undefined() {
+		assertNull(parseValue(FLOAT64, ModbusRecordFloat64.UNDEFINED_BYTE_ARRAY));
+	}
+
+
+	@Test
+	public void testParseValueString16() {
+		var raw = new byte[32];
+		var hello = "hello".getBytes(StandardCharsets.US_ASCII);
+		System.arraycopy(hello, 0, raw, 0, hello.length);
+		assertEquals("hello", parseValue(STRING16, raw));
+	}
+
+	@Test
+	public void testParseValueString16Undefined() {
+		assertNull(parseValue(STRING16, ModbusRecordString16.UNDEFINED_BYTE_ARRAY));
+	}
+
+
+	@Test
+	public void testWriteValueCallsCallback() {
+		var sut = new ModbusRecordChannel(0, UINT16, DummyComponent.ChannelId.READ_WRITE_CHANNEL, READ_WRITE);
+		var result = new AtomicReference<Object>(new Object()); // sentinel
+		sut.onWriteValue(result::set);
+		sut.writeValue(0, (byte) 0, (byte) 42);
+		assertEquals((short) 42, result.get());
+	}
+
+	@Test
+	public void testWriteValueUndefinedCallsCallbackWithNull() {
+		var sut = new ModbusRecordChannel(0, UINT16, DummyComponent.ChannelId.READ_WRITE_CHANNEL, READ_WRITE);
+		var result = new AtomicReference<Object>(new Object()); // sentinel
+		sut.onWriteValue(result::set);
+		sut.writeValue(0, (byte) 0xFF, (byte) 0xFF);
+		assertNull(result.get());
+	}
+
+
+	@Test
+	public void testWriteValueReadOnlyIgnored() {
+		var sut = new ModbusRecordChannel(0, UINT16, DummyComponent.ChannelId.READ_ONLY_CHANNEL, READ_WRITE);
+		var result = new AtomicReference<Object>(null);
+		sut.onWriteValue(result::set);
+		sut.writeValue(0, (byte) 0, (byte) 42);
+		assertNull(result.get()); // callback should not have been called
 	}
 
 }


### PR DESCRIPTION
This commit updates the ModbusRecordChannel to interpret UNDEFINED_VALUE as null for numeric types (FLOAT64, FLOAT32, UINT16, UINT32, UINT64). This change ensures that when a Modbus record contains a value that is designated as undefined or not applicable, it is correctly handled as a null value in the system, rather than being processed as a valid numeric value. This is crucial for avoiding incorrect data interpretation and ensuring data integrity in applications that rely on Modbus communication.