### PR TITLE
[UI] Enable TypeScript strict checks on login, overview, and registration

### DIFF
--- a/ui/src/app/index/login.component.ts
+++ b/ui/src/app/index/login.component.ts
@@ -1,5 +1,4 @@
-// @ts-strict-ignore
-import { AfterContentChecked, ChangeDetectorRef, Component, computed, effect, inject, OnDestroy, ChangeDetectionStrategy, } from "@angular/core";
+import { AfterContentChecked, ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, effect, inject, OnDestroy, } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Capacitor } from "@capacitor/core";
@@ -26,9 +25,9 @@ import { States } from "../shared/states/states";
 })
 export class LoginComponent implements ViewWillEnter, AfterContentChecked, OnDestroy {
     private static readonly DEFAULT_THEME: UserTheme = UserTheme.LIGHT;
-    public currentThemeMode: UserTheme;
+    public currentThemeMode!: UserTheme;
     public environment = environment;
-    public form: FormGroup;
+    public form!: FormGroup;
     protected formIsDisabled: boolean = false;
     protected popoverActive: "android" | "ios" | null = null;
     protected showPassword: boolean = false;
@@ -72,9 +71,9 @@ export class LoginComponent implements ViewWillEnter, AfterContentChecked, OnDes
      * @param username The username
      * @returns Trimmed credentials
      */
-    public static preprocessCredentials(password: string, username?: string): { password: string; username?: string } {
+    public static preprocessCredentials(password: string | null, username?: string | null): { password: string; username?: string } {
         return {
-            password: password?.trim(),
+            password: password?.trim() ?? "",
             ...(username && { username: username?.trim().toLowerCase() }),
         };
     }
@@ -85,7 +84,7 @@ export class LoginComponent implements ViewWillEnter, AfterContentChecked, OnDes
 
     async ionViewWillEnter() {
         // Execute Login-Request if url path matches 'demo'
-        if (this.route.snapshot.routeConfig.path == "demo") {
+        if (this.route.snapshot.routeConfig?.path == "demo") {
             await new Promise((resolve) =>
                 setTimeout(() => {
                     // Wait for Websocket

--- a/ui/src/app/index/login.spec.ts
+++ b/ui/src/app/index/login.spec.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { TestBed } from "@angular/core/testing";
 import { LoginComponent } from "./login.component";
 
@@ -23,7 +22,7 @@ describe("Login", () => {
         }
         {
             // Password is null
-            expect(LoginComponent.preprocessCredentials(null)).toEqual({ password: undefined });
+            expect(LoginComponent.preprocessCredentials(null)).toEqual({ password: "" });
         }
         {
             // Username is null
@@ -31,7 +30,7 @@ describe("Login", () => {
         }
         {
             // Username and password are null
-            expect(LoginComponent.preprocessCredentials(null, null)).toEqual({ password: undefined });
+            expect(LoginComponent.preprocessCredentials(null, null)).toEqual({ password: "" });
         }
         {
             // Username in Upper case

--- a/ui/src/app/index/overview/overview.component.spec.ts
+++ b/ui/src/app/index/overview/overview.component.spec.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { LOCALE_ID, signal } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
@@ -31,8 +30,8 @@ describe("OverviewComponent", () => {
         ["getCurrentEdge", "getEdges", "getIsSmartphoneResolution"],
         {
             metadata: new BehaviorSubject({
-                edges: null,
-                user: null,
+                edges: {},
+                user: new User("", "", "admin", "", true, { theme: Theme.LIGHT }),
             }),
             getIsSmartphoneResolution: () => false,
             getEdges(): Promise<Edge[]> {

--- a/ui/src/app/index/overview/overview.component.ts
+++ b/ui/src/app/index/overview/overview.component.ts
@@ -1,5 +1,4 @@
-// @ts-strict-ignore
-import { Component, effect, model, OnDestroy, signal, ChangeDetectionStrategy, untracked } from "@angular/core";
+import { ChangeDetectionStrategy, Component, effect, model, OnDestroy, signal, untracked } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { InfiniteScrollCustomEvent, Platform, ViewWillEnter } from "@ionic/angular";
@@ -31,7 +30,7 @@ export class OverViewComponent implements ViewWillEnter, OnDestroy {
     /** True, if the logged in user is allowed to install new edges. */
     public loggedInUserCanInstall = model<boolean>(false);
 
-    public form: FormGroup;
+    public form!: FormGroup;
     public filteredEdges = model<Edge[]>([]);
 
     protected loading = signal(false);
@@ -155,7 +154,7 @@ export class OverViewComponent implements ViewWillEnter, OnDestroy {
                 return;
             }
 
-            const searchParamsObj = {};
+            const searchParamsObj: Record<string, unknown> = {};
             if (this.searchParams && this.searchParams.size > 0) {
                 for (const [key, value] of this.searchParams) {
                     searchParamsObj[key] = value;
@@ -174,7 +173,7 @@ export class OverViewComponent implements ViewWillEnter, OnDestroy {
                     this.limitReached = edges.length < this.limit;
                     const user = this.userService.currentUser();
                     // TODO could be applied before calling getEdges
-                    if (!UserPermission.isUserAllowedToSeeOverview(user) && edges.length > 0) {
+                    if (user != null && !UserPermission.isUserAllowedToSeeOverview(user) && edges.length > 0) {
                         const edge = edges[0];
                         setTimeout(() => {
                             this.router.navigate(["/device", edge.id]);

--- a/ui/src/app/index/registration/modal/modal.component.ts
+++ b/ui/src/app/index/registration/modal/modal.component.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Component, OnInit } from "@angular/core";
 import { FormBuilder, FormControl, FormGroup, Validators } from "@angular/forms";
 import { ModalController } from "@ionic/angular";
@@ -18,7 +17,7 @@ import { environment } from "src/environments";
     standalone: false,
 })
 export class RegistrationModalComponent implements OnInit {
-    protected formGroup: FormGroup;
+    protected formGroup!: FormGroup;
     protected activeSegment: string = "installer";
     protected readonly countries = COUNTRY_OPTIONS(this.translate);
     protected docsLink: string | null = null;
@@ -94,7 +93,7 @@ export class RegistrationModalComponent implements OnInit {
                 name: companyName,
             };
         }
-        this.service.startSpinner(this.spinnerId);
+        this.service.startSpinner(this.spinnerId ?? "");
         this.websocket
             .sendRequest(request)
             .then(() => {
@@ -104,7 +103,7 @@ export class RegistrationModalComponent implements OnInit {
             .catch((reason) => {
                 this.service.toast(reason.error.message, "danger");
             })
-            .finally(() => this.service.stopSpinner(this.spinnerId));
+            .finally(() => this.service.stopSpinner(this.spinnerId ?? ""));
     }
 
     /** Get from depending on given role. If no role matches then the default (owner) from will be returnd. */


### PR DESCRIPTION
- Remove '@ts-strict-ignore' from login, overview, and registration.
- Widen types / use definite assignment and optional chaining so strict checks pass.
- Treat a missing login password as "" (matches preprocessCredentials return type).
