### PR TITLE
[Edge] Edge2Edge.Websocket: migrate reference target & update JUnit tests

### DIFF
--- a/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/ess/Edge2EdgeEss.java
+++ b/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/ess/Edge2EdgeEss.java
@@ -11,15 +11,15 @@ import io.openems.edge.common.component.OpenemsComponent;
 public interface Edge2EdgeEss extends OpenemsComponent {
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
-		MINIMUM_POWER_SET_POINT(Doc.of(OpenemsType.FLOAT) //
-				.accessMode(AccessMode.READ_ONLY) //
-				.unit(Unit.WATT) //
-				.text("Minimum available active power")), //
-		MAXIMUM_POWER_SET_POINT(Doc.of(OpenemsType.FLOAT) //
+		MINIMUM_POWER_SET_POINT(Doc.of(OpenemsType.FLOAT)//
 				.accessMode(AccessMode.READ_ONLY)//
-				.unit(Unit.WATT) //
+				.unit(Unit.WATT)//
+				.text("Minimum available active power")), //
+		MAXIMUM_POWER_SET_POINT(Doc.of(OpenemsType.FLOAT)//
+				.accessMode(AccessMode.READ_ONLY)//
+				.unit(Unit.WATT)//
 				.text("Maximum available electrical power")), //
-		REMOTE_SET_ACTIVE_POWER_EQUALS(Doc.of(OpenemsType.FLOAT) //
+		REMOTE_SET_ACTIVE_POWER_EQUALS(Doc.of(OpenemsType.FLOAT)//
 				.accessMode(AccessMode.WRITE_ONLY)//
 				.unit(Unit.WATT)), //
 		REMOTE_SET_REACTIVE_POWER_EQUALS(Doc.of(OpenemsType.FLOAT) //

--- a/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/bridge/Edge2EdgeWebsocketBridge.java
+++ b/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/bridge/Edge2EdgeWebsocketBridge.java
@@ -22,7 +22,7 @@ import io.openems.edge.common.component.OpenemsComponent;
 public interface Edge2EdgeWebsocketBridge extends OpenemsComponent {
 
 	public enum ChannelId implements io.openems.edge.common.channel.ChannelId {
-		CONNECTION_STATE(Doc.of(ConnectionStateOption.values()) //
+		CONNECTION_STATE(Doc.of(ConnectionStateOption.values())//
 				.persistencePriority(PersistencePriority.HIGH)), //
 		NO_CONNECTION(Doc.of(Level.WARNING)), //
 		NOT_AUTHENTICATED(Doc.of(Level.INFO)), //
@@ -30,7 +30,7 @@ public interface Edge2EdgeWebsocketBridge extends OpenemsComponent {
 		/**
 		 * Copies the _sum/State of the remote edge.
 		 */
-		REMOTE_SUM_STATE(Doc.of(Level.values()) //
+		REMOTE_SUM_STATE(Doc.of(Level.values())//
 				.persistencePriority(PersistencePriority.HIGH)), //
 		REMOTE_SUM_STATE_FAULT(Doc.of(Level.FAULT)), //
 		REMOTE_SUM_STATE_WARNING(Doc.of(Level.WARNING)), //

--- a/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/ess/Config.java
+++ b/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/ess/Config.java
@@ -28,9 +28,6 @@ import io.openems.common.channel.AccessMode;
 	@AttributeDefinition(name = "Bridge-ID")
 	String bridge_id() default "bridge0";
 
-	@AttributeDefinition(name = "Bridge-Target")
-	String Bridge_target();
-
 	String webconsole_configurationFactory_nameHint() default "Edge-2-Edge ESS Websocket [{id}]";
 
 }

--- a/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/ess/Edge2EdgeWebsocketEssImpl.java
+++ b/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/ess/Edge2EdgeWebsocketEssImpl.java
@@ -4,7 +4,6 @@ import static io.openems.common.utils.IntUtils.maxInteger;
 import static io.openems.common.utils.IntUtils.minInteger;
 import static java.util.stream.Collectors.toSet;
 
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -27,6 +26,7 @@ import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsRuntimeException;
 import io.openems.common.function.Disposable;
 import io.openems.common.jsonrpc.request.GetChannelsOfComponent;
+import io.openems.common.referencetarget.GenerateTargetsFromReferences;
 import io.openems.common.types.ChannelAddress;
 import io.openems.common.types.OpenemsType;
 import io.openems.common.utils.JsonUtils;
@@ -50,13 +50,11 @@ import io.openems.edge.ess.power.api.Power;
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE //
 )
+@GenerateTargetsFromReferences("Bridge")
 public class Edge2EdgeWebsocketEssImpl extends AbstractOpenemsComponent implements ManagedSymmetricEss, AsymmetricEss,
 		SymmetricEss, Edge2EdgeWebsocketEss, Edge2EdgeWebsocket, OpenemsComponent {
 
 	private final Logger log = LoggerFactory.getLogger(Edge2EdgeWebsocketEssImpl.class);
-
-	@Reference
-	private ConfigurationAdmin cm;
 
 	@Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY, policy = ReferencePolicy.DYNAMIC)
 	private volatile Power power;
@@ -73,7 +71,8 @@ public class Edge2EdgeWebsocketEssImpl extends AbstractOpenemsComponent implemen
 	 */
 	@Reference(policy = ReferencePolicy.DYNAMIC, //
 			policyOption = ReferencePolicyOption.GREEDY, //
-			cardinality = ReferenceCardinality.OPTIONAL)
+			cardinality = ReferenceCardinality.OPTIONAL, //
+			target = "(&(id=${config.bridge_id})(enabled=true))")
 	public void bindBridge(Edge2EdgeWebsocketBridge bridge) {
 		this.bridgeStateHandler.bindBridge(bridge);
 
@@ -172,8 +171,6 @@ public class Edge2EdgeWebsocketEssImpl extends AbstractOpenemsComponent implemen
 	protected void activate(ComponentContext context, Config config) {
 		super.activate(context, config.id(), config.alias(), config.enabled());
 		this.config = config;
-
-		OpenemsComponent.updateReferenceFilter(this.cm, this.servicePid(), "Bridge", config.bridge_id());
 
 		this.bridgeStateHandler.updateComponentId(config.enabled() ? config.remoteComponentId() : null);
 	}

--- a/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/ess/Edge2EdgeWebsocketEssImpl.java
+++ b/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/ess/Edge2EdgeWebsocketEssImpl.java
@@ -3,6 +3,9 @@ package io.openems.edge.edge2edge.websocket.ess;
 import static io.openems.common.utils.IntUtils.maxInteger;
 import static io.openems.common.utils.IntUtils.minInteger;
 import static java.util.stream.Collectors.toSet;
+import static org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL;
+import static org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC;
+import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
 
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -10,9 +13,6 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +56,7 @@ public class Edge2EdgeWebsocketEssImpl extends AbstractOpenemsComponent implemen
 
 	private final Logger log = LoggerFactory.getLogger(Edge2EdgeWebsocketEssImpl.class);
 
-	@Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY, policy = ReferencePolicy.DYNAMIC)
+	@Reference(cardinality = OPTIONAL, policyOption = GREEDY, policy = DYNAMIC)
 	private volatile Power power;
 
 	private Config config;
@@ -69,9 +69,7 @@ public class Edge2EdgeWebsocketEssImpl extends AbstractOpenemsComponent implemen
 	 *
 	 * @param bridge the bridge to bind
 	 */
-	@Reference(policy = ReferencePolicy.DYNAMIC, //
-			policyOption = ReferencePolicyOption.GREEDY, //
-			cardinality = ReferenceCardinality.OPTIONAL, //
+	@Reference(policy = DYNAMIC, policyOption = GREEDY, cardinality = OPTIONAL, //
 			target = "(&(id=${config.bridge_id})(enabled=true))")
 	public void bindBridge(Edge2EdgeWebsocketBridge bridge) {
 		this.bridgeStateHandler.bindBridge(bridge);

--- a/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/genericreadcomponent/Config.java
+++ b/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/genericreadcomponent/Config.java
@@ -23,9 +23,6 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Bridge-ID")
 	String bridge_id() default "bridge0";
 
-	@AttributeDefinition(name = "Bridge-Target")
-	String Bridge_target();
-
 	String webconsole_configurationFactory_nameHint() default "Edge-2-Edge GenericReadComponent [{id}]";
 
 }

--- a/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/genericreadcomponent/Edge2EdgeGenericReadComponentImpl.java
+++ b/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/genericreadcomponent/Edge2EdgeGenericReadComponentImpl.java
@@ -1,6 +1,9 @@
 package io.openems.edge.edge2edge.websocket.genericreadcomponent;
 
 import static java.util.stream.Collectors.toSet;
+import static org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL;
+import static org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC;
+import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
 
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -8,9 +11,6 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,9 +61,7 @@ public class Edge2EdgeGenericReadComponentImpl extends AbstractOpenemsComponent
 	 * 
 	 * @param bridge the bridge to bind
 	 */
-	@Reference(policy = ReferencePolicy.DYNAMIC, //
-			policyOption = ReferencePolicyOption.GREEDY, //
-			cardinality = ReferenceCardinality.OPTIONAL, //
+	@Reference(policy = DYNAMIC, policyOption = GREEDY, cardinality = OPTIONAL, //
 			target = "(&(id=${config.bridge_id})(enabled=true))")
 	public void bindBridge(Edge2EdgeWebsocketBridge bridge) {
 		this.bridgeStateHandler.bindBridge(bridge);

--- a/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/genericreadcomponent/Edge2EdgeGenericReadComponentImpl.java
+++ b/io.openems.edge.edge2edge/src/io/openems/edge/edge2edge/websocket/genericreadcomponent/Edge2EdgeGenericReadComponentImpl.java
@@ -2,7 +2,6 @@ package io.openems.edge.edge2edge.websocket.genericreadcomponent;
 
 import static java.util.stream.Collectors.toSet;
 
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -23,6 +22,7 @@ import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.common.function.Disposable;
 import io.openems.common.jsonrpc.request.GetChannelsOfComponent.ChannelRecord;
+import io.openems.common.referencetarget.GenerateTargetsFromReferences;
 import io.openems.common.types.ChannelAddress;
 import io.openems.common.types.OpenemsType;
 import io.openems.common.utils.JsonUtils;
@@ -42,13 +42,11 @@ import io.openems.edge.ess.power.api.Power;
 		immediate = true, //
 		configurationPolicy = ConfigurationPolicy.REQUIRE //
 )
+@GenerateTargetsFromReferences("Bridge")
 public class Edge2EdgeGenericReadComponentImpl extends AbstractOpenemsComponent
 		implements Edge2EdgeGenericReadComponent, Edge2EdgeWebsocket, OpenemsComponent {
 
 	private final Logger log = LoggerFactory.getLogger(Edge2EdgeGenericReadComponentImpl.class);
-
-	@Reference
-	private ConfigurationAdmin cm;
 
 	@Reference
 	private Power power;
@@ -65,7 +63,8 @@ public class Edge2EdgeGenericReadComponentImpl extends AbstractOpenemsComponent
 	 */
 	@Reference(policy = ReferencePolicy.DYNAMIC, //
 			policyOption = ReferencePolicyOption.GREEDY, //
-			cardinality = ReferenceCardinality.OPTIONAL)
+			cardinality = ReferenceCardinality.OPTIONAL, //
+			target = "(&(id=${config.bridge_id})(enabled=true))")
 	public void bindBridge(Edge2EdgeWebsocketBridge bridge) {
 		this.bridgeStateHandler.bindBridge(bridge);
 
@@ -153,8 +152,6 @@ public class Edge2EdgeGenericReadComponentImpl extends AbstractOpenemsComponent
 	private void activate(ComponentContext context, Config config) throws OpenemsException {
 		super.activate(context, config.id(), config.alias(), config.enabled());
 		this.config = config;
-
-		OpenemsComponent.updateReferenceFilter(this.cm, this.servicePid(), "Bridge", config.bridge_id());
 
 		this.bridgeStateHandler.updateComponentId(config.enabled() ? config.remoteComponentId() : null);
 	}

--- a/io.openems.edge.edge2edge/test/io/openems/edge/edge2edge/common/AbstractEdge2EdgeTest.java
+++ b/io.openems.edge.edge2edge/test/io/openems/edge/edge2edge/common/AbstractEdge2EdgeTest.java
@@ -1,11 +1,11 @@
 package io.openems.edge.edge2edge.common;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.openems.edge.common.modbusslave.ModbusRecordFloat32;
 import io.openems.edge.common.modbusslave.ModbusRecordFloat64;

--- a/io.openems.edge.edge2edge/test/io/openems/edge/edge2edge/common/AbstractEdge2EdgeTest2.java
+++ b/io.openems.edge.edge2edge/test/io/openems/edge/edge2edge/common/AbstractEdge2EdgeTest2.java
@@ -1,9 +1,9 @@
 package io.openems.edge.edge2edge.common;
 
 import static io.openems.edge.edge2edge.common.AbstractEdge2Edge.generateModbusElement;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.openems.common.types.OpenemsType;
 import io.openems.edge.bridge.modbus.api.element.AbstractModbusElement;

--- a/io.openems.edge.edge2edge/test/io/openems/edge/edge2edge/ess/Edge2EdgeEssImplTest.java
+++ b/io.openems.edge.edge2edge/test/io/openems/edge/edge2edge/ess/Edge2EdgeEssImplTest.java
@@ -1,6 +1,6 @@
 package io.openems.edge.edge2edge.ess;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.openems.common.channel.AccessMode;
 import io.openems.common.test.DummyConfigurationAdmin;
@@ -21,7 +21,8 @@ public class Edge2EdgeEssImplTest {
 						.setRemoteAccessMode(AccessMode.READ_WRITE) //
 						.setRemoteComponentId("ess0") //
 						.build())
-				.next(new TestCase());
+				.next(new TestCase()) //
+				.deactivate();
 	}
 
 }

--- a/io.openems.edge.edge2edge/test/io/openems/edge/edge2edge/meter/Edge2EdgeEssMeterImplTest.java
+++ b/io.openems.edge.edge2edge/test/io/openems/edge/edge2edge/meter/Edge2EdgeEssMeterImplTest.java
@@ -2,7 +2,7 @@ package io.openems.edge.edge2edge.meter;
 
 import static io.openems.common.types.MeterType.PRODUCTION;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.openems.common.test.DummyConfigurationAdmin;
 import io.openems.edge.bridge.modbus.test.DummyModbusBridge;
@@ -22,7 +22,8 @@ public class Edge2EdgeEssMeterImplTest {
 						.setRemoteComponentId("meter0") //
 						.setMeterType(PRODUCTION) //
 						.build())
-				.next(new TestCase());
+				.next(new TestCase()) //
+				.deactivate();
 	}
 
 }


### PR DESCRIPTION
## Summary
Follow-up to the Reference Target Plugin migration: migrates the Edge2Edge Websocket components that still used `OpenemsComponent.updateReferenceFilter()` for the Bridge reference.
- `Edge2Edge.Websocket.Ess`
- `Edge2Edge.Websocket.GenericReadComponent`
Changes:
- Add `@GenerateTargetsFromReferences("Bridge")` and target filter `(&(id=${config.bridge_id})(enabled=true))` on `bindBridge`
- Keep Bridge as DYNAMIC / GREEDY / OPTIONAL (unchanged)
- Remove `ConfigurationAdmin` (was only used for `updateReferenceFilter`)
- Remove obsolete `Bridge_target()` from both Configs
