### PR TITLE
fix(PowerSolverV1): DurationCalculation

### DIFF
--- a/io.openems.edge.ess.core/src/io/openems/edge/ess/core/power/v1/Solver.java
+++ b/io.openems.edge.ess.core/src/io/openems/edge/ess/core/power/v1/Solver.java
@@ -7,6 +7,7 @@ import static io.openems.edge.ess.power.api.SolverStrategy.OPTIMIZE_BY_KEEPING_A
 import static io.openems.edge.ess.power.api.SolverStrategy.OPTIMIZE_BY_KEEPING_TARGET_DIRECTION_AND_MAXIMIZING_IN_ORDER;
 import static io.openems.edge.ess.power.api.SolverStrategy.OPTIMIZE_BY_MOVING_TOWARDS_TARGET;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -213,7 +214,7 @@ public class Solver {
 		}
 
 		// finish time measure (in milliseconds)
-		var duration = (int) (System.nanoTime() - startTime) / 1_000_000;
+		var duration = (int) Duration.ofNanos(System.nanoTime() - startTime).toMillis();
 
 		// announce success/failure
 		var isSolved = solution.getPoints() != null;


### PR DESCRIPTION
This PR fixes a wrong Duration calculation in PowerSolver V1.

If for whatever reason, the powersolver might take longer than Integer.MAX nano seconds (~2.14s) -> it will show the wrong time in the duration channel (possibly even negative values simply bc the int casting takes place before applying the milliseconds conversion)

This PR offers a solution, using Duration.

Alternative solution:

```java
(int) ((System.nanoTime() - startTime) / 1_000_000);
```

See: [javaplayground](https://dev.java/p?id=9ef4f6d142d27048829e237f) showing the differences between both castings