### PR TITLE
Fix link to GermanDSO.java in timeofusetariff.entsoe/readme.adoc

### DIFF
--- a/io.openems.edge.timeofusetariff.entsoe/readme.adoc
+++ b/io.openems.edge.timeofusetariff.entsoe/readme.adoc
@@ -36,7 +36,7 @@ Configuration example:
 * `biddingZone`: `GERMANY`
 * `ancillaryCosts`: `{"dso":"BAYERNWERK"}`
 
-For a list of predefined DSOs see https://github.com/OpenEMS/openems/blob/develop/io.openems.edge.timeofusetariff.entsoe/src/io/openems/edge/timeofusetariff/entsoe/GermanDSO.java[`GermanDSO.java`].
+For a list of predefined DSOs see https://github.com/OpenEMS/openems/blob/develop/io.openems.edge.timeofusetariff.api/src/io/openems/edge/timeofusetariff/api/GermanDSO.java[`GermanDSO.java`].
 
 '''
 


### PR DESCRIPTION
Updated the link to the predefined DSOs in the documentation (it's now in timeofusetariff.api).