### PR TITLE
Set `java.awt.headless=true` in runproperties for minimal JREs setups

### DIFF
--- a/io.openems.backend.application/BackendApp.bndrun
+++ b/io.openems.backend.application/BackendApp.bndrun
@@ -9,6 +9,7 @@
 	-Dfile.encoding=UTF-8
 
 -runproperties: \
+	java.awt.headless=true,\
 	org.osgi.service.http.port=8079,\
 	felix.cm.dir=c:/openems-backend/config,\
 	openems.data.dir=c:/openems-backend/data,\

--- a/io.openems.backend.edge.application/BackendEdgeApp.bndrun
+++ b/io.openems.backend.edge.application/BackendEdgeApp.bndrun
@@ -5,6 +5,7 @@
 -resolve.effective: active
 
 -runproperties: \
+	java.awt.headless=true,\
 	org.osgi.service.http.port=8078,\
 	felix.cm.dir=c:/openems-backend-edge/config,\
 	org.apache.felix.eventadmin.Timeout=0,\

--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -5,6 +5,7 @@
 -resolve.effective: active
 
 -runproperties:\
+	java.awt.headless=true,\
 	org.osgi.service.http.port=8080,\
 	felix.cm.dir=c:/openems/config,\
 	openems.data.dir=c:/openems/data,\


### PR DESCRIPTION
This PR adds `java.awt.headless=true` to the `-runproperties` across OpenEMS bndrun configurations.

While OpenEMS operates as a headless runtime, certain components utilize `java.awt` packages to render dynamic forms and graphics. So a completely headless runtime without `java.desktop` is not possible.

But, by default, Java attempts to initialize native display subsystems when AWT classes are referenced. To save storage on small embedded linux devices and don't require display and sound capabilities like x11, i want to explicitly set `java.awt.headless=true`.