### PR TITLE
Fix typo in nginx.adoc

### DIFF
--- a/doc/modules/ROOT/pages/ui/deploy/nginx.adoc
+++ b/doc/modules/ROOT/pages/ui/deploy/nginx.adoc
@@ -15,7 +15,7 @@ NOTE: These instructions are intended for a quick setup, e.g. to get started wit
 
 === Setup
 
-We assume that the files for OpemEMS UI are in /home/user/openems/openems-ui
+We assume that the files for OpenEMS UI are in /home/user/openems/openems-ui
 
 . Install nginx (e.g. `apt install nginx` on Debian / Ubuntu and derivatives)
  


### PR DESCRIPTION
This PR fixes the typo `OpemEMS UI` in the nginx documentation page.

I also thought about if we could update this part to include the following command for users less familiar with terminal commands, but i wanted to hear your opinion about this first. 

```
. Start nginx:
+
[source,bash]
----
sudo systemctl start nginx
----
+
See `man nginx` and the documentation on https://nginx.org for more information.
```