### PR TITLE
Update docker.adoc: link optimization

### DIFF
--- a/doc/modules/ROOT/pages/edge/deploy/docker.adoc
+++ b/doc/modules/ROOT/pages/edge/deploy/docker.adoc
@@ -154,7 +154,7 @@ CONTAINER ID  IMAGE                   COMMAND   CREATED               STATUS
 
 == InfluxDB
 
-If you want to add the InfluxDB time series database to your setup, follow the https://openems.github.io/openems.io/openems/latest/backend/deploy/docker.html#_setup_influxdb[OpenEMS Backend deploy instructions to setup InfluxDB].
+If you want to add the InfluxDB time series database to your setup, follow the https://openems.github.io/openems.io/openems/latest/backend/deploy/docker.html#_add_influxdb_container[OpenEMS Backend deploy instructions to setup InfluxDB].
 
 == Changing the Language in the UI
 


### PR DESCRIPTION
optimized link to influxdb container setup by specifying an earlier headline.
Before you had to scroll up some lines, as you were jumping directly to the `influxdb` command, instead of to the `docker_compose.yml` changes.