### PR TITLE
Docker: select explicit influxdb version

### DIFF
--- a/doc/modules/ROOT/pages/backend/deploy/docker.adoc
+++ b/doc/modules/ROOT/pages/backend/deploy/docker.adoc
@@ -158,7 +158,7 @@ to add InfluxDB to your setup, you can do so by adjusting your `docker-compose.y
 ----
   …
   openems-influxdb:
-    image: influxdb:2-alpine
+    image: influxdb:2.9-alpine
     container_name: openems-influxdb
     hostname: openems-influxdb
     restart: unless-stopped

--- a/doc/modules/ROOT/pages/backend/deploy/docker.adoc
+++ b/doc/modules/ROOT/pages/backend/deploy/docker.adoc
@@ -157,19 +157,19 @@ to add InfluxDB to your setup, you can do so by adjusting your `docker-compose.y
 [source,yaml]
 ----
   …
-  openems_influxdb:
-    image: influxdb:alpine
-    container_name: openems_influxdb
-    hostname: openems_influxdb
+  openems-influxdb:
+    image: influxdb:2-alpine
+    container_name: openems-influxdb
+    hostname: openems-influxdb
     restart: unless-stopped
     volumes:
-      - openems-influxdb:/var/lib/influxdb2:rw
+      - openems-influxdb2-data:/var/lib/influxdb2:rw
     ports:
       - 8086:8086
 
 volumes:
   …
-  openems-influxdb:
+  openems-influxdb2-data:
 ----
 
 === Setup InfluxDB
@@ -201,7 +201,7 @@ NOTE: Note down Token
 [%noheader,cols="1,1",width="50%"]
 |===
 | Query Language | INFLUX_QL
-| URL | http://openems_influxdb:8086
+| URL | http://openems-influxdb:8086
 | Org | openems.io
 | ApiKey | InfluxDB-Token
 | Bucket | openems

--- a/tools/docker/backend/README.md
+++ b/tools/docker/backend/README.md
@@ -1,11 +1,12 @@
-# How to use OpenEMS Backend docker image:
+# How to use OpenEMS Backend docker image
 
-- [How to use OpenEMS Backend docker image:](#how-to-use-openems-backend-docker-image)
+- [How to use OpenEMS Backend docker image](#how-to-use-openems-backend-docker-image)
   - [Start openems docker containers](#start-openems-docker-containers)
     - [With docker compose](#with-docker-compose)
   - [Setup Container](#setup-container)
     - [Setup Timedata.InfluxDB](#setup-timedatainfluxdb)
   - [Build your own OpenEMS Backend docker image](#build-your-own-openems-backend-docker-image)
+  - [Common Problems and Solutions](#common-problems-and-solutions)
 
 ## Start openems docker containers
 
@@ -60,7 +61,7 @@
     | Timedata.InfluxDB |                              |
     | ----------------- | ---------------------------- |
     | Query Language    | INFLUX_QL                    |
-    | URL               | http://openems_influxdb:8086 |
+    | URL               | http://openems-influxdb:8086 |
     | Org               | openems.io                   |
     | ApiKey            | *InfluxDB-Token*             |
     | Bucket            | openems                      |

--- a/tools/docker/backend/docker-compose.yml
+++ b/tools/docker/backend/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
-  openems_backend:
+  openems-backend:
     image: openems/backend:latest
-    container_name: openems_backend
+    container_name: openems-backend
     hostname: openems-backend
     restart: unless-stopped
     volumes:
@@ -14,7 +14,7 @@ services:
 
   openems-ui:
     image: openems/ui-backend:latest
-    container_name: openems_ui
+    container_name: openems-ui
     hostname: openems-ui
     restart: unless-stopped
     volumes:
@@ -27,13 +27,13 @@ services:
       - 80:80
       - 443:443
 
-  openems_influxdb:
-    image: influxdb:alpine
-    container_name: openems_influxdb
+  openems-influxdb:
+    image: influxdb:2-alpine
+    container_name: openems-influxdb
     hostname: openems-influxdb
     restart: unless-stopped
     volumes:
-      - openems-influxdb:/var/lib/influxdb2:rw
+      - openems-influxdb2-data:/var/lib/influxdb2:rw
     ports:
       - 8086:8086
 
@@ -42,4 +42,4 @@ volumes:
   openems-backend-data:
   openems-ui-conf:
   openems-ui-log:
-  openems-influxdb:
+  openems-influxdb2-data:

--- a/tools/docker/backend/docker-compose.yml
+++ b/tools/docker/backend/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - 443:443
 
   openems-influxdb:
-    image: influxdb:2-alpine
+    image: influxdb:2.9-alpine
     container_name: openems-influxdb
     hostname: openems-influxdb
     restart: unless-stopped


### PR DESCRIPTION
like @sjjh [pointed out](https://community.openems.io/t/update-getting-started-docker-info-to-prevent-influxdb-upgrade/10880?u=da-kai), it is better to pin a specific InfluxDB version in the docker-compose examples.

Changes:
- pinned InfluxDB version to `2.9-alpine`
- renamed the InfluxDB volume, so it will not clash with a potential future upgrade to v3
- unify container names using lower-kebab-case