### PR TITLE
Fix null body for http error responses

### DIFF
--- a/io.openems.common.bridge.http/src/io/openems/common/bridge/http/NetworkEndpointFetcher.java
+++ b/io.openems.common.bridge.http/src/io/openems/common/bridge/http/NetworkEndpointFetcher.java
@@ -88,12 +88,16 @@ public class NetworkEndpointFetcher implements EndpointFetcher {
 		}
 	}
 
-	private static String readBody(HttpURLConnection con, HttpStatus status) throws HttpError.ResponseError {
-		try (var in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
-			return in.lines().collect(joining(System.lineSeparator()));
-		} catch (IOException e) {
-			throw new HttpError.ResponseError(status, null);
+	private static String readBody(HttpURLConnection con, HttpStatus status) throws IOException {
+		var stream = status.isError() ? con.getErrorStream() : con.getInputStream();
+
+		if (stream != null) {
+			try (var in = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+				return in.lines().collect(joining(System.lineSeparator()));
+			}
 		}
+
+		return null;
 	}
 
 }


### PR DESCRIPTION
This PR fixes the body of http error responses always being null in the http bridge.

The behavior is not documented clearly, but getInputStream() always throws an IOException when the server returned an error response. If a body was still sent, getErrorStream() has to be called to read it.

The error stream can be null, so an additional check was added for this. Any remaining IOExceptions thrown when attempting to read the body will now cause an UnknownError instead of a ResponseError.