### PR TITLE
[Backend] Edge.Manager: register directly-connected Edge so its data persists

### DIFF
--- a/io.openems.backend.edge.manager/src/io/openems/backend/edge/manager/OnOpen.java
+++ b/io.openems.backend.edge.manager/src/io/openems/backend/edge/manager/OnOpen.java
@@ -55,6 +55,14 @@ public class OnOpen implements io.openems.common.websocket.OnOpen {
 
 		wsData.setId(id);
 
+		// Register this directly-connected Edge so its data notifications are accepted
+		// and persisted. In the multi-edge topology Edges are announced via a
+		// ConnectedEdges.Notification (which creates the EdgeCache); a directly
+		// connected Edge announces only itself via the 'id' header, so register it
+		// here. Without this the EdgeCache is null and handleDataNotification silently
+		// drops every TimestampedData/AggregatedData notification.
+		wsData.updateEdgeStatus(id, true);
+
 		// Send a UpdateMetadataCache.Notification
 		wsData.send(this.generateUpdateMetadataCacheNotification.get());
 

--- a/io.openems.backend.edge.manager/test/io/openems/backend/edge/manager/OnOpenTest.java
+++ b/io.openems.backend.edge.manager/test/io/openems/backend/edge/manager/OnOpenTest.java
@@ -1,0 +1,82 @@
+package io.openems.backend.edge.manager;
+
+import static java.util.Collections.emptyIterator;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetSocketAddress;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.Handshakedata;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import io.openems.backend.common.edge.jsonrpc.UpdateMetadataCache;
+import io.openems.common.exceptions.OpenemsError;
+import io.openems.common.jsonrpc.base.JsonrpcNotification;
+
+public class OnOpenTest {
+
+	@Test
+	public void testDirectEdgeIsRegisteredOnOpen() {
+		final var notification = UpdateMetadataCache.Notification.empty();
+		final var ws = mock(WebSocket.class);
+		final var handshakedata = mock(Handshakedata.class);
+		final var wsData = new CapturingWsData(ws);
+		when(ws.getAttachment()).thenReturn(wsData);
+		when(handshakedata.iterateHttpFields()).thenReturn(singletonList("id").iterator());
+		when(handshakedata.getFieldValue("id")).thenReturn("edge0");
+
+		final var sut = new OnOpen(() -> notification, (Logger log, String message) -> {
+		});
+
+		assertNull(sut.apply(ws, handshakedata));
+		assertEquals("edge0", wsData.getId());
+		assertTrue(wsData.containsEdgeId("edge0"));
+		assertNotNull(wsData.getEdgeCache("edge0"));
+		assertSame(notification, wsData.message);
+		verify(ws, never()).closeConnection(anyInt(), anyString());
+	}
+
+	@Test
+	public void testMissingIdIsRejected() {
+		final var ws = mock(WebSocket.class);
+		final var handshakedata = mock(Handshakedata.class);
+		final var wsData = new CapturingWsData(ws);
+		when(ws.getAttachment()).thenReturn(wsData);
+		when(ws.getRemoteSocketAddress()).thenReturn(new InetSocketAddress("localhost", 1234));
+		when(handshakedata.iterateHttpFields()).thenReturn(emptyIterator());
+
+		final var sut = new OnOpen(UpdateMetadataCache.Notification::empty, (Logger log, String message) -> {
+		});
+
+		assertEquals(OpenemsError.COMMON_AUTHENTICATION_FAILED, sut.apply(ws, handshakedata));
+		assertNull(wsData.getId());
+		assertEquals(0, wsData.getNumberOfEdges());
+		verify(ws).closeConnection(anyInt(), anyString());
+	}
+
+	private static final class CapturingWsData extends WsData {
+		private JsonrpcNotification message;
+
+		private CapturingWsData(WebSocket ws) {
+			super(ws);
+		}
+
+		@Override
+		public boolean send(JsonrpcNotification message) {
+			this.message = message;
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
`edge.manager` persists data only for Edges present in `WsData.edges`, which is populated exclusively by `ConnectedEdges.Notification` (the aggregator path for multi-Edge deployments).

An Edge connecting directly authenticates via the `id` header in `OnOpen` (`setId(id)`) but is never added to that map. `getEdgeCache(edgeId)` then returns null and `handleDataNotification` silently drops every `TimestampedData` / `AggregatedData` notification (`if (edgeCache == null) return;`).

This registers the directly-connected Edge in `OnOpen` via `updateEdgeStatus(id, true)`, so its `EdgeCache` exists and its data is persisted.

Pairs with a separate Controller.Api.Backend PR that lets an Edge connect directly to a 2026.x Backend.