### PR TITLE
fix(ui): use EMS timezone for historic and live charts

### DIFF
--- a/ui/src/app/edge/history/abstracthistorychart.ts
+++ b/ui/src/app/edge/history/abstracthistorychart.ts
@@ -322,7 +322,8 @@ export abstract class AbstractHistoryChart {
                 this.service.getConfig().then(config => {
                     this.setLabel(config);
                     this.getChannelAddresses(edge, config).then(channelAddresses => {
-                        const request = new QueryHistoricTimeseriesDataRequest(DateUtils.maxDate(fromDate, this.edge?.firstSetupProtocol), toDate, channelAddresses, resolution);
+                        const timeZone = config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone();
+                        const request = new QueryHistoricTimeseriesDataRequest(DateUtils.maxDate(fromDate, this.edge?.firstSetupProtocol), toDate, channelAddresses, resolution, timeZone);
                         edge.sendRequest(this.service.websocket, request).then(response => {
                             resolve(response as QueryHistoricTimeseriesDataResponse);
                         }).catch(error => {
@@ -340,7 +341,8 @@ export abstract class AbstractHistoryChart {
                 this.service.stopSpinner(this.spinnerId);
                 this.initializeChart();
             }
-            return DateTimeUtils.normalizeTimestamps(resolution.unit, response);
+            const timeZone = this.service.currentEdge()?.getConfig(this.service.websocket).value?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone();
+            return DateTimeUtils.normalizeTimestamps(resolution.unit, response, timeZone);
         });
 
         return result;
@@ -363,7 +365,8 @@ export abstract class AbstractHistoryChart {
         const response: Promise<QueryHistoricTimeseriesEnergyPerPeriodResponse> = new Promise<QueryHistoricTimeseriesEnergyPerPeriodResponse>((resolve, reject) => {
             this.service.getCurrentEdge().then(edge => {
                 this.service.getConfig().then(config => {
-                    edge.sendRequest(this.service.websocket, new QueryHistoricTimeseriesEnergyPerPeriodRequest(DateUtils.maxDate(fromDate, this.edge?.firstSetupProtocol), toDate, channelAddresses, resolution)).then(response => {
+                    const timeZone = config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone();
+                    edge.sendRequest(this.service.websocket, new QueryHistoricTimeseriesEnergyPerPeriodRequest(DateUtils.maxDate(fromDate, this.edge?.firstSetupProtocol), toDate, channelAddresses, resolution, timeZone)).then(response => {
                         resolve(response as QueryHistoricTimeseriesEnergyPerPeriodResponse ?? new QueryHistoricTimeseriesEnergyPerPeriodResponse(response.id, {
                             timestamps: [null], data: { null: null },
                         }));
@@ -381,7 +384,8 @@ export abstract class AbstractHistoryChart {
                 this.service.stopSpinner(this.spinnerId);
                 this.initializeChart();
             }
-            return DateTimeUtils.normalizeTimestamps(resolution.unit, response);
+            const timeZone = this.service.currentEdge()?.getConfig(this.service.websocket).value?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone();
+            return DateTimeUtils.normalizeTimestamps(resolution.unit, response, timeZone);
         });
         return response;
     }

--- a/ui/src/app/edge/history/abstracthistorywidget.ts
+++ b/ui/src/app/edge/history/abstracthistorywidget.ts
@@ -59,7 +59,8 @@ export abstract class AbstractHistoryWidget {
             this.service.getCurrentEdge().then(edge => {
                 this.service.getConfig().then(config => {
                     this.getChannelAddresses(edge, config).then(channelAddresses => {
-                        const request = new QueryHistoricTimeseriesDataRequest(DateUtils.maxDate(fromDate, edge?.firstSetupProtocol), toDate, channelAddresses, resolution);
+                        const timeZone = config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone();
+                        const request = new QueryHistoricTimeseriesDataRequest(DateUtils.maxDate(fromDate, edge?.firstSetupProtocol), toDate, channelAddresses, resolution, timeZone);
                         edge.sendRequest(this.service.websocket, request).then(response => {
                             const result = (response as QueryHistoricTimeseriesDataResponse).result;
                             this.activeQueryData = response.id;
@@ -76,7 +77,8 @@ export abstract class AbstractHistoryWidget {
             if (this.activeQueryData !== response.id) {
                 return;
             }
-            return DateTimeUtils.normalizeTimestamps(resolution.unit, response);
+            const timeZone = this.service.currentEdge()?.getConfig(this.service.websocket).value?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone();
+            return DateTimeUtils.normalizeTimestamps(resolution.unit, response, timeZone);
         });
         return result;
     }

--- a/ui/src/app/edge/history/common/energy/flat/flat.ts
+++ b/ui/src/app/edge/history/common/energy/flat/flat.ts
@@ -16,6 +16,7 @@ import { QueryHistoricTimeseriesExportXlxsRequest } from "src/app/shared/jsonrpc
 import { Base64PayloadResponse } from "src/app/shared/jsonrpc/response/base64PayloadResponse";
 import { UserService } from "src/app/shared/service/user.service";
 import { DateUtils } from "src/app/shared/utils/date/dateutils";
+import { DateTimeUtils } from "src/app/shared/utils/datetime/datetime-utils";
 import { ChannelAddress, CurrentData, Service, Utils, Websocket } from "../../../../../shared/shared";
 
 @Component({
@@ -78,7 +79,11 @@ export class FlatComponent extends AbstractFlatWidget {
 
         this.service.getCurrentEdge().then(edge => {
             this.service.startSpinner(this.spinnerId);
-            edge.sendRequest(this.websocket, new QueryHistoricTimeseriesExportXlxsRequest(DateUtils.maxDate(this.service.historyPeriod.value.from, this.edge?.firstSetupProtocol), this.service.historyPeriod.value.to)).then(response => {
+            this.service.getConfig().then(config => edge.sendRequest(this.websocket, new QueryHistoricTimeseriesExportXlxsRequest(
+                DateUtils.maxDate(this.service.historyPeriod.value.from, this.edge?.firstSetupProtocol),
+                this.service.historyPeriod.value.to,
+                config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone(),
+            )).then(response => {
                 const r = response as Base64PayloadResponse;
                 const binary = atob(r.result.payload.replace(/\s/g, ""));
                 const len = binary.length;
@@ -110,9 +115,7 @@ export class FlatComponent extends AbstractFlatWidget {
                 console.warn(reason);
             }).finally(() => {
                 this.service.stopSpinner(this.spinnerId);
-            }
-            );
+            }));
         });
     }
 }
-

--- a/ui/src/app/edge/history/historydataservice.ts
+++ b/ui/src/app/edge/history/historydataservice.ts
@@ -6,6 +6,7 @@ import { QueryHistoricTimeseriesEnergyRequest } from "src/app/shared/jsonrpc/req
 import { Service } from "src/app/shared/service/service";
 import { Websocket } from "src/app/shared/service/websocket";
 import { DateUtils } from "src/app/shared/utils/date/dateutils";
+import { DateTimeUtils } from "src/app/shared/utils/datetime/datetime-utils";
 import { DataService } from "../../shared/components/shared/dataservice";
 import { QueryHistoricTimeseriesEnergyResponse } from "../../shared/jsonrpc/response/queryHistoricTimeseriesEnergyResponse";
 import { ChannelAddress, Edge } from "../../shared/shared";
@@ -38,32 +39,35 @@ export class HistoryDataService extends DataService {
 
                     this.service.historyPeriod.subscribe(date => {
 
-                        const request = new QueryHistoricTimeseriesEnergyRequest(
-                            DateUtils.maxDate(date.from, edge?.firstSetupProtocol),
-                            date.to,
-                            Object.values(this.channelAddresses),
-                        );
+                        this.service.getConfig().then(config => {
+                            const request = new QueryHistoricTimeseriesEnergyRequest(
+                                DateUtils.maxDate(date.from, edge?.firstSetupProtocol),
+                                date.to,
+                                Object.values(this.channelAddresses),
+                                config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone(),
+                            );
 
-                        this.activeQueryData = request.id;
+                            this.activeQueryData = request.id;
 
-                        edge.sendRequest(this.websocket, request)
-                            .then((response) => {
-                                if (this.activeQueryData === response.id) {
-                                    const allComponents = {};
-                                    const result = (response as QueryHistoricTimeseriesEnergyResponse).result;
+                            edge.sendRequest(this.websocket, request)
+                                .then((response) => {
+                                    if (this.activeQueryData === response.id) {
+                                        const allComponents = {};
+                                        const result = (response as QueryHistoricTimeseriesEnergyResponse).result;
 
-                                    for (const [key, value] of Object.entries(result.data)) {
-                                        allComponents[key] = value;
+                                        for (const [key, value] of Object.entries(result.data)) {
+                                            allComponents[key] = value;
+                                        }
+
+                                        this.currentValue.set({ allComponents: allComponents });
+                                        this.timestamps = response.result["timestamps"] ?? [];
                                     }
-
-                                    this.currentValue.set({ allComponents: allComponents });
-                                    this.timestamps = response.result["timestamps"] ?? [];
-                                }
-                            })
-                            .catch(err => console.warn(err))
-                            .finally(() => {
-                                this.queryChannelsTimeout = null;
-                            });
+                                })
+                                .catch(err => console.warn(err))
+                                .finally(() => {
+                                    this.queryChannelsTimeout = null;
+                                });
+                        });
                     });
                 }
             }, ChartConstants.REQUEST_TIMEOUT);

--- a/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/modal/predictionChart.ts
+++ b/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/modal/predictionChart.ts
@@ -8,6 +8,7 @@ import { ChronoUnit, DEFAULT_TIME_CHART_OPTIONS } from "src/app/edge/history/sha
 import { AbstractHistoryChart as NewAbstractHistoryChart } from "src/app/shared/components/chart/abstracthistorychart";
 import { ChannelAddress, Edge, EdgeConfig, Service, Utils } from "src/app/shared/shared";
 import { DefaultTypes } from "src/app/shared/type/defaulttypes";
+import { DateTimeUtils } from "src/app/shared/utils/datetime/datetime-utils";
 import { ChartAxis, HistoryUtils, YAxisType } from "src/app/shared/utils/utils";
 
 @Component({
@@ -59,10 +60,12 @@ export class PredictionChartComponent extends AbstractHistoryChart implements On
         this.queryHistoricTimeseriesData(PredictionChartComponent.DEFAULT_PERIOD.from, PredictionChartComponent.DEFAULT_PERIOD.to, { unit: ChronoUnit.Type.MINUTES, value: 5 }).then(async response => {
             const result = response.result;
             const datasets = [];
+            const timeZone = this.service.currentEdge()?.getConfig(this.service.websocket).value?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone();
 
             // Get the 5 min index of the current time
-            const hours = new Date().getHours();
-            const minutes = new Date().getMinutes();
+            const now = DateTimeUtils.toWallClockDate(new Date(), timeZone);
+            const hours = now.getHours();
+            const minutes = now.getMinutes();
             const currIndex = Math.trunc((hours * 60 + minutes) / 5);
 
             // Add one buffer hour at the beginning to see at least one hour of the past soc
@@ -91,15 +94,14 @@ export class PredictionChartComponent extends AbstractHistoryChart implements On
                     }
                 }
 
-                const targetTime = new Date(0);
-                targetTime.setUTCSeconds(this.targetEpochSeconds);
+                const targetTime = DateTimeUtils.toWallClockDate(new Date(this.targetEpochSeconds * 1000), timeZone);
 
                 // Predicted charge start only used, if a value is present. There's no Channel for it in older Openems Versions.
                 const isChargeStartPresent = this.chargeStartEpochSeconds != null;
-                const chargeStartTime = new Date(0);
+                let chargeStartTime: Date | null = null;
                 let chargeStartIndex = 0;
                 if (isChargeStartPresent) {
-                    chargeStartTime.setUTCSeconds(this.chargeStartEpochSeconds);
+                    chargeStartTime = DateTimeUtils.toWallClockDate(new Date(this.chargeStartEpochSeconds * 1000), timeZone);
                     const chargeStartHours = chargeStartTime.getHours();
                     const chargeStartMinutes = chargeStartTime.getMinutes();
 
@@ -170,7 +172,7 @@ export class PredictionChartComponent extends AbstractHistoryChart implements On
                 // Convert labels
                 const labels: Date[] = [];
                 for (const timestamp of result.timestamps) {
-                    labels.push(new Date(timestamp));
+                    labels.push(DateTimeUtils.toWallClockDate(timestamp, timeZone));
                 }
                 this.labels = labels;
 

--- a/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/shared/prediction-chart.ts
+++ b/ui/src/app/edge/live/Controller/Ess/GridOptimizedCharge/shared/prediction-chart.ts
@@ -12,6 +12,7 @@ import { QueryHistoricTimeseriesDataResponse } from "src/app/shared/jsonrpc/resp
 import { ChannelAddress, Edge, EdgeConfig, Logger, Service } from "src/app/shared/shared";
 import { DefaultTypes } from "src/app/shared/type/defaulttypes";
 import { ColorUtils } from "src/app/shared/utils/color/color.utils";
+import { DateTimeUtils } from "src/app/shared/utils/datetime/datetime-utils";
 import { ChartAxis, HistoryUtils, YAxisType } from "src/app/shared/utils/utils";
 
 @Component({
@@ -152,6 +153,7 @@ export class NewNavigationPredictionChartComponent extends AbstractHistoryChart 
     private preparePredictionData(
         response: QueryHistoricTimeseriesDataResponse,
     ): { labels: Date[]; datasets: Chart.ChartDataset[] } | null {
+        const timeZone = this.config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone();
         const result = response?.result;
         const rawSocData = result?.data?.["_sum/EssSoc"];
 
@@ -171,15 +173,13 @@ export class NewNavigationPredictionChartComponent extends AbstractHistoryChart 
 
         const startSoc = this.findStartSoc(socData, currentIndex);
 
-        const targetTime = new Date(0);
-        targetTime.setUTCSeconds(this.targetEpochSeconds);
+        const targetTime = DateTimeUtils.toWallClockDate(new Date(this.targetEpochSeconds * 1000), timeZone);
 
         const isChargeStartPresent = this.chargeStartEpochSeconds != null;
         let chargeStartIndex = 0;
 
         if (isChargeStartPresent) {
-            const chargeStartTime = new Date(0);
-            chargeStartTime.setUTCSeconds(this.chargeStartEpochSeconds);
+            const chargeStartTime = DateTimeUtils.toWallClockDate(new Date(this.chargeStartEpochSeconds * 1000), timeZone);
 
             const chargeStartHours = chargeStartTime.getHours();
             const chargeStartMinutes = chargeStartTime.getMinutes();
@@ -237,7 +237,7 @@ export class NewNavigationPredictionChartComponent extends AbstractHistoryChart 
         }
 
         return {
-            labels: trimmedTimestamps.map(timestamp => new Date(timestamp)),
+            labels: trimmedTimestamps.map(timestamp => DateTimeUtils.toWallClockDate(timestamp, timeZone)),
             datasets: [
                 {
                     type: "line",

--- a/ui/src/app/edge/live/common/production/new-navigation/production-chart-component.ts
+++ b/ui/src/app/edge/live/common/production/new-navigation/production-chart-component.ts
@@ -13,6 +13,7 @@ import { GetScheduleResponse } from "src/app/shared/jsonrpc/response/getSchedule
 import { QueryHistoricTimeseriesDataResponse } from "src/app/shared/jsonrpc/response/queryHistoricTimeseriesDataResponse";
 import { ChannelAddress, Edge, EdgeConfig, Logger, Service, Utils, Websocket } from "src/app/shared/shared";
 import { ColorUtils } from "src/app/shared/utils/color/color.utils";
+import { DateTimeUtils } from "src/app/shared/utils/datetime/datetime-utils";
 import { ChartAxis, HistoryUtils, TimeOfUseTariffUtils, YAxisType } from "src/app/shared/utils/utils";
 
 @Component({
@@ -83,13 +84,14 @@ export class ProductionChartComponent extends AbstractHistoryChart implements On
         this.chartObject = this.getChartData();
 
         try {
-            const now = new Date();
+            const timeZone = this.config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone();
+            const now = DateTimeUtils.toWallClockDate(new Date(), timeZone);
             const nowMs = now.getTime();
             // Apply a delay to align datasets: forecast data is in 15-minute intervals,
             // while historical data is in 5-minute intervals, which can cause 15 minute gaps at the transition
             const delayedNowMs = nowMs - 10 * 60 * 1000;
 
-            const startOfToday = new Date();
+            const startOfToday = DateTimeUtils.toWallClockDate(new Date(), timeZone);
             startOfToday.setHours(0, 0, 0, 0);
 
             const endOfToday = new Date(startOfToday);
@@ -108,7 +110,7 @@ export class ProductionChartComponent extends AbstractHistoryChart implements On
 
             const schedule = (scheduleResponse as GetScheduleResponse).result.schedule ?? [];
 
-            const historyTimestamps = historyResponse?.result?.timestamps?.map(timestamp => new Date(timestamp)) ?? [];
+            const historyTimestamps = historyResponse?.result?.timestamps?.map(timestamp => DateTimeUtils.toWallClockDate(timestamp, timeZone)) ?? [];
             const historyValuesRaw =
                 historyResponse?.result?.data?.["_sum/ProductionActivePower"]
                 ?? historyResponse?.result?.data?.[ChannelAddress.fromString("_sum/ProductionActivePower").toString()]
@@ -116,7 +118,7 @@ export class ProductionChartComponent extends AbstractHistoryChart implements On
 
             const historyPoints = historyTimestamps
                 .map((timestamp, index) => ({
-                    timestamp: new Date(timestamp).getTime(),
+                    timestamp: timestamp.getTime(),
                     value: Utils.divideSafely(historyValuesRaw[index], 1000),
                 }))
                 .filter(point =>
@@ -128,7 +130,7 @@ export class ProductionChartComponent extends AbstractHistoryChart implements On
 
             const forecastPoints = schedule
                 .map(entry => ({
-                    timestamp: new Date(entry.timestamp).getTime(),
+                    timestamp: DateTimeUtils.toWallClockDate(entry.timestamp, timeZone).getTime(),
                     value: Utils.divideSafely(entry.production, 1000),
                 }))
                 .filter(point =>

--- a/ui/src/app/shared/components/chart/abstracthistorychart.ts
+++ b/ui/src/app/shared/components/chart/abstracthistorychart.ts
@@ -1125,9 +1125,10 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy, AfterVi
         return new Promise<QueryHistoricTimeseriesDataResponse>((resolve, reject) => {
             this.service.getCurrentEdge()
                 .then(edge => this.service.getConfig()
-                    .then(async () => {
+                    .then(async config => {
                         const channelAddresses = (await this.getChannelAddresses()).powerChannels;
-                        const request = new QueryHistoricTimeseriesDataRequest(DateUtils.maxDate(fromDate, this.edge?.firstSetupProtocol), toDate, channelAddresses, resolution);
+                        const timeZone = config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone();
+                        const request = new QueryHistoricTimeseriesDataRequest(DateUtils.maxDate(fromDate, this.edge?.firstSetupProtocol), toDate, channelAddresses, resolution, timeZone);
 
                         edge.sendRequest(this.service.websocket, request)
                             .then(response => {
@@ -1174,10 +1175,11 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy, AfterVi
 
         const result: Promise<QueryHistoricTimeseriesEnergyPerPeriodResponse> = new Promise<QueryHistoricTimeseriesEnergyPerPeriodResponse>((resolve, reject) => {
             this.service.getCurrentEdge().then(edge => {
-                this.service.getConfig().then(async () => {
+                this.service.getConfig().then(async config => {
 
                     const channelAddresses = (await this.getChannelAddresses()).energyChannels.filter(element => element != null);
-                    const request = new QueryHistoricTimeseriesEnergyPerPeriodRequest(DateUtils.maxDate(fromDate, edge?.firstSetupProtocol), toDate, channelAddresses, resolution);
+                    const timeZone = config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone();
+                    const request = new QueryHistoricTimeseriesEnergyPerPeriodRequest(DateUtils.maxDate(fromDate, edge?.firstSetupProtocol), toDate, channelAddresses, resolution, timeZone);
                     if (channelAddresses.length > 0) {
 
 
@@ -1228,9 +1230,10 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy, AfterVi
 
         const result: Promise<QueryHistoricTimeseriesEnergyResponse> = new Promise<QueryHistoricTimeseriesEnergyResponse>((resolve, reject) => {
             this.service.getCurrentEdge().then(edge => {
-                this.service.getConfig().then(async () => {
+                this.service.getConfig().then(async config => {
                     const channelAddresses = (await this.getChannelAddresses()).energyChannels?.filter(element => element != null) ?? [];
-                    const request = new QueryHistoricTimeseriesEnergyRequest(DateUtils.maxDate(fromDate, edge?.firstSetupProtocol), toDate, channelAddresses);
+                    const timeZone = config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone();
+                    const request = new QueryHistoricTimeseriesEnergyRequest(DateUtils.maxDate(fromDate, edge?.firstSetupProtocol), toDate, channelAddresses, timeZone);
                     if (channelAddresses.length > 0) {
                         edge.sendRequest(this.service.websocket, request).then(response => {
                             const result = (response as QueryHistoricTimeseriesEnergyResponse)?.result;
@@ -1306,7 +1309,7 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy, AfterVi
             ])
                 .then(([dataResponse, energyResponse]) => {
                     this.chartType = "line";
-                    dataResponse = DateTimeUtils.normalizeTimestamps(unit, dataResponse);
+                    dataResponse = DateTimeUtils.normalizeTimestamps(unit, dataResponse, this.config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone());
                     this.chartObject = this.getChartData();
                     const displayValues = AbstractHistoryChart.fillChart(this.chartType, this.chartObject, dataResponse, energyResponse);
                     this.datasets = displayValues.datasets;
@@ -1333,7 +1336,7 @@ export abstract class AbstractHistoryChart implements OnInit, OnDestroy, AfterVi
                 this.chartType = "bar";
                 this.chartObject = this.getChartData();
                 // TODO after chartjs migration, look for config
-                energyPeriodResponse = DateTimeUtils.normalizeTimestamps(unit, energyPeriodResponse);
+                energyPeriodResponse = DateTimeUtils.normalizeTimestamps(unit, energyPeriodResponse, this.config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone());
 
                 const displayValues = AbstractHistoryChart.fillChart(this.chartType, this.chartObject, energyPeriodResponse, energyResponse);
                 this.datasets = displayValues.datasets;

--- a/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesDataRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesDataRequest.ts
@@ -31,9 +31,10 @@ export class QueryHistoricTimeseriesDataRequest extends JsonrpcRequest {
         private toDate: Date,
         private channels: ChannelAddress[],
         private resolution: Resolution,
+        private timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
     ) {
         super(QueryHistoricTimeseriesDataRequest.METHOD, {
-            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            timezone: timeZone,
             fromDate: format(fromDate, "yyyy-MM-dd"),
             toDate: format(toDate, "yyyy-MM-dd"),
             channels: JsonRpcUtils.channelsToStringArray(channels),
@@ -44,6 +45,7 @@ export class QueryHistoricTimeseriesDataRequest extends JsonrpcRequest {
         delete this.toDate;
         delete this.channels;
         delete this.resolution;
+        delete this.timeZone;
     }
 
 }

--- a/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesEnergyPerPeriodRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesEnergyPerPeriodRequest.ts
@@ -33,9 +33,10 @@ export class QueryHistoricTimeseriesEnergyPerPeriodRequest extends JsonrpcReques
         private toDate: Date,
         private channels: ChannelAddress[],
         private resolution: Resolution,
+        private timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
     ) {
         super(QueryHistoricTimeseriesEnergyPerPeriodRequest.METHOD, {
-            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            timezone: timeZone,
             fromDate: format(fromDate, "yyyy-MM-dd"),
             toDate: format(toDate, "yyyy-MM-dd"),
             channels: JsonRpcUtils.channelsToStringArray(channels),
@@ -46,7 +47,7 @@ export class QueryHistoricTimeseriesEnergyPerPeriodRequest extends JsonrpcReques
         delete this.toDate;
         delete this.channels;
         delete this.resolution;
+        delete this.timeZone;
     }
 
 }
-

--- a/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesEnergyRequest.ts
+++ b/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesEnergyRequest.ts
@@ -29,9 +29,10 @@ export class QueryHistoricTimeseriesEnergyRequest extends JsonrpcRequest {
         private fromDate: Date,
         private toDate: Date,
         private channels: ChannelAddress[],
+        private timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
     ) {
         super(QueryHistoricTimeseriesEnergyRequest.METHOD, {
-            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            timezone: timeZone,
             fromDate: format(fromDate, "yyyy-MM-dd"),
             toDate: format(toDate, "yyyy-MM-dd"),
             channels: JsonRpcUtils.channelsToStringArray(channels),
@@ -40,7 +41,7 @@ export class QueryHistoricTimeseriesEnergyRequest extends JsonrpcRequest {
         delete this.fromDate;
         delete this.toDate;
         delete this.channels;
+        delete this.timeZone;
     }
 
 }
-

--- a/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesExportXlxs.ts
+++ b/ui/src/app/shared/jsonrpc/request/queryHistoricTimeseriesExportXlxs.ts
@@ -25,15 +25,17 @@ export class QueryHistoricTimeseriesExportXlxsRequest extends JsonrpcRequest {
     public constructor(
         private fromDate: Date,
         private toDate: Date,
+        private timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
     ) {
         super(QueryHistoricTimeseriesExportXlxsRequest.METHOD, {
-            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            timezone: timeZone,
             fromDate: format(fromDate, "yyyy-MM-dd"),
             toDate: format(toDate, "yyyy-MM-dd"),
         });
         // delete local fields, otherwise they are sent with the JSON-RPC Request
         delete this.fromDate;
         delete this.toDate;
+        delete this.timeZone;
     }
 
 }

--- a/ui/src/app/shared/service/service.ts
+++ b/ui/src/app/shared/service/service.ts
@@ -25,6 +25,7 @@ import { DefaultTypes } from "../type/defaulttypes";
 import { Language } from "../type/language";
 import { Role } from "../type/role";
 import { DateUtils } from "../utils/date/dateutils";
+import { DateTimeUtils } from "../utils/datetime/datetime-utils";
 import { AbstractService } from "./abstractservice";
 import { RouteService } from "./route.service";
 import { Websocket } from "./websocket";
@@ -289,45 +290,48 @@ export class Service extends AbstractService {
 
                 // send merged requests
                 this.getCurrentEdge().then(edge => {
-                    for (const source of mergedRequests) {
+                    this.getConfig().then(config => {
+                        for (const source of mergedRequests) {
 
-                        // Jump to next request for empty channelAddresses
-                        if (!source?.channels?.length) {
-                            continue;
-                        }
+                            // Jump to next request for empty channelAddresses
+                            if (!source?.channels?.length) {
+                                continue;
+                            }
 
-                        const request = new QueryHistoricTimeseriesEnergyRequest(
-                            DateUtils.maxDate(source.fromDate, edge?.firstSetupProtocol),
-                            source.toDate,
-                            source.channels,
-                        );
+                            const request = new QueryHistoricTimeseriesEnergyRequest(
+                                DateUtils.maxDate(source.fromDate, edge?.firstSetupProtocol),
+                                source.toDate,
+                                source.channels,
+                                config?.getPropertyFromComponentId<string>("_meta", "timezone") ?? DateTimeUtils.getLocaleTimeZone(),
+                            );
 
-                        this.activeQueryData = request.id;
-                        edge.sendRequest(this.websocket, request)
-                            .then(response => {
-                                if (this.activeQueryData !== response.id) {
-                                    return;
-                                }
-
-                                const result = (response as QueryHistoricTimeseriesEnergyResponse).result;
-
-                                if (Object.keys(result.data).length === 0) {
-                                    for (const promise of source.promises) {
-                                        promise.reject(new JsonrpcResponseError(response.id, { code: 0, message: "Result was empty" }));
+                            this.activeQueryData = request.id;
+                            edge.sendRequest(this.websocket, request)
+                                .then(response => {
+                                    if (this.activeQueryData !== response.id) {
+                                        return;
                                     }
-                                    return;
-                                }
 
-                                for (const promise of source.promises) {
-                                    promise.resolve(response as QueryHistoricTimeseriesEnergyResponse);
-                                }
-                            })
-                            .catch(async reason => {
-                                for (const promise of source.promises) {
-                                    promise.reject(new JsonrpcResponseError((await response).id, { code: 0, message: "Result was empty" }));
-                                }
-                            });
-                    }
+                                    const result = (response as QueryHistoricTimeseriesEnergyResponse).result;
+
+                                    if (Object.keys(result.data).length === 0) {
+                                        for (const promise of source.promises) {
+                                            promise.reject(new JsonrpcResponseError(response.id, { code: 0, message: "Result was empty" }));
+                                        }
+                                        return;
+                                    }
+
+                                    for (const promise of source.promises) {
+                                        promise.resolve(response as QueryHistoricTimeseriesEnergyResponse);
+                                    }
+                                })
+                                .catch(async reason => {
+                                    for (const promise of source.promises) {
+                                        promise.reject(new JsonrpcResponseError((await response).id, { code: 0, message: "Result was empty" }));
+                                    }
+                                });
+                        }
+                    });
                 });
             }, ChartConstants.REQUEST_TIMEOUT);
         }

--- a/ui/src/app/shared/utils/datetime/datetime-utils.spec.ts
+++ b/ui/src/app/shared/utils/datetime/datetime-utils.spec.ts
@@ -1,4 +1,5 @@
 import { subSeconds } from "date-fns";
+import { QueryHistoricTimeseriesDataResponse } from "../../jsonrpc/response/queryHistoricTimeseriesDataResponse";
 import { DATE_TIME_REGEX, DateTimeUtils } from "./datetime-utils";
 
 describe("DateTimeUtils", () => {
@@ -31,5 +32,22 @@ describe("DateTimeUtils", () => {
     it("+isOfValidDateTimeFormat - test all valid ionic date-time formats", () => {
         const validDateTime: string[] = ["2025", "2023-11-16T08:07:00", "2023-11-16T08:07", "2023-11-16T08:07:00Z", "08:07"];
         expect(validDateTime.map(datetime => DateTimeUtils.isOfValidDateTimeFormat(datetime))).toEqual(validDateTime.map(_el => true));
+    });
+    it("+toWallClockDate - keeps the target timezone wall clock instead of the device timezone", () => {
+        const wallClockDate = DateTimeUtils.toWallClockDate("2024-06-30T22:00:00Z", timeZone);
+        expect(DateTimeUtils.toLocalDateTimeString(wallClockDate)).toEqual("2024-07-01T00:00:00");
+    });
+    it("+normalizeTimestamps - converts ISO instants to EMS wall clock timestamps for chart rendering", () => {
+        const response = new QueryHistoricTimeseriesDataResponse("1", {
+            timestamps: ["2024-06-30T22:00:00Z", "2024-06-30T23:00:00Z"],
+            data: { "_sum/ConsumptionActivePower": [1, 2] },
+        });
+
+        const normalized = DateTimeUtils.normalizeTimestamps("Hours" as any, response, timeZone);
+
+        expect(normalized.result.timestamps).toEqual([
+            "2024-07-01T00:00:00",
+            "2024-07-01T01:00:00",
+        ]);
     });
 });

--- a/ui/src/app/shared/utils/datetime/datetime-utils.ts
+++ b/ui/src/app/shared/utils/datetime/datetime-utils.ts
@@ -30,6 +30,39 @@ export class DateTimeUtils {
     public static getLocaleTimeZone() {
         return Intl.DateTimeFormat().resolvedOptions().timeZone;
     }
+
+    public static toWallClockDate(date: Date | string, timeZone: string = DateTimeUtils.getLocaleTimeZone()): Date {
+        const sourceDate = typeof date === "string" ? new Date(date) : date;
+        const formattedParts = new Intl.DateTimeFormat("sv-SE", {
+            timeZone,
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+            hourCycle: "h23",
+        }).formatToParts(sourceDate).reduce((acc, part) => {
+            if (part.type !== "literal") {
+                acc[part.type] = part.value;
+            }
+            return acc;
+        }, {} as { [key: string]: string });
+
+        return new Date(
+            Number(formattedParts.year),
+            Number(formattedParts.month) - 1,
+            Number(formattedParts.day),
+            Number(formattedParts.hour),
+            Number(formattedParts.minute),
+            Number(formattedParts.second),
+            sourceDate.getMilliseconds(),
+        );
+    }
+
+    public static toLocalDateTimeString(date: Date): string {
+        return format(date, "yyyy-MM-dd'T'HH:mm:ss");
+    }
     /**
    * Tests if the given string matches at least one of the ionic supported datetime formats.
    *
@@ -51,7 +84,18 @@ export class DateTimeUtils {
    * @param energyPerPeriodResponse the timeseries data
    * @returns the adjusted timestamps
    */
-    public static normalizeTimestamps(unit: ChronoUnit.Type, energyPerPeriodResponse: QueryHistoricTimeseriesDataResponse | QueryHistoricTimeseriesEnergyPerPeriodResponse): QueryHistoricTimeseriesDataResponse | QueryHistoricTimeseriesEnergyPerPeriodResponse {
+    public static normalizeTimestamps(
+        unit: ChronoUnit.Type,
+        energyPerPeriodResponse: QueryHistoricTimeseriesDataResponse | QueryHistoricTimeseriesEnergyPerPeriodResponse,
+        timeZone: string = DateTimeUtils.getLocaleTimeZone(),
+    ): QueryHistoricTimeseriesDataResponse | QueryHistoricTimeseriesEnergyPerPeriodResponse {
+
+        energyPerPeriodResponse.result.timestamps = energyPerPeriodResponse.result.timestamps.map(timestamp => {
+            if (timestamp == null) {
+                return timestamp;
+            }
+            return DateTimeUtils.toLocalDateTimeString(DateTimeUtils.toWallClockDate(timestamp, timeZone));
+        });
 
         switch (unit) {
             case ChronoUnit.Type.MONTHS: {


### PR DESCRIPTION
## Summary

This fixes a timezone bug in the OpenEMS UI where historic and some live charts used the client device timezone instead of the EMS installation timezone.

The issue affected Android/iOS app access and browser access:
- historic timeseries requests were sent with the device timezone
- returned timestamps were rendered again in the device timezone
- some live chart flows also converted timestamps and “today” calculations using the client timezone

As a result, chart grouping and displayed labels could drift away from the local time of the EMS system.

## Changes

- read the EMS timezone from `_meta.timezone`
- use the EMS timezone for:
  - `queryHistoricTimeseriesData`
  - `queryHistoricTimeseriesEnergy`
  - `queryHistoricTimeseriesEnergyPerPeriod`
  - `queryHistoricTimeseriesExportXlxs`
- normalize returned timestamps into EMS wall-clock time before chart rendering
- apply the same timezone handling to affected live chart flows:
  - Grid Optimized Charge prediction charts
  - production live chart
- add regression coverage for timezone normalization

## Testing

Ran locally:
- `npx tsc -p tsconfig.json --noEmit`
- `npm test -- --watch=false --browsers=ChromeHeadless --include=src/app/shared/utils/datetime/datetime-utils.spec.ts`
- `npm test -- --watch=false --browsers=ChromeHeadless --include=src/app/edge/history/common/energy/chart/chart.spec.ts`

Results:
- TypeScript compile check passed
- datetime timezone spec: `8/8 SUCCESS`
- history chart spec: `6/6 SUCCESS`