### PR TITLE
[Edge] Controller.Api.Backend: support Backend 2026.x edge.manager

### DIFF
--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/Config.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/Config.java
@@ -25,6 +25,12 @@ import io.openems.common.channel.PersistencePriority;
 	@AttributeDefinition(name = "Apikey", description = "Apikey for authentication at OpenEMS Backend.", type = AttributeType.PASSWORD)
 	String apikey();
 
+	@AttributeDefinition(name = "Edge-ID", description = "Edge ID for Edge.Manager protocol (Backend 2026.2+). "
+			+ "Set to the Edge ID registered in Backend Metadata.File (e.g. 'my-site-pi-1'). "
+			+ "When set, an 'id' HTTP header is added to the WebSocket handshake so Edge.Manager "
+			+ "can route the connection. Leave empty for 2025.x Backends.")
+	String edgeId() default "";
+
 	@AttributeDefinition(name = "Uri", description = "The connection Uri to OpenEMS Backend.")
 	String uri() default "";
 

--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/ControllerApiBackendImpl.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/ControllerApiBackendImpl.java
@@ -33,9 +33,12 @@ import org.slf4j.LoggerFactory;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.jsonrpc.base.JsonrpcMessage;
+import io.openems.common.jsonrpc.base.JsonrpcNotification;
 import io.openems.common.jsonrpc.base.JsonrpcRequest;
 import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
 import io.openems.common.jsonrpc.notification.EdgeConfigNotification;
+import io.openems.common.jsonrpc.notification.EdgeRpcNotification;
 import io.openems.common.oem.OpenemsEdgeOem;
 import io.openems.common.types.EdgeConfig;
 import io.openems.common.utils.ThreadPoolUtils;
@@ -146,6 +149,12 @@ public class ControllerApiBackendImpl extends AbstractOpenemsComponent
 		Map<String, String> httpHeaders = new HashMap<>();
 		httpHeaders.put(CommonHttpHeader.APIKEY.asString(), config.apikey());
 		httpHeaders.put(CommonHttpHeader.INSTANCE_ID.asString(), this.instanceId);
+		// Edge.Manager (Backend 2026.2+) identifies connections by 'id' header rather
+		// than 'apikey'. Send it when edgeId is configured so both old and new Backends
+		// are supported simultaneously.
+		if (!config.edgeId().isBlank()) {
+			httpHeaders.put("id", config.edgeId());
+		}
 
 		final var uriScheme = uri.getScheme();
 		if (!("https".equalsIgnoreCase(uriScheme) || "wss".equalsIgnoreCase(uriScheme))) {
@@ -165,7 +174,7 @@ public class ControllerApiBackendImpl extends AbstractOpenemsComponent
 				this.getLastSuccessFulResendChannel().address(), //
 				config.resendPriority(), //
 				t -> this.getLastSuccessFulResendChannel().setNextValue(t), //
-				t -> this.websocket.sendMessage(t) //
+				t -> this.websocket.sendMessage(this.wrap(t)) //
 		));
 		this.resendHistoricDataWorker.activate(this.id(), false);
 
@@ -229,7 +238,7 @@ public class ControllerApiBackendImpl extends AbstractOpenemsComponent
 				if (ws == null) {
 					return;
 				}
-				ws.sendMessage(message);
+				ws.sendMessage(this.wrap(message));
 
 				// Trigger sending of all channel values, because a Component might have
 				// disappeared
@@ -272,6 +281,26 @@ public class ControllerApiBackendImpl extends AbstractOpenemsComponent
 			return null;
 		}
 		return this.executor.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+	}
+
+	/**
+	 * Wraps a notification in {@link EdgeRpcNotification} when edgeId is set
+	 * (Backend 2026.x edge.manager protocol). Falls back to raw notification for
+	 * 2025.x Backends where edgeId is empty.
+	 */
+	JsonrpcNotification wrap(JsonrpcNotification notification) {
+		var edgeId = this.config.edgeId();
+		if (edgeId == null || edgeId.isBlank()) {
+			return notification;
+		}
+		return new EdgeRpcNotification(edgeId, notification);
+	}
+
+	JsonrpcMessage wrap(JsonrpcMessage message) {
+		if (message instanceof JsonrpcNotification n) {
+			return this.wrap(n);
+		}
+		return message;
 	}
 
 	@Override

--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/ControllerApiBackendImpl.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/ControllerApiBackendImpl.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import io.openems.common.websocket.CommonHttpHeader;
 import org.osgi.service.component.ComponentContext;
@@ -72,6 +73,9 @@ public class ControllerApiBackendImpl extends AbstractOpenemsComponent
 	protected static final String COMPONENT_NAME = "Controller.Api.Backend";
 
 	public static final Key<WebsocketClient> WEBSOCKET_CLIENT_KEY = new Key<>("websocketClient", WebsocketClient.class);
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public static final Key<Function<JsonrpcNotification, JsonrpcNotification>> NOTIFICATION_WRAPPER_KEY //
+			= new Key<>("notificationWrapper", (Class) Function.class);
 
 	protected final SendChannelValuesWorker sendChannelValuesWorker = new SendChannelValuesWorker(this);
 	protected final ApiWorker apiWorker = new ApiWorker(this);
@@ -180,6 +184,7 @@ public class ControllerApiBackendImpl extends AbstractOpenemsComponent
 
 		this.requestHandler.setOnCall(call -> {
 			call.put(WEBSOCKET_CLIENT_KEY, this.websocket);
+			call.put(NOTIFICATION_WRAPPER_KEY, this::wrap);
 			call.put(ComponentConfigRequestHandler.API_WORKER_KEY, this.apiWorker);
 			call.put(EdgeKeys.IS_FROM_BACKEND_KEY, true);
 		});
@@ -287,6 +292,9 @@ public class ControllerApiBackendImpl extends AbstractOpenemsComponent
 	 * Wraps a notification in {@link EdgeRpcNotification} when edgeId is set
 	 * (Backend 2026.x edge.manager protocol). Falls back to raw notification for
 	 * 2025.x Backends where edgeId is empty.
+	 *
+	 * @param notification the {@link JsonrpcNotification}
+	 * @return the wrapped or original {@link JsonrpcNotification}
 	 */
 	JsonrpcNotification wrap(JsonrpcNotification notification) {
 		var edgeId = this.config.edgeId();

--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/OnOpen.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/OnOpen.java
@@ -24,7 +24,7 @@ public class OnOpen implements io.openems.common.websocket.OnOpen {
 		// Immediately send Config
 		var config = this.parent.componentManager.getEdgeConfig();
 		var message = new EdgeConfigNotification(config);
-		this.parent.websocket.sendMessage(message);
+		this.parent.websocket.sendMessage(this.parent.wrap(message));
 
 		// Send all Channel values
 		this.parent.sendChannelValuesWorker.sendValuesOfAllChannelsOnce();

--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/SendChannelValuesWorker.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/SendChannelValuesWorker.java
@@ -405,7 +405,7 @@ public class SendChannelValuesWorker {
 			}
 
 			// Try to send
-			var wasSent = this.parent.parent.websocket.sendMessage(message);
+			var wasSent = this.parent.parent.websocket.sendMessage(this.parent.parent.wrap(message));
 
 			if (wasSent) {
 				// Successfully sent: update information for next runs
@@ -439,7 +439,7 @@ public class SendChannelValuesWorker {
 			final var message = new AggregatedDataNotification();
 			message.add(this.timestamp.toEpochMilli(), this.allValues);
 
-			final var wasSent = this.parent.parent.websocket.sendMessage(message);
+			final var wasSent = this.parent.parent.websocket.sendMessage(this.parent.parent.wrap(message));
 
 			// Set the UNABLE_TO_SEND channel
 			this.parent.parent.getUnableToSendChannel().setNextValue(!wasSent);

--- a/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/handler/SubscribeSystemLogJsonApiHandler.java
+++ b/io.openems.edge.controller.api.backend/src/io/openems/edge/controller/api/backend/handler/SubscribeSystemLogJsonApiHandler.java
@@ -2,6 +2,7 @@ package io.openems.edge.controller.api.backend.handler;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import org.ops4j.pax.logging.spi.PaxAppender;
 import org.ops4j.pax.logging.spi.PaxLoggingEvent;
@@ -9,6 +10,7 @@ import org.osgi.service.component.annotations.Component;
 
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.jsonrpc.base.GenericJsonrpcResponseSuccess;
+import io.openems.common.jsonrpc.base.JsonrpcNotification;
 import io.openems.common.jsonrpc.notification.SystemLogNotification;
 import io.openems.common.jsonrpc.request.SubscribeSystemLogRequest;
 import io.openems.common.jsonrpc.response.AuthenticatedRpcResponse;
@@ -23,7 +25,11 @@ import io.openems.edge.controller.api.backend.WebsocketClient;
 })
 public class SubscribeSystemLogJsonApiHandler implements JsonApi, PaxAppender {
 
-	private final Set<WebsocketClient> subscriber = ConcurrentHashMap.newKeySet();
+	record Subscriber(WebsocketClient webSocket, Function<JsonrpcNotification, JsonrpcNotification> wrap) {
+
+	}
+
+	private final Set<Subscriber> subscriber = ConcurrentHashMap.newKeySet();
 
 	@Override
 	public void buildJsonApiRoutes(JsonApiBuilder builder) {
@@ -33,10 +39,11 @@ public class SubscribeSystemLogJsonApiHandler implements JsonApi, PaxAppender {
 				throw new OpenemsException("Websocket is not defined.");
 			}
 			final var request = SubscribeSystemLogRequest.from(call.getRequest());
+			final var wrapper = call.get(ControllerApiBackendImpl.NOTIFICATION_WRAPPER_KEY);
 			if (request.isSubscribe()) {
-				this.subscriber.add(webSocket);
+				this.subscribe(webSocket, wrapper);
 			} else {
-				this.subscriber.remove(webSocket);
+				this.unsubscribe(webSocket);
 			}
 
 			return new AuthenticatedRpcResponse(call.getRequest().getId(),
@@ -51,10 +58,23 @@ public class SubscribeSystemLogJsonApiHandler implements JsonApi, PaxAppender {
 		}
 
 		final var notification = SystemLogNotification.fromPaxLoggingEvent(event);
+		this.sendSystemLogNotification(notification);
+	}
+
+	void subscribe(WebsocketClient webSocket, Function<JsonrpcNotification, JsonrpcNotification> wrapper) {
+		this.unsubscribe(webSocket);
+		this.subscriber.add(new Subscriber(webSocket, wrapper == null ? Function.identity() : wrapper));
+	}
+
+	void unsubscribe(WebsocketClient webSocket) {
+		this.subscriber.removeIf(subscriber -> subscriber.webSocket() == webSocket);
+	}
+
+	void sendSystemLogNotification(SystemLogNotification notification) {
 		final var iterator = this.subscriber.iterator();
 		while (iterator.hasNext()) {
-			final var ws = iterator.next();
-			if (!ws.sendMessage(notification)) {
+			final var subscriber = iterator.next();
+			if (!subscriber.webSocket().sendMessage(subscriber.wrap().apply(notification))) {
 				iterator.remove();
 			}
 		}

--- a/io.openems.edge.controller.api.backend/test/io/openems/edge/controller/api/backend/ControllerApiBackendImplTest.java
+++ b/io.openems.edge.controller.api.backend/test/io/openems/edge/controller/api/backend/ControllerApiBackendImplTest.java
@@ -1,14 +1,24 @@
 package io.openems.edge.controller.api.backend;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import java.net.Proxy.Type;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.UUID;
 
+import com.google.gson.JsonObject;
 import org.junit.Test;
 
 import io.openems.common.channel.PersistencePriority;
+import io.openems.common.jsonrpc.base.GenericJsonrpcNotification;
+import io.openems.common.jsonrpc.base.GenericJsonrpcRequest;
+import io.openems.common.jsonrpc.notification.EdgeRpcNotification;
 import io.openems.common.oem.DummyOpenemsEdgeOem;
 import io.openems.common.test.TimeLeapClock;
+import io.openems.common.utils.JsonUtils;
 import io.openems.common.websocket.DummyWebsocketServer;
 import io.openems.edge.common.sum.DummySum;
 import io.openems.edge.common.test.ComponentTest;
@@ -56,6 +66,52 @@ public class ControllerApiBackendImplTest {
 			sut.deactivate();
 			server.stop();
 		}
+	}
+
+	@Test
+	public void testWrapKeepsNotificationUnchangedWithoutEdgeId() {
+		final var sut = new ControllerApiBackendImpl();
+		final var notification = new GenericJsonrpcNotification("testNotification", new JsonObject());
+		sut.config = MyConfig.create() //
+				.setId("ctrl0") //
+				.setEdgeId("") //
+				.build();
+
+		assertSame(notification, sut.wrap(notification));
+	}
+
+	@Test
+	public void testWrapAddsEdgeRpcNotificationWithEdgeId() {
+		final var sut = new ControllerApiBackendImpl();
+		final var notification = new GenericJsonrpcNotification("testNotification", JsonUtils.buildJsonObject() //
+				.addProperty("value", 1) //
+				.build());
+		sut.config = MyConfig.create() //
+				.setId("ctrl0") //
+				.setEdgeId("edge0") //
+				.build();
+
+		final var wrapped = sut.wrap(notification);
+		assertTrue(wrapped instanceof EdgeRpcNotification);
+		assertEquals(EdgeRpcNotification.METHOD, wrapped.getMethod());
+
+		final var params = wrapped.getParams();
+		assertEquals("edge0", params.get("edgeId").getAsString());
+		final var payload = params.get("payload").getAsJsonObject();
+		assertEquals("testNotification", payload.get("method").getAsString());
+		assertEquals(1, payload.get("params").getAsJsonObject().get("value").getAsInt());
+	}
+
+	@Test
+	public void testWrapKeepsRequestsUnchanged() {
+		final var sut = new ControllerApiBackendImpl();
+		final var request = new GenericJsonrpcRequest(UUID.randomUUID(), "testRequest", new JsonObject(), 60);
+		sut.config = MyConfig.create() //
+				.setId("ctrl0") //
+				.setEdgeId("edge0") //
+				.build();
+
+		assertSame(request, sut.wrap(request));
 	}
 
 }

--- a/io.openems.edge.controller.api.backend/test/io/openems/edge/controller/api/backend/MyConfig.java
+++ b/io.openems.edge.controller.api.backend/test/io/openems/edge/controller/api/backend/MyConfig.java
@@ -11,6 +11,7 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	protected static class Builder {
 		private String id;
 		private String apikey;
+		private String edgeId = "";
 		private String uri;
 		private String proxyAddress;
 		private int proxyPort;
@@ -31,6 +32,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 
 		public Builder setApikey(String apikey) {
 			this.apikey = apikey;
+			return this;
+		}
+
+		public Builder setEdgeId(String edgeId) {
+			this.edgeId = edgeId;
 			return this;
 		}
 
@@ -103,6 +109,11 @@ public class MyConfig extends AbstractComponentConfig implements Config {
 	@Override
 	public String apikey() {
 		return this.builder.apikey;
+	}
+
+	@Override
+	public String edgeId() {
+		return this.builder.edgeId;
 	}
 
 	@Override

--- a/io.openems.edge.controller.api.backend/test/io/openems/edge/controller/api/backend/handler/SubscribeSystemLogJsonApiHandlerTest.java
+++ b/io.openems.edge.controller.api.backend/test/io/openems/edge/controller/api/backend/handler/SubscribeSystemLogJsonApiHandlerTest.java
@@ -1,0 +1,55 @@
+package io.openems.edge.controller.api.backend.handler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.openems.common.jsonrpc.base.JsonrpcMessage;
+import io.openems.common.jsonrpc.notification.EdgeRpcNotification;
+import io.openems.common.jsonrpc.notification.SystemLogNotification;
+import io.openems.common.types.SystemLog;
+import io.openems.common.websocket.AbstractWebsocketClient;
+import io.openems.edge.controller.api.backend.ControllerApiBackendImpl;
+import io.openems.edge.controller.api.backend.WebsocketClient;
+
+public class SubscribeSystemLogJsonApiHandlerTest {
+
+	@Test
+	public void testSystemLogNotificationIsWrappedForEdgeManager() {
+		final var sut = new SubscribeSystemLogJsonApiHandler();
+		final var webSocket = new CapturingWebsocketClient();
+
+		sut.subscribe(webSocket, notification -> new EdgeRpcNotification("edge0", notification));
+		sut.sendSystemLogNotification(new SystemLogNotification(new SystemLog(//
+				ZonedDateTime.of(2026, 7, 1, 12, 0, 0, 0, ZoneOffset.UTC), //
+				SystemLog.Level.INFO, //
+				"test", //
+				"message")));
+
+		assertTrue(webSocket.message instanceof EdgeRpcNotification);
+		final var message = (EdgeRpcNotification) webSocket.message;
+		assertEquals("edge0", message.getEdgeId());
+		assertEquals(SystemLogNotification.METHOD, message.getPayload().getMethod());
+	}
+
+	private static final class CapturingWebsocketClient extends WebsocketClient {
+		private JsonrpcMessage message;
+
+		private CapturingWebsocketClient() {
+			super(new ControllerApiBackendImpl(), "test", URI.create("ws://localhost"), Map.of(),
+					AbstractWebsocketClient.NO_PROXY);
+		}
+
+		@Override
+		public boolean sendMessage(JsonrpcMessage message) {
+			this.message = message;
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
Backend 2026.x replaced the edgewebsocket module with `edge.manager`, which identifies Edges by an `id` HTTP header and only accepts notifications wrapped in `EdgeRpcNotification`. An Edge connecting directly to a 2026.x Backend currently stays offline, because it sends only the apikey and raw, unwrapped notifications.

This adds an `edgeId` config property to `Controller.Api.Backend`. When it is set:
- the `id` header is sent on the WebSocket handshake;
- every outgoing notification is wrapped in `EdgeRpcNotification`, including the initial `OnOpen` `EdgeConfigNotification`.

When `edgeId` is empty the behaviour is unchanged, so connections to 2025.x Backends keep working.

Tested against Backend 2026.6.0: the Edge connects and streams live data.

Pairs with a separate PR that lets `edge.manager` register a directly-connected Edge.