### PR TITLE
[Backend] Metadata.File: implement generateUpdateMetadataCacheNotification (Backend.Edge.App support)

### DIFF
--- a/io.openems.backend.metadata.file/src/io/openems/backend/metadata/file/MetadataFile.java
+++ b/io.openems.backend.metadata.file/src/io/openems/backend/metadata/file/MetadataFile.java
@@ -35,6 +35,7 @@ import com.google.gson.JsonObject;
 
 import io.openems.backend.common.alerting.OfflineEdgeAlertingSetting;
 import io.openems.backend.common.alerting.SumStateAlertingSetting;
+import io.openems.backend.common.edge.jsonrpc.UpdateMetadataCache;
 import io.openems.backend.common.alerting.UserAlertingSettings;
 import io.openems.backend.common.metadata.AbstractMetadata;
 import io.openems.backend.common.metadata.Edge;
@@ -132,6 +133,15 @@ public class MetadataFile extends AbstractMetadata implements Metadata, EventHan
 			}
 		}
 		return Optional.empty();
+	}
+
+	@Override
+	public synchronized UpdateMetadataCache.Notification generateUpdateMetadataCacheNotification() {
+		this.refreshData();
+		var apikeysToEdgeIds = this.edges.values().stream() //
+				.filter(edge -> edge.getApikey() != null && !edge.getApikey().isBlank()) //
+				.collect(Collectors.toMap(MyEdge::getApikey, MyEdge::getId, (a, b) -> a));
+		return new UpdateMetadataCache.Notification(apikeysToEdgeIds);
 	}
 
 	@Override

--- a/io.openems.backend.metadata.file/test/io/openems/backend/metadata/file/MetadataFileTest.java
+++ b/io.openems.backend.metadata.file/test/io/openems/backend/metadata/file/MetadataFileTest.java
@@ -1,0 +1,60 @@
+package io.openems.backend.metadata.file;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.openems.backend.common.test.DummyEventAdmin;
+
+public class MetadataFileTest {
+
+	@Test
+	public void testGenerateUpdateMetadataCacheNotification() throws Exception {
+		final var path = Files.createTempFile("metadata-file-test", ".json");
+		Files.writeString(path, """
+				{
+				  "edges": {
+				    "edge0": {
+				      "apikey": "apikey0",
+				      "comment": "Edge 0"
+				    },
+				    "edge1": {
+				      "apikey": "apikey1",
+				      "comment": "Edge 1"
+				    },
+				    "edgeWithoutApikey": {
+				      "apikey": "",
+				      "comment": "Edge without Apikey"
+				    }
+				  }
+				}
+				""");
+
+		final var sut = createMetadataFile(path);
+		final var notification = sut.generateUpdateMetadataCacheNotification();
+
+		assertEquals(Map.of(//
+				"apikey0", "edge0", //
+				"apikey1", "edge1"), //
+				notification.getApikeysToEdgeIds());
+		assertFalse(notification.getApikeysToEdgeIds().containsKey(""));
+	}
+
+	private static MetadataFile createMetadataFile(Path path) throws Exception {
+		final var sut = new MetadataFile();
+		final Field pathField = MetadataFile.class.getDeclaredField("path");
+		pathField.setAccessible(true);
+		pathField.set(sut, path.toString());
+		final Field eventAdminField = MetadataFile.class.getDeclaredField("eventAdmin");
+		eventAdminField.setAccessible(true);
+		eventAdminField.set(sut, new DummyEventAdmin(event -> {
+		}));
+		return sut;
+	}
+}


### PR DESCRIPTION
When connecting Edges through the `Backend.Edge.App` aggregator (the supported architecture, see #3795 and #3818), the app needs the API-key to Edge-ID mapping from the central Backend's Metadata service. `MetadataOdoo` and `MetadataDummy` implement `generateUpdateMetadataCacheNotification()`, but `MetadataFile` inherited the empty default, so a File-metadata Backend cannot serve the aggregator (the cache never initializes and Edges are rejected).

This implements it for `MetadataFile`, mirroring `MetadataOdoo`/`MetadataDummy`, so deployments that use File-based Metadata (i.e. without running Odoo) can use the Backend.Edge.App aggregator.