### PR TITLE
Make Metadata.File default language configurable

### DIFF
--- a/io.openems.backend.metadata.file/readme.adoc
+++ b/io.openems.backend.metadata.file/readme.adoc
@@ -6,6 +6,17 @@ Allows you to configure multiple edges by a single JSON file.
 Using this bundle enables you to easily set up an OpenEMS 
 Backend for testing purposes.
 
+The component configuration accepts a `defaultLanguage` setting for the shared
+user. Supported values are `EN`, `DE`, `CS`, `NL`, `ES`, `FR` and `JA`. It
+defaults to `DE` for backwards compatibility.
+
+Example component configuration:
+
+```
+path="/var/opt/openems/metadata.json"
+defaultLanguage="EN"
+```
+
 
 == Example configuration file
 

--- a/io.openems.backend.metadata.file/src/io/openems/backend/metadata/file/Config.java
+++ b/io.openems.backend.metadata.file/src/io/openems/backend/metadata/file/Config.java
@@ -3,6 +3,8 @@ package io.openems.backend.metadata.file;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
+import io.openems.common.session.Language;
+
 @ObjectClassDefinition(//
 		name = "Metadata.File", //
 		description = "Configures the Metadata File provider")
@@ -10,6 +12,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 	@AttributeDefinition(name = "Path", description = "The path to the JSON file.")
 	String path();
+
+	@AttributeDefinition(name = "Default Language", description = "The default language for the shared user.")
+	Language defaultLanguage() default Language.DE;
 
 	String webconsole_configurationFactory_nameHint() default "Metadata.File";
 

--- a/io.openems.backend.metadata.file/src/io/openems/backend/metadata/file/MetadataFile.java
+++ b/io.openems.backend.metadata.file/src/io/openems/backend/metadata/file/MetadataFile.java
@@ -90,7 +90,7 @@ public class MetadataFile extends AbstractMetadata implements Metadata, EventHan
 	private static final Role USER_GLOBAL_ROLE = Role.ADMIN;
 	private JsonObject settings = new JsonObject();
 
-	private static Language LANGUAGE = Language.DE;
+	private Language defaultLanguage = Language.DE;
 
 	private final Logger log = LoggerFactory.getLogger(MetadataFile.class);
 	private final Map<String, MyEdge> edges = new HashMap<>();
@@ -108,8 +108,10 @@ public class MetadataFile extends AbstractMetadata implements Metadata, EventHan
 
 	@Activate
 	private void activate(Config config) {
-		this.log.info("Activate [path=" + config.path() + "]");
+		this.log.info("Activate [path=" + config.path() + ", defaultLanguage=" + config.defaultLanguage() + "]");
 		this.path = config.path();
+		this.defaultLanguage = config.defaultLanguage();
+		this.user = this.generateUser();
 
 		// Read the data async
 		CompletableFuture.runAsync(() -> {
@@ -225,7 +227,7 @@ public class MetadataFile extends AbstractMetadata implements Metadata, EventHan
 
 	private User generateUser() {
 		return new User(MetadataFile.USER_ID, MetadataFile.USER_NAME, UUID.randomUUID().toString(),
-				MetadataFile.LANGUAGE, MetadataFile.USER_GLOBAL_ROLE, this.edges.size() > 1, this.settings);
+				this.defaultLanguage, MetadataFile.USER_GLOBAL_ROLE, this.edges.size() > 1, this.settings);
 	}
 
 	@Override
@@ -280,8 +282,11 @@ public class MetadataFile extends AbstractMetadata implements Metadata, EventHan
 	}
 
 	@Override
-	public void updateUserLanguage(User user, Language locale) throws OpenemsNamedException {
-		MetadataFile.LANGUAGE = locale;
+	public synchronized void updateUserLanguage(User user, Language locale) throws OpenemsNamedException {
+		this.defaultLanguage = locale;
+		final var previousUser = this.user;
+		this.user = new User(previousUser.getId(), previousUser.getName(), previousUser.getToken(), locale,
+				previousUser.getGlobalRole(), previousUser.hasMultipleEdges(), previousUser.getSettings());
 	}
 
 	@Override

--- a/io.openems.backend.metadata.file/test/io/openems/backend/metadata/file/MetadataFileTest.java
+++ b/io.openems.backend.metadata.file/test/io/openems/backend/metadata/file/MetadataFileTest.java
@@ -1,0 +1,128 @@
+package io.openems.backend.metadata.file;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+import io.openems.backend.common.test.DummyEventAdmin;
+import io.openems.common.session.Language;
+
+public class MetadataFileTest {
+
+	@Test
+	public void testConfigurableDefaultLanguageAndInstanceIsolation() throws Exception {
+		final var path = createEmptyMetadataFile();
+		final var englishMetadata = createMetadataFile(path);
+		final var frenchMetadata = createMetadataFile(path);
+
+		activate(englishMetadata, path, Language.EN);
+		activate(frenchMetadata, path, Language.FR);
+
+		assertEquals(Language.EN, englishMetadata.getUser("admin").orElseThrow().getLanguage());
+		assertEquals(Language.FR, frenchMetadata.getUser("admin").orElseThrow().getLanguage());
+	}
+
+	@Test
+	public void testUpdateUserLanguageUpdatesSharedUser() throws Exception {
+		final var path = createEmptyMetadataFile();
+		final var sut = createMetadataFile(path);
+		activate(sut, path, Language.EN);
+
+		final var user = sut.getUser("admin").orElseThrow();
+		sut.updateUserLanguage(user, Language.NL);
+
+		assertEquals(Language.NL, sut.getUser("admin").orElseThrow().getLanguage());
+	}
+
+	@Test
+	public void testConfigurableDefaultLanguageWithMultipleEdges() throws Exception {
+		final var path = createMetadataFileWithTwoEdges();
+		final var sut = createMetadataFile(path);
+
+		activate(sut, path, Language.EN);
+		assertTrue(sut.getEdge("edge0").isPresent());
+
+		// Simulate a component reactivation after its metadata was loaded.
+		activate(sut, path, Language.FR);
+
+		final var user = sut.getUser("admin").orElseThrow();
+		assertEquals(Language.FR, user.getLanguage());
+		assertTrue(user.hasMultipleEdges());
+	}
+
+	private static Path createEmptyMetadataFile() throws Exception {
+		final var path = Files.createTempFile("metadata-file-language-test", ".json");
+		Files.writeString(path, """
+				{
+				  "edges": {}
+				}
+				""");
+		return path;
+	}
+
+	private static Path createMetadataFileWithTwoEdges() throws Exception {
+		final var path = Files.createTempFile("metadata-file-language-test", ".json");
+		Files.writeString(path, """
+				{
+				  "edges": {
+				    "edge0": {
+				      "apikey": "apikey0",
+				      "comment": "Edge 0"
+				    },
+				    "edge1": {
+				      "apikey": "apikey1",
+				      "comment": "Edge 1"
+				    }
+				  }
+				}
+				""");
+		return path;
+	}
+
+	private static void activate(MetadataFile sut, Path path, Language defaultLanguage) throws Exception {
+		final Config config = new Config() {
+
+			@Override
+			public Class<? extends Annotation> annotationType() {
+				return Config.class;
+			}
+
+			@Override
+			public String path() {
+				return path.toString();
+			}
+
+			@Override
+			public Language defaultLanguage() {
+				return defaultLanguage;
+			}
+
+			@Override
+			public String webconsole_configurationFactory_nameHint() {
+				return "Metadata.File";
+			}
+		};
+		final Method activateMethod = MetadataFile.class.getDeclaredMethod("activate", Config.class);
+		activateMethod.setAccessible(true);
+		activateMethod.invoke(sut, config);
+	}
+
+	private static MetadataFile createMetadataFile(Path path) throws Exception {
+		final var sut = new MetadataFile();
+		final Field pathField = MetadataFile.class.getDeclaredField("path");
+		pathField.setAccessible(true);
+		pathField.set(sut, path.toString());
+		final Field eventAdminField = MetadataFile.class.getDeclaredField("eventAdmin");
+		eventAdminField.setAccessible(true);
+		eventAdminField.set(sut, new DummyEventAdmin(event -> {
+		}));
+		return sut;
+	}
+}


### PR DESCRIPTION
## Summary

Make the shared user language of `Metadata.File` configurable through its OSGi component configuration.

`Metadata.File` currently hardcodes German in a static field. As a result, Backend installations that use this metadata provider cannot choose another initial UI language, and changing the language affects all provider instances in the JVM.

This change:

- adds a `defaultLanguage` OSGi setting, defaulting to `DE` for backwards compatibility
- keeps language state scoped to each `Metadata.File` instance
- creates the shared user with the configured language during activation
- updates the current shared user immediately when `updateUserLanguage()` is called
- documents the setting and all currently supported `Language` enum values
- adds focused tests for configuration, instance isolation, and runtime language updates

Example:

```properties
path="/var/opt/openems/metadata.json"
defaultLanguage="EN"
```

## Validation

Validated against the current upstream `develop` branch with:

```text
./gradlew --no-daemon -Dorg.gradle.vfs.watch=false \
  :io.openems.backend.metadata.file:checkstyleMain \
  :io.openems.backend.metadata.file:checkstyleTest \
  :io.openems.backend.metadata.file:test \
  :io.openems.backend.metadata.file:jar

./gradlew --no-daemon -Dorg.gradle.vfs.watch=false \
  checkstyleAll build resolve --console=plain --warn
```

Both commands completed successfully.

The same implementation was also built into the Nearly Free Energy pilot Backend, deployed with `defaultLanguage="EN"`, and verified through an actual UI logout/login and a Backend container restart. The UI opened in English and the configured default remained effective after restart.
