### PR TITLE
Fix EssPower thread-safety race condition (#3500)

### DIFF
--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/power/api/Coefficients.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/power/api/Coefficients.java
@@ -26,32 +26,25 @@ public class Coefficients {
 	 * @param essIds        Set of ESS-Ids
 	 */
 	public synchronized void initialize(boolean symmetricMode, Set<String> essIds) {
-		// Build the new coefficients in a temporary list first, then swap atomically.
-		// This avoids a window where the list is cleared but not yet rebuilt, which
-		// would cause concurrent readers in of() to throw "Coefficient was not found".
-		var newCoefficients = new java.util.ArrayList<Coefficient>();
+		this.coefficients.clear();
+		this.symmetricMode = symmetricMode;
 		var index = 0;
 		for (String essId : essIds) {
 			if (symmetricMode) {
 				// Symmetric Mode
 				for (Pwr pwr : Pwr.values()) {
-					newCoefficients.add(new Coefficient(index++, essId, SingleOrAllPhase.ALL, pwr));
+					this.coefficients.add(new Coefficient(index++, essId, SingleOrAllPhase.ALL, pwr));
 				}
 			} else {
 				// Asymmetric Mode
 				for (var phase : SingleOrAllPhase.values()) {
 					for (Pwr pwr : Pwr.values()) {
-						newCoefficients.add(new Coefficient(index++, essId, phase, pwr));
+						this.coefficients.add(new Coefficient(index++, essId, phase, pwr));
 					}
 				}
 			}
 		}
-		this.symmetricMode = symmetricMode;
 		this.noOfCoefficients = index;
-		// Atomic swap: clear and addAll in immediate succession on CopyOnWriteArrayList.
-		// Because of() is also synchronized on 'this', no reader can see the empty state.
-		this.coefficients.clear();
-		this.coefficients.addAll(newCoefficients);
 	}
 
 	/**

--- a/io.openems.edge.ess.api/src/io/openems/edge/ess/power/api/Coefficients.java
+++ b/io.openems.edge.ess.api/src/io/openems/edge/ess/power/api/Coefficients.java
@@ -26,25 +26,32 @@ public class Coefficients {
 	 * @param essIds        Set of ESS-Ids
 	 */
 	public synchronized void initialize(boolean symmetricMode, Set<String> essIds) {
-		this.coefficients.clear();
-		this.symmetricMode = symmetricMode;
+		// Build the new coefficients in a temporary list first, then swap atomically.
+		// This avoids a window where the list is cleared but not yet rebuilt, which
+		// would cause concurrent readers in of() to throw "Coefficient was not found".
+		var newCoefficients = new java.util.ArrayList<Coefficient>();
 		var index = 0;
 		for (String essId : essIds) {
 			if (symmetricMode) {
 				// Symmetric Mode
 				for (Pwr pwr : Pwr.values()) {
-					this.coefficients.add(new Coefficient(index++, essId, SingleOrAllPhase.ALL, pwr));
+					newCoefficients.add(new Coefficient(index++, essId, SingleOrAllPhase.ALL, pwr));
 				}
 			} else {
 				// Asymmetric Mode
 				for (var phase : SingleOrAllPhase.values()) {
 					for (Pwr pwr : Pwr.values()) {
-						this.coefficients.add(new Coefficient(index++, essId, phase, pwr));
+						newCoefficients.add(new Coefficient(index++, essId, phase, pwr));
 					}
 				}
 			}
 		}
+		this.symmetricMode = symmetricMode;
 		this.noOfCoefficients = index;
+		// Atomic swap: clear and addAll in immediate succession on CopyOnWriteArrayList.
+		// Because of() is also synchronized on 'this', no reader can see the empty state.
+		this.coefficients.clear();
+		this.coefficients.addAll(newCoefficients);
 	}
 
 	/**
@@ -57,7 +64,7 @@ public class Coefficients {
 	 * @return the {@link Coefficient}
 	 * @throws OpenemsException on error
 	 */
-	public Coefficient of(String essId, SingleOrAllPhase phase, Pwr pwr) throws OpenemsException {
+	public synchronized Coefficient of(String essId, SingleOrAllPhase phase, Pwr pwr) throws OpenemsException {
 		if (this.symmetricMode && phase != SingleOrAllPhase.ALL) {
 			throw new OpenemsException("Symmetric-Mode is activated. Coefficients for [" + essId + "," + phase + ","
 					+ pwr + "] is not available!");

--- a/io.openems.edge.ess.core/src/io/openems/edge/ess/core/power/v1/Data.java
+++ b/io.openems.edge.ess.core/src/io/openems/edge/ess/core/power/v1/Data.java
@@ -166,7 +166,7 @@ public class Data {
 	 * @return List of Constraints
 	 * @throws OpenemsException on error
 	 */
-	public List<Constraint> getConstraintsForAllInverters() throws OpenemsException {
+	public synchronized List<Constraint> getConstraintsForAllInverters() throws OpenemsException {
 		return this.getConstraintsWithoutDisabledInverters(Collections.emptyList());
 	}
 
@@ -177,7 +177,7 @@ public class Data {
 	 * @return List of {@link Constraint}s
 	 * @throws OpenemsException on error
 	 */
-	public List<Constraint> getConstraintsForInverters(Collection<Inverter> enabledInverters) throws OpenemsException {
+	public synchronized List<Constraint> getConstraintsForInverters(Collection<Inverter> enabledInverters) throws OpenemsException {
 		List<Inverter> disabledInverters = new ArrayList<>(this.inverters);
 		disabledInverters.removeAll(enabledInverters);
 		return this.getConstraintsWithoutDisabledInverters(disabledInverters);
@@ -190,7 +190,7 @@ public class Data {
 	 * @return List of Constraints
 	 * @throws OpenemsException on error
 	 */
-	public List<Constraint> getConstraintsWithoutDisabledInverters(Collection<Inverter> disabledInverters)
+	public synchronized List<Constraint> getConstraintsWithoutDisabledInverters(Collection<Inverter> disabledInverters)
 			throws OpenemsException {
 		final var esss = this.esssSupplier.get();
 


### PR DESCRIPTION
## Summary
- Race condition between OSGi thread (adding ESS) and Solver thread (reading coefficients) causes "Coefficient was not found" errors
- ESS operates at 0W until manual restart — 40+ hour production downtime reported
- Root cause: `Data.getConstraints*` and `Coefficients.of()` are not synchronized, while `Coefficients.initialize()` clears-then-rebuilds (non-atomic)

## Root cause
1. OSGi thread: `Data.addEss()` → `updateInverters()` → `Coefficients.initialize()` → clears coefficient list
2. Solver thread (concurrent): `getConstraintsWithoutDisabledInverters()` → sees new ESS in CopyOnWriteArrayList → calls `Coefficients.of(essId)` → coefficient not found (list was cleared)

## Changes

### `Coefficients.java` (`io.openems.edge.ess.api`)
- **`of()` → `synchronized`**: Prevents reading coefficients while `initialize()` is rebuilding them
- **`initialize()` → build-then-swap**: Coefficients are built in a temporary `ArrayList` first, then `clear()` + `addAll()` happen at the end while holding the monitor lock. No reader (via `of()`) can observe the empty intermediate state.

### `Data.java` (`io.openems.edge.ess.core`)
- **`getConstraintsForAllInverters()` → `synchronized`**
- **`getConstraintsForInverters()` → `synchronized`**
- **`getConstraintsWithoutDisabledInverters()` → `synchronized`**

These methods read `esss`, `inverters`, `coefficients`, and `symmetricMode` — all of which are mutated by `addEss()`/`removeEss()`/`updateInverters()` (which are already `synchronized` on the same `Data` instance). Without synchronization, the Solver thread can observe partially-updated state.

## Test plan
- [ ] Start OpenEMS with multiple ESS components — verify no "Coefficient not found" errors in log
- [ ] Add/remove ESS component during active operation — verify no race condition errors
- [ ] Verify ESS power limits are correctly applied after component restart
- [ ] Stress test: rapidly add/remove ESS components while solver is running

Fixes #3500