### PR TITLE
HTTP Bridge: Replace thread pool

### DIFF
--- a/io.openems.common.bridge.http/src/io/openems/common/bridge/http/AsyncBridgeHttpExecutor.java
+++ b/io.openems.common.bridge.http/src/io/openems/common/bridge/http/AsyncBridgeHttpExecutor.java
@@ -91,7 +91,7 @@ public class AsyncBridgeHttpExecutor implements BridgeHttpExecutor {
 	}
 
 	@Deactivate
-	private void deactivate() {
+	protected void deactivate() {
 		ThreadPoolUtils.shutdownAndAwaitTermination(this.scheduler, 0);
 		ThreadPoolUtils.shutdownAndAwaitTermination(this.executor, 0);
 	}

--- a/io.openems.common.bridge.http/src/io/openems/common/bridge/http/AsyncBridgeHttpExecutor.java
+++ b/io.openems.common.bridge.http/src/io/openems/common/bridge/http/AsyncBridgeHttpExecutor.java
@@ -1,9 +1,13 @@
 package io.openems.common.bridge.http;
 
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -16,41 +20,94 @@ import io.openems.common.utils.ThreadPoolUtils;
 @Component(scope = ServiceScope.PROTOTYPE)
 public class AsyncBridgeHttpExecutor implements BridgeHttpExecutor {
 
-	private final ScheduledThreadPoolExecutor pool = new ScheduledThreadPoolExecutor(0, Thread.ofVirtual().factory());
+	/**
+	 * A Semaphore that allows setting the total number of permits.
+	 * 
+	 * <p>
+	 * This requires that all threads acquire and release an equal amount of
+	 * permits. Otherwise, the number of actual permits will drift.
+	 */
+	private class MySemaphore extends Semaphore {
+		private static final long serialVersionUID = 1122515497359767441L;
 
-	public AsyncBridgeHttpExecutor() {
-		// set the default maximum pool size
-		this.pool.setMaximumPoolSize(10);
+		private int totalPermits;
+
+		public MySemaphore(int permits) {
+			this(permits, false);
+		}
+
+		public MySemaphore(int permits, boolean fair) {
+			super(permits, fair);
+			this.totalPermits = permits;
+		}
+
+		public void setTotalPermits(int totalPermits) {
+			if (totalPermits >= this.totalPermits) {
+				this.release(totalPermits - this.totalPermits);
+			} else {
+				this.reducePermits(this.totalPermits - totalPermits);
+			}
+			this.totalPermits = totalPermits;
+		}
 	}
+
+	private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+	private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+	private final MySemaphore semaphore = new MySemaphore(10);
+
+	private final AtomicLong activeCounter = new AtomicLong();
+	private final AtomicLong completedCounter = new AtomicLong();
 
 	@Override
 	public ScheduledFuture<?> schedule(Runnable task, DelayTimeProvider.Delay.DurationDelay durationDelay) {
-		return this.pool.schedule(task, durationDelay.getDuration().toMillis(), TimeUnit.MILLISECONDS);
+		return this.scheduler.schedule(() -> this.execute(task), durationDelay.getDuration().toMillis(),
+				TimeUnit.MILLISECONDS);
 	}
 
 	@Override
 	public void execute(Runnable task) {
-		this.pool.execute(task);
+		this.executor.execute(() -> {
+			try {
+				this.semaphore.acquire();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return;
+			}
+
+			try {
+				this.activeCounter.incrementAndGet();
+				task.run();
+			} finally {
+				this.semaphore.release();
+				this.activeCounter.decrementAndGet();
+				this.completedCounter.incrementAndGet();
+			}
+		});
 	}
 
 	@Override
 	public boolean isShutdown() {
-		return this.pool.isShutdown();
+		return this.scheduler.isShutdown() && this.executor.isShutdown();
 	}
 
 	@Deactivate
 	private void deactivate() {
-		ThreadPoolUtils.shutdownAndAwaitTermination(this.pool, 0);
+		ThreadPoolUtils.shutdownAndAwaitTermination(this.scheduler, 0);
+		ThreadPoolUtils.shutdownAndAwaitTermination(this.executor, 0);
 	}
 
 	@Override
 	public Map<String, Long> getMetrics() {
-		return ThreadPoolUtils.debugMetrics(this.pool);
+		return Map.of(//
+				"Permits", (long) this.semaphore.availablePermits(), //
+				"Active", this.activeCounter.get(), //
+				"Pending", (long) this.semaphore.getQueueLength(), //
+				"Completed", this.completedCounter.get());
 	}
 
 	@Override
 	public void setMaximumPoolSize(int maximumPoolSize) {
-		this.pool.setMaximumPoolSize(maximumPoolSize);
+		this.semaphore.setTotalPermits(maximumPoolSize);
 	}
 
 }

--- a/io.openems.common.bridge.http/test/io/openems/common/bridge/http/AsyncBridgeHttpExecutorTest.java
+++ b/io.openems.common.bridge.http/test/io/openems/common/bridge/http/AsyncBridgeHttpExecutorTest.java
@@ -1,0 +1,86 @@
+package io.openems.common.bridge.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AsyncBridgeHttpExecutorTest {
+
+	private static final Duration TIMEOUT = Duration.ofSeconds(2);
+
+	private AsyncBridgeHttpExecutor executor;
+
+	@BeforeEach
+	void setUp() {
+		this.executor = new AsyncBridgeHttpExecutor();
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		this.executor.deactivate();
+	}
+
+	@Test
+	void executesTasksConcurrentlyUpToMaximumPoolSize() throws InterruptedException {
+		final var maxPoolSize = 15;
+		this.executor.setMaximumPoolSize(maxPoolSize);
+
+		var release = new CompletableFuture<Void>();
+
+		for (int i = 0; i < maxPoolSize; i++) {
+			this.executor.execute(() -> {
+				release.join();
+			});
+		}
+
+		this.awaitAndAssertMetric("Active", 15L, TIMEOUT);
+
+		this.executor.execute(() -> {
+			release.join();
+		});
+
+		this.awaitAndAssertMetric("Pending", 1L, TIMEOUT);
+
+		release.complete(null);
+
+		this.awaitAndAssertMetric("Completed", maxPoolSize + 1L, TIMEOUT);
+		this.awaitAndAssertMetric("Active", 0L, TIMEOUT);
+	}
+
+	@Test
+	void maintainsTotalPermits() throws InterruptedException {
+		final var maxPoolSize = 5;
+		this.executor.setMaximumPoolSize(maxPoolSize);
+
+		var release = new CompletableFuture<Void>();
+
+		for (int i = 0; i < maxPoolSize; i++) {
+			this.executor.execute(() -> {
+				release.join();
+			});
+		}
+
+		this.awaitAndAssertMetric("Permits", 0L, TIMEOUT);
+
+		release.complete(null);
+
+		this.awaitAndAssertMetric("Permits", maxPoolSize, TIMEOUT);
+	}
+
+	private void awaitAndAssertMetric(String key, long expected, Duration timeout) throws InterruptedException {
+		var deadline = System.nanoTime() + timeout.toNanos();
+		while (System.nanoTime() < deadline) {
+			if (Objects.equals(this.executor.getMetrics().get(key), expected)) {
+				break;
+			}
+			Thread.sleep(10);
+		}
+		assertEquals(expected, this.executor.getMetrics().get(key));
+	}
+}


### PR DESCRIPTION
This change fixes an issue that prevented http bridge requests from running concurrently, as discussed in https://community.openems.io/t/broken-thread-pools-in-openems/10947.

With this appraoch, I tried to mirror the original intended behavior as closely as possible. However, moving the initialization of the maximum pool size from a method to the constructor would enable the custom subclass of Semaphore to be dropped entirely and the code could be simplified quite a bit. Also, the debug logging could be reduced if desired to remove the need for separate counters.

Originally, I tested this using the MetadataOdoo provider. I also expanded the debug logging there and fixed a deadlock with one of the ConcurrentHashMaps that I discovered once several requests were running concurrently. However, the use of the HTTP bridge in that class was removed in https://github.com/OpenEMS/openems/commit/aa79e27a2f333a7a132e593c1e333ca9678cd4c3, so those changes are not included in this PR. If desired, I can also revert that commit and include those additional changes.

The flawed thread pool pattern exists in other places in the code as well, however this initial PR only touches the HTTP bridge.

I'm looking forward to your feedback :) 