### PR TITLE
fix(ui/energymonitor): shift kW and price texts above grid icon when buy price is shown

### DIFF
--- a/ui/src/app/edge/live/energymonitor/chart/section/grid.component.html
+++ b/ui/src/app/edge/live/energymonitor/chart/section/grid.component.html
@@ -25,7 +25,7 @@
   }
   @if (isEnabled && squarePosition && square) {
     <svg:g attr.transform="translate({{squarePosition.x}},{{squarePosition.y}})">
-      <svg:text [attr.x]="square.valueText.x" [attr.y]="square.valueText.y" text-anchor="middle" font-family="sans-serif" [attr.font-size]="square.valueText.fontsize" fill="var(--ion-text-color)">
+    <svg:text [attr.x]="square.valueText.x" [attr.y]="square.valueText.y" text-anchor="middle" font-family="sans-serif" [attr.font-size]="square.valueText.fontsize" fill="var(--ion-text-color)">
         @if (valueText) {
           <ng-container>{{valueText}}</ng-container>
         } @else {

--- a/ui/src/app/edge/live/energymonitor/chart/section/grid.component.spec.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/grid.component.spec.ts
@@ -1,0 +1,130 @@
+import { registerLocaleData } from "@angular/common";
+import localeDe from "@angular/common/locales/de";
+import localeDeExtra from "@angular/common/locales/extra/de";
+import { Subject } from "rxjs";
+import { GridMode } from "src/app/shared/shared";
+import { DefaultTypes } from "src/app/shared/type/defaulttypes";
+import { SvgImagePosition, SvgSquare, SvgSquarePosition, SvgTextPosition } from "./abstractsection.component";
+import { GridSectionComponent } from "./grid.component";
+
+function makeMockSummary(gridBuyPrice: number | null, buyActivePower = 0): DefaultTypes.Summary {
+    return {
+        grid: {
+            powerRatio: 0,
+            activePowerL1: 0, activePowerL2: 0, activePowerL3: 0,
+            buyActivePower,
+            maxBuyActivePower: 0,
+            sellActivePower: 0,
+            sellActivePowerL1: 0, sellActivePowerL2: 0, sellActivePowerL3: 0,
+            maxSellActivePower: 0,
+            gridMode: GridMode.ON_GRID,
+            restrictionMode: 0,
+            gridBuyPrice,
+        },
+        system: { totalPower: 0 } as any,
+        storage: {} as any,
+        production: {} as any,
+        consumption: {} as any,
+    } as DefaultTypes.Summary;
+}
+
+function makeComponent(): GridSectionComponent {
+    const mockConfig = {
+        getComponent: () => ({}),
+        getPropertyFromComponent: () => "EUR",
+        widgets: { classes: [] },
+    };
+    const component = new GridSectionComponent(
+        { instant: (k: string) => k } as any,
+        { getConfig: () => Promise.resolve(mockConfig) } as any,
+        { position: () => null } as any,
+        {} as any,
+        {} as any,
+        { transform: (_v: number, _u: string) => "0 kW" } as any,
+        { toggleAnimation$: new Subject<boolean>() } as any,
+    );
+
+    // Simulate the square state that updateOnWindowResize would set up.
+    (component as any).square = new SvgSquare(
+        84,
+        new SvgTextPosition(42, 48, 30),
+        new SvgImagePosition("", 16, 52, 48),
+    );
+    (component as any).squarePosition = new SvgSquarePosition(-115, -42);
+    (component as any).innerRadius = 120;
+    (component as any).isEnabled = true;
+
+    return component;
+}
+
+describe("GridSectionComponent – grid buy price text offset", () => {
+    beforeAll(() => registerLocaleData(localeDe, "de", localeDeExtra));
+
+    it("shifts both texts up by 25 px when price first appears", async () => {
+        const component = makeComponent();
+        const originalY = (component as any).square.valueText.y as number;
+
+        await component._updateCurrentData(makeMockSummary(0.05));
+
+        expect((component as any).square.valueText.y).toBe(originalY - 25);
+        expect((component as any).priceOffsetApplied).toBeTrue();
+        expect((component as any).savedValueTextY).toBe(originalY);
+    });
+
+    it("recalculates gridBuyPrice.yPosition from the shifted y", async () => {
+        const component = makeComponent();
+        const iconY = (component as any).square.image.y as number;
+
+        await component._updateCurrentData(makeMockSummary(0.05));
+
+        const priceY = (component as any).gridBuyPrice?.yPosition as number;
+        expect(priceY).toBeLessThan(iconY);
+    });
+
+    it("does not shift again on subsequent calls when price stays", async () => {
+        const component = makeComponent();
+        await component._updateCurrentData(makeMockSummary(0.05));
+        const yAfterFirst = (component as any).square.valueText.y as number;
+
+        await component._updateCurrentData(makeMockSummary(0.05));
+
+        expect((component as any).square.valueText.y).toBe(yAfterFirst);
+    });
+
+    it("restores original y when price disappears", async () => {
+        const component = makeComponent();
+        const originalY = (component as any).square.valueText.y as number;
+
+        await component._updateCurrentData(makeMockSummary(0.05));
+        await component._updateCurrentData(makeMockSummary(null));
+
+        expect((component as any).square.valueText.y).toBe(originalY);
+        expect((component as any).priceOffsetApplied).toBeFalse();
+        expect((component as any).savedValueTextY).toBeNull();
+    });
+
+    it("re-applies offset after setElementHeight resets state (window resize)", async () => {
+        const component = makeComponent();
+        await component._updateCurrentData(makeMockSummary(0.05));
+
+        // Window resize triggers setElementHeight which resets the offset tracking.
+        (component as any).setElementHeight();
+        expect((component as any).priceOffsetApplied).toBeFalse();
+        expect((component as any).savedValueTextY).toBeNull();
+
+        const yAfterReset = (component as any).square.valueText.y as number;
+        await component._updateCurrentData(makeMockSummary(0.05));
+
+        expect((component as any).square.valueText.y).toBe(yAfterReset - 25);
+    });
+
+    it("does not shift texts when no price is available", async () => {
+        const component = makeComponent();
+        const originalY = (component as any).square.valueText.y as number;
+
+        await component._updateCurrentData(makeMockSummary(null));
+
+        expect((component as any).square.valueText.y).toBe(originalY);
+        expect((component as any).priceOffsetApplied).toBeFalse();
+    });
+});

--- a/ui/src/app/edge/live/energymonitor/chart/section/grid.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/grid.component.ts
@@ -27,6 +27,10 @@ export class GridSectionComponent extends AbstractSection implements OnInit, OnD
     protected buyAnimationClass: string = "grid-buy-hide";
     protected gridBuyPrice: SubValueProperties | null = null;
 
+    // Applied lazily in _updateCurrentData because gridBuyPrice is set async.
+    private priceOffsetApplied: boolean = false;
+    private savedValueTextY: number | null = null;
+
     private subShow?: Subscription;
 
     constructor(
@@ -151,6 +155,18 @@ export class GridSectionComponent extends AbstractSection implements OnInit, OnD
         this.gridBuyPrice = this.calculateSubValueProperties(value);
 
         if (this.square) {
+            const hasBuyPrice = this.gridBuyPrice !== null;
+            if (hasBuyPrice !== this.priceOffsetApplied) {
+                if (hasBuyPrice) {
+                    this.savedValueTextY = this.square.valueText.y;
+                    this.square.valueText.y -= 25;
+                    this.gridBuyPrice = this.calculateSubValueProperties(value);
+                } else if (this.savedValueTextY !== null) {
+                    this.square.valueText.y = this.savedValueTextY;
+                    this.savedValueTextY = null;
+                }
+                this.priceOffsetApplied = hasBuyPrice;
+            }
             // Set Grid-Mode
             this.square.image.image = this.getImagePath();
         }
@@ -170,10 +186,7 @@ export class GridSectionComponent extends AbstractSection implements OnInit, OnD
 
     protected getSquarePosition(square: SvgSquare, innerRadius: number): SvgSquarePosition {
         const x = (innerRadius - 5) * -1;
-        const y =
-            (square.length / 2) * -1 -
-            // Move up for grid-buy-price
-            (this.gridBuyPrice !== null ? 6 : 0);
+        const y = (square.length / 2) * -1;
         return new SvgSquarePosition(x, y);
     }
 
@@ -206,11 +219,10 @@ export class GridSectionComponent extends AbstractSection implements OnInit, OnD
 
     protected setElementHeight() {
         this.square.valueText.y = this.square.valueText.y - this.square.valueText.y * 0.3;
-        this.square.image.y =
-            this.square.image.y -
-            this.square.image.y * 0.3 +
-            // Move down for grid-buy-price
-            (this.gridBuyPrice !== null ? 12 : 0);
+        this.square.image.y = this.square.image.y - this.square.image.y * 0.3;
+        // Reset so _updateCurrentData re-applies the text offset after window resize.
+        this.priceOffsetApplied = false;
+        this.savedValueTextY = null;
     }
 
     protected getSvgEnergyFlow(ratio: number, radius: number): SvgEnergyFlow {


### PR DESCRIPTION
## Summary

- When `gridBuyPrice` is present, both the kW value text and the price text are shifted up by 25 px so they appear above the grid pole icon
- The icon position stays unchanged to keep alignment with the consumption section icon
- The offset is applied lazily in `_updateCurrentData` (async config fetch means `gridBuyPrice` is always `null` when `setElementHeight` runs); `setElementHeight` resets the tracking flag so the offset is correctly re-applied after a window resize
- Removes dead code: the `(this.gridBuyPrice !== null ? 12 : 0)` conditional in `setElementHeight` and the `? 6 : 0` in `getSquarePosition` never fired for the same reason

## Test plan

- [ ] Start the UI with a grid buy price configured — kW value and price text both appear above the icon
- [ ] Resize the browser window — texts remain above the icon after resize
- [ ] Remove the grid buy price — layout returns to default (no offset)
- [ ] 6 new unit tests in `grid.component.spec.ts` cover all cases (all green)

Closes #3882