### PR TITLE
[doc] Update MeterType import from edge.meter.api to common.types in documentation

### DIFF
--- a/doc/modules/ROOT/pages/edge/implement.adoc
+++ b/doc/modules/ROOT/pages/edge/implement.adoc
@@ -136,7 +136,7 @@ package io.openems.edge.meter.simulated;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
-import io.openems.edge.meter.api.MeterType;
+import io.openems.common.types.MeterType;
 
 @ObjectClassDefinition(// <1>
 		name = "Meter Simulated", //
@@ -303,7 +303,7 @@ import io.openems.edge.bridge.modbus.api.task.FC3ReadRegistersTask;
 import io.openems.edge.common.component.OpenemsComponent;
 import io.openems.edge.common.taskmanager.Priority;
 import io.openems.edge.meter.api.ElectricityMeter;
-import io.openems.edge.meter.api.MeterType;
+import io.openems.common.types.MeterType;
 
 @Designate(ocd = Config.class, factory = true) <1>
 @Component(// <2>
@@ -450,7 +450,7 @@ import org.junit.Test;
 import io.openems.edge.bridge.modbus.test.DummyModbusBridge;
 import io.openems.edge.common.test.AbstractComponentTest.TestCase;
 import io.openems.edge.common.test.ComponentTest;
-import io.openems.edge.meter.api.MeterType;
+import io.openems.common.types.MeterType;
 
 public class MyModbusDeviceTest {
 


### PR DESCRIPTION
the example wasn't working anymore, with this change it works again.  Somewhere along the development metertype was moved from meter.api to common.types