### PR TITLE
Feature/edge bridgembus & MeterAbbB23Impl reference target migrate

### DIFF
--- a/io.openems.edge.bridge.mbus/src/io/openems/edge/bridge/mbus/api/AbstractOpenemsMbusComponent.java
+++ b/io.openems.edge.bridge.mbus/src/io/openems/edge/bridge/mbus/api/AbstractOpenemsMbusComponent.java
@@ -3,11 +3,9 @@ package io.openems.edge.bridge.mbus.api;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
 
 import io.openems.edge.common.component.AbstractOpenemsComponent;
-import io.openems.edge.common.component.OpenemsComponent;
 
 public abstract class AbstractOpenemsMbusComponent extends AbstractOpenemsComponent {
 
@@ -40,25 +38,11 @@ public abstract class AbstractOpenemsMbusComponent extends AbstractOpenemsCompon
 	 *                       'config.enabled()'
 	 * @param primaryAddress Primary address of the M-Bus device. Typically
 	 *                       'config.primaryAddress'
-	 * @param cm             An instance of ConfigurationAdmin. Receive it
-	 *                       using @Reference
-	 * @param mbusReference  The name of the @Reference setter method for the M-Bus
-	 *                       bridge
-	 * @param mbusId         The ID of the M-Bus bridge. Typically
-	 *                       'config.mbus_id()'
-	 * @return true if the target filter was updated. You may use it to abort the
-	 *         activate() method.
 	 */
-	protected boolean activate(ComponentContext context, String id, String alias, boolean enabled, int primaryAddress,
-			ConfigurationAdmin cm, String mbusReference, String mbusId) {
+	protected void activate(ComponentContext context, String id, String alias, boolean enabled, int primaryAddress) {
 		super.activate(context, id, alias, enabled);
 		this.primaryAddress = primaryAddress;
-
-		if (OpenemsComponent.updateReferenceFilter(cm, this.servicePid(), "mbus", mbusId)) {
-			return true;
-		}
 		this.addChannelDataRecords();
-		return false;
 	}
 
 	/**

--- a/io.openems.edge.meter.abb/src/io/openems/edge/meter/abb/b32/MeterAbbB23Impl.java
+++ b/io.openems.edge.meter.abb/src/io/openems/edge/meter/abb/b32/MeterAbbB23Impl.java
@@ -1,17 +1,18 @@
 package io.openems.edge.meter.abb.b32;
 
-import org.osgi.service.cm.ConfigurationAdmin;
+import static org.osgi.service.component.annotations.ReferencePolicy.STATIC;
+import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
+import static org.osgi.service.component.annotations.ReferenceCardinality.MANDATORY;
+
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.metatype.annotations.Designate;
 
+import io.openems.common.referencetarget.GenerateTargetsFromReferences;
 import io.openems.common.types.MeterType;
 import io.openems.edge.bridge.mbus.api.AbstractOpenemsMbusComponent;
 import io.openems.edge.bridge.mbus.api.BridgeMbus;
@@ -27,13 +28,12 @@ import io.openems.edge.meter.api.ElectricityMeter;
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE //
 )
+@GenerateTargetsFromReferences("mbus")
 public class MeterAbbB23Impl extends AbstractOpenemsMbusComponent
 		implements MeterAbbB23, ElectricityMeter, OpenemsComponent {
 
-	@Reference
-	private ConfigurationAdmin cm;
-
-	@Reference(policy = ReferencePolicy.STATIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.MANDATORY)
+	@Reference(policy = STATIC, policyOption = GREEDY, cardinality = MANDATORY, //
+			target = "(&(id=${config.mbus_id})(enabled=true))")
 	private BridgeMbus mbus;
 
 	private MeterType meterType = MeterType.PRODUCTION;
@@ -52,8 +52,7 @@ public class MeterAbbB23Impl extends AbstractOpenemsMbusComponent
 	@Activate
 	private void activate(ComponentContext context, Config config) {
 		this.meterType = config.type();
-		super.activate(context, config.id(), config.alias(), config.enabled(), config.primaryAddress(), this.cm, "mbus",
-				config.mbus_id());
+		super.activate(context, config.id(), config.alias(), config.enabled(), config.primaryAddress());
 		// register into mbus bridge task list
 		this.mbus.addTask(config.id(), new MbusTask(this.mbus, this));
 	}

--- a/io.openems.edge.meter.abb/test/io/openems/edge/meter/abb/b32/MeterAbbB23ImplTest.java
+++ b/io.openems.edge.meter.abb/test/io/openems/edge/meter/abb/b32/MeterAbbB23ImplTest.java
@@ -1,8 +1,9 @@
 package io.openems.edge.meter.abb.b32;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.openems.common.test.DummyConfigurationAdmin;
+import org.junit.jupiter.api.Test;
+
 import io.openems.common.types.MeterType;
 import io.openems.common.utils.ReflectionUtils.ReflectionException;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
@@ -10,19 +11,19 @@ import io.openems.edge.common.test.ComponentTest;
 
 public class MeterAbbB23ImplTest {
 
-	@Test(expected = ReflectionException.class)
+	@Test
 	public void test() throws Exception {
-		new ComponentTest(new MeterAbbB23Impl()) //
-				.addReference("cm", new DummyConfigurationAdmin()) // #
-				.addReference("mbus", null) // TODO create DummyMbusBridge
-				.activate(MyConfig.create() //
-						.setId("meter0") //
-						.setMbusId("bridge0") //
-						.setPrimaryAddress(10) //
-						.setType(MeterType.PRODUCTION) //
-						.build()) //
-				.next(new TestCase()) //
-				.deactivate();
+		assertThrows(ReflectionException.class, () -> {
+			new ComponentTest(new MeterAbbB23Impl()) //
+					.addReference("mbus", null) // TODO create DummyMbusBridge
+					.activate(MyConfig.create() //
+							.setId("meter0") //
+							.setMbusId("bridge0") //
+							.setPrimaryAddress(10) //
+							.setType(MeterType.PRODUCTION) //
+							.build()) //
+					.next(new TestCase()) //
+					.deactivate();
+		});
 	}
-
 }


### PR DESCRIPTION
- Remove 'updateReferenceFilter' from 'AbstractOpenemsMbusComponent' and simplify 'activate'.
- Migrate 'MeterAbbB23Impl' to '@GenerateTargetsFromReferences("mbus")' with 'config.mbus_id' target filter.
- Update meter test to JUnit 4 to JUnit 6.