### PR TITLE
Fix/ess cluster power distribution v1

### DIFF
--- a/io.openems.edge.ess.core/src/io/openems/edge/ess/core/power/v1/Data.java
+++ b/io.openems.edge.ess.core/src/io/openems/edge/ess/core/power/v1/Data.java
@@ -16,6 +16,7 @@ import com.google.common.collect.Streams;
 import io.openems.common.exceptions.OpenemsException;
 import io.openems.edge.common.type.Phase.SingleOrAllPhase;
 import io.openems.edge.ess.api.ManagedSymmetricEss;
+import io.openems.edge.ess.api.MetaEss;
 import io.openems.edge.ess.core.power.EssPower;
 import io.openems.edge.ess.core.power.v1.data.ConstraintUtil;
 import io.openems.edge.ess.core.power.v1.data.WeightsUtil;
@@ -77,16 +78,24 @@ public class Data {
 
 		this.inverters.clear();
 
-		// Create inverters and add them to list
+		// Create inverters and add them to list; skip MetaEss wrappers (e.g.
+		// EssCluster) as they have no physical inverter of their own
 		for (ManagedSymmetricEss ess : esss) {
+			if (ess instanceof MetaEss) {
+				continue;
+			}
 			var essType = EssType.getEssType(ess);
 			Collections.addAll(this.inverters, Inverter.of(this.symmetricMode, ess, essType));
 		}
 
-		// Re-Initialize Coefficients
+		// Re-Initialize Coefficients; also register member IDs of MetaEss wrappers so
+		// that MetaEss constraints (e.g. cluster = ess0 + ess1) can be created
 		Set<String> essIds = new HashSet<>();
 		for (ManagedSymmetricEss ess : esss) {
 			essIds.add(ess.id());
+			if (ess instanceof MetaEss me) {
+				Collections.addAll(essIds, me.getEssIds());
+			}
 		}
 		this.coefficients.initialize(this.symmetricMode, essIds);
 

--- a/io.openems.edge.ess.core/test/io/openems/edge/ess/core/power/v1/DataTest.java
+++ b/io.openems.edge.ess.core/test/io/openems/edge/ess/core/power/v1/DataTest.java
@@ -53,4 +53,39 @@ public class DataTest {
 		data.setSymmetricMode(false);
 		assertEquals(esss.size() * 4 /* phases + all */ * 2 /* pwr */, data.getCoefficients().getNoOfCoefficients());
 	}
+
+	/**
+	 * Verifies that a MetaEss (e.g. EssCluster) does not get its own Inverter entry.
+	 * Only physical ESS members should have Inverters so that the solver never tries
+	 * to call applyPower() on the wrapper.
+	 */
+	@Test
+	public void testNoInverterForMetaEss() {
+		data.setSymmetricMode(true);
+		// esss = [ess0(MetaEss), ess1, ess2] → only ess1 and ess2 should have inverters
+		assertEquals(2, data.getInverters().size());
+	}
+
+	/**
+	 * Verifies that member ESS IDs of a MetaEss are registered in the Coefficients
+	 * even when only the cluster itself is listed in esss. This is the core of
+	 * issue #3752: createMetaEssConstraints() requires member IDs in the coefficient
+	 * set to build the cluster = ess0 + ess1 constraint.
+	 */
+	@Test
+	public void testMemberCoefficientsRegisteredWhenOnlyClusterInEsss() {
+		EssPower powerComponent = new EssPowerImpl();
+		var ess1 = new DummyManagedSymmetricEss("ess1").setPower(powerComponent);
+		var ess2 = new DummyManagedSymmetricEss("ess2").setPower(powerComponent);
+		var cluster = new DummyMetaEss("essCluster0", ess1, ess2).setPower(powerComponent);
+
+		// Only the cluster in esss — mirrors the real OSGi scenario where members may
+		// not be collected before the cluster processes its cycle
+		var clusterOnly = Lists.<ManagedSymmetricEss>newArrayList(cluster);
+		var clusterData = new Data(() -> clusterOnly);
+		clusterData.setSymmetricMode(true);
+
+		// Expected: coefficients for essCluster0, ess1, ess2 = 3 IDs × 2 pwr = 6
+		assertEquals(3 * 2, clusterData.getCoefficients().getNoOfCoefficients());
+	}
 }


### PR DESCRIPTION
## Summary

`Controller.Symmetric.Balancing` (and other controllers using the V1 power
distribution) silently fails when `Ess.Cluster` is used as `ess.id`. The
scheduler cycle logs repeated errors like:

Coefficient for [essCluster0,ALL,ACTIVE] was not found
Coefficient for [essCluster0,ALL,REACTIVE] was not found



Meanwhile `ctrlBalancing0/State` reports `Ok` — no setpoints are applied to
the underlying physical ESS components.

## Root Cause

The V1 power distribution (`Data.updateInverters()`) had two related gaps
when a `MetaEss` wrapper (e.g. `EssCluster`) was present in the ESS list:

1. **Phantom Inverter**: An `Inverter` entry was created for the `MetaEss`
   itself, even though it has no physical inverter and its `applyPower()`
   intentionally throws `"should never be called"`.

2. **Missing member coefficients**: Only the cluster's own ID was added to
   the `Coefficients` set. The member IDs (`ess0`, `ess1`, …) were never
   registered, so `ConstraintUtil.createMetaEssConstraints()` could not
   build the `cluster = ess0 + ess1` constraint — causing the
   "Coefficient not found" error at runtime.

Note: The V2 power distribution (`BALANCE` strategy) already handles
`MetaEss` correctly via its `Virtual`/`Actual` entry pattern. This fix
brings V1 to the same level.

## Fix

Two small changes in
`io.openems.edge.ess.core/…/power/v1/Data.java` (`updateInverters()`):

- **Skip `MetaEss` during `Inverter` creation** — only physical ESS
  instances get an `Inverter` entry.
- **Expand `MetaEss` member IDs into the `Coefficients` set** — member IDs
  are resolved via `MetaEss.getEssIds()` and added alongside the cluster ID.

No other changes are needed: `ConstraintUtil.createMetaEssConstraints()` and
`Solver.applySolution()` already handle `MetaEss` correctly once the
coefficients are in place.

## Tests

Two new test cases added to `DataTest`:

- `testNoInverterForMetaEss` — asserts that a `MetaEss` does not produce an
  `Inverter` entry.
- `testMemberCoefficientsRegisteredWhenOnlyClusterInEsss` — asserts that
  member ESS IDs are registered in `Coefficients` even when only the cluster
  itself appears in the ESS list (the exact failure scenario of #3752).

## Checklist

- [x] Existing tests pass (`./gradlew :io.openems.edge.ess.core:test`)
- [x] New regression tests added
- [x] No changes outside `io.openems.edge.ess.core`
- [x] V2 / `BALANCE` strategy behaviour unchanged

Closes #3752