### PR TITLE
[UI] EVCS: subscribe to Plug and _PropertyReadOnly only when available

### DIFF
--- a/ui/src/app/edge/live/Controller/Evcs/flat/flat.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/flat/flat.ts
@@ -69,7 +69,6 @@ export class FlatComponent extends AbstractFlatWidget {
         const result = [
             this.chargePoint.powerChannel,
             new ChannelAddress(this.component.id, "Phases"),
-            new ChannelAddress(this.component.id, "Plug"),
             new ChannelAddress(this.component.id, "Status"),
             new ChannelAddress(this.component.id, "State"),
             new ChannelAddress(this.component.id, "EnergySession"),
@@ -78,6 +77,11 @@ export class FlatComponent extends AbstractFlatWidget {
             new ChannelAddress(this.component.id, "MaximumHardwarePower"),
             new ChannelAddress(this.component.id, "SetChargePowerLimit"),
         ];
+
+        // Plug is only available on certain EVCS implementations (e.g. Keba)
+        if (this.component.channels?.["Plug"] != null) {
+            result.push(new ChannelAddress(this.component.id, "Plug"));
+        }
 
         const controllers = this.config.getComponentsByFactory("Controller.Evcs");
         for (const controller of controllers) {

--- a/ui/src/app/edge/live/Controller/Evcs/modal/modal.ts
+++ b/ui/src/app/edge/live/Controller/Evcs/modal/modal.ts
@@ -127,15 +127,23 @@ export class ModalComponent extends AbstractModal {
 
         channels.push(
             new ChannelAddress(this.component.id, "Phases"),
-            new ChannelAddress(this.component.id, "Plug"),
             new ChannelAddress(this.component.id, "Status"),
             new ChannelAddress(this.component.id, "State"),
             new ChannelAddress(this.component.id, "EnergySession"),
             new ChannelAddress(this.component.id, "MinimumHardwarePower"),
             new ChannelAddress(this.component.id, "MaximumHardwarePower"),
             new ChannelAddress(this.component.id, "SetChargePowerLimit"),
-            new ChannelAddress(this.component.id, "_PropertyReadOnly"),
         );
+
+        // Plug is only available on certain EVCS implementations (e.g. Keba)
+        if (this.component.channels?.["Plug"] != null) {
+            channels.push(new ChannelAddress(this.component.id, "Plug"));
+        }
+
+        // _PropertyReadOnly only exists on components with a readOnly config property
+        if (this.component.channels?.["_PropertyReadOnly"] != null) {
+            channels.push(new ChannelAddress(this.component.id, "_PropertyReadOnly"));
+        }
 
         if (this.controller == null) {
             return channels;


### PR DESCRIPTION
Fixes #3642

The EVCS flat widget and modal both unconditionally subscribe to the `Plug` and `_PropertyReadOnly` channels for every EVCS component. The `Plug` channel is only defined on the `EvcsKeba` / `EvseKeba` interface, and `_PropertyReadOnly` is only generated for components that have a `readOnly` configuration property (Keba, go-e). Any EVCS that lacks these channels — simulators, ABL, Mennekes, Heidelberg, etc. — produces repeated "Unable to read value for Channel" warnings in the log every time the widget refreshes.

I've added a guard that checks the component's channel metadata (`this.component.channels?.["..."]`) before subscribing. The existing `getState()` method already handles a null `plug` value gracefully, so the UI behavior is unchanged — the only difference is the backend no longer receives subscription requests for channels that don't exist.

Tested by verifying the Angular lint passes (`ng lint`) with no errors on the changed files.