### PR TITLE
[Edge] Meter.Mqtt: add generic config-driven MQTT meter

### DIFF
--- a/io.openems.edge.application/EdgeApp.bndrun
+++ b/io.openems.edge.application/EdgeApp.bndrun
@@ -182,6 +182,7 @@
 	bnd.identity;id='io.openems.edge.meter.hager',\
 	bnd.identity;id='io.openems.edge.meter.janitza',\
 	bnd.identity;id='io.openems.edge.meter.kdk',\
+	bnd.identity;id='io.openems.edge.meter.mqtt',\
 	bnd.identity;id='io.openems.edge.meter.opendtu',\
 	bnd.identity;id='io.openems.edge.meter.phoenixcontact',\
 	bnd.identity;id='io.openems.edge.meter.plexlog',\
@@ -397,6 +398,7 @@
 	io.openems.edge.meter.hager;version=snapshot,\
 	io.openems.edge.meter.janitza;version=snapshot,\
 	io.openems.edge.meter.kdk;version=snapshot,\
+	io.openems.edge.meter.mqtt;version=snapshot,\
 	io.openems.edge.meter.opendtu;version=snapshot,\
 	io.openems.edge.meter.phoenixcontact;version=snapshot,\
 	io.openems.edge.meter.plexlog;version=snapshot,\

--- a/io.openems.edge.meter.mqtt/.classpath
+++ b/io.openems.edge.meter.mqtt/.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="src" output="bin_test" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/io.openems.edge.meter.mqtt/.gitignore
+++ b/io.openems.edge.meter.mqtt/.gitignore
@@ -1,0 +1,2 @@
+/bin_test/
+/generated/

--- a/io.openems.edge.meter.mqtt/.project
+++ b/io.openems.edge.meter.mqtt/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openems.edge.meter.mqtt</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/io.openems.edge.meter.mqtt/.settings/org.eclipse.core.resources.prefs
+++ b/io.openems.edge.meter.mqtt/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/io.openems.edge.meter.mqtt/bnd.bnd
+++ b/io.openems.edge.meter.mqtt/bnd.bnd
@@ -1,0 +1,14 @@
+Bundle-Name: OpenEMS Edge Meter MQTT
+Bundle-Vendor: energy-iot
+Bundle-Version: 1.0.0.${tstamp}
+Bundle-License: https://opensource.org/licenses/EPL-2.0
+
+-buildpath: \
+	${buildpath},\
+	io.openems.common,\
+	io.openems.edge.bridge.mqtt,\
+	io.openems.edge.common,\
+	io.openems.edge.meter.api,\
+
+-testpath: \
+	${testpath}

--- a/io.openems.edge.meter.mqtt/readme.adoc
+++ b/io.openems.edge.meter.mqtt/readme.adoc
@@ -1,0 +1,55 @@
+= Meter MQTT
+
+Generic, config-driven electricity meter that maps a flat JSON MQTT payload to standard `ElectricityMeter` channels.
+
+== Overview
+
+This bundle subscribes to a single MQTT topic through the OpenEMS MQTT bridge and, on each received message, parses a flat JSON object and applies a configured list of field-to-channel mappings. No field names, device model, or production/consumption direction are hardcoded; everything is expressed through configuration, so one component can serve 1- or 3-phase meters from any vendor that publishes JSON over MQTT.
+
+== Components
+
+=== <<_meter_mqtt,Meter MQTT>>
+
+*Name*: Meter MQTT
+
+*Factory-PID*: `Meter.Mqtt`
+
+.Implemented Natures/Interfaces
+* MeterMqtt
+* ElectricityMeter
+* OpenemsComponent
+* MqttComponent
+
+*Description*: Subscribes to a configured MQTT topic and maps a flat JSON payload to `ElectricityMeter` channels. Configuration is done through the OpenEMS UI or the Apache Felix Web Console; no example configuration is shipped.
+
+.*Configuration*:
+* `id` (String): Component ID for unique identification (default: "meter0")
+* `alias` (String): Human-readable alias for the component
+* `enabled` (Boolean): Enable/disable this component (default: true)
+* `type` (Enum): Meter type - GRID, PRODUCTION, or CONSUMPTION_METERED (default: CONSUMPTION_METERED). This sets the direction: `PRODUCTION` marks the meter as generating, `CONSUMPTION_METERED`/`GRID` as consuming
+* `phaseRotation` (Enum): Physical rotation of the phases (default: L1_L2_L3)
+* `mqttBridgeId` (String): ID of the MQTT bridge component (default: "mqtt0")
+* `topic` (String): The MQTT topic filter to subscribe to
+* `mapping` (String[]): One entry per mapped value, formatted as `jsonField:CHANNEL:scale`, where `CHANNEL` is an `ElectricityMeter` Channel-ID and `scale` is a numeric factor applied to the raw JSON value
+
+*Mapping format*: each entry is `jsonField:CHANNEL:scale`.
+
+* `jsonField` - the field name to read from the flat JSON payload
+* `CHANNEL` - an `ElectricityMeter` Channel-ID (e.g. `ACTIVE_POWER`, `VOLTAGE`)
+* `scale` - a numeric factor applied to the raw value (e.g. `1000` converts Volt to Millivolt). A *negative* scale *inverts* the value, so a meter wired in reverse can be corrected per-channel (e.g. `PhW:ACTIVE_POWER:-1`). Combined with `type()` (which sets PRODUCTION vs CONSUMPTION), this covers both the sign and the direction of every mapped value.
+
+Energy channels are of type `Long`; all other channels are of type `Integer`. The target type is detected from the Channel, so scaled values are cast to `long` for energy channels and rounded to `int` otherwise.
+
+.*Mapping example*:
+----
+PhW:ACTIVE_POWER:1
+PhV:VOLTAGE:1000
+PhA:CURRENT:1000
+Var:REACTIVE_POWER:1
+Hz:FREQUENCY:1000
+TotWhImport:ACTIVE_CONSUMPTION_ENERGY:1
+----
+
+[[_meter_mqtt]]
+
+https://github.com/OpenEMS/openems/tree/develop/io.openems.edge.meter.mqtt[Source Code icon:github[]]

--- a/io.openems.edge.meter.mqtt/src/io/openems/edge/meter/mqtt/Config.java
+++ b/io.openems.edge.meter.mqtt/src/io/openems/edge/meter/mqtt/Config.java
@@ -1,0 +1,45 @@
+package io.openems.edge.meter.mqtt;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+import io.openems.common.types.MeterType;
+import io.openems.edge.meter.api.PhaseRotation;
+
+@ObjectClassDefinition(//
+		name = "Meter MQTT", //
+		description = "Implements a generic, config-driven electricity meter that maps a flat JSON MQTT payload "
+				+ "to ElectricityMeter channels")
+@interface Config {
+
+	@AttributeDefinition(name = "Component-ID", description = "Unique ID of this Component")
+	String id() default "meter0";
+
+	@AttributeDefinition(name = "Alias", description = "Human-readable name of this Component; defaults to Component-ID")
+	String alias() default "";
+
+	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
+	boolean enabled() default true;
+
+	@AttributeDefinition(name = "Meter-Type", description = "Grid, Production, Consumption-Metered (default)")
+	MeterType type() default MeterType.CONSUMPTION_METERED;
+
+	@AttributeDefinition(name = "Phase rotation", description = "The way in which the phases are physically rotated.")
+	PhaseRotation phaseRotation() default PhaseRotation.L1_L2_L3;
+
+	@AttributeDefinition(name = "MQTT Bridge ID", description = "ID of the MQTT Bridge component (e.g., mqtt0)")
+	String mqttBridgeId() default "mqtt0";
+
+	@AttributeDefinition(name = "Topic", description = "The MQTT topic filter to subscribe to "
+			+ "(e.g., openami/StreetPoleEMS_37EAB0/meter_0)")
+	String topic() default "";
+
+	@AttributeDefinition(name = "Mapping", description = "Maps JSON fields to ElectricityMeter channels. "
+			+ "Each entry is \"jsonField:CHANNEL:scale\", where CHANNEL is an ElectricityMeter Channel-ID "
+			+ "(e.g., ACTIVE_POWER) and scale is a numeric factor applied to the JSON value "
+			+ "(e.g., \"PhV:VOLTAGE:1000\" converts Volt to Millivolt).")
+	String[] mapping() default {};
+
+	String webconsole_configurationFactory_nameHint() default "Meter MQTT [{id}]";
+
+}

--- a/io.openems.edge.meter.mqtt/src/io/openems/edge/meter/mqtt/MeterMqtt.java
+++ b/io.openems.edge.meter.mqtt/src/io/openems/edge/meter/mqtt/MeterMqtt.java
@@ -1,0 +1,9 @@
+package io.openems.edge.meter.mqtt;
+
+import io.openems.edge.bridge.mqtt.api.MqttComponent;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.meter.api.ElectricityMeter;
+
+public interface MeterMqtt extends ElectricityMeter, OpenemsComponent, MqttComponent {
+
+}

--- a/io.openems.edge.meter.mqtt/src/io/openems/edge/meter/mqtt/MeterMqttImpl.java
+++ b/io.openems.edge.meter.mqtt/src/io/openems/edge/meter/mqtt/MeterMqttImpl.java
@@ -1,0 +1,233 @@
+package io.openems.edge.meter.mqtt;
+
+import static org.osgi.service.component.annotations.ConfigurationPolicy.REQUIRE;
+import static org.osgi.service.component.annotations.ReferenceCardinality.MANDATORY;
+import static org.osgi.service.component.annotations.ReferencePolicy.STATIC;
+import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.metatype.annotations.Designate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import io.openems.common.referencetarget.GenerateTargetsFromReferences;
+import io.openems.common.types.MeterType;
+import io.openems.common.types.OpenemsType;
+import io.openems.edge.bridge.mqtt.api.BridgeMqtt;
+import io.openems.edge.bridge.mqtt.api.BridgeMqtt.MqttSubscription;
+import io.openems.edge.bridge.mqtt.api.MqttComponent;
+import io.openems.edge.bridge.mqtt.api.MqttMessage;
+import io.openems.edge.bridge.mqtt.api.QoS;
+import io.openems.edge.common.component.AbstractOpenemsComponent;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.meter.api.ElectricityMeter;
+import io.openems.edge.meter.api.PhaseRotation;
+
+@Designate(ocd = Config.class, factory = true)
+@Component(//
+		name = "Meter.Mqtt", //
+		immediate = true, //
+		configurationPolicy = REQUIRE)
+@GenerateTargetsFromReferences("mqttBridge")
+public class MeterMqttImpl extends AbstractOpenemsComponent
+		implements MeterMqtt, ElectricityMeter, OpenemsComponent, MqttComponent {
+
+	private final Logger log = LoggerFactory.getLogger(MeterMqttImpl.class);
+	private final List<Mapping> mappings = new ArrayList<>();
+
+	@Reference(//
+			policy = STATIC, policyOption = GREEDY, cardinality = MANDATORY, //
+			target = "(&(id=${config.mqttBridgeId})(enabled=true))")
+	private BridgeMqtt mqttBridge;
+
+	private Config config;
+	private MqttSubscription subscription;
+
+	public MeterMqttImpl() {
+		super(//
+				OpenemsComponent.ChannelId.values(), //
+				ElectricityMeter.ChannelId.values(), //
+				MqttComponent.ChannelId.values() //
+		);
+	}
+
+	@Activate
+	protected void activate(ComponentContext context, Config config) {
+		super.activate(context, config.id(), config.alias(), config.enabled());
+		this.config = config;
+
+		this.parseMappings(config.mapping());
+
+		if (config.enabled()) {
+			this.subscribeToMqtt();
+		}
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		this.unsubscribeFromMqtt();
+		super.deactivate();
+	}
+
+	/**
+	 * Parses the configured mapping entries into {@link Mapping} objects. Malformed
+	 * entries are logged and skipped.
+	 *
+	 * @param mapping the raw mapping entries from configuration
+	 */
+	private void parseMappings(String[] mapping) {
+		this.mappings.clear();
+		if (mapping == null) {
+			return;
+		}
+		for (var entry : mapping) {
+			if (entry == null || entry.isBlank()) {
+				continue;
+			}
+			var parts = entry.split(":");
+			if (parts.length != 3) {
+				this.logWarn(this.log, "Ignoring malformed mapping entry [" + entry + "]: "
+						+ "expected format \"jsonField:CHANNEL:scale\"");
+				continue;
+			}
+			var jsonField = parts[0].trim();
+			var channelName = parts[1].trim();
+			ElectricityMeter.ChannelId channelId;
+			try {
+				channelId = ElectricityMeter.ChannelId.valueOf(channelName);
+			} catch (IllegalArgumentException e) {
+				this.logWarn(this.log, "Ignoring mapping entry [" + entry + "]: unknown Channel [" + channelName + "]");
+				continue;
+			}
+			double scale;
+			try {
+				scale = Double.parseDouble(parts[2].trim());
+			} catch (NumberFormatException e) {
+				this.logWarn(this.log, "Ignoring mapping entry [" + entry + "]: invalid scale [" + parts[2] + "]");
+				continue;
+			}
+			this.mappings.add(new Mapping(jsonField, channelId, scale));
+		}
+	}
+
+	/**
+	 * Subscribes to the configured MQTT topic via the bridge.
+	 */
+	private void subscribeToMqtt() {
+		try {
+			this.subscription = this.mqttBridge.subscribe(this.config.topic(), QoS.AT_LEAST_ONCE,
+					this::handleMqttMessage);
+			this.logInfo(this.log, "Subscribed to: " + this.config.topic());
+			this._setMqttCommunicationFailed(false);
+		} catch (Exception e) {
+			this.logError(this.log, "Failed to subscribe to MQTT topic [" + this.config.topic() + "]: " + e.getMessage());
+			this._setMqttCommunicationFailed(true);
+		}
+	}
+
+	/**
+	 * Unsubscribes from the MQTT topic, if subscribed.
+	 */
+	private void unsubscribeFromMqtt() {
+		if (this.subscription != null) {
+			try {
+				this.subscription.unsubscribe();
+			} catch (Exception e) {
+				this.logWarn(this.log, "Error unsubscribing from MQTT: " + e.getMessage());
+			}
+			this.subscription = null;
+		}
+	}
+
+	@Override
+	public void retryMqttCommunication() {
+		this.unsubscribeFromMqtt();
+		this.subscribeToMqtt();
+	}
+
+	/**
+	 * Handles an incoming MQTT message: parses the flat JSON payload and applies the
+	 * configured mappings to the {@link ElectricityMeter} channels.
+	 *
+	 * @param message the received {@link MqttMessage}
+	 */
+	private void handleMqttMessage(MqttMessage message) {
+		var payload = message.payloadAsString();
+		try {
+			var json = JsonParser.parseString(payload).getAsJsonObject();
+			this.applyMappings(json);
+			this._setMqttCommunicationFailed(false);
+		} catch (Exception e) {
+			this.logWarn(this.log,
+					"Failed to parse MQTT message on topic " + message.topic() + ": " + e.getMessage());
+			this._setMqttCommunicationFailed(true);
+		}
+	}
+
+	/**
+	 * Applies the configured mappings to the given JSON object.
+	 *
+	 * @param json the parsed JSON payload
+	 */
+	private void applyMappings(JsonObject json) {
+		for (var mapping : this.mappings) {
+			var element = json.get(mapping.jsonField());
+			if (element == null || element.isJsonNull()) {
+				this.logDebug(this.log, "Field [" + mapping.jsonField() + "] absent in payload; skipping");
+				continue;
+			}
+			var scaled = element.getAsDouble() * mapping.scale();
+			var channel = this.channel(mapping.channelId());
+			if (channel.getType() == OpenemsType.LONG) {
+				channel.setNextValue((long) scaled);
+			} else {
+				channel.setNextValue((int) Math.round(scaled));
+			}
+		}
+	}
+
+	/**
+	 * Internal method to set the 'nextValue' on
+	 * {@link MqttComponent.ChannelId#MQTT_COMMUNICATION_FAILED} Channel.
+	 *
+	 * @param value the next value
+	 */
+	private void _setMqttCommunicationFailed(boolean value) {
+		this.channel(MqttComponent.ChannelId.MQTT_COMMUNICATION_FAILED).setNextValue(value);
+	}
+
+	@Override
+	public MeterType getMeterType() {
+		return this.config.type();
+	}
+
+	@Override
+	public PhaseRotation getPhaseRotation() {
+		return this.config.phaseRotation();
+	}
+
+	@Override
+	public String debugLog() {
+		return "L:" + this.getActivePower().asString();
+	}
+
+	/**
+	 * A single JSON-field-to-Channel mapping.
+	 *
+	 * @param jsonField the JSON field name to read
+	 * @param channelId the target {@link ElectricityMeter.ChannelId}
+	 * @param scale     the factor applied to the raw JSON value
+	 */
+	private record Mapping(String jsonField, ElectricityMeter.ChannelId channelId, double scale) {
+	}
+}

--- a/io.openems.edge.meter.mqtt/test/io/openems/edge/meter/mqtt/MeterMqttImplTest.java
+++ b/io.openems.edge.meter.mqtt/test/io/openems/edge/meter/mqtt/MeterMqttImplTest.java
@@ -1,0 +1,92 @@
+package io.openems.edge.meter.mqtt;
+
+import static io.openems.edge.meter.api.ElectricityMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY;
+import static io.openems.edge.meter.api.ElectricityMeter.ChannelId.ACTIVE_POWER;
+import static io.openems.edge.meter.api.ElectricityMeter.ChannelId.CURRENT;
+import static io.openems.edge.meter.api.ElectricityMeter.ChannelId.FREQUENCY;
+import static io.openems.edge.meter.api.ElectricityMeter.ChannelId.REACTIVE_POWER;
+import static io.openems.edge.meter.api.ElectricityMeter.ChannelId.VOLTAGE;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import io.openems.common.channel.Level;
+import io.openems.common.types.MeterType;
+import io.openems.edge.bridge.mqtt.api.MqttComponent;
+import io.openems.edge.bridge.mqtt.test.DummyBridgeMqtt;
+import io.openems.edge.common.component.OpenemsComponent;
+import io.openems.edge.common.test.AbstractComponentTest.TestCase;
+import io.openems.edge.common.test.ComponentTest;
+import io.openems.edge.meter.api.ElectricityMeter;
+
+public class MeterMqttImplTest {
+
+	private static final String COMPONENT_ID = "meter0";
+	private static final String MQTT_BRIDGE_ID = "mqtt0";
+	private static final String TOPIC = "openami/StreetPoleEMS_37EAB0/meter_0";
+
+	private static final String[] MAPPING = { //
+			"PhW:ACTIVE_POWER:1", //
+			"PhV:VOLTAGE:1000", //
+			"PhA:CURRENT:1000", //
+			"Var:REACTIVE_POWER:1", //
+			"Hz:FREQUENCY:1000", //
+			"TotWhImport:ACTIVE_CONSUMPTION_ENERGY:1" //
+	};
+
+	private static final String SAMPLE_PAYLOAD = "{\"model_id\":11,\"Hz\":50.02,\"PhA\":2.83,\"PhV\":228.5,"
+			+ "\"PhW\":616.7,\"Var\":198.2,\"TotWhImport\":100286.4}";
+
+	@Test
+	public void test() throws Exception {
+		var mqttBridge = new DummyBridgeMqtt(MQTT_BRIDGE_ID);
+
+		new ComponentTest(new MeterMqttImpl()) //
+				.addReference("mqttBridge", mqttBridge) //
+				.activate(MyConfig.create() //
+						.setId(COMPONENT_ID) //
+						.setMqttBridgeId(MQTT_BRIDGE_ID) //
+						.setType(MeterType.CONSUMPTION_METERED) //
+						.setTopic(TOPIC) //
+						.setMapping(MAPPING) //
+						.build()) //
+				.next(new TestCase() //
+						.activateStrictMode() //
+						.onBeforeProcessImage(() -> {
+							assertTrue(mqttBridge.isSubscribed(TOPIC));
+							mqttBridge.simulateMessage(TOPIC, SAMPLE_PAYLOAD);
+						}) //
+						// OpenemsComponent
+						.output(OpenemsComponent.ChannelId.STATE, Level.OK) //
+						// MqttComponent
+						.output(MqttComponent.ChannelId.MQTT_COMMUNICATION_FAILED, false) //
+						// ElectricityMeter - mapped by the sample payload
+						.output(ACTIVE_POWER, 617) // W
+						.output(VOLTAGE, 228500) // V -> mV
+						.output(CURRENT, 2830) // A -> mA
+						.output(REACTIVE_POWER, 198) // var
+						.output(FREQUENCY, 50020) // Hz -> mHz
+						.output(ACTIVE_CONSUMPTION_ENERGY, 100286L) // Wh (Long)
+						// ElectricityMeter - not mapped -> null
+						.output(ElectricityMeter.ChannelId.ACTIVE_POWER_L1, null) //
+						.output(ElectricityMeter.ChannelId.ACTIVE_POWER_L2, null) //
+						.output(ElectricityMeter.ChannelId.ACTIVE_POWER_L3, null) //
+						.output(ElectricityMeter.ChannelId.REACTIVE_POWER_L1, null) //
+						.output(ElectricityMeter.ChannelId.REACTIVE_POWER_L2, null) //
+						.output(ElectricityMeter.ChannelId.REACTIVE_POWER_L3, null) //
+						.output(ElectricityMeter.ChannelId.VOLTAGE_L1, null) //
+						.output(ElectricityMeter.ChannelId.VOLTAGE_L2, null) //
+						.output(ElectricityMeter.ChannelId.VOLTAGE_L3, null) //
+						.output(ElectricityMeter.ChannelId.CURRENT_L1, null) //
+						.output(ElectricityMeter.ChannelId.CURRENT_L2, null) //
+						.output(ElectricityMeter.ChannelId.CURRENT_L3, null) //
+						.output(ElectricityMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY, null) //
+						.output(ElectricityMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY_L1, null) //
+						.output(ElectricityMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY_L2, null) //
+						.output(ElectricityMeter.ChannelId.ACTIVE_PRODUCTION_ENERGY_L3, null) //
+						.output(ElectricityMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY_L1, null) //
+						.output(ElectricityMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY_L2, null) //
+						.output(ElectricityMeter.ChannelId.ACTIVE_CONSUMPTION_ENERGY_L3, null)) //
+				.deactivate();
+	}
+}

--- a/io.openems.edge.meter.mqtt/test/io/openems/edge/meter/mqtt/MyConfig.java
+++ b/io.openems.edge.meter.mqtt/test/io/openems/edge/meter/mqtt/MyConfig.java
@@ -1,0 +1,96 @@
+package io.openems.edge.meter.mqtt;
+
+import io.openems.common.test.AbstractComponentConfig;
+import io.openems.common.types.MeterType;
+import io.openems.edge.meter.api.PhaseRotation;
+
+@SuppressWarnings("all")
+public class MyConfig extends AbstractComponentConfig implements Config {
+
+	protected static class Builder {
+		private String id;
+		private MeterType type = MeterType.CONSUMPTION_METERED;
+		private PhaseRotation phaseRotation = PhaseRotation.L1_L2_L3;
+		private String mqttBridgeId = "mqtt0";
+		private String topic = "";
+		private String[] mapping = {};
+
+		private Builder() {
+		}
+
+		public Builder setId(String id) {
+			this.id = id;
+			return this;
+		}
+
+		public Builder setType(MeterType type) {
+			this.type = type;
+			return this;
+		}
+
+		public Builder setPhaseRotation(PhaseRotation phaseRotation) {
+			this.phaseRotation = phaseRotation;
+			return this;
+		}
+
+		public Builder setMqttBridgeId(String mqttBridgeId) {
+			this.mqttBridgeId = mqttBridgeId;
+			return this;
+		}
+
+		public Builder setTopic(String topic) {
+			this.topic = topic;
+			return this;
+		}
+
+		public Builder setMapping(String... mapping) {
+			this.mapping = mapping;
+			return this;
+		}
+
+		public MyConfig build() {
+			return new MyConfig(this);
+		}
+	}
+
+	/**
+	 * Create a Config builder.
+	 *
+	 * @return a {@link Builder}
+	 */
+	public static Builder create() {
+		return new Builder();
+	}
+
+	private final Builder builder;
+
+	private MyConfig(Builder builder) {
+		super(Config.class, builder.id);
+		this.builder = builder;
+	}
+
+	@Override
+	public MeterType type() {
+		return this.builder.type;
+	}
+
+	@Override
+	public PhaseRotation phaseRotation() {
+		return this.builder.phaseRotation;
+	}
+
+	@Override
+	public String mqttBridgeId() {
+		return this.builder.mqttBridgeId;
+	}
+
+	@Override
+	public String topic() {
+		return this.builder.topic;
+	}
+
+	@Override
+	public String[] mapping() {
+		return this.builder.mapping;
+	}
+}


### PR DESCRIPTION
Adds io.openems.edge.meter.mqtt, an ElectricityMeter that subscribes to an MQTT topic via Bridge.Mqtt, parses a flat JSON payload, and maps configured fields to ElectricityMeter channels.

New meters/vendors are onboarded by configuration alone (a topic plus a "jsonField:CHANNEL:scale" mapping list) without code changes. A negative scale inverts a value, and the meter type sets PRODUCTION vs CONSUMPTION. The reference to the MQTT bridge is selected via @GenerateTargetsFromReferences.

Registered in EdgeApp.bndrun.