### PR TITLE
[UI] Migrate TimeUtils to strict TypeScript

### DIFF
--- a/ui/src/app/shared/components/shared/converter.ts
+++ b/ui/src/app/shared/components/shared/converter.ts
@@ -39,11 +39,11 @@ export namespace Converter {
         return "" + value + " %";
     };
 
-    export const IF_NUMBER = (value: number | string | null, callback: (number: number) => string) => {
+    export const IF_NUMBER = (value: number | string | null | undefined, callback: (number: number) => string) => {
         if (typeof value === "number") {
             return callback(value);
         }
-        return "-"; // null or string
+        return "-"; // null, undefined or string
     };
 
     export const IF_STRING = (value: number | string | null, callback: (text: string) => string) => {
@@ -466,7 +466,7 @@ export namespace Converter {
     export const FORMAT_SECONDS_TO_DURATION: any = (locale: string) => {
         return (raw: number): any => {
             return IF_NUMBER(raw, (value) => {
-                return TimeUtils.formatSecondsToDuration(value, locale);
+                return TimeUtils.formatSecondsToDuration(value, locale) ?? "-";
             });
         };
     };

--- a/ui/src/app/shared/utils/time/timeutils.spec.ts
+++ b/ui/src/app/shared/utils/time/timeutils.spec.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { TestContext, TestingUtils } from "../../components/shared/testing/utils.spec";
 import { TimeUtils } from "./timeutils";
 

--- a/ui/src/app/shared/utils/time/timeutils.ts
+++ b/ui/src/app/shared/utils/time/timeutils.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { DecimalPipe } from "@angular/common";
 
 import { TranslateService } from "@ngx-translate/core";
@@ -14,7 +13,7 @@ export class TimeUtils {
    * @param value the value
    * @returns a time string with hours and minutes
    */
-    public static formatSecondsToDuration(value: number, locale: string): string {
+    public static formatSecondsToDuration(value: number | null | undefined, locale: string | null | undefined): string | null {
 
         if (value === null || value === undefined) {
             return null;
@@ -38,7 +37,7 @@ export class TimeUtils {
    * @param seconds the value
    * @returns a time string with hours and minutes
    */
-    public static formatSecondsToRelevantDuration(seconds: number, threshold: number, locale: string): string {
+    public static formatSecondsToRelevantDuration(seconds: number | null | undefined, threshold: number, locale: string): string | null {
 
         if (seconds == null) {
             return null;
@@ -92,7 +91,7 @@ export class TimeUtils {
             return value === key ? "" : value;
         };
 
-        return (raw: number): string => {
+        return (raw: number | null | undefined): string => {
             return Converter.IF_NUMBER(raw, (value) => {
                 const date = new Date();
                 date.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary

- Remove `@ts-strict-ignore` from `TimeUtils` and its tests
- Correct nullable input and return types to match existing behavior
- Preserve the existing `"-"` fallback for invalid converter values
- Extend `Converter.IF_NUMBER` typing to accept `undefined`

## Validation

- `npx.cmd --no-install tsc-strict --noEmit`
- `npm test -- --watch=false --browsers=ChromeHeadlessCI --include=src/app/shared/utils/time/timeutils.spec.ts`
- `npm run lint`

All 776 strict files passed, and all 3 focused TimeUtils tests passed.