### PR TITLE
Controller Api Modbus: Fix Modify Method

### DIFF
--- a/io.openems.edge.controller.api.modbus/src/io/openems/edge/controller/api/modbus/AbstractModbusApi.java
+++ b/io.openems.edge.controller.api.modbus/src/io/openems/edge/controller/api/modbus/AbstractModbusApi.java
@@ -109,7 +109,6 @@ public abstract class AbstractModbusApi extends AbstractOpenemsComponent
 	}
 
 	protected void modified(ComponentContext context, CommonConfig config, Clock clock) {
-		this.config = config;
 		this.clock = clock;
 		super.modified(context, config.id(), config.alias(), config.enabled());
 


### PR DESCRIPTION
In the previous version, the `modified` method always returned in line 117, as `this.config = config` was set too early. Therefore, if you e.g. modified the timeout, it didn't have any effect (only after restarting the system).