### PR TITLE
[UI] Widen null-safe signatures to drop @ts-strict-ignore

### DIFF
--- a/ui/src/app/edge/live/common/storage/storage.component.ts
+++ b/ui/src/app/edge/live/common/storage/storage.component.ts
@@ -54,7 +54,7 @@ export class StorageComponent extends AbstractFlatWidget {
      * @param value Takes passed value when called
      * @returns Only positive and 0
      */
-    public convertPower(value: number, isCharge?: boolean) {
+    public convertPower(value: number | null, isCharge?: boolean) {
         const locale: string = Language.geti18nLocale();
         if (value == null) {
             return "-";

--- a/ui/src/app/edge/live/energymonitor/chart/section/abstractsection.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/abstractsection.component.ts
@@ -459,7 +459,7 @@ export abstract class AbstractSection {
         rect: SvgSquare,
         innerRadius: number,
     ): SvgSquarePosition;
-    protected abstract getValueText(value: number): string;
+    protected abstract getValueText(value: number | null): string;
     protected abstract initEnergyFlow(radius: number): EnergyFlow;
     protected abstract setElementHeight();
 }

--- a/ui/src/app/edge/live/energymonitor/chart/section/consumption.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/consumption.component.ts
@@ -89,7 +89,7 @@ export class ConsumptionSectionComponent extends AbstractSection implements OnIn
         return environment.icons.COMMON.CONSUMPTION;
     }
 
-    protected getValueText(value: number): string {
+    protected getValueText(value: number | null): string {
         if (value == null || Number.isNaN(value)) {
             return "";
         }

--- a/ui/src/app/edge/live/energymonitor/chart/section/grid.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/grid.component.ts
@@ -193,7 +193,7 @@ export class GridSectionComponent extends AbstractSection implements OnInit, OnD
         return environment.icons.COMMON.GRID;
     }
 
-    protected getValueText(value: number): string {
+    protected getValueText(value: number | null): string {
         if (value == null || Number.isNaN(value)) {
             return "";
         }

--- a/ui/src/app/edge/live/energymonitor/chart/section/production.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/production.component.ts
@@ -98,7 +98,7 @@ export class ProductionSectionComponent extends AbstractSection implements OnIni
         return environment.icons.COMMON.PRODUCTION;
     }
 
-    protected getValueText(value: number): string {
+    protected getValueText(value: number | null): string {
         if (value == null || Number.isNaN(value)) {
             return "";
         }

--- a/ui/src/app/edge/live/energymonitor/chart/section/storage.component.ts
+++ b/ui/src/app/edge/live/energymonitor/chart/section/storage.component.ts
@@ -153,7 +153,7 @@ export class StorageSectionComponent extends AbstractSection implements OnInit, 
         return environment.icons.COMMON.STORAGE;
     }
 
-    protected getValueText(value: number): string {
+    protected getValueText(value: number | null): string {
         if (value == null || Number.isNaN(value)) {
             return "";
         }

--- a/ui/src/app/index/login.component.ts
+++ b/ui/src/app/index/login.component.ts
@@ -72,7 +72,7 @@ export class LoginComponent implements ViewWillEnter, AfterContentChecked, OnDes
      * @param username The username
      * @returns Trimmed credentials
      */
-    public static preprocessCredentials(password: string, username?: string): { password: string; username?: string } {
+    public static preprocessCredentials(password: string | null, username?: string | null): { password: string | undefined; username?: string } {
         return {
             password: password?.trim(),
             ...(username && { username: username?.trim().toLowerCase() }),

--- a/ui/src/app/index/login.spec.ts
+++ b/ui/src/app/index/login.spec.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { TestBed } from "@angular/core/testing";
 import { LoginComponent } from "./login.component";
 

--- a/ui/src/app/shared/type/language.spec.ts
+++ b/ui/src/app/shared/type/language.spec.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { TestContext, TestingUtils } from "../components/shared/testing/utils.spec";
 import { Language } from "./language";
 describe("Language", () => {

--- a/ui/src/app/shared/type/language.ts
+++ b/ui/src/app/shared/type/language.ts
@@ -83,8 +83,8 @@ export class Language {
         return Language.getByKey(localStorage.LANGUAGE);
     }
 
-    public static getByKey(key: string | null): Language | null {
-        if (key === null) {
+    public static getByKey(key: string | null | undefined): Language | null {
+        if (key == null) {
             return null;
         }
         for (const language of Language.ALL) {
@@ -95,7 +95,7 @@ export class Language {
         return null;
     }
 
-    public static getByBrowserLang(browserLang: string): Language | null {
+    public static getByBrowserLang(browserLang: string | null | undefined): Language | null {
         switch (browserLang) {
             case "de":
                 return Language.DE;
@@ -144,7 +144,7 @@ export class Language {
      * @param language The language
      * @returns The i18n locale
      */
-    public static geti18nLocaleByKey(language: string) {
+    public static geti18nLocaleByKey(language: string | null | undefined) {
         const lang = this.getByBrowserLang(language?.toLowerCase());
 
         if (!lang) {


### PR DESCRIPTION
- Allow 'null/undefined` on helpers that already handle missing values (Language, login credentials, energy-monitor 'getValueText', storage 'convertPower').
- Remove '@ts-strict-ignore' from 'login.spec.ts' and 'language.spec.ts'.
- No runtime behavior change.