### PR TITLE
fix(backend/core): self-heal stale EdgeConfig cache on GetEdgeConfig

### DIFF
--- a/io.openems.backend.core/src/io/openems/backend/core/jsonrpcrequesthandler/EdgeRpcRequestHandler.java
+++ b/io.openems.backend.core/src/io/openems/backend/core/jsonrpcrequesthandler/EdgeRpcRequestHandler.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import io.openems.backend.common.metadata.AppCenterHandler;
+import io.openems.backend.common.metadata.Edge;
 import io.openems.backend.common.metadata.Metadata.GenericSystemLog;
 import io.openems.backend.common.metadata.User;
 import io.openems.common.exceptions.OpenemsError;
@@ -41,6 +42,7 @@ import io.openems.common.timedata.Resolution;
 import io.openems.common.timedata.XlsxExportDetailData.XlsxExportDataEntry.HistoricTimedataSaveType;
 import io.openems.common.timedata.XlsxExportUtil;
 import io.openems.common.types.ChannelAddress;
+import io.openems.common.types.EdgeConfig;
 
 public class EdgeRpcRequestHandler {
 
@@ -84,7 +86,7 @@ public class EdgeRpcRequestHandler {
 				edgeId, user, QueryHistoricTimeseriesExportXlxsRequest.from(request));
 
 		case GetEdgeConfigRequest.METHOD ->
-			this.handleGetEdgeConfigRequest(edgeId, user, GetEdgeConfigRequest.from(request));
+			this.handleGetEdgeConfigRequest(edgeId, user, role, GetEdgeConfigRequest.from(request));
 
 		case ComponentJsonApiRequest.METHOD -> {
 			final var componentRequest = ComponentJsonApiRequest.from(request);
@@ -317,11 +319,22 @@ public class EdgeRpcRequestHandler {
 	 * @return the Future JSON-RPC Response
 	 * @throws OpenemsNamedException on error
 	 */
-	private CompletableFuture<JsonrpcResponseSuccess> handleGetEdgeConfigRequest(String edgeId, User user,
+	private CompletableFuture<JsonrpcResponseSuccess> handleGetEdgeConfigRequest(String edgeId, User user, Role role,
 			GetEdgeConfigRequest request) throws OpenemsNamedException {
 		var config = this.parent.metadata.edge().getEdgeConfig(edgeId);
 
-		// JSON-RPC response
+		// Self-heal: if the cached config has no factories but the Edge is online, fetch
+		// the live config directly from the Edge. This covers the case where the Backend
+		// restarted and the Edge reconnected without re-firing onOpen (e.g. 1006/1008
+		// close codes), so the config cache was never populated.
+		if (config.getFactories().isEmpty()
+				&& this.parent.metadata.getEdge(edgeId).map(Edge::isOnline).orElse(false)) {
+			return this.parent.edgeManager.send(edgeId, user, role,
+					new ComponentJsonApiRequest("_componentManager", request)) //
+					.thenApply(response -> new GetEdgeConfigResponse(request.getId(),
+							EdgeConfig.fromJson(response.getResult().getAsJsonObject())));
+		}
+
 		return CompletableFuture.completedFuture(new GetEdgeConfigResponse(request.getId(), config));
 	}
 

--- a/io.openems.backend.core/src/io/openems/backend/core/jsonrpcrequesthandler/EdgeRpcRequestHandler.java
+++ b/io.openems.backend.core/src/io/openems/backend/core/jsonrpcrequesthandler/EdgeRpcRequestHandler.java
@@ -315,6 +315,7 @@ public class EdgeRpcRequestHandler {
 	 *
 	 * @param edgeId  the Edge-ID
 	 * @param user    the {@link User} - no specific level required
+	 * @param role    the {@link Role} of the user to this edge
 	 * @param request the {@link GetEdgeConfigRequest}
 	 * @return the Future JSON-RPC Response
 	 * @throws OpenemsNamedException on error

--- a/io.openems.backend.core/test/io/openems/backend/core/jsonrpcrequesthandler/EdgeRpcRequestHandlerTest.java
+++ b/io.openems.backend.core/test/io/openems/backend/core/jsonrpcrequesthandler/EdgeRpcRequestHandlerTest.java
@@ -1,0 +1,140 @@
+package io.openems.backend.core.jsonrpcrequesthandler;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Test;
+
+import io.openems.backend.common.metadata.Edge;
+import io.openems.backend.common.metadata.EdgeHandler;
+import io.openems.backend.common.metadata.User;
+import io.openems.backend.common.test.DummyEdge;
+import io.openems.backend.common.test.DummyEdgeManager;
+import io.openems.backend.common.test.DummyMetadata;
+import io.openems.backend.common.test.DummyUser;
+import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
+import io.openems.common.jsonrpc.base.JsonrpcRequest;
+import io.openems.common.jsonrpc.base.JsonrpcResponseSuccess;
+import io.openems.common.jsonrpc.request.EdgeRpcRequest;
+import io.openems.common.jsonrpc.request.GetEdgeConfigRequest;
+import io.openems.common.jsonrpc.response.GetEdgeConfigResponse;
+import io.openems.common.session.Role;
+import io.openems.common.types.EdgeConfig;
+import io.openems.common.utils.JsonUtils;
+
+public class EdgeRpcRequestHandlerTest {
+
+	private static final String EDGE_ID = "edge0";
+	private static final DummyUser USER = DummyUser.DUMMY_GUEST;
+
+	/**
+	 * Cached config with factories → served directly, no Edge contact.
+	 */
+	@Test
+	public void testGetEdgeConfig_returnsCache_whenFactoriesPresent()
+			throws OpenemsNamedException, ExecutionException, InterruptedException {
+		final var cachedConfig = buildConfigWithFactory();
+		final var handler = buildHandler(cachedConfig, false, EdgeConfig.empty());
+
+		final var result = invokeGetEdgeConfig(handler);
+
+		assertFalse("cached config must have factories", result.getFactories().isEmpty());
+	}
+
+	/**
+	 * Empty cached config + Edge online → live config fetched from Edge.
+	 */
+	@Test
+	public void testGetEdgeConfig_fetchesLive_whenFactoriesEmptyAndOnline()
+			throws OpenemsNamedException, ExecutionException, InterruptedException {
+		final var liveConfig = buildConfigWithFactory();
+		final var handler = buildHandler(EdgeConfig.empty(), true, liveConfig);
+
+		final var result = invokeGetEdgeConfig(handler);
+
+		assertFalse("live config must have factories", result.getFactories().isEmpty());
+	}
+
+	/**
+	 * Empty cached config + Edge offline → empty cache returned, no live fetch.
+	 */
+	@Test
+	public void testGetEdgeConfig_returnsEmptyCache_whenFactoriesEmptyAndOffline()
+			throws OpenemsNamedException, ExecutionException, InterruptedException {
+		final var handler = buildHandler(EdgeConfig.empty(), false, buildConfigWithFactory());
+
+		final var result = invokeGetEdgeConfig(handler);
+
+		assertTrue("offline: empty cache must be returned", result.getFactories().isEmpty());
+	}
+
+	// --- helpers ---
+
+	private static EdgeConfig invokeGetEdgeConfig(EdgeRpcRequestHandler handler)
+			throws OpenemsNamedException, ExecutionException, InterruptedException {
+		final var request = new GetEdgeConfigRequest();
+		final var edgeRpcRequest = new EdgeRpcRequest(EDGE_ID, request);
+		final var edgeRpcResponse = handler.handleRequest(USER, UUID.randomUUID(), edgeRpcRequest).get();
+		// EdgeRpcResponse.getResult() = { "payload": { "jsonrpc", "id", "result": <EdgeConfig json> } }
+		final var configJson = edgeRpcResponse.getResult()
+				.get("payload").getAsJsonObject()
+				.get("result").getAsJsonObject();
+		return EdgeConfig.fromJson(configJson);
+	}
+
+	private static EdgeRpcRequestHandler buildHandler(EdgeConfig cachedConfig, boolean edgeOnline,
+			EdgeConfig liveConfig) {
+		final var parent = new CoreJsonRpcRequestHandlerImpl();
+
+		parent.metadata = new DummyMetadata(e -> { /* no-op: swallow edge online/offline events */ }) {
+			@Override
+			public Optional<Edge> getEdge(String edgeId) {
+				final var edge = new DummyEdge(this, EDGE_ID, "", "", "", ZonedDateTime.now());
+				edge.setOnline(edgeOnline);
+				return Optional.of(edge);
+			}
+
+			@Override
+			public EdgeHandler edge() {
+				return edgeId -> cachedConfig;
+			}
+
+			@Override
+			public Role getUserRole(User user, String edgeId) {
+				return Role.GUEST;
+			}
+		};
+
+		parent.edgeManager = new DummyEdgeManager(Collections.emptyMap()) {
+			@Override
+			public CompletableFuture<JsonrpcResponseSuccess> send(String edgeId, User user, Role role,
+					JsonrpcRequest request) {
+				return CompletableFuture.completedFuture(new GetEdgeConfigResponse(request.getId(), liveConfig));
+			}
+		};
+
+		return new EdgeRpcRequestHandler(parent);
+	}
+
+	private static EdgeConfig buildConfigWithFactory() {
+		return EdgeConfig.fromJson(JsonUtils.buildJsonObject()
+				.add("components", JsonUtils.buildJsonObject().build())
+				.add("factories", JsonUtils.buildJsonObject()
+						.add("io.openems.impl.controller.api.websocket.WebsocketApiController",
+								JsonUtils.buildJsonObject()
+										.addProperty("id",
+												"io.openems.impl.controller.api.websocket.WebsocketApiController")
+										.add("properties", JsonUtils.buildJsonArray().build())
+										.add("natureIds", JsonUtils.buildJsonArray().build())
+										.build())
+						.build())
+				.build());
+	}
+}


### PR DESCRIPTION
## Summary

- When the Backend restarts and an Edge reconnects with a 1006/1008 WebSocket close code, the `onOpen` callback is skipped so the EdgeConfig cache is never repopulated
- Subsequent `GetEdgeConfig` requests then returned an empty config, breaking the UI
- Fix: in `EdgeRpcRequestHandler.handleGetEdgeConfigRequest`, if the cached config has no factories **and** the Edge is online, fetch the live config directly from the Edge via `ComponentJsonApiRequest` before responding

## Test plan

- [ ] `EdgeRpcRequestHandlerTest.testGetEdgeConfig_returnsCache_whenFactoriesPresent` — cached config with factories is returned directly
- [ ] `EdgeRpcRequestHandlerTest.testGetEdgeConfig_fetchesLive_whenFactoriesEmptyAndOnline` — empty cache + online Edge triggers live fetch
- [ ] `EdgeRpcRequestHandlerTest.testGetEdgeConfig_returnsEmptyCache_whenFactoriesEmptyAndOffline` — empty cache + offline Edge returns empty (no live fetch attempted)

Closes #3756