### PR TITLE
[UI] Enable strict TypeScript checking for date-picker popover

### DIFF
--- a/ui/src/app/shared/components/pickdate/popover/popover.component.ts
+++ b/ui/src/app/shared/components/pickdate/popover/popover.component.ts
@@ -1,5 +1,4 @@
-// @ts-strict-ignore
-import { ChangeDetectorRef, Component, Input, OnInit, ChangeDetectionStrategy } from "@angular/core";
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } from "@angular/core";
 import { PopoverController } from "@ionic/angular";
 import { TranslateService } from "@ngx-translate/core";
 import { CalAnimation, IAngularMyDpOptions, IMyDate, IMyDateRangeModel } from "@nodro7/angular-mydatepicker";
@@ -24,7 +23,7 @@ import { Edge } from "../../edge/edge";
     ],
 })
 export class PickDatePopoverComponent implements OnInit {
-    @Input() public setDateRange: (period: DefaultTypes.HistoryPeriod) => void;
+    @Input() public setDateRange!: (period: DefaultTypes.HistoryPeriod) => void;
     @Input() public edge: Edge | null = null;
     @Input() public historyPeriods: DefaultTypes.PeriodStringValues[] = [];
 
@@ -121,10 +120,12 @@ export class PickDatePopoverComponent implements OnInit {
 
     ngOnInit() {
         this.locale = Language.getCurrentLanguage().key;
+        const firstSetupProtocol = this.edge?.firstSetupProtocol;
+        const dateInput = firstSetupProtocol === undefined ? NaN : firstSetupProtocol;
         // Restrict user to pick date before ibn-date
         this.myDpOptions.disableUntil = {
-            day: Utils.subtractSafely(getDate(this.edge?.firstSetupProtocol), 1) ?? 1,
-            month: Utils.addSafely(getMonth(this.edge?.firstSetupProtocol), 1) ?? 1,
+            day: Utils.subtractSafely(getDate(dateInput), 1) ?? 1,
+            month: Utils.addSafely(getMonth(dateInput), 1) ?? 1,
             year: this.edge?.firstSetupProtocol?.getFullYear() ?? 2013,
         };
 

--- a/ui/src/app/shared/shared.ts
+++ b/ui/src/app/shared/shared.ts
@@ -81,7 +81,11 @@ export class EdgePermission {
      * @param historyPeriods The historyPeriods i.e 'day', 'week' or 'custom'
      * @returns The list of allowed periods for this edge
      */
-    public static getAllowedHistoryPeriods(edge: Edge, historyPeriods?: DefaultTypes.PeriodStringValues[]) {
+    public static getAllowedHistoryPeriods(
+        edge: Edge | null,
+        historyPeriods?: DefaultTypes.PeriodStringValues[],
+    ): `${DefaultTypes.PeriodString}`[] {
+
         if (historyPeriods?.length > 0) {
             return historyPeriods;
         }


### PR DESCRIPTION
## Changes
- Enable strict checking for the date-picker popover.
- Declare the callback supplied when creating the popover.
- Preserve existing date-function behavior for undefined input.
- Correct the allowed-history-periods helper's input and return types