### PR TITLE
fix(evse.keba): apply SCALE_FACTOR_1 to Keba energy limit register

### DIFF
--- a/io.openems.edge.evse.chargepoint.keba/src/io/openems/edge/evcs/keba/modbus/EvcsKebaModbusImpl.java
+++ b/io.openems.edge.evse.chargepoint.keba/src/io/openems/edge/evcs/keba/modbus/EvcsKebaModbusImpl.java
@@ -89,8 +89,6 @@ import io.openems.edge.timedata.api.TimedataProvider;
 public class EvcsKebaModbusImpl extends KebaModbus implements EvcsKeba, ManagedEvcs, Evcs, DeprecatedEvcs,
 		ElectricityMeter, OpenemsComponent, EventHandler, ModbusSlave, ModbusComponent, TimedataProvider {
 
-	static final ElementToChannelConverter ENERGY_LIMIT_CONVERTER = SCALE_FACTOR_1;
-
 	private final Logger log = LoggerFactory.getLogger(EvcsKebaModbusImpl.class);
 	private final KebaUtils kebaUtils = new KebaUtils(this);
 	private final KebaModbusUtils kebaModbusUtils = new KebaModbusUtils(this);
@@ -397,8 +395,7 @@ public class EvcsKebaModbusImpl extends KebaModbus implements EvcsKeba, ManagedE
 					new FC6WriteRegisterTask(5004,
 							m(Keba.ChannelId.SET_CHARGING_CURRENT, new UnsignedWordElement(5004))),
 					new FC6WriteRegisterTask(5010,
-							m(EvseKeba.ChannelId.SET_ENERGY_LIMIT, new UnsignedWordElement(5010),
-									ENERGY_LIMIT_CONVERTER)),
+							m(EvseKeba.ChannelId.SET_ENERGY_LIMIT, new UnsignedWordElement(5010), SCALE_FACTOR_1)),
 					new FC6WriteRegisterTask(5012, m(Keba.ChannelId.SET_UNLOCK_PLUG, new UnsignedWordElement(5012))),
 					new FC6WriteRegisterTask(5014, m(Keba.ChannelId.SET_ENABLE, new UnsignedWordElement(5014))),
 					new FC6WriteRegisterTask(5050,

--- a/io.openems.edge.evse.chargepoint.keba/src/io/openems/edge/evcs/keba/modbus/EvcsKebaModbusImpl.java
+++ b/io.openems.edge.evse.chargepoint.keba/src/io/openems/edge/evcs/keba/modbus/EvcsKebaModbusImpl.java
@@ -2,6 +2,7 @@ package io.openems.edge.evcs.keba.modbus;
 
 import static io.openems.common.types.OpenemsType.INTEGER;
 import static io.openems.edge.bridge.modbus.api.ElementToChannelConverter.DIRECT_1_TO_1;
+import static io.openems.edge.bridge.modbus.api.ElementToChannelConverter.SCALE_FACTOR_1;
 import static io.openems.edge.bridge.modbus.api.ElementToChannelConverter.SCALE_FACTOR_3;
 import static io.openems.edge.bridge.modbus.api.ElementToChannelConverter.SCALE_FACTOR_MINUS_1;
 import static io.openems.edge.bridge.modbus.api.ElementToChannelConverter.SCALE_FACTOR_MINUS_3;
@@ -87,6 +88,8 @@ import io.openems.edge.timedata.api.TimedataProvider;
 })
 public class EvcsKebaModbusImpl extends KebaModbus implements EvcsKeba, ManagedEvcs, Evcs, DeprecatedEvcs,
 		ElectricityMeter, OpenemsComponent, EventHandler, ModbusSlave, ModbusComponent, TimedataProvider {
+
+	static final ElementToChannelConverter ENERGY_LIMIT_CONVERTER = SCALE_FACTOR_1;
 
 	private final Logger log = LoggerFactory.getLogger(EvcsKebaModbusImpl.class);
 	private final KebaUtils kebaUtils = new KebaUtils(this);
@@ -393,8 +396,9 @@ public class EvcsKebaModbusImpl extends KebaModbus implements EvcsKeba, ManagedE
 			modbusProtocol.addTasks(//
 					new FC6WriteRegisterTask(5004,
 							m(Keba.ChannelId.SET_CHARGING_CURRENT, new UnsignedWordElement(5004))),
-					new FC6WriteRegisterTask(5010, // TODO Scalefactor for Unit: 10 Wh
-							m(EvseKeba.ChannelId.SET_ENERGY_LIMIT, new UnsignedWordElement(5010))),
+					new FC6WriteRegisterTask(5010,
+							m(EvseKeba.ChannelId.SET_ENERGY_LIMIT, new UnsignedWordElement(5010),
+									ENERGY_LIMIT_CONVERTER)),
 					new FC6WriteRegisterTask(5012, m(Keba.ChannelId.SET_UNLOCK_PLUG, new UnsignedWordElement(5012))),
 					new FC6WriteRegisterTask(5014, m(Keba.ChannelId.SET_ENABLE, new UnsignedWordElement(5014))),
 					new FC6WriteRegisterTask(5050,

--- a/io.openems.edge.evse.chargepoint.keba/src/io/openems/edge/evse/chargepoint/keba/modbus/EvseKebaModbusImpl.java
+++ b/io.openems.edge.evse.chargepoint.keba/src/io/openems/edge/evse/chargepoint/keba/modbus/EvseKebaModbusImpl.java
@@ -1,5 +1,6 @@
 package io.openems.edge.evse.chargepoint.keba.modbus;
 
+import static io.openems.edge.bridge.modbus.api.ElementToChannelConverter.SCALE_FACTOR_1;
 import static io.openems.edge.bridge.modbus.api.ElementToChannelConverter.SCALE_FACTOR_3;
 import static io.openems.edge.bridge.modbus.api.ElementToChannelConverter.SCALE_FACTOR_MINUS_1;
 import static io.openems.edge.bridge.modbus.api.ElementToChannelConverter.SCALE_FACTOR_MINUS_3;
@@ -201,8 +202,8 @@ public class EvseKebaModbusImpl extends KebaModbus implements EvseKeba, EvseChar
 			modbusProtocol.addTasks(//
 					new FC6WriteRegisterTask(5004,
 							m(Keba.ChannelId.SET_CHARGING_CURRENT, new UnsignedWordElement(5004))),
-					new FC6WriteRegisterTask(5010, // TODO Scalefactor for Unit: 10 Wh
-							m(EvseKeba.ChannelId.SET_ENERGY_LIMIT, new UnsignedWordElement(5010))),
+					new FC6WriteRegisterTask(5010,
+							m(EvseKeba.ChannelId.SET_ENERGY_LIMIT, new UnsignedWordElement(5010), SCALE_FACTOR_1)),
 					new FC6WriteRegisterTask(5012, m(Keba.ChannelId.SET_UNLOCK_PLUG, new UnsignedWordElement(5012))),
 					new FC6WriteRegisterTask(5014, m(Keba.ChannelId.SET_ENABLE, new UnsignedWordElement(5014))),
 					new FC6WriteRegisterTask(5050,

--- a/io.openems.edge.evse.chargepoint.keba/src/io/openems/edge/evse/chargepoint/keba/modbus/EvseKebaModbusImpl.java
+++ b/io.openems.edge.evse.chargepoint.keba/src/io/openems/edge/evse/chargepoint/keba/modbus/EvseKebaModbusImpl.java
@@ -253,6 +253,7 @@ public class EvseKebaModbusImpl extends KebaModbus implements EvseKeba, EvseChar
 			this.kebaUtils.onBeforeProcessImage();
 			this.evseKebaUtils.onBeforeProcessImage();
 		}
+		}
 	}
 
 	@Override

--- a/io.openems.edge.evse.chargepoint.keba/src/io/openems/edge/evse/chargepoint/keba/modbus/EvseKebaModbusImpl.java
+++ b/io.openems.edge.evse.chargepoint.keba/src/io/openems/edge/evse/chargepoint/keba/modbus/EvseKebaModbusImpl.java
@@ -32,6 +32,7 @@ import org.osgi.service.metatype.annotations.Designate;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.edge.bridge.modbus.api.BridgeModbus;
+import io.openems.edge.bridge.modbus.api.ElementToChannelConverter;
 import io.openems.edge.bridge.modbus.api.ModbusComponent;
 import io.openems.edge.bridge.modbus.api.ModbusProtocol;
 import io.openems.edge.bridge.modbus.api.element.UnsignedDoublewordElement;
@@ -67,6 +68,8 @@ import io.openems.edge.timedata.api.TimedataProvider;
 })
 public class EvseKebaModbusImpl extends KebaModbus implements EvseKeba, EvseChargePoint, ElectricityMeter,
 		OpenemsComponent, TimedataProvider, EventHandler, ModbusComponent {
+
+	static final ElementToChannelConverter ENERGY_LIMIT_CONVERTER = SCALE_FACTOR_1;
 
 	private final KebaUtils kebaUtils = new KebaUtils(this);
 	private final EvseKebaUtils evseKebaUtils = new EvseKebaUtils(this);
@@ -203,7 +206,8 @@ public class EvseKebaModbusImpl extends KebaModbus implements EvseKeba, EvseChar
 					new FC6WriteRegisterTask(5004,
 							m(Keba.ChannelId.SET_CHARGING_CURRENT, new UnsignedWordElement(5004))),
 					new FC6WriteRegisterTask(5010,
-							m(EvseKeba.ChannelId.SET_ENERGY_LIMIT, new UnsignedWordElement(5010), SCALE_FACTOR_1)),
+							m(EvseKeba.ChannelId.SET_ENERGY_LIMIT, new UnsignedWordElement(5010),
+									ENERGY_LIMIT_CONVERTER)),
 					new FC6WriteRegisterTask(5012, m(Keba.ChannelId.SET_UNLOCK_PLUG, new UnsignedWordElement(5012))),
 					new FC6WriteRegisterTask(5014, m(Keba.ChannelId.SET_ENABLE, new UnsignedWordElement(5014))),
 					new FC6WriteRegisterTask(5050,
@@ -248,7 +252,6 @@ public class EvseKebaModbusImpl extends KebaModbus implements EvseKeba, EvseChar
 		case TOPIC_CYCLE_BEFORE_PROCESS_IMAGE -> {
 			this.kebaUtils.onBeforeProcessImage();
 			this.evseKebaUtils.onBeforeProcessImage();
-		}
 		}
 	}
 

--- a/io.openems.edge.evse.chargepoint.keba/src/io/openems/edge/evse/chargepoint/keba/modbus/EvseKebaModbusImpl.java
+++ b/io.openems.edge.evse.chargepoint.keba/src/io/openems/edge/evse/chargepoint/keba/modbus/EvseKebaModbusImpl.java
@@ -32,7 +32,6 @@ import org.osgi.service.metatype.annotations.Designate;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.edge.bridge.modbus.api.BridgeModbus;
-import io.openems.edge.bridge.modbus.api.ElementToChannelConverter;
 import io.openems.edge.bridge.modbus.api.ModbusComponent;
 import io.openems.edge.bridge.modbus.api.ModbusProtocol;
 import io.openems.edge.bridge.modbus.api.element.UnsignedDoublewordElement;
@@ -68,8 +67,6 @@ import io.openems.edge.timedata.api.TimedataProvider;
 })
 public class EvseKebaModbusImpl extends KebaModbus implements EvseKeba, EvseChargePoint, ElectricityMeter,
 		OpenemsComponent, TimedataProvider, EventHandler, ModbusComponent {
-
-	static final ElementToChannelConverter ENERGY_LIMIT_CONVERTER = SCALE_FACTOR_1;
 
 	private final KebaUtils kebaUtils = new KebaUtils(this);
 	private final EvseKebaUtils evseKebaUtils = new EvseKebaUtils(this);
@@ -206,8 +203,7 @@ public class EvseKebaModbusImpl extends KebaModbus implements EvseKeba, EvseChar
 					new FC6WriteRegisterTask(5004,
 							m(Keba.ChannelId.SET_CHARGING_CURRENT, new UnsignedWordElement(5004))),
 					new FC6WriteRegisterTask(5010,
-							m(EvseKeba.ChannelId.SET_ENERGY_LIMIT, new UnsignedWordElement(5010),
-									ENERGY_LIMIT_CONVERTER)),
+							m(EvseKeba.ChannelId.SET_ENERGY_LIMIT, new UnsignedWordElement(5010), SCALE_FACTOR_1)),
 					new FC6WriteRegisterTask(5012, m(Keba.ChannelId.SET_UNLOCK_PLUG, new UnsignedWordElement(5012))),
 					new FC6WriteRegisterTask(5014, m(Keba.ChannelId.SET_ENABLE, new UnsignedWordElement(5014))),
 					new FC6WriteRegisterTask(5050,

--- a/io.openems.edge.evse.chargepoint.keba/test/io/openems/edge/evcs/keba/modbus/EvcsKebaModbusImplTest.java
+++ b/io.openems.edge.evse.chargepoint.keba/test/io/openems/edge/evcs/keba/modbus/EvcsKebaModbusImplTest.java
@@ -101,4 +101,9 @@ public class EvcsKebaModbusImplTest {
 
 		assertEquals("L:5678 W|SetCurrent:UNDEFINED|SetEnable:-1:Undefined", sut.debugLog());
 	}
+
+	@Test
+	public void testEnergyLimitScaleFactor() {
+		assertEquals(Integer.valueOf(100), EvcsKebaModbusImpl.ENERGY_LIMIT_CONVERTER.channelToElement(1000));
+	}
 }

--- a/io.openems.edge.evse.chargepoint.keba/test/io/openems/edge/evcs/keba/modbus/EvcsKebaModbusImplTest.java
+++ b/io.openems.edge.evse.chargepoint.keba/test/io/openems/edge/evcs/keba/modbus/EvcsKebaModbusImplTest.java
@@ -7,6 +7,7 @@ import static io.openems.edge.evse.chargepoint.keba.common.CommonNaturesTest.tes
 import static io.openems.edge.evse.chargepoint.keba.common.CommonNaturesTest.testManagedEvcsChannels;
 import static io.openems.edge.evse.chargepoint.keba.common.EvcsKebaTest.testEvcsKebaChannels;
 import static io.openems.edge.evse.chargepoint.keba.common.KebaModbusTest.prepareKebaModbus;
+import static io.openems.edge.evse.chargepoint.keba.common.KebaModbusTest.testEnergyLimitWriteScale;
 import static io.openems.edge.evse.chargepoint.keba.common.KebaModbusTest.testKebaModbusChannels;
 import static io.openems.edge.evse.chargepoint.keba.common.KebaTest.testKebaChannels;
 import static io.openems.edge.meter.api.PhaseRotation.L2_L3_L1;
@@ -103,7 +104,22 @@ public class EvcsKebaModbusImplTest {
 	}
 
 	@Test
-	public void testEnergyLimitScaleFactor() {
-		assertEquals(Integer.valueOf(100), EvcsKebaModbusImpl.ENERGY_LIMIT_CONVERTER.channelToElement(1000));
+	public void testEnergyLimitScaleFactor() throws Exception {
+		final var sut = new EvcsKebaModbusImpl();
+		new ComponentTest(sut) //
+				.addReference("evcsPower", new DummyEvcsPower()) //
+				.addReference("cm", new DummyConfigurationAdmin()) //
+				.addReference("componentManager", new DummyComponentManager(createDummyClock()))
+				.addReference("setModbus", new DummyModbusBridge("modbus0")) //
+				.activate(MyConfig.create() //
+						.setId("evcs0") //
+						.setDebugMode(false)//
+						.setMinHwCurrent(6000)//
+						.setPhaseRotation(PhaseRotation.L1_L2_L3) //
+						.setModbusId("modbus0") //
+						.setModbusUnitId(255) //
+						.setReadOnly(false) //
+						.build());
+		testEnergyLimitWriteScale(sut, 1000, 100);
 	}
 }

--- a/io.openems.edge.evse.chargepoint.keba/test/io/openems/edge/evse/chargepoint/keba/common/KebaModbusTest.java
+++ b/io.openems.edge.evse.chargepoint.keba/test/io/openems/edge/evse/chargepoint/keba/common/KebaModbusTest.java
@@ -1,9 +1,17 @@
 package io.openems.edge.evse.chargepoint.keba.common;
 
+import static io.openems.common.utils.ReflectionUtils.getValueViaReflection;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.test.DummyConfigurationAdmin;
 import io.openems.edge.bridge.modbus.api.ModbusComponent;
+import io.openems.edge.bridge.modbus.api.ModbusProtocol;
+import io.openems.edge.bridge.modbus.api.element.UnsignedWordElement;
+import io.openems.edge.bridge.modbus.api.task.FC6WriteRegisterTask;
 import io.openems.edge.bridge.modbus.test.DummyModbusBridge;
+import io.openems.edge.common.channel.WriteChannel;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
 import io.openems.edge.common.test.ComponentTest;
 
@@ -96,5 +104,28 @@ public class KebaModbusTest {
 				.output(KebaModbus.ChannelId.PTAF_RFID, ProductTypeAndFeatures.Rfid.WITH_RFID) //
 				.output(KebaModbus.ChannelId.PTAF_BUTTON, ProductTypeAndFeatures.Button.WITH_BUTTON) //
 		;
+	}
+
+	/**
+	 * Writes SET_ENERGY_LIMIT in Wh and asserts the scaled FC6 value on register
+	 * 5010.
+	 *
+	 * @param sut the {@link KebaModbus} implementation
+	 * @param energyLimitWh the channel write in Wh
+	 * @param expectedRegister the expected register 5010 value
+	 * @throws Exception on error
+	 */
+	public static void testEnergyLimitWriteScale(KebaModbus sut, int energyLimitWh, int expectedRegister)
+			throws Exception {
+		((WriteChannel<?>) sut.channel(EvseKeba.ChannelId.SET_ENERGY_LIMIT))
+				.setNextWriteValueFromObject(energyLimitWh);
+		ModbusProtocol protocol = getValueViaReflection(sut, "protocol");
+		var task = protocol.getTaskManager().getTasks().stream() //
+				.filter(t -> t instanceof FC6WriteRegisterTask && t.getStartAddress() == 5010) //
+				.findFirst() //
+				.orElseThrow();
+		var registers = ((UnsignedWordElement) task.getElements()[0]).getNextWriteValueAndReset();
+		assertNotNull(registers);
+		assertEquals(expectedRegister, registers[0].getValue());
 	}
 }

--- a/io.openems.edge.evse.chargepoint.keba/test/io/openems/edge/evse/chargepoint/keba/modbus/EvseChargePointKebaModbusImplTest.java
+++ b/io.openems.edge.evse.chargepoint.keba/test/io/openems/edge/evse/chargepoint/keba/modbus/EvseChargePointKebaModbusImplTest.java
@@ -4,6 +4,7 @@ import static io.openems.edge.common.type.Phase.SingleOrThreePhase.THREE_PHASE;
 import static io.openems.edge.evse.chargepoint.keba.common.CommonNaturesTest.testElectricityMeterChannels;
 import static io.openems.edge.evse.chargepoint.keba.common.EvseKebaTest.testEvseKebaChannels;
 import static io.openems.edge.evse.chargepoint.keba.common.KebaModbusTest.prepareKebaModbus;
+import static io.openems.edge.evse.chargepoint.keba.common.KebaModbusTest.testEnergyLimitWriteScale;
 import static io.openems.edge.evse.chargepoint.keba.common.KebaModbusTest.testKebaModbusChannels;
 import static io.openems.edge.evse.chargepoint.keba.common.KebaTest.testKebaChannels;
 import static io.openems.edge.evse.chargepoint.keba.common.enums.LogVerbosity.DEBUG_LOG;
@@ -79,8 +80,18 @@ public class EvseChargePointKebaModbusImplTest {
 	}
 
 	@Test
-	public void testEnergyLimitWriteScaleFactor() {
-		assertEquals(Integer.valueOf(100), EvseKebaModbusImpl.ENERGY_LIMIT_CONVERTER.channelToElement(1000));
+	public void testEnergyLimitWriteScaleFactor() throws Exception {
+		final var sut = new EvseKebaModbusImpl();
+		prepareKebaModbus(sut) //
+				.activate(MyConfig.create() //
+						.setId("evseChargePoint0") //
+						.setModbusId("modbus0") //
+						.setWiring(THREE_PHASE) //
+						.setPhaseRotation(L2_L3_L1) //
+						.setLogVerbosity(DEBUG_LOG) //
+						.setReadOnly(false) //
+						.build());
+		testEnergyLimitWriteScale(sut, 1000, 100);
 	}
 
 	@Test

--- a/io.openems.edge.evse.chargepoint.keba/test/io/openems/edge/evse/chargepoint/keba/modbus/EvseChargePointKebaModbusImplTest.java
+++ b/io.openems.edge.evse.chargepoint.keba/test/io/openems/edge/evse/chargepoint/keba/modbus/EvseChargePointKebaModbusImplTest.java
@@ -79,6 +79,11 @@ public class EvseChargePointKebaModbusImplTest {
 	}
 
 	@Test
+	public void testEnergyLimitWriteScaleFactor() {
+		assertEquals(Integer.valueOf(100), EvseKebaModbusImpl.ENERGY_LIMIT_CONVERTER.channelToElement(1000));
+	}
+
+	@Test
 	public void testFirmwareOutdated() throws OpenemsException, Exception {
 		final var sut = new EvseKebaModbusImpl();
 		final var test = prepareKebaModbus(sut) //


### PR DESCRIPTION
### Summary

Keba energy-limit register 5010 (SET_ENERGY_LIMIT) is in units of 10 Wh, but the write task had no scale converter. A 1000 Wh limit wrote register 1000 instead of 100.

Apply existing SCALE_FACTOR_1 on both EvseKebaModbusImpl and EvcsKebaModbusImpl, with JUnit on both.

Fixes #3765

### Validation
- JUnit writes 1000 Wh and asserts register 5010 is 100 on EvcsKebaModbusImpl and EvseKebaModbusImpl

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.