### PR TITLE
fix documentation structure and links for UI.

### DIFF
--- a/doc/modules/ROOT/nav.adoc
+++ b/doc/modules/ROOT/nav.adoc
@@ -56,8 +56,6 @@ include::pages/edge/core.d/_nav.adoc[]
 *** xref:edge/deploy/docker.adoc[Deploy to Docker]
 
 * OpenEMS UI
-** xref:ui/run-prebuilt.adoc[Run prebuilt UI]
-** xref:ui/deploy.adoc[Deploy UI to Docker]
 ** xref:ui/setup-ide.adoc[Setup IDE]
 ** xref:ui/architecture.adoc[Architecture]
 ** xref:ui/build.adoc[Build OpenEMS UI]
@@ -65,6 +63,9 @@ include::pages/edge/core.d/_nav.adoc[]
 *** xref:ui/implementing-a-widget/components/flat.adoc[Flat-Widget]
 *** xref:ui/implementing-a-widget/components/modal.adoc[Modal-Widget]
 *** xref:ui/implementing-a-widget/components/chart.adoc[Chart]
+** Deploy
+*** xref:ui/deploy/docker.adoc[Deploy UI to Docker]
+*** xref:ui/deploy/nginx.adoc[Set up the nginx web server for OpenEMS UI]
 
 * OpenEMS Backend
 ** xref:backend/architecture.adoc[Architecture]

--- a/doc/modules/ROOT/pages/gettingstarted.adoc
+++ b/doc/modules/ROOT/pages/gettingstarted.adoc
@@ -186,7 +186,7 @@ NOTE: Values will differ slightly for you, but note how the Controller now tells
 
 == Run OpenEMS UI
 
-NOTE: If you plan to actively develop on OpenEMS UI, you can now also setup a development environment for it using xref:ui/setup-ide.adoc[this guide]. Otherwise you can use the prebuilt UI as described below, or xref:ui/deploy.adoc[deploy the OpenEMS UI as docker image].
+NOTE: If you plan to actively develop on OpenEMS UI, you can now also setup a development environment for it using xref:ui/setup-ide.adoc[this guide]. Otherwise you can use the prebuilt UI as described below, or xref:ui/deploy/docker.adoc[deploy the OpenEMS UI as docker image].
 
 . To use the prebuilt UI, go to the https://github.com/OpenEMS/openems/releases/[OpenEMS release page] on GitHub and download the latest `openems-ui.tar.xz`. Extract it to a local directory.
 


### PR DESCRIPTION
Being not so experienced with adoc, I broke some links and a part of the navigation for the UI documentation in the previous commit (https://github.com/OpenEMS/openems/commit/2ff269d1781e7aa6dc96d1e3bc064cbbbc85c836). This PR hopefully repairs that.