### PR TITLE
[Edge]  adds a full login form to edge

### DIFF
--- a/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/handler/AuthenticationRequestHandler.java
+++ b/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/handler/AuthenticationRequestHandler.java
@@ -7,6 +7,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,8 +41,8 @@ public class AuthenticationRequestHandler implements JsonApi {
 
 	private final Map<String, String /* userid */> sessionTokens = new ConcurrentHashMap<>();
 
-	@Reference
-	private UserService userService;
+	@Reference(policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+	private volatile UserService userService;
 
 	@Override
 	public void buildJsonApiRoutes(JsonApiBuilder builder) {
@@ -58,8 +60,14 @@ public class AuthenticationRequestHandler implements JsonApi {
 		builder.handleRequest(AuthenticateWithPasswordRequest.METHOD, call -> {
 			final var request = AuthenticateWithPasswordRequest.from(call.getRequest());
 
+			User user = request.usernameOpt.isPresent()
+				?
+				this.userService.authenticate(request.usernameOpt.get(), request.password).orElse(null)
+				:
+				this.userService.authenticate(request.password).orElse(null);
+
 			return this.handleAuthentication(call.get(OnRequest.WS_DATA_KEY), request.getId(),
-					this.userService.authenticate(request.password).orElse(null), UUID.randomUUID().toString());
+					user, UUID.randomUUID().toString());
 		});
 
 		builder.handleRequest(LogoutRequest.METHOD, endpoint -> {

--- a/ui/src/app/index/login.component.html
+++ b/ui/src/app/index/login.component.html
@@ -13,7 +13,7 @@
                         <ion-label>{{"LOGIN.TITLE" | translate}}</ion-label>
                     </ion-item>
                     <!-- OpenEMS Edge Login -->
-                    @if (environment.backend === 'OpenEMS Edge') {
+                    @if (environment.backend === 'OpenEMS Edge' && environment.fullLogin !== true) {
                     <ion-card-content>
                         <form (ngSubmit)="doLogin({ password: password.value})">
                             <div class="ion-padding">
@@ -23,9 +23,39 @@
                                     </ion-text>
                                 </ion-item>
                                 <ion-item>
-                                    <ion-input #password required type="password"
+                                    <ion-input #password required type="password" autocomplete="current-password"
                                         [label]="'LOGIN.PASSWORD_LABEL' | translate" label-placement="floating"
                                         [placeholder]="'LOGIN.PASSWORD_LABEL' | translate" value="user"></ion-input>
+                                </ion-item>
+                                <!-- workaround for submit with enter key https://github.com/ionic-team/ionic-framework/issues/19368 -->
+                                <input type="submit" style="visibility: hidden; position: absolute; position: -999px" />
+                                <ion-button [disabled]="formIsDisabled" type="submit" class="ion-float-right">
+                                    <ion-icon slot="icon-only" name="log-in-outline"></ion-icon>
+                                </ion-button>
+                            </div>
+                        </form>
+                    </ion-card-content>
+                    }
+                    <!-- OpenEMS Edge Full Login -->
+                    @if (environment.backend === 'OpenEMS Edge' && environment.fullLogin === true) {
+                    <ion-card-content>
+                        <form (ngSubmit)="doLogin({username: username.value, password: password.value})">
+                            <div class="ion-padding">
+                                <ion-item>
+                                    <ion-text class="ion-text-wrap" color="medium" translate>
+                                        LOGIN.PREAMBLE
+                                    </ion-text>
+                                </ion-item>
+                                <ion-item>
+                                    <ion-input #username required autocomplete="on"
+                                      [label]="('LOGIN.USER' | translate)" label-placement="floating"
+                                      [placeholder]="('LOGIN.USER' | translate)"
+                                      ></ion-input>
+                                </ion-item>
+                                <ion-item>
+                                    <ion-input #password required type="password" autocomplete="current-password"
+                                        [label]="'LOGIN.PASSWORD_LABEL' | translate" label-placement="floating"
+                                        [placeholder]="'LOGIN.PASSWORD_LABEL' | translate"></ion-input>
                                 </ion-item>
                                 <!-- workaround for submit with enter key https://github.com/ionic-team/ionic-framework/issues/19368 -->
                                 <input type="submit" style="visibility: hidden; position: absolute; position: -999px" />
@@ -47,7 +77,7 @@
                                 </ion-input>
                             </ion-item>
                             <ion-item>
-                                <ion-input #password required type="password"
+                                <ion-input #password required type="password" autocomplete="current-password"
                                     [placeholder]="'LOGIN.PASSWORD_LABEL' | translate" label-placement="floating"
                                     [label]="'LOGIN.PASSWORD_LABEL' | translate">
                                 </ion-input>

--- a/ui/src/themes/openems/environments/edge-dev.ts
+++ b/ui/src/themes/openems/environments/edge-dev.ts
@@ -9,5 +9,6 @@ export const environment: Environment = {
 
         production: false,
         debugMode: true,
+        fullLogin: false
     },
 };

--- a/ui/src/themes/openems/environments/edge-docker.ts
+++ b/ui/src/themes/openems/environments/edge-docker.ts
@@ -9,5 +9,6 @@ export const environment: Environment = {
 
         production: true,
         debugMode: false,
+        fullLogin: false
     },
 };

--- a/ui/src/themes/openems/environments/edge-prod.ts
+++ b/ui/src/themes/openems/environments/edge-prod.ts
@@ -9,5 +9,6 @@ export const environment: Environment = {
 
         production: true,
         debugMode: false,
+        fullLogin: false
     },
 };


### PR DESCRIPTION
I've added a full login form for edge, so it gets possible to login with user and password.

The changes in AuthenticationRequestHandler make it possible to add an own UserService with a higher service ranking for handling authentication requests. The code should be transparent, so everything should work as before, if you do not add an own UserService.

In the UI I added a setting for the login form type - with fullLogin you can decide, if you want a username+password login or just a password login as before. Only password is also the default.

I've written this code as I only run an edge and no backend and I can attach it to ldap this way. But of course you could use/write other UserService implementations for adapting different authentication systems.

The patch is a diff against main and I will keep it in sync to main.