### PR TITLE
[UI] Enable strict checking for ColorUtils tests

### DIFF
--- a/ui/src/app/shared/utils/color/color.utils.spec.ts
+++ b/ui/src/app/shared/utils/color/color.utils.spec.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ColorUtils } from "./color.utils";
 
 describe("Color-Utils", () => {

--- a/ui/src/app/shared/utils/color/color.utils.ts
+++ b/ui/src/app/shared/utils/color/color.utils.ts
@@ -9,7 +9,7 @@ export namespace ColorUtils {
    * @param opacity the opacity
    * @returns a string in rgba format
    */
-    export function rgbStringToRgba(color: string, opacity: number): string {
+    export function rgbStringToRgba(color: string | null, opacity: number | null): string {
         return RGBColor.fromString(color).toRgba(opacity);
     }
 
@@ -20,7 +20,7 @@ export namespace ColorUtils {
    * @param opacity the opacity
    * @returns a string in rgba format
    */
-    export function changeOpacityFromRGBA(color: string | null, opacity: number): string | null {
+    export function changeOpacityFromRGBA(color: string | null, opacity: number | null): string | null {
         return RGBColor.fromString(color).toRgba(opacity);
     }
 }


### PR DESCRIPTION
Enable strict checking for ColorUtils tests by removing `@ts-strict-ignore`.

Update color and opacity parameter types to accept `null`, matching the underlying RGBColor helpers and existing invalid-input tests. Color conversion logic and runtime error handling remain unchanged.
