### PR TITLE
Backend AppCenterHandler: return empty results when no AppCenter metadata service is present

### DIFF
--- a/io.openems.backend.common/src/io/openems/backend/common/metadata/AppCenterHandler.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/metadata/AppCenterHandler.java
@@ -1,6 +1,7 @@
 package io.openems.backend.common.metadata;
 
-import java.util.Objects;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -31,6 +32,7 @@ import io.openems.common.jsonrpc.response.AppCenterGetPossibleAppsResponse;
 import io.openems.common.jsonrpc.response.AppCenterGetRegisteredKeysResponse;
 import io.openems.common.jsonrpc.response.AppCenterIsAppFreeResponse;
 import io.openems.common.jsonrpc.response.AppCenterIsKeyApplicableResponse;
+import io.openems.common.utils.JsonUtils;
 
 public final class AppCenterHandler {
 
@@ -53,7 +55,12 @@ public final class AppCenterHandler {
 			final User user, //
 			final String edgeId //
 	) throws OpenemsNamedException {
-		Objects.requireNonNull(metadata, "No AppCenter Metadata provided.");
+		if (metadata == null) {
+			// OrbitEOS patch: no AppCenter metadata service in this deployment.
+			// Answer with benign empty results instead of an error so UIs and
+			// Edges degrade gracefully.
+			return handleWithoutMetadata(request);
+		}
 
 		return switch (request.getPayload().getMethod()) {
 		case AppCenterAddRegisterKeyHistoryRequest.METHOD -> handleAsync(metadata, request, //
@@ -130,7 +137,10 @@ public final class AppCenterHandler {
 			final AppCenterRequest request, //
 			final String edgeId //
 	) throws OpenemsNamedException {
-		Objects.requireNonNull(metadata, "No AppCenter Metadata provided.");
+		if (metadata == null) {
+			// OrbitEOS patch: see handleUserRequest.
+			return handleWithoutMetadata(request);
+		}
 
 		return switch (request.getPayload().getMethod()) {
 		case AppCenterAddInstallInstanceHistoryRequest.METHOD -> handleAsync(metadata, request, //
@@ -209,6 +219,31 @@ public final class AppCenterHandler {
 	) throws OpenemsNamedException {
 		return metadataCall.apply(metadata, requestMapper.apply(request.getPayload())) //
 				.thenApply(r -> new GenericJsonrpcResponseSuccess(request.id));
+	}
+
+	private static CompletableFuture<? extends JsonrpcResponseSuccess> handleWithoutMetadata(//
+			final AppCenterRequest request //
+	) throws OpenemsNamedException {
+		final var result = switch (request.getPayload().getMethod()) {
+		case AppCenterGetInstalledAppsRequest.METHOD -> JsonUtils.buildJsonObject() //
+				.add("installedApps", new JsonArray()) //
+				.build();
+		case AppCenterGetPossibleAppsRequest.METHOD -> JsonUtils.buildJsonObject() //
+				.add("bundles", new JsonArray()) //
+				.build();
+		case AppCenterGetRegisteredKeysRequest.METHOD -> JsonUtils.buildJsonObject() //
+				.add("keys", new JsonArray()) //
+				.build();
+		case AppCenterIsKeyApplicableRequest.METHOD -> JsonUtils.buildJsonObject() //
+				.addProperty("isKeyApplicable", false) //
+				.add("additionalInfo", new JsonObject()) //
+				.build();
+		case AppCenterIsAppFreeRequest.METHOD -> JsonUtils.buildJsonObject() //
+				.addProperty("isAppFree", false) //
+				.build();
+		default -> new JsonObject();
+		};
+		return CompletableFuture.completedFuture(new GenericJsonrpcResponseSuccess(request.id, result));
 	}
 
 	private AppCenterHandler() {

--- a/io.openems.backend.common/src/io/openems/backend/common/metadata/AppCenterHandler.java
+++ b/io.openems.backend.common/src/io/openems/backend/common/metadata/AppCenterHandler.java
@@ -56,9 +56,9 @@ public final class AppCenterHandler {
 			final String edgeId //
 	) throws OpenemsNamedException {
 		if (metadata == null) {
-			// OrbitEOS patch: no AppCenter metadata service in this deployment.
-			// Answer with benign empty results instead of an error so UIs and
-			// Edges degrade gracefully.
+			// No AppCenter metadata service in this deployment. Answer with
+			// benign empty results instead of an error so UIs and Edges degrade
+			// gracefully.
 			return handleWithoutMetadata(request);
 		}
 
@@ -138,7 +138,7 @@ public final class AppCenterHandler {
 			final String edgeId //
 	) throws OpenemsNamedException {
 		if (metadata == null) {
-			// OrbitEOS patch: see handleUserRequest.
+			// No AppCenter metadata service; see handleUserRequest.
 			return handleWithoutMetadata(request);
 		}
 


### PR DESCRIPTION
## Problem

Deployments without an AppCenter metadata service — e.g. `Metadata.File` based setups, which have no Odoo/AppCenter backend — receive a hard JSON-RPC error for every `appCenter/*` request:

```
Objects.requireNonNull(metadata, "No AppCenter Metadata provided.");
```

Edges send `getInstalledApps` periodically and the UI issues appCenter requests on edge pages, so backend logs fill with `JSON-RPC Error "No AppCenter Metadata provided." of type NullPointerException`, and the 2026.x UI can crash when navigating away from pages that triggered these requests (observed on 2026.8.0: UI breaks when returning from the edge app view on a file-metadata deployment).

## Fix

When the injected `AppCenterMetadata` is `null`, `AppCenterHandler` now returns benign empty results instead of throwing:

- `getInstalledApps` → `{ "installedApps": [] }`
- `getPossibleApps` → `{ "bundles": [] }`
- `getRegisteredKeys` → `{ "keys": [] }`
- `isKeyApplicable` → `{ "isKeyApplicable": false, "additionalInfo": {} }`
- `isAppFree` → `{ "isAppFree": false }`
- history/write requests → generic empty success (no-op)

Clients degrade gracefully: the UI shows an empty App Center, Edges get valid empty responses, logs stay clean. Verified on a live 2026.8.0 deployment (file metadata, 6 edges): the UI navigation crash disappears and the appCenter requests return the empty results above.

Related: #3865 (same deployment class — file-based metadata with the split backend / backend-edge topology).


