### PR TITLE
Metadata.File: implement generateUpdateMetadataCacheNotification (fix backend-edge with file metadata)

### DIFF
--- a/io.openems.backend.metadata.file/src/io/openems/backend/metadata/file/MetadataFile.java
+++ b/io.openems.backend.metadata.file/src/io/openems/backend/metadata/file/MetadataFile.java
@@ -39,6 +39,7 @@ import io.openems.backend.common.alerting.UserAlertingSettings;
 import io.openems.backend.common.metadata.AbstractMetadata;
 import io.openems.backend.common.metadata.Edge;
 import io.openems.backend.common.metadata.EdgeHandler;
+import io.openems.backend.common.edge.jsonrpc.UpdateMetadataCache;
 import io.openems.backend.common.metadata.Metadata;
 import io.openems.backend.common.metadata.MetadataUtils;
 import io.openems.backend.common.metadata.SimpleEdgeHandler;
@@ -132,6 +133,17 @@ public class MetadataFile extends AbstractMetadata implements Metadata, EventHan
 			}
 		}
 		return Optional.empty();
+	}
+
+	@Override
+	public synchronized UpdateMetadataCache.Notification generateUpdateMetadataCacheNotification() {
+		this.refreshData();
+		var apikeysToEdgeIds = new HashMap<String, String>();
+		for (Entry<String, MyEdge> entry : this.edges.entrySet()) {
+			var edge = entry.getValue();
+			apikeysToEdgeIds.put(edge.getApikey(), edge.getId());
+		}
+		return new UpdateMetadataCache.Notification(apikeysToEdgeIds);
 	}
 
 	@Override


### PR DESCRIPTION
## Problem

In the split backend / backend-edge topology (introduced 2026.2), `Backend.Edge.App` only starts its edge-facing websocket server after its cache is initialized from the Edge Manager's `UpdateMetadataCache` notification (`BackendEdgeServerApp.evaluateServerStart()` requires `cache.isInitialized()`, which requires a non-empty apikey→edgeId map).

`Metadata.generateUpdateMetadataCacheNotification()` has a default implementation returning `UpdateMetadataCache.Notification.empty()`, and only the Odoo metadata provides a real implementation. As a result, **deployments using `Metadata.File` can never accept Edge connections** on any post-2026.1 backend: the backend-edge connects to the Edge Manager, receives an empty cache notification, and its edge websocket server (port 8081) never starts.

Reproduced on 2026.4.0 and 2026.8.0 with the official docker images (`openems/backend` + `openems/backend-edge`) and a standard `metadata.json`.

## Fix

Override `generateUpdateMetadataCacheNotification()` in `MetadataFile`: refresh the parsed file and publish the apikey→edgeId map for all configured edges — mirroring what the Odoo metadata does.

Verified on a live deployment (backend 2026.8.0 + backend-edge 2026.8.0, file metadata, 6 edges): after this patch the backend-edge cache initializes, its edge server starts, edges authenticate by apikey and stream data end-to-end (websocket UI + InfluxDB timedata).


