### PR TITLE
Add dynamic component rendering for component-line

### DIFF
--- a/ui/src/app/shared/components/formly/formly-field-navigation/formly-field-navigation.html
+++ b/ui/src/app/shared/components/formly/formly-field-navigation/formly-field-navigation.html
@@ -156,6 +156,11 @@
                     </oe-modal-line>
                   }
 
+                  @case ('component-line') {
+                    <ng-container *ngComponentOutlet="line.component; inputs: line.inputs">
+                    </ng-container>
+                  }
+
                   @case ('select-line') {
                     <oe-modal-line [name]="line.name" [controlName]="line.controlName"
                       [control]="{type: 'SELECT', options: line.options}" [formGroup]="form" leftColumnWidth="50">


### PR DESCRIPTION
Restored OeFormlyField.ComponentLine - removed this in FEMS Backports 2026-05-01 (commit 26fa540c21) but left the type and call sites in place, silently dropping prediction charts in GridOptimizedCharge / TimeOfUseTariff / Production navigation views.