### PR TITLE
Workaround/Fix Cloudflare blocking maven repository

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -1,7 +1,7 @@
 # Configure Repositories
 -plugin.6.Central: \
 	aQute.bnd.repository.maven.pom.provider.BndPomRepository; \
-		releaseUrls=https://repo.maven.apache.org/maven2/; \
+		releaseUrls=https://maven-central-eu.storage-download.googleapis.com/maven2/; \
 		snapshotUrl=https://central.sonatype.com/repository/maven-snapshots/; \
 		pom=${build}/pom.xml; \
 		readOnly=true; \


### PR DESCRIPTION
Github Actions are currently not working. Reason is Cloudflare blocking access to https://repo.maven.apache.org/maven2/

See [Cloudflare 1015 Error](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1015/)

This is probably only a workaround. We may use more Caching within github actions. I am not an expert in github actions. I am not sure, if caching is enabled and working currently.