### PR TITLE
[Edge] Controller.Evcs: fix awaitLastChanges checking INCREASING twice instead of DECREASING

### DIFF
--- a/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/ControllerEvcsImpl.java
+++ b/io.openems.edge.controller.evcs/src/io/openems/edge/controller/evcs/ControllerEvcsImpl.java
@@ -381,7 +381,7 @@ public class ControllerEvcsImpl extends AbstractOpenemsComponent
 	 * @return The cvcs should await or not
 	 */
 	private static boolean awaitLastChanges(ChargeState chargeState) {
-		if (chargeState.equals(ChargeState.INCREASING) || chargeState.equals(ChargeState.INCREASING)) {
+		if (chargeState.equals(ChargeState.INCREASING) || chargeState.equals(ChargeState.DECREASING)) {
 			// Still waiting for increasing, decreasing the power
 			return true;
 		}

--- a/io.openems.edge.controller.evcs/test/io/openems/edge/controller/evcs/ControllerEvcsImplTest.java
+++ b/io.openems.edge.controller.evcs/test/io/openems/edge/controller/evcs/ControllerEvcsImplTest.java
@@ -11,6 +11,7 @@ import static io.openems.edge.evcs.api.ChargeMode.FORCE_CHARGE;
 import static io.openems.edge.evcs.api.Evcs.ChannelId.MAXIMUM_HARDWARE_POWER;
 import static io.openems.edge.evcs.api.Evcs.ChannelId.MAXIMUM_POWER;
 import static io.openems.edge.evcs.api.Evcs.ChannelId.STATUS;
+import static io.openems.edge.evcs.api.ManagedEvcs.ChannelId.CHARGE_STATE;
 import static io.openems.edge.evcs.api.ManagedEvcs.ChannelId.IS_CLUSTERED;
 import static io.openems.edge.evcs.api.ManagedEvcs.ChannelId.SET_CHARGE_POWER_LIMIT;
 import static io.openems.edge.evcs.api.ManagedEvcs.ChannelId.SET_CHARGE_POWER_REQUEST;
@@ -24,6 +25,7 @@ import io.openems.common.test.DummyConfigurationAdmin;
 import io.openems.edge.common.sum.DummySum;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
 import io.openems.edge.controller.test.ControllerTest;
+import io.openems.edge.evcs.api.ChargeState;
 import io.openems.edge.evcs.api.Evcs;
 import io.openems.edge.evcs.api.Status;
 import io.openems.edge.evcs.test.DummyManagedEvcs;
@@ -326,6 +328,50 @@ public class ControllerEvcsImplTest {
 						.input("evcs0", ACTIVE_POWER, 0) //
 						.output("evcs0", SET_CHARGE_POWER_LIMIT, 5000) //
 						.output(AWAITING_HYSTERESIS, false)) //
+				.deactivate();
+	}
+
+	@Test
+	public void awaitDecreasingChargeStateTest() throws Exception {
+		final var clock = createDummyClock();
+		new ControllerTest(new ControllerEvcsImpl(clock)) //
+				.addReference("cm", new DummyConfigurationAdmin()) //
+				.addReference("sum", new DummySum()) //
+				.addReference("evcs", DummyManagedEvcs.ofDisabled("evcs0")) //
+				.activate(MyConfig.create() //
+						.setId("ctrlEvcs0") //
+						.setEvcsId("evcs0") //
+						.setEnableCharging(true) //
+						.setChargeMode(EXCESS_POWER) //
+						.setForceChargeMinPower(DEFAULT_FORCE_CHARGE_MIN_POWER) //
+						.setDefaultChargeMinPower(DEFAULT_CHARGE_MIN_POWER) //
+						.setPriority(CAR) //
+						.setEnergySessionLimit(0) //
+						.build()) //
+
+				// First cycle: establish a charge power of 6000 W
+				.next(new TestCase() //
+						.input(ESS_DISCHARGE_POWER, 0) //
+						.input("evcs0", IS_CLUSTERED, false) //
+						.input(GRID_ACTIVE_POWER, -6000) //
+						.input("evcs0", ACTIVE_POWER, 0) //
+						.output("evcs0", SET_CHARGE_POWER_LIMIT, 6000)) //
+
+				// DECREASING state: controller should hold the last charge power
+				.next(new TestCase() //
+						.input(ESS_DISCHARGE_POWER, 0) //
+						.input(GRID_ACTIVE_POWER, 2000) //
+						.input("evcs0", ACTIVE_POWER, 6000) //
+						.input("evcs0", CHARGE_STATE, ChargeState.DECREASING) //
+						.output("evcs0", SET_CHARGE_POWER_LIMIT, 6000)) //
+
+				// INCREASING state: controller should also hold the last charge power
+				.next(new TestCase() //
+						.input(ESS_DISCHARGE_POWER, 0) //
+						.input(GRID_ACTIVE_POWER, -10000) //
+						.input("evcs0", ACTIVE_POWER, 6000) //
+						.input("evcs0", CHARGE_STATE, ChargeState.INCREASING) //
+						.output("evcs0", SET_CHARGE_POWER_LIMIT, 6000)) //
 				.deactivate();
 	}
 }


### PR DESCRIPTION
The `awaitLastChanges()` method in `ControllerEvcsImpl` has a copy-paste bug — it checks for `ChargeState.INCREASING` twice instead of checking for both `INCREASING` and `DECREASING`.

This means the controller never waits for the EVCS response time when the charge state is DECREASING. The `ChargeStateHandler` correctly sets DECREASING and starts a pause timer, but `applyHysteresis` skips the wait and immediately calculates a new power target. During PV excess charging, when available solar power drops, the controller sends repeated decreasing commands every cycle without waiting for the car to respond — causing power oscillations instead of smooth ramp-down.

Added a test that verifies both INCREASING and DECREASING states cause the controller to hold the last charge power.