### PR TITLE
Fix: Evse Controller Automatic phase switch never triggers with slower Core-Cycle-Time

### DIFF
--- a/io.openems.edge.controller.evse/src/io/openems/edge/controller/evse/cluster/RunUtils.java
+++ b/io.openems.edge.controller.evse/src/io/openems/edge/controller/evse/cluster/RunUtils.java
@@ -61,7 +61,6 @@ public class RunUtils {
 	 * is checked.
 	 */
 	private static final Duration AUTOMATIC_PROBABLE_PHASE_SWITCH_WINDOW = Duration.ofSeconds(20);
-	private static final int AUTOMATIC_THREE_TO_SINGLE_PHASE_SWITCH_WINDOW_MIN_SAMPLE_COUNT = 20;
 	/**
 	 * Delay for the EpochSecond probable phase switch evaluation. If a probable
 	 * phase switch is detected the next switch is set to now plus this Duration.
@@ -920,8 +919,7 @@ public class RunUtils {
 				.evaluateAutomaticPhaseSwitchSetPointWithoutPhaseLimitationForWindow(now, singlePhaseMinInWatt,
 						AutomaticPhaseSwitchThresholdDirection.ABOVE, AUTOMATIC_PROBABLE_PHASE_SWITCH_WINDOW,
 						context.setPointWithoutPhaseLimitation());
-		final var singlePhaseFeasibleInRecentWindow = isAutomaticPhaseSwitchWindowThresholdReached(
-				singlePhaseFeasibilityEvaluation, AUTOMATIC_THREE_TO_SINGLE_PHASE_SWITCH_WINDOW_MIN_SAMPLE_COUNT);
+		final var singlePhaseFeasibleInRecentWindow = singlePhaseFeasibilityEvaluation.shouldSwitch();
 		if (threeToSingleEvaluation.shouldSwitch() && singlePhaseFeasibleInRecentWindow) {
 			setProbableNextPhaseSwitchEpochSecondsIfUnset(context.ctrl(), now, shortWindowEvaluation,
 					context.probableSwitchTimestampWasCleared());
@@ -1057,20 +1055,6 @@ public class RunUtils {
 			return minSetPointInWatt;
 		}
 		return Math.max(minSetPointInWatt, applySetPointAbility.fitWithin(setPointInWatt));
-	}
-
-	private static boolean isAutomaticPhaseSwitchWindowThresholdReached(
-			AutomaticPhaseSwitchSetPointWithoutPhaseLimitationEvaluation evaluation, int minSampleCount) {
-		return evaluation.windowActive() && evaluation.sampleCount() >= minSampleCount
-				&& isAutomaticPhaseSwitchThresholdReached(evaluation);
-	}
-
-	private static boolean isAutomaticPhaseSwitchThresholdReached(
-			AutomaticPhaseSwitchSetPointWithoutPhaseLimitationEvaluation evaluation) {
-		return switch (evaluation.direction()) {
-		case ABOVE -> evaluation.directionalNinetyPercentAverage() >= evaluation.thresholdInWatt();
-		case BELOW -> evaluation.directionalNinetyPercentAverage() <= evaluation.thresholdInWatt();
-		};
 	}
 
 	private static Long getProbableNextPhaseSwitchEpochSeconds(ControllerEvseSingle ctrl) {

--- a/io.openems.edge.controller.evse/src/io/openems/edge/controller/evse/single/Types.java
+++ b/io.openems.edge.controller.evse/src/io/openems/edge/controller/evse/single/Types.java
@@ -35,7 +35,7 @@ public class Types {
 		private static final Duration AUTOMATIC_PHASE_SWITCH_COOLDOWN = Duration.ofSeconds(MAX_AGE);
 		static final Duration AUTOMATIC_PHASE_SWITCH_PV_LIMIT_WINDOW = Duration.ofMinutes(2);
 		/**
-		 * Fraction of the theoretically expected sample count (derived from the
+		 * 90% of the theoretically expected sample count (derived from the
 		 * actually observed Cycle-Time) that must be reached within a window before a
 		 * phase switch decision is made.
 		 */

--- a/io.openems.edge.controller.evse/src/io/openems/edge/controller/evse/single/Types.java
+++ b/io.openems.edge.controller.evse/src/io/openems/edge/controller/evse/single/Types.java
@@ -33,8 +33,13 @@ public class Types {
 		protected static final int MAX_AGE = 300; // [s]
 
 		private static final Duration AUTOMATIC_PHASE_SWITCH_COOLDOWN = Duration.ofSeconds(MAX_AGE);
-		private static final Duration AUTOMATIC_PHASE_SWITCH_PV_LIMIT_WINDOW = Duration.ofMinutes(2);
-		private static final int AUTOMATIC_PHASE_SWITCH_MIN_SAMPLE_COUNT = 60;
+		static final Duration AUTOMATIC_PHASE_SWITCH_PV_LIMIT_WINDOW = Duration.ofMinutes(2);
+		/**
+		 * Fraction of the theoretically expected sample count (derived from the
+		 * actually observed Cycle-Time) that must be reached within a window before a
+		 * phase switch decision is made.
+		 */
+		static final double AUTOMATIC_PHASE_SWITCH_MIN_SAMPLE_COUNT_FACTOR = 0.9;
 
 		private final TreeMap<Instant, Entry> entries = new TreeMap<>();
 
@@ -207,12 +212,45 @@ public class Types {
 			if (currentSetPointWithoutPhaseLimitation != null) {
 				samples.add(currentSetPointWithoutPhaseLimitation);
 			}
+			final var minSampleCount = this.calculateMinSampleCount(window);
 			return this.evaluateAutomaticPhaseSwitchSetPointWithoutPhaseLimitationSamples(samples, thresholdInWatt,
-					direction);
+					direction, minSampleCount);
+		}
+
+		/**
+		 * Calculates the minimum sample count required within the given window,
+		 * derived from the actually observed Core-Cycle-Time (average interval
+		 * between recorded entries) instead of a fixed constant.
+		 *
+		 * <p>
+		 * This way the requirement automatically scales with the Cycle-Time: e.g. a
+		 * Cycle-Time of 5 s allows for at most 24 samples within a 2-minute window
+		 * (instead of the fixed 60 that assumed a 1 s Cycle-Time and could never be
+		 * reached with a slower Cycle). {@link #AUTOMATIC_PHASE_SWITCH_MIN_SAMPLE_COUNT_FACTOR}
+		 * leaves some tolerance for Cycle-Time jitter or a temporarily slower Cycle.
+		 *
+		 * @param window the evaluation window
+		 * @return the required minimum sample count; {@link Integer#MAX_VALUE} if the
+		 *         Cycle-Time cannot yet be estimated (too little History)
+		 */
+		private int calculateMinSampleCount(Duration window) {
+			if (this.entries.size() < 2) {
+				return Integer.MAX_VALUE;
+			}
+			final var oldest = this.entries.firstKey();
+			final var newest = this.entries.lastKey();
+			final var spanMillis = Duration.between(oldest, newest).toMillis();
+			if (spanMillis <= 0) {
+				return Integer.MAX_VALUE;
+			}
+			final var averageCycleTimeMillis = (double) spanMillis / (this.entries.size() - 1);
+			final var expectedSampleCount = window.toMillis() / averageCycleTimeMillis;
+			return (int) Math.ceil(expectedSampleCount * AUTOMATIC_PHASE_SWITCH_MIN_SAMPLE_COUNT_FACTOR);
 		}
 
 		private AutomaticPhaseSwitchSetPointWithoutPhaseLimitationEvaluation evaluateAutomaticPhaseSwitchSetPointWithoutPhaseLimitationSamples(
-				List<Integer> samples, int thresholdInWatt, AutomaticPhaseSwitchThresholdDirection direction) {
+				List<Integer> samples, int thresholdInWatt, AutomaticPhaseSwitchThresholdDirection direction,
+				int minSampleCount) {
 			if (samples.isEmpty()) {
 				return new AutomaticPhaseSwitchSetPointWithoutPhaseLimitationEvaluation(false, false, 0, 0,
 						thresholdInWatt, direction, 0);
@@ -223,7 +261,7 @@ public class Types {
 			case ABOVE -> directionalNinetyPercentAverage >= thresholdInWatt;
 			case BELOW -> directionalNinetyPercentAverage <= thresholdInWatt;
 			};
-			final var sampleCountReached = samples.size() >= AUTOMATIC_PHASE_SWITCH_MIN_SAMPLE_COUNT;
+			final var sampleCountReached = samples.size() >= minSampleCount;
 			final var currentPercentage = calculateDirectionalPercentage(directionalNinetyPercentAverage,
 					thresholdInWatt, direction);
 

--- a/io.openems.edge.controller.evse/test/io/openems/edge/controller/evse/cluster/RunUtilsTest.java
+++ b/io.openems.edge.controller.evse/test/io/openems/edge/controller/evse/cluster/RunUtilsTest.java
@@ -1013,8 +1013,19 @@ class RunUtilsTest {
 		assertEquals(PhaseSwitchDirection.TO_SINGLE_PHASE, exec.get(0).getPhaseSwitchDirection());
 	}
 
+	/**
+	 * Number of History entries required in the 2-minute automatic phase switch
+	 * window at a simulated 1-second Core-Cycle-Time, i.e.
+	 * {@code ceil(120 * 0.9) = 108} samples (see
+	 * {@code Types.History.calculateMinSampleCount()}). The warmup below builds up
+	 * one entry short of that (107), so that the caller's own subsequent
+	 * {@code execute()} call becomes the 108th sample and is the one expected to
+	 * trigger the switch.
+	 */
+	private static final int AUTOMATIC_PHASE_SWITCH_MIN_SAMPLE_COUNT = 108;
+
 	private static void executeAutomaticPhaseSwitchWarmup(CalculateTester ct, History history, int index) {
-		IntStream.range(0, 59).forEach(i -> {
+		IntStream.range(0, AUTOMATIC_PHASE_SWITCH_MIN_SAMPLE_COUNT - 1).forEach(i -> {
 			var warmup = ct.execute(DistributionStrategy.EQUAL_POWER);
 			assertNull(warmup.get(index).getPhaseSwitchDirection());
 			appendHistoryEntry(ct, history, warmup, index);

--- a/io.openems.edge.controller.evse/test/io/openems/edge/controller/evse/single/TypesTest.java
+++ b/io.openems.edge.controller.evse/test/io/openems/edge/controller/evse/single/TypesTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.stream.IntStream;
 
@@ -79,10 +80,14 @@ public class TypesTest {
 
 	@Test
 	public void testAutomaticPhaseSwitchRequiresMinimumSampleCount() {
+		// Simulates a 1-second Core-Cycle-Time. The required sample count is derived
+		// from the same window/factor constants the production code uses, so this
+		// test keeps working automatically if either constant is ever tuned.
 		var now = Instant.now(createDummyClock());
 		var h = new History();
+		var minSampleCount = expectedMinSampleCount(Duration.ofSeconds(1));
 
-		for (int i = 0; i < 59; i++) {
+		for (int i = 0; i < minSampleCount - 1; i++) {
 			var evaluation = h.evaluateAutomaticPhaseSwitchSetPointWithoutPhaseLimitation(now.plusSeconds(i), 5_000,
 					4_100, History.AutomaticPhaseSwitchThresholdDirection.ABOVE);
 			assertFalse(evaluation.shouldSwitch());
@@ -90,10 +95,51 @@ public class TypesTest {
 			h.addEntry(now.plusSeconds(i), 1_000, 1_000, 5_000, true);
 		}
 
-		var sixtiethEvaluation = h.evaluateAutomaticPhaseSwitchSetPointWithoutPhaseLimitation(now.plusSeconds(59),
-				5_000, 4_100, History.AutomaticPhaseSwitchThresholdDirection.ABOVE);
-		assertTrue(sixtiethEvaluation.shouldSwitch());
-		assertEquals(60, sixtiethEvaluation.sampleCount());
+		var evaluationAtMinSampleCount = h.evaluateAutomaticPhaseSwitchSetPointWithoutPhaseLimitation(
+				now.plusSeconds(minSampleCount - 1), 5_000, 4_100,
+				History.AutomaticPhaseSwitchThresholdDirection.ABOVE);
+		assertTrue(evaluationAtMinSampleCount.shouldSwitch());
+		assertEquals(minSampleCount, evaluationAtMinSampleCount.sampleCount());
+	}
+
+	@Test
+	public void testAutomaticPhaseSwitchMinimumSampleCountScalesWithCycleTime() {
+		// Simulates a slower 5-second Core-Cycle-Time (e.g. a loaded system). With the
+		// previous fixed threshold of 60 samples this could never be reached, so
+		// automatic phase switching would never trigger. The expected count below
+		// scales dynamically with the Cycle-Time, same as the production code.
+		var now = Instant.now(createDummyClock());
+		var h = new History();
+		var cycleTime = Duration.ofSeconds(5);
+		var minSampleCount = expectedMinSampleCount(cycleTime);
+
+		for (int i = 0; i < minSampleCount - 1; i++) {
+			var evaluation = h.evaluateAutomaticPhaseSwitchSetPointWithoutPhaseLimitation(
+					now.plus(cycleTime.multipliedBy(i)), 5_000, 4_100,
+					History.AutomaticPhaseSwitchThresholdDirection.ABOVE);
+			assertFalse(evaluation.shouldSwitch());
+			h.addEntry(now.plus(cycleTime.multipliedBy(i)), 1_000, 1_000, 5_000, true);
+		}
+
+		var evaluationAtMinSampleCount = h.evaluateAutomaticPhaseSwitchSetPointWithoutPhaseLimitation(
+				now.plus(cycleTime.multipliedBy(minSampleCount - 1)), 5_000, 4_100,
+				History.AutomaticPhaseSwitchThresholdDirection.ABOVE);
+		assertTrue(evaluationAtMinSampleCount.shouldSwitch());
+		assertEquals(minSampleCount, evaluationAtMinSampleCount.sampleCount());
+	}
+
+	/**
+	 * Mirrors {@code Types.History.calculateMinSampleCount(Duration)} using the
+	 * package-visible window/factor constants, so tests derive their expectations
+	 * from the same source of truth instead of hardcoded numbers.
+	 *
+	 * @param cycleTime the simulated Core-Cycle-Time
+	 * @return the expected minimum sample count
+	 */
+	private static int expectedMinSampleCount(Duration cycleTime) {
+		final var expectedSampleCount = (double) History.AUTOMATIC_PHASE_SWITCH_PV_LIMIT_WINDOW.toMillis()
+				/ cycleTime.toMillis();
+		return (int) Math.ceil(expectedSampleCount * History.AUTOMATIC_PHASE_SWITCH_MIN_SAMPLE_COUNT_FACTOR);
 	}
 
 }


### PR DESCRIPTION
Problem: 
Currently automatic phase switching uses a fixed rate of 60 samples in 2 minutes. If the core cycle time is higher than about 2 seconds it will probably never shift. 
Reason for that is that I'm using a core cycle time of 4 seconds, otherwise used hardware isn't fast enough. 

Fix:
Switching from fixed 60 sample window to a dynamic one. The sample window of the dynamic window depends on the average cycle time of taken samples x factor 90%. Reason for the 90% is that there might be a deviation of the cycle time.

Tests:
The test files are also changed to the same dynamic window. 