### PR TITLE
[UI] Enable strict checking for ArrayUtils tests

### DIFF
--- a/ui/src/app/shared/utils/array/array.utils.spec.ts
+++ b/ui/src/app/shared/utils/array/array.utils.spec.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ArrayUtils } from "./array.utils";
 
 describe("Array-Utils", () => {
@@ -22,7 +21,7 @@ describe("Array-Utils", () => {
         expect(ArrayUtils.sortedAlphabetically(inputArr, (a) => a)).toEqual(sortedArr);
         expect(ArrayUtils.sortedAlphabetically(inputArr, (_a) => null)).toEqual(inputArr);
 
-        expect(() => ArrayUtils.sortedAlphabetically(inputArr, null)).toThrow();
+        expect(() => Reflect.apply(ArrayUtils.sortedAlphabetically, undefined, [inputArr, null])).toThrow();
     });
 
     describe("ReducerFunctions", () => {

--- a/ui/src/app/shared/utils/array/array.utils.ts
+++ b/ui/src/app/shared/utils/array/array.utils.ts
@@ -58,7 +58,7 @@ export namespace ArrayUtils {
      * @param fn To get a string to sort by
      * @returns Sorted array
      */
-    export function sortedAlphabetically<T>(array: T[], fn: (arg: T) => string = () => ""): T[] {
+    export function sortedAlphabetically<T>(array: T[], fn: (arg: T) => string | null | undefined = () => ""): T[] {
         return array.sort((a: T, b: T) => {
             const aVal = fn(a);
             const bVal = fn(b);


### PR DESCRIPTION
Enable strict checking for ArrayUtils tests and allow sorting callbacks
to return null or undefined, matching existing documented behavior.

Preserve the invalid-callback runtime test using Reflect.apply().
The sorting implementation remains unchanged.