### PR TITLE
fix SchedulerFixedOrder: include OpenemsComponent

### DIFF
--- a/io.openems.edge.scheduler.fixedorder/src/io/openems/edge/scheduler/fixedorder/SchedulerFixedOrderImpl.java
+++ b/io.openems.edge.scheduler.fixedorder/src/io/openems/edge/scheduler/fixedorder/SchedulerFixedOrderImpl.java
@@ -24,7 +24,8 @@ import io.openems.edge.scheduler.api.Scheduler;
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE //
 )
-public class SchedulerFixedOrderImpl extends AbstractOpenemsComponent implements SchedulerFixedOrder, Scheduler {
+public class SchedulerFixedOrderImpl extends AbstractOpenemsComponent
+		implements SchedulerFixedOrder, Scheduler, OpenemsComponent {
 
 	private final LinkedHashSet<String> controllerIds = new LinkedHashSet<>();
 

--- a/io.openems.edge.scheduler.fixedorder/test/io/openems/edge/scheduler/fixedorder/SchedulerFixedOrderImplTest.java
+++ b/io.openems.edge.scheduler.fixedorder/test/io/openems/edge/scheduler/fixedorder/SchedulerFixedOrderImplTest.java
@@ -1,11 +1,11 @@
 package io.openems.edge.scheduler.fixedorder;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
@@ -35,13 +35,12 @@ public class SchedulerFixedOrderImplTest {
 				.activate(MyConfig.create() //
 						.setId(SCHEDULER_ID) //
 						.setControllersIds(CTRL3_ID, CTRL1_ID) //
-						.build()); //
-
-		test.next(new TestCase()); //
+						.build()) //
+				.next(new TestCase()); //
 		assertEquals(//
 				List.of(CTRL3_ID, CTRL1_ID), //
 				getControllerIds(sut));
-
+		test.deactivate();
 	}
 
 	private static List<String> getControllerIds(Scheduler scheduler) throws OpenemsNamedException {


### PR DESCRIPTION
**Problem:**

1. The Controller Detailed Log can not find this scheduler by its id: `[_cycle  ] WARN  [ms.edge.core.cycle.CycleWorker] Error in Cycle-Step [Controller [ctrlDetailedLog0]]: Unable to find OpenEMS Component with ID [scheduler0]`

2. The OsgiValidateWorker is constantly restarting this scheduler: `[tManager] INFO  [nentmanager.OsgiValidateWorker] [_componentManager] Trying to restart Component [scheduler0]`
`[d5b5053)] INFO  [dorder.SchedulerFixedOrderImpl] [scheduler0] Modified Scheduler.FixedOrder`

**Fix:**

Explicitly stating that the scheduler implements OpenemsComponent.