### PR TITLE
OpenDTU Meter: Clean up code and implement ManagedSymmetricPvInverter

### DIFF
--- a/io.openems.edge.meter.opendtu/bnd.bnd
+++ b/io.openems.edge.meter.opendtu/bnd.bnd
@@ -10,7 +10,8 @@ Bundle-Version: 1.0.0.${tstamp}
 	io.openems.edge.bridge.http,\
 	io.openems.edge.common,\
 	io.openems.edge.meter.api,\
+	io.openems.edge.pvinverter.api,\
 	io.openems.edge.timedata.api,\
-	io.openems.edge.pvinverter.api
+
 -testpath: \
 	${testpath},\

--- a/io.openems.edge.meter.opendtu/bnd.bnd
+++ b/io.openems.edge.meter.opendtu/bnd.bnd
@@ -11,6 +11,6 @@ Bundle-Version: 1.0.0.${tstamp}
 	io.openems.edge.common,\
 	io.openems.edge.meter.api,\
 	io.openems.edge.timedata.api,\
-
+	io.openems.edge.pvinverter.api
 -testpath: \
 	${testpath},\

--- a/io.openems.edge.meter.opendtu/src/io/openems/edge/meter/opendtu/MeterOpenDtuImpl.java
+++ b/io.openems.edge.meter.opendtu/src/io/openems/edge/meter/opendtu/MeterOpenDtuImpl.java
@@ -42,10 +42,10 @@ import io.openems.edge.common.event.EdgeEventConstants;
 import io.openems.edge.common.type.Phase.SinglePhase;
 import io.openems.edge.meter.api.ElectricityMeter;
 import io.openems.edge.meter.api.SinglePhaseMeter;
+import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 import io.openems.edge.timedata.api.Timedata;
 import io.openems.edge.timedata.api.TimedataProvider;
 import io.openems.edge.timedata.api.utils.CalculateEnergyFromPower;
-import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 
 @Designate(ocd = Config.class, factory = true)
 @Component(//
@@ -203,6 +203,5 @@ public class MeterOpenDtuImpl extends AbstractOpenemsComponent implements MeterO
 	public SinglePhase getPhase() {
 		return this.config.phase();
 	}
-
 
 }

--- a/io.openems.edge.meter.opendtu/src/io/openems/edge/meter/opendtu/MeterOpenDtuImpl.java
+++ b/io.openems.edge.meter.opendtu/src/io/openems/edge/meter/opendtu/MeterOpenDtuImpl.java
@@ -83,6 +83,7 @@ public class MeterOpenDtuImpl extends AbstractOpenemsComponent implements MeterO
 		super(//
 				OpenemsComponent.ChannelId.values(), //
 				ElectricityMeter.ChannelId.values(), //
+				ManagedSymmetricPvInverter.ChannelId.values(), //
 				MeterOpenDtu.ChannelId.values() //
 		);
 

--- a/io.openems.edge.meter.opendtu/src/io/openems/edge/meter/opendtu/MeterOpenDtuImpl.java
+++ b/io.openems.edge.meter.opendtu/src/io/openems/edge/meter/opendtu/MeterOpenDtuImpl.java
@@ -31,7 +31,6 @@ import com.google.gson.JsonElement;
 import io.openems.common.bridge.http.api.BridgeHttp;
 import io.openems.common.bridge.http.api.BridgeHttpFactory;
 import io.openems.common.bridge.http.api.HttpResponse;
-import io.openems.common.channel.AccessMode;
 import io.openems.common.exceptions.InvalidValueException;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
@@ -40,15 +39,13 @@ import io.openems.edge.bridge.http.cycle.HttpBridgeCycleServiceDefinition;
 import io.openems.edge.common.component.AbstractOpenemsComponent;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.event.EdgeEventConstants;
-import io.openems.edge.common.modbusslave.ModbusSlave;
-import io.openems.edge.common.modbusslave.ModbusSlaveNatureTable;
-import io.openems.edge.common.modbusslave.ModbusSlaveTable;
 import io.openems.edge.common.type.Phase.SinglePhase;
 import io.openems.edge.meter.api.ElectricityMeter;
 import io.openems.edge.meter.api.SinglePhaseMeter;
 import io.openems.edge.timedata.api.Timedata;
 import io.openems.edge.timedata.api.TimedataProvider;
 import io.openems.edge.timedata.api.utils.CalculateEnergyFromPower;
+import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 
 @Designate(ocd = Config.class, factory = true)
 @Component(//
@@ -61,7 +58,7 @@ import io.openems.edge.timedata.api.utils.CalculateEnergyFromPower;
 		EdgeEventConstants.TOPIC_CYCLE_EXECUTE_WRITE //
 })
 public class MeterOpenDtuImpl extends AbstractOpenemsComponent implements MeterOpenDtu, ElectricityMeter,
-		SinglePhaseMeter, OpenemsComponent, TimedataProvider, EventHandler, ModbusSlave {
+		SinglePhaseMeter, OpenemsComponent, TimedataProvider, EventHandler, ManagedSymmetricPvInverter {
 
 	private final CalculateEnergyFromPower calculateProductionEnergy = new CalculateEnergyFromPower(this,
 			ElectricityMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY);
@@ -207,13 +204,5 @@ public class MeterOpenDtuImpl extends AbstractOpenemsComponent implements MeterO
 		return this.config.phase();
 	}
 
-	@Override
-	public ModbusSlaveTable getModbusSlaveTable(AccessMode accessMode) {
-		return new ModbusSlaveTable(//
-				OpenemsComponent.getModbusSlaveNatureTable(accessMode), //
-				ElectricityMeter.getModbusSlaveNatureTable(accessMode), //
-				ModbusSlaveNatureTable.of(MeterOpenDtu.class, accessMode, 100) //
-						.build());
-	}
 
 }

--- a/io.openems.edge.meter.opendtu/test/io/openems/edge/meter/opendtu/MeterOpenDtuImplTest.java
+++ b/io.openems.edge.meter.opendtu/test/io/openems/edge/meter/opendtu/MeterOpenDtuImplTest.java
@@ -15,6 +15,7 @@ import io.openems.edge.common.test.AbstractComponentTest.TestCase;
 import io.openems.edge.common.test.ComponentTest;
 import io.openems.edge.common.type.Phase.SinglePhase;
 import io.openems.edge.meter.api.ElectricityMeter;
+import io.openems.edge.pvinverter.api.ManagedSymmetricPvInverter;
 import io.openems.edge.timedata.test.DummyTimedata;
 
 public class MeterOpenDtuImplTest {
@@ -112,6 +113,11 @@ public class MeterOpenDtuImplTest {
 						.output(ElectricityMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY_L1, null) //
 						.output(ElectricityMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY_L2, null) //
 						.output(ElectricityMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY_L3, null) //
+
+						.output(ManagedSymmetricPvInverter.ChannelId.ACTIVE_POWER_LIMIT, null) //
+						.output(ManagedSymmetricPvInverter.ChannelId.MAX_ACTIVE_POWER, null) //
+						.output(ManagedSymmetricPvInverter.ChannelId.MAX_APPARENT_POWER, null) //
+						.output(ManagedSymmetricPvInverter.ChannelId.MAX_REACTIVE_POWER, null) //
 
 						.output(MeterOpenDtu.ChannelId.SLAVE_COMMUNICATION_FAILED, false)) //
 				.deactivate();


### PR DESCRIPTION
Follow up of https://github.com/OpenEMS/openems/pull/3562 that fixes the display issue in the OpenEMS live view.
With these changes the OpenDTU appears in the production widget.
Some unused code has been removed.